### PR TITLE
Remove duplicate service injection

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -38,7 +38,6 @@ import java.util.Optional;
 public class MovimientoInventarioController {
 
     private final MovimientoInventarioService service;
-    private final MovimientoInventarioService movimientoInventarioService;
     private final ProductoRepository productoRepo;
     private final LoteProductoRepository loteRepo;
 
@@ -97,7 +96,7 @@ public class MovimientoInventarioController {
     public ResponseEntity<byte[]> exportarReporteMovimientos() throws IOException {
         byte[] contenido;
 
-        try (Workbook workbook = movimientoInventarioService.generarReporteMovimientosExcel();
+        try (Workbook workbook = service.generarReporteMovimientosExcel();
              ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
             workbook.write(bos);
             contenido = bos.toByteArray();


### PR DESCRIPTION
## Summary
- clean MovimientoInventarioController by dropping duplicate MovimientoInventarioService injection
- reference the single service field in the Excel export endpoint

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ebe0559f48333993ce793f79036f2