### PR TITLE
Refactor: migrate remaining mappers to MapStruct

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/application/mapper/CategoriaProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/application/mapper/CategoriaProductoMapper.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.inventario.application.mapper;
+
+import com.willyes.clemenintegra.inventario.application.dto.CategoriaProductoRequestDTO;
+import com.willyes.clemenintegra.inventario.application.dto.CategoriaProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.domain.model.CategoriaProducto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface CategoriaProductoMapper {
+
+    @Mapping(target = "id", ignore = true)
+    CategoriaProducto toEntity(CategoriaProductoRequestDTO dto);
+
+    CategoriaProductoResponseDTO toDTO(CategoriaProducto categoria);
+
+    @Mapping(target = "id", ignore = true)
+    void updateEntityFromDto(CategoriaProductoRequestDTO dto, @MappingTarget CategoriaProducto categoria);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/application/mapper/ProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/application/mapper/ProductoMapper.java
@@ -1,0 +1,30 @@
+package com.willyes.clemenintegra.inventario.application.mapper;
+
+import com.willyes.clemenintegra.inventario.application.dto.ProductoRequestDTO;
+import com.willyes.clemenintegra.inventario.application.dto.ProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.domain.model.Producto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface ProductoMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "fechaCreacion", ignore = true)
+    @Mapping(target = "unidadMedida", ignore = true)
+    @Mapping(target = "categoriaProducto", ignore = true)
+    @Mapping(target = "creadoPor", ignore = true)
+    Producto toEntity(ProductoRequestDTO dto);
+
+    @Mapping(target = "unidadMedida", source = "unidadMedida.nombre")
+    @Mapping(target = "categoria", source = "categoriaProducto.nombre")
+    ProductoResponseDTO toDTO(Producto producto);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "fechaCreacion", ignore = true)
+    @Mapping(target = "unidadMedida", ignore = true)
+    @Mapping(target = "categoriaProducto", ignore = true)
+    @Mapping(target = "creadoPor", ignore = true)
+    void updateEntityFromDto(ProductoRequestDTO dto, @MappingTarget Producto producto);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/application/mapper/UnidadMedidaMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/application/mapper/UnidadMedidaMapper.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.inventario.application.mapper;
+
+import com.willyes.clemenintegra.inventario.application.dto.UnidadMedidaRequestDTO;
+import com.willyes.clemenintegra.inventario.application.dto.UnidadMedidaResponseDTO;
+import com.willyes.clemenintegra.inventario.domain.model.UnidadMedida;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface UnidadMedidaMapper {
+
+    @Mapping(target = "id", ignore = true)
+    UnidadMedida toEntity(UnidadMedidaRequestDTO dto);
+
+    UnidadMedidaResponseDTO toDTO(UnidadMedida unidad);
+
+    @Mapping(target = "id", ignore = true)
+    void updateEntityFromDto(UnidadMedidaRequestDTO dto, @MappingTarget UnidadMedida unidad);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/application/service/CategoriaProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/application/service/CategoriaProductoService.java
@@ -1,10 +1,11 @@
 package com.willyes.clemenintegra.inventario.application.service;
 
+import com.willyes.clemenintegra.inventario.application.dto.CategoriaProductoRequestDTO;
+import com.willyes.clemenintegra.inventario.application.dto.CategoriaProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.application.mapper.CategoriaProductoMapper;
 import com.willyes.clemenintegra.inventario.domain.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.domain.repository.CategoriaProductoRepository;
 import com.willyes.clemenintegra.inventario.domain.repository.ProductoRepository;
-import com.willyes.clemenintegra.inventario.application.dto.CategoriaProductoRequestDTO;
-import com.willyes.clemenintegra.inventario.application.dto.CategoriaProductoResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,38 +18,35 @@ public class CategoriaProductoService {
 
     private final CategoriaProductoRepository categoriaProductoRepository;
     private final ProductoRepository productoRepository;
+    private final CategoriaProductoMapper mapper;
 
     public List<CategoriaProductoResponseDTO> listarTodas() {
         return categoriaProductoRepository.findAll()
                 .stream()
-                .map(this::mapearADTO)
+                .map(mapper::toDTO)
                 .collect(Collectors.toList());
     }
 
     public CategoriaProductoResponseDTO obtenerPorId(Long id) {
         CategoriaProducto categoria = categoriaProductoRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Categoría no encontrada"));
-        return mapearADTO(categoria);
+        return mapper.toDTO(categoria);
     }
 
     public CategoriaProductoResponseDTO crear(CategoriaProductoRequestDTO dto) {
-        CategoriaProducto categoria = CategoriaProducto.builder()
-                .nombre(dto.getNombre())
-                .tipo(dto.getTipo())
-                .build();
+        CategoriaProducto categoria = mapper.toEntity(dto);
         categoriaProductoRepository.save(categoria);
-        return mapearADTO(categoria);
+        return mapper.toDTO(categoria);
     }
 
     public CategoriaProductoResponseDTO actualizar(Long id, CategoriaProductoRequestDTO dto) {
         CategoriaProducto categoria = categoriaProductoRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Categoría no encontrada"));
 
-        categoria.setNombre(dto.getNombre());
-        categoria.setTipo(dto.getTipo());
+        mapper.updateEntityFromDto(dto, categoria);
 
         categoriaProductoRepository.save(categoria);
-        return mapearADTO(categoria);
+        return mapper.toDTO(categoria);
     }
 
     public void eliminar(Long id) {
@@ -60,13 +58,5 @@ public class CategoriaProductoService {
         }
 
         categoriaProductoRepository.delete(categoria);
-    }
-
-    private CategoriaProductoResponseDTO mapearADTO(CategoriaProducto categoria) {
-        return CategoriaProductoResponseDTO.builder()
-                .id(categoria.getId())
-                .nombre(categoria.getNombre())
-                .tipo(categoria.getTipo())
-                .build();
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/application/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/application/service/ProductoService.java
@@ -1,14 +1,14 @@
 package com.willyes.clemenintegra.inventario.application.service;
 
+import com.willyes.clemenintegra.inventario.application.dto.ProductoRequestDTO;
+import com.willyes.clemenintegra.inventario.application.dto.ProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.application.mapper.ProductoMapper;
 import com.willyes.clemenintegra.inventario.domain.model.Producto;
 import com.willyes.clemenintegra.inventario.domain.repository.*;
 import com.willyes.clemenintegra.inventario.domain.repository.UsuarioRepository;
-import com.willyes.clemenintegra.inventario.application.dto.ProductoRequestDTO;
-import com.willyes.clemenintegra.inventario.application.dto.ProductoResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,11 +21,12 @@ public class ProductoService {
     private final CategoriaProductoRepository categoriaProductoRepository;
     private final UsuarioRepository usuarioRepository;
     private final LoteProductoRepository loteProductoRepository;
+    private final ProductoMapper mapper;
 
     public List<ProductoResponseDTO> listarTodos() {
         return productoRepository.findAll()
                 .stream()
-                .map(this::mapearADTO)
+                .map(mapper::toDTO)
                 .collect(Collectors.toList());
     }
 
@@ -41,23 +42,13 @@ public class ProductoService {
         var usuario = usuarioRepository.findById(dto.getUsuarioId())
                 .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado"));
 
-        Producto producto = Producto.builder()
-                .codigoSku(dto.getCodigoSku())
-                .nombre(dto.getNombre())
-                .descripcionProducto(dto.getDescripcionProducto())
-                .stockActual(dto.getStockActual())
-                .stockMinimo(dto.getStockMinimo())
-                .stockMinimoProveedor(dto.getStockMinimoProveedor())
-                .activo(dto.getActivo())
-                .requiereInspeccion(dto.getRequiereInspeccion())
-                .fechaCreacion(LocalDateTime.now())
-                .unidadMedida(unidad)
-                .categoriaProducto(categoria)
-                .creadoPor(usuario)
-                .build();
+        Producto producto = mapper.toEntity(dto);
+        producto.setUnidadMedida(unidad);
+        producto.setCategoriaProducto(categoria);
+        producto.setCreadoPor(usuario);
 
         productoRepository.save(producto);
-        return mapearADTO(producto);
+        return mapper.toDTO(producto);
     }
 
     private void validarDuplicados(String sku, String nombre) {
@@ -69,27 +60,11 @@ public class ProductoService {
         }
     }
 
-    private ProductoResponseDTO mapearADTO(Producto producto) {
-        return ProductoResponseDTO.builder()
-                .id(producto.getId())
-                .codigoSku(producto.getCodigoSku())
-                .nombre(producto.getNombre())
-                .descripcionProducto(producto.getDescripcionProducto())
-                .stockActual(producto.getStockActual())
-                .stockMinimo(producto.getStockMinimo())
-                .activo(producto.getActivo())
-                .requiereInspeccion(producto.getRequiereInspeccion())
-                .unidadMedida(producto.getUnidadMedida().getNombre())
-                .categoria(producto.getCategoriaProducto().getNombre())
-                .fechaCreacion(producto.getFechaCreacion())
-                .build();
-    }
-
     public ProductoResponseDTO obtenerPorId(Long id) {
         Producto producto = productoRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Producto no encontrado con ID: " + id));
 
-        return mapearADTO(producto);
+        return mapper.toDTO(producto);
     }
 
     public ProductoResponseDTO actualizarProducto(Long id, ProductoRequestDTO dto) {
@@ -116,22 +91,14 @@ public class ProductoService {
         var usuario = usuarioRepository.findById(dto.getUsuarioId())
                 .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado"));
 
-        // Actualizar campos
-        producto.setCodigoSku(dto.getCodigoSku());
-        producto.setNombre(dto.getNombre());
-        producto.setDescripcionProducto(dto.getDescripcionProducto());
-        producto.setStockActual(dto.getStockActual());
-        producto.setStockMinimo(dto.getStockMinimo());
-        producto.setStockMinimoProveedor(dto.getStockMinimoProveedor());
-        producto.setActivo(dto.getActivo());
-        producto.setRequiereInspeccion(dto.getRequiereInspeccion());
+        mapper.updateEntityFromDto(dto, producto);
         producto.setUnidadMedida(unidad);
         producto.setCategoriaProducto(categoria);
         producto.setCreadoPor(usuario);
 
         productoRepository.save(producto);
 
-        return mapearADTO(producto);
+        return mapper.toDTO(producto);
     }
 
     public void eliminarProducto(Long id) {

--- a/src/main/java/com/willyes/clemenintegra/inventario/application/service/UnidadMedidaService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/application/service/UnidadMedidaService.java
@@ -1,10 +1,11 @@
 package com.willyes.clemenintegra.inventario.application.service;
 
+import com.willyes.clemenintegra.inventario.application.dto.UnidadMedidaRequestDTO;
+import com.willyes.clemenintegra.inventario.application.dto.UnidadMedidaResponseDTO;
+import com.willyes.clemenintegra.inventario.application.mapper.UnidadMedidaMapper;
 import com.willyes.clemenintegra.inventario.domain.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.domain.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.domain.repository.UnidadMedidaRepository;
-import com.willyes.clemenintegra.inventario.application.dto.UnidadMedidaRequestDTO;
-import com.willyes.clemenintegra.inventario.application.dto.UnidadMedidaResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,39 +18,36 @@ public class UnidadMedidaService {
 
     private final UnidadMedidaRepository unidadMedidaRepository;
     private final ProductoRepository productoRepository;
+    private final UnidadMedidaMapper mapper;
 
     public List<UnidadMedidaResponseDTO> listarTodas() {
         return unidadMedidaRepository.findAll()
                 .stream()
-                .map(this::mapearADTO)
+                .map(mapper::toDTO)
                 .collect(Collectors.toList());
     }
 
     public UnidadMedidaResponseDTO obtenerPorId(Long id) {
         UnidadMedida unidad = unidadMedidaRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Unidad de medida no encontrada"));
-        return mapearADTO(unidad);
+        return mapper.toDTO(unidad);
     }
 
     public UnidadMedidaResponseDTO crear(UnidadMedidaRequestDTO dto) {
-        UnidadMedida unidad = UnidadMedida.builder()
-                .nombre(dto.getNombre())
-                .simbolo(dto.getSimbolo())
-                .build();
+        UnidadMedida unidad = mapper.toEntity(dto);
 
         unidadMedidaRepository.save(unidad);
-        return mapearADTO(unidad);
+        return mapper.toDTO(unidad);
     }
 
     public UnidadMedidaResponseDTO actualizar(Long id, UnidadMedidaRequestDTO dto) {
         UnidadMedida unidad = unidadMedidaRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Unidad no encontrada"));
 
-        unidad.setNombre(dto.getNombre());
-        unidad.setSimbolo(dto.getSimbolo());
+        mapper.updateEntityFromDto(dto, unidad);
 
         unidadMedidaRepository.save(unidad);
-        return mapearADTO(unidad);
+        return mapper.toDTO(unidad);
     }
 
     public void eliminar(Long id) {
@@ -61,14 +59,6 @@ public class UnidadMedidaService {
         }
 
         unidadMedidaRepository.delete(unidad);
-    }
-
-    private UnidadMedidaResponseDTO mapearADTO(UnidadMedida unidad) {
-        return UnidadMedidaResponseDTO.builder()
-                .id(unidad.getId())
-                .nombre(unidad.getNombre())
-                .simbolo(unidad.getSimbolo())
-                .build();
     }
 }
 


### PR DESCRIPTION
## Summary
- create `ProductoMapper`, `CategoriaProductoMapper` and `UnidadMedidaMapper`
- inject new mappers into services and delegate DTO conversions
- remove manual mapping code

## Testing
- `mvn test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dda4c8eac83339f565221ae316104