### PR TITLE
Integrate MapStruct mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <java.version>17</java.version>
+    <mapstruct.version>1.5.5.Final</mapstruct.version>
   </properties>
 
   <dependencies>
@@ -60,6 +61,17 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+      <version>${mapstruct.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct-processor</artifactId>
+      <version>${mapstruct.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
@@ -71,6 +83,27 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.30</version>
+            </path>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>${mapstruct.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/willyes/clemenintegra/inventario/application/mapper/MovimientoInventarioMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/application/mapper/MovimientoInventarioMapper.java
@@ -1,43 +1,58 @@
 package com.willyes.clemenintegra.inventario.application.mapper;
 
 import com.willyes.clemenintegra.inventario.application.dto.MovimientoInventarioDTO;
-import com.willyes.clemenintegra.inventario.domain.enums.TipoMovimientoDetalle;
 import com.willyes.clemenintegra.inventario.domain.model.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-public class MovimientoInventarioMapper {
+@Mapper(componentModel = "spring")
+public interface MovimientoInventarioMapper {
 
-    public static MovimientoInventario toEntity(MovimientoInventarioDTO dto) {
-        return MovimientoInventario.builder()
-                .cantidad(dto.cantidad())
-                .tipoMovimiento(dto.tipoMovimiento())
-                .docReferencia(dto.docReferencia())
-                .producto(new Producto(dto.productoId()))
-                .lote(new LoteProducto(dto.loteId()))
-                .almacen(new Almacen(dto.almacenId()))
-                .proveedor(new Proveedor(dto.proveedorId()))
-                .ordenCompra(new OrdenCompra(dto.ordenCompraId()))
-                .motivoMovimiento(new MotivoMovimiento(dto.motivoMovimientoId()))
-                .tipoMovimientoDetalle(dto.tipoMovimientoDetalle())
-                .registradoPor(new Usuario(dto.registradoPorId()))
-                .build();
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "fechaIngreso", ignore = true)
+    @Mapping(target = "producto", source = "productoId")
+    @Mapping(target = "lote", source = "loteId")
+    @Mapping(target = "almacen", source = "almacenId")
+    @Mapping(target = "proveedor", source = "proveedorId")
+    @Mapping(target = "ordenCompra", source = "ordenCompraId")
+    @Mapping(target = "motivoMovimiento", source = "motivoMovimientoId")
+    @Mapping(target = "registradoPor", source = "registradoPorId")
+    MovimientoInventario toEntity(MovimientoInventarioDTO dto);
+
+    @Mapping(target = "productoId", source = "producto.id")
+    @Mapping(target = "loteId", source = "lote.id")
+    @Mapping(target = "almacenId", source = "almacen.id")
+    @Mapping(target = "proveedorId", source = "proveedor.id")
+    @Mapping(target = "ordenCompraId", source = "ordenCompra.id")
+    @Mapping(target = "motivoMovimientoId", source = "motivoMovimiento.id")
+    @Mapping(target = "registradoPorId", source = "registradoPor.id")
+    MovimientoInventarioDTO toDTO(MovimientoInventario movimiento);
+
+    default Producto map(Long id) {
+        return id == null ? null : new Producto(id);
     }
 
-    public static MovimientoInventarioDTO toDTO(MovimientoInventario movimiento) {
-        return new MovimientoInventarioDTO(
-                movimiento.getCantidad(),
-                movimiento.getTipoMovimiento(),
-                movimiento.getDocReferencia(),
-                movimiento.getProducto() != null ? movimiento.getProducto().getId() : null,
-                movimiento.getLote() != null ? movimiento.getLote().getId() : null,
-                movimiento.getAlmacen() != null ? movimiento.getAlmacen().getId() : null,
-                movimiento.getProveedor() != null ? movimiento.getProveedor().getId() : null,
-                movimiento.getOrdenCompra() != null ? movimiento.getOrdenCompra().getId() : null,
-                movimiento.getMotivoMovimiento() != null ? movimiento.getMotivoMovimiento().getId() : null,
-                movimiento.getTipoMovimientoDetalle(),
-                movimiento.getRegistradoPor() != null ? movimiento.getRegistradoPor().getId() : null
-        );
+    default LoteProducto mapLote(Long id) {
+        return id == null ? null : new LoteProducto(id);
     }
 
+    default Almacen mapAlmacen(Long id) {
+        return id == null ? null : new Almacen(id);
+    }
 
+    default Proveedor mapProveedor(Long id) {
+        return id == null ? null : new Proveedor(id);
+    }
+
+    default OrdenCompra mapOrden(Long id) {
+        return id == null ? null : new OrdenCompra(id);
+    }
+
+    default MotivoMovimiento mapMotivo(Long id) {
+        return id == null ? null : new MotivoMovimiento(id);
+    }
+
+    default Usuario mapUsuario(Long id) {
+        return id == null ? null : new Usuario(id);
+    }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/inventario/application/service/MovimientoInventarioService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/application/service/MovimientoInventarioService.java
@@ -25,6 +25,7 @@ public class MovimientoInventarioService {
     private final ProveedorRepository proveedorRepository;
     private final OrdenCompraRepository ordenCompraRepository;
     private final MotivoMovimientoRepository motivoMovimientoRepository;
+    private final MovimientoInventarioMapper mapper;
 
     @Transactional
     public MovimientoInventarioDTO registrarMovimiento(MovimientoInventarioDTO dto) {
@@ -52,7 +53,7 @@ public class MovimientoInventarioService {
             throw new IllegalArgumentException("El tipo de movimiento no corresponde con el detalle especificado");
         }
 
-        MovimientoInventario movimiento = MovimientoInventarioMapper.toEntity(dto);
+        MovimientoInventario movimiento = mapper.toEntity(dto);
         movimiento.setProducto(producto);
         movimiento.setAlmacen(almacen);
         movimiento.setProveedor(proveedor);
@@ -60,7 +61,7 @@ public class MovimientoInventarioService {
         movimiento.setMotivoMovimiento(motivo);
 
         MovimientoInventario entidadGuardada = repository.save(movimiento);
-        return MovimientoInventarioMapper.toDTO(entidadGuardada);
+        return mapper.toDTO(entidadGuardada);
     }
 
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/application/service/MovimientoInventarioServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/application/service/MovimientoInventarioServiceTest.java
@@ -6,9 +6,10 @@ import com.willyes.clemenintegra.inventario.domain.model.*;
 import com.willyes.clemenintegra.inventario.domain.repository.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mapstruct.factory.Mappers;
+import com.willyes.clemenintegra.inventario.application.mapper.MovimientoInventarioMapper;
 
 import java.math.BigDecimal;
 import java.util.NoSuchElementException;
@@ -34,12 +35,23 @@ class MovimientoInventarioServiceTest {
     @Mock
     private LoteProductoRepository loteProductoRepository;
 
-    @InjectMocks
     private MovimientoInventarioService service;
+
+    private final MovimientoInventarioMapper mapper =
+            Mappers.getMapper(MovimientoInventarioMapper.class);
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        service = new MovimientoInventarioService(
+                repository,
+                productoRepository,
+                almacenRepository,
+                proveedorRepository,
+                ordenCompraRepository,
+                motivoMovimientoRepository,
+                mapper
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add MapStruct dependency and compiler plugin
- replace manual `MovimientoInventarioMapper` with MapStruct interface
- inject mapper into `MovimientoInventarioService`
- adjust unit tests to instantiate service with MapStruct mapper

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de001760c8333ab525dad56b5c90f