### PR TITLE
feat: add lote filters by expiration

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
@@ -22,9 +22,11 @@ import org.springframework.data.web.PageableDefault;
 import com.willyes.clemenintegra.shared.util.PaginationUtil;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.io.IOException;
 import java.io.ByteArrayOutputStream;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -84,11 +86,14 @@ public class LoteProductoController {
             @RequestParam(required = false) String producto,
             @RequestParam(required = false) String estado,
             @RequestParam(required = false) String almacen,
+            @RequestParam(required = false) Boolean vencidos,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaInicio,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaFin,
             @PageableDefault(size = 10, sort = "fechaFabricacion", direction = Sort.Direction.DESC) Pageable pageable) {
         if (pageable.getPageNumber() < 0 || pageable.getPageSize() < 1 || pageable.getPageSize() > 100) {
             return ResponseEntity.badRequest().build();
         }
-        Pageable sanitized = PaginationUtil.sanitize(pageable, List.of("fechaFabricacion", "id"), "fechaFabricacion");
+        Pageable sanitized = PaginationUtil.sanitize(pageable, List.of("fechaFabricacion", "fechaVencimiento", "id"), "fechaFabricacion");
         EstadoLote enumEstado = null;
         if (estado != null && !estado.isBlank()) {
             try {
@@ -97,7 +102,7 @@ public class LoteProductoController {
                 // ignorar filtro inválido
             }
         }
-        Page<LoteProductoResponseDTO> lotes = service.listarTodos(producto, enumEstado, almacen, sanitized);
+        Page<LoteProductoResponseDTO> lotes = service.listarTodos(producto, enumEstado, almacen, vencidos, fechaInicio, fechaFin, sanitized);
         return ResponseEntity.ok(lotes);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 
 import java.io.ByteArrayOutputStream;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface LoteProductoService {
@@ -16,7 +17,7 @@ public interface LoteProductoService {
     List<LoteProductoResponseDTO> obtenerLotesPorEvaluar();
     Workbook generarReporteLotesPorVencerExcel();
     ByteArrayOutputStream generarReporteAlertasActivasExcel();
-    Page<LoteProductoResponseDTO> listarTodos(String producto, EstadoLote estado, String almacen, Pageable pageable);
+    Page<LoteProductoResponseDTO> listarTodos(String producto, EstadoLote estado, String almacen, Boolean vencidos, LocalDateTime fechaInicio, LocalDateTime fechaFin, Pageable pageable);
 
     LoteProductoResponseDTO liberarLote(Long id);
     LoteProductoResponseDTO rechazarLote(Long id);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/spec/LoteProductoSpecifications.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/spec/LoteProductoSpecifications.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.domain.Specification;
 import jakarta.persistence.criteria.JoinType;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import java.time.LocalDateTime;
 
 public final class LoteProductoSpecifications {
     private LoteProductoSpecifications() {}
@@ -26,5 +27,9 @@ public final class LoteProductoSpecifications {
             var a = root.join("almacen", JoinType.LEFT);
             return cb.like(cb.upper(a.get("nombre")), "%" + texto.trim().toUpperCase() + "%");
         };
+    }
+
+    public static Specification<LoteProducto> fechaVencimientoAntesDe(LocalDateTime fecha) {
+        return (root, query, cb) -> (fecha == null) ? cb.conjunction() : cb.lessThan(root.get("fechaVencimiento"), fecha);
     }
 }


### PR DESCRIPTION
## Summary
- add specification for expiration date filtering
- allow LoteProducto listing to filter by vencidos or date range
- expose vencidos/date range filters in controller and allow sorting by expiration

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa42c7e5388333b250ae7deea7d26f