### PR TITLE
Externaliza secreto JWT

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/service/JwtTokenService.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/service/JwtTokenService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.security.Key;
@@ -14,7 +15,11 @@ import java.util.Date;
 public class JwtTokenService {
 
     private static final long EXPIRATION_MS = 3600_000; // 1 hora
-    private static final Key SECRET_KEY = Keys.hmacShaKeyFor("clave-super-secreta-de-al-menos-32-caracteres".getBytes());
+    private final Key secretKey;
+
+    public JwtTokenService(@Value("${clemen.jwt.secret}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+    }
 
     public String generarToken(Usuario usuario) {
         return Jwts.builder()
@@ -23,13 +28,13 @@ public class JwtTokenService {
                 .claim("usuarioId", usuario.getId())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_MS))
-                .signWith(SECRET_KEY, SignatureAlgorithm.HS256)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
 
     public Claims extraerClaims(String token) {
         return Jwts.parserBuilder()
-                .setSigningKey(SECRET_KEY)
+                .setSigningKey(secretKey)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,9 @@ springdoc.api-docs.enabled=true
 springdoc.api-docs.path=/v3/api-docs
 springdoc.packages-to-scan=com.willyes.clemenintegra
 
+# Clave secreta para firma JWT
+clemen.jwt.secret=clave-super-secreta-de-al-menos-32-caracteres
+
 
 
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -10,11 +10,14 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.h2.console.enabled=true
 
-# Desactiva Hibernate DDL autom·tico
+
+# Clave secreta para pruebas
+clemen.jwt.secret=clave-super-secreta-de-al-menos-32-caracteres
+# Desactiva Hibernate DDL autom√°tico
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.hbm2ddl.auto=none
 
-# Usa scripts SQL explÌcitos
+# Usa scripts SQL expl√≠citos
 spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.data-locations=classpath:data.sql


### PR DESCRIPTION
## Summary
- obtain JWT secret from `clemen.jwt.secret` property
- configure `application.properties` and test properties with JWT secret

## Testing
- `mvn test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684eb7a8b6e08333aa9d47eae62e77c3