### PR TITLE
Regenerar tests de AlmacenController

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/AlmacenControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/AlmacenControllerTest.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.willyes.clemenintegra.inventario.dto.AlmacenRequestDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
@@ -24,9 +25,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(com.willyes.clemenintegra.inventario.config.TestSecurityConfig.class)
 class AlmacenControllerTest {
 
-    @Autowired private MockMvc mockMvc;
-    @Autowired private ObjectMapper objectMapper;
-    @Autowired private AlmacenRepository almacenRepository;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private AlmacenRepository almacenRepository;
 
     @BeforeEach
     void setUp() {
@@ -34,35 +38,36 @@ class AlmacenControllerTest {
     }
 
     @Test
-    void crearAlmacen_PrincipalMateriaPrima_RetornaCreated() throws Exception {
-        AlmacenRequestDTO dto = new AlmacenRequestDTO();
-        dto.setNombre("Bodega Principal MP");
-        dto.setUbicacion("Planta 1");
-        dto.setTipo(TipoAlmacen.PRINCIPAL);
-        dto.setCategoria(TipoCategoria.MATERIA_PRIMA);
+    void crearAlmacenValido_debeRetornarCreated() throws Exception {
+        AlmacenRequestDTO dto = AlmacenRequestDTO.builder()
+                .nombre("Almacen Principal")
+                .ubicacion("Zona A")
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .build();
 
         mockMvc.perform(post("/api/almacenes")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isCreated());
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.nombre").value("Almacen Principal"));
     }
 
     @Test
-    void crearAlmacen_NombreDuplicado_RetornaConflict() throws Exception {
-        AlmacenRequestDTO dto = new AlmacenRequestDTO();
-        dto.setNombre("Duplicado");
-        dto.setUbicacion("Zona A");
-        dto.setTipo(TipoAlmacen.PRINCIPAL);
-        dto.setCategoria(TipoCategoria.PRODUCTO_TERMINADO);
+    void crearAlmacenDuplicado_debeRetornarConflict() throws Exception {
+        almacenRepository.save(Almacen.builder()
+                .nombre("Duplicado")
+                .ubicacion("B1")
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .build());
 
-        almacenRepository.save(
-                com.willyes.clemenintegra.inventario.model.Almacen.builder()
-                        .nombre("Duplicado")
-                        .ubicacion("Otra")
-                        .tipo(TipoAlmacen.SATELITE)
-                        .categoria(TipoCategoria.MATERIAL_EMPAQUE)
-                        .build()
-        );
+        AlmacenRequestDTO dto = AlmacenRequestDTO.builder()
+                .nombre("Duplicado")
+                .ubicacion("B2")
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .categoria(TipoCategoria.PRODUCTO_TERMINADO)
+                .build();
 
         mockMvc.perform(post("/api/almacenes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -71,9 +76,52 @@ class AlmacenControllerTest {
     }
 
     @Test
-    void consultarAlmacenes_PorTipoYCategoria_RetornaLista() throws Exception {
-        mockMvc.perform(get("/api/almacenes?tipo=PRINCIPAL&categoria=MATERIA_PRIMA"))
+    void crearAlmacenInvalido_debeRetornarBadRequest() throws Exception {
+        AlmacenRequestDTO dto = AlmacenRequestDTO.builder()
+                .nombre("")
+                .ubicacion("B1")
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .build();
+
+        mockMvc.perform(post("/api/almacenes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void obtenerAlmacenPorId_debeRetornarAlmacen() throws Exception {
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Existente")
+                .ubicacion("C1")
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        mockMvc.perform(get("/api/almacenes/{id}", almacen.getId()))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+                .andExpect(jsonPath("$.id").value(almacen.getId()))
+                .andExpect(jsonPath("$.nombre").value("Existente"));
+    }
+
+    @Test
+    void obtenerAlmacenNoExistente_debeRetornarNotFound() throws Exception {
+        mockMvc.perform(get("/api/almacenes/{id}", 9999L))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void listarTodosLosAlmacenes_debeRetornarLista() throws Exception {
+        almacenRepository.save(Almacen.builder()
+                .nombre("A1")
+                .ubicacion("U1")
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        mockMvc.perform(get("/api/almacenes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").exists());
     }
 }


### PR DESCRIPTION
## Summary
- refactor AlmacenControllerTest using builders and adding scenarios

## Testing
- `mvn -q test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684ee304e7c88333996dfdeca8aa92b8