### PR TITLE
Add bean validation to DTOs

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaRequest.java
@@ -1,9 +1,20 @@
 package com.willyes.clemenintegra.bom.dto;
 
+import jakarta.validation.constraints.*;
 public class DetalleFormulaRequest {
+    @NotNull
     public Long formulaId;
+
+    @NotNull
     public Long insumoId;
+
+    @NotNull
+    @Positive
     public Double cantidadNecesaria;
+
+    @NotNull
     public Long unidadMedidaId;
+
+    @NotNull
     public Boolean obligatorio;
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/DocumentoFormulaRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/DocumentoFormulaRequest.java
@@ -1,7 +1,13 @@
 package com.willyes.clemenintegra.bom.dto;
 
+import jakarta.validation.constraints.*;
 public class DocumentoFormulaRequest {
+    @NotNull
     public Long formulaId;
+
+    @NotBlank
     public String tipoDocumento;
+
+    @NotBlank
     public String rutaArchivo;
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoRequest.java
@@ -1,11 +1,21 @@
 package com.willyes.clemenintegra.bom.dto;
 
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.*;
 
 public class FormulaProductoRequest {
+    @NotNull
     public Long productoId;
+
+    @NotBlank
     public String version;
+
+    @NotBlank
     public String estado;
+
+    @PastOrPresent
     public LocalDateTime fechaCreacion;
+
+    @NotNull
     public Long creadoPorId;
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/AlmacenRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/AlmacenRequestDTO.java
@@ -2,6 +2,9 @@ package com.willyes.clemenintegra.inventario.dto;
 
 import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
@@ -10,8 +13,16 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class AlmacenRequestDTO {
+    @NotBlank
+    @Size(max = 100)
     private String nombre;
+
+    @Size(max = 255)
     private String ubicacion;
+
+    @NotNull
     private TipoCategoria categoria;
+
+    @NotNull
     private TipoAlmacen tipo;
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/HistorialEstadoOrdenRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/HistorialEstadoOrdenRequest.java
@@ -1,11 +1,20 @@
 package com.willyes.clemenintegra.inventario.dto;
 
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.*;
 
 public class HistorialEstadoOrdenRequest {
+    @NotNull
     public Long ordenCompraId;
+
+    @NotBlank
+    @Size(max = 50)
     public String estado;
+
+    @PastOrPresent
     public LocalDateTime fechaCambio;
+
+    @NotNull
     public Long usuarioId;
     public String observaciones;
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoRequestDTO.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.dto;
 
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -12,15 +13,32 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Builder
 public class LoteProductoRequestDTO {
+    @NotBlank
     private String codigoLote;
+
+    @PastOrPresent
     private LocalDate fechaFabricacion;
+
+    @Future
     private LocalDate fechaVencimiento;
+
+    @NotNull
+    @Positive
     private BigDecimal stockLote;
+
+    @NotNull
     private EstadoLote estado;
+
     private Double temperaturaAlmacenamiento;
+
     private LocalDate fechaLiberacion;
+
+    @NotNull
     private Long productoId;
+
+    @NotNull
     private Long almacenId;
+
     private Long usuario_liberador_id;
     private Long orden_produccion_id;
     private Long produccion_id;

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDetalleRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDetalleRequestDTO.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,10 +11,20 @@ import java.math.BigDecimal;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OrdenCompraDetalleRequestDTO {
+    @NotNull
+    @DecimalMin(value = "0.01")
     private BigDecimal cantidad;
+
+    @NotNull
+    @DecimalMin(value = "0.0")
     private BigDecimal valorUnitario;
+
     private BigDecimal iva;
+
+    @NotNull
     private Long productoId;
+
+    @NotNull
     private Long ordenCompraId;
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoAlertaRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoAlertaRequestDTO.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Data
@@ -9,6 +10,7 @@ import lombok.*;
 public class ProductoAlertaRequestDTO {
 
     // Opcional: dejar preparado para agregar filtros más adelante
+    @Size(max = 50)
     private String categoria;   // ej. MATERIA_PRIMA
     private Boolean soloActivos;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ControlCalidadProcesoRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ControlCalidadProcesoRequest.java
@@ -1,10 +1,22 @@
 package com.willyes.clemenintegra.produccion.dto;
 
+import jakarta.validation.constraints.*;
 public class ControlCalidadProcesoRequest {
+    @NotBlank
     public String parametro;
+
+    @NotBlank
     public String valorMedido;
+
+    @NotNull
     public Boolean cumple;
+
+    @Size(max = 255)
     public String observaciones;
+
+    @NotNull
     public Long detalleEtapaId;
+
+    @NotNull
     public Long evaluadorId;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/DetalleEtapaRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/DetalleEtapaRequest.java
@@ -1,12 +1,25 @@
 package com.willyes.clemenintegra.produccion.dto;
 
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.*;
 
 public class DetalleEtapaRequest {
+    @NotNull
+    @PastOrPresent
     public LocalDateTime fechaInicio;
+
+    @FutureOrPresent
     public LocalDateTime fechaFin;
+
+    @Size(max = 255)
     public String observaciones;
+
+    @NotNull
     public Long etapaProduccionId;
+
+    @NotNull
     public Long ordenProduccionId;
+
+    @NotNull
     public Long operarioId;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaProduccionRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaProduccionRequest.java
@@ -1,7 +1,14 @@
 package com.willyes.clemenintegra.produccion.dto;
 
+import jakarta.validation.constraints.*;
 public class EtapaProduccionRequest {
+    @NotBlank
     public String nombre;
+
+    @NotNull
+    @Min(1)
     public Integer secuencia;
+
+    @NotNull
     public Long ordenProduccionId;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.produccion.dto;
 
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -10,12 +11,30 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class OrdenProduccionRequestDTO {
+    @NotBlank
     private String loteProduccion;
+
+    @NotNull
+    @PastOrPresent
     private LocalDateTime fechaInicio;
+
+    @NotNull
+    @FutureOrPresent
     private LocalDateTime fechaFin;
+
+    @NotNull
+    @Min(1)
     private Integer cantidadProgramada;
+
+    @Min(0)
     private Integer cantidadProducida;
+
+    @NotBlank
     private String estado;
+
+    @NotNull
     private Long productoId;
+
+    @NotNull
     private Long responsableId;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ProduccionRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ProduccionRequest.java
@@ -1,12 +1,26 @@
 package com.willyes.clemenintegra.produccion.dto;
 
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.*;
 
 public class ProduccionRequest {
+    @NotBlank
     public String codigoLote;
+
+    @NotNull
+    @PastOrPresent
     public LocalDateTime fechaInicio;
+
+    @NotNull
+    @FutureOrPresent
     public LocalDateTime fechaFin;
+
+    @NotBlank
     public String estado;
+
+    @NotNull
     public Long usuarioId;
+
+    @NotNull
     public Long productoId;
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/dto/auth/Codigo2FARequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/dto/auth/Codigo2FARequestDTO.java
@@ -1,4 +1,9 @@
 package com.willyes.clemenintegra.shared.dto.auth;
 
-public record Codigo2FARequestDTO(String nombreUsuario, String codigo) { }
+import jakarta.validation.constraints.NotBlank;
+
+public record Codigo2FARequestDTO(
+        @NotBlank String nombreUsuario,
+        @NotBlank String codigo
+) { }
 

--- a/src/main/java/com/willyes/clemenintegra/shared/dto/auth/LoginRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/dto/auth/LoginRequestDTO.java
@@ -1,4 +1,9 @@
 package com.willyes.clemenintegra.shared.dto.auth;
 
-public record LoginRequestDTO(String nombreUsuario, String clave) { }
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequestDTO(
+        @NotBlank String nombreUsuario,
+        @NotBlank String clave
+) { }
 


### PR DESCRIPTION
## Summary
- enforce validation in several request DTOs across modules
- include basic checks for strings, numbers and dates

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ec4fa4b448333a0ce99052c9ff079