### PR TITLE
revert: restore LocalDateTime filters with flexible parsing

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
@@ -6,10 +6,10 @@ import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoResponseDTO;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
 import com.willyes.clemenintegra.inventario.service.SolicitudMovimientoService;
 import com.willyes.clemenintegra.shared.util.PaginationUtil;
+import com.willyes.clemenintegra.shared.util.DateParser;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/inventarios/solicitudes")
@@ -44,12 +45,28 @@ public class SolicitudMovimientoController {
             @RequestParam(required = false) String busqueda,
             @RequestParam(required = false) Long almacenOrigenId,
             @RequestParam(required = false) Long almacenDestinoId,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaDesde,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaHasta
+            @RequestParam(required = false) String fechaDesde,
+            @RequestParam(required = false) String fechaHasta
     ) {
         Pageable sanitized = PaginationUtil.sanitize(pageable, List.of("fechaSolicitud", "estado", "id"), "fechaSolicitud");
-        Page<SolicitudMovimientoListadoDTO> page = service.listarSolicitudes(estado, busqueda, almacenOrigenId, almacenDestinoId, fechaDesde, fechaHasta, sanitized);
-        return ResponseEntity.ok(page);
+        LocalDateTime inicio = null;
+        LocalDateTime fin = null;
+        if ((fechaDesde != null && fechaHasta == null) || (fechaDesde == null && fechaHasta != null)) {
+            return ResponseEntity.badRequest().body(Map.of("message", "Se requieren fechaDesde y fechaHasta"));
+        }
+        try {
+            if (fechaDesde != null) {
+                inicio = DateParser.parseStart(fechaDesde);
+                fin = DateParser.parseEnd(fechaHasta);
+                if (inicio.isAfter(fin)) {
+                    return ResponseEntity.badRequest().body(Map.of("message", "fechaDesde no puede ser mayor a fechaHasta"));
+                }
+            }
+            Page<SolicitudMovimientoListadoDTO> page = service.listarSolicitudes(estado, busqueda, almacenOrigenId, almacenDestinoId, inicio, fin, sanitized);
+            return ResponseEntity.ok(page);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
     }
 
     @PutMapping("/{id}/aprobar")

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioFiltroDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioFiltroDTO.java
@@ -2,14 +2,14 @@ package com.willyes.clemenintegra.inventario.dto;
 
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record MovimientoInventarioFiltroDTO(
         Long productoId,
         Long almacenId,
         TipoMovimiento tipoMovimiento,
         ClasificacionMovimientoInventario clasificacion,
-        LocalDate fechaInicio,
-        LocalDate fechaFin
+        LocalDateTime fechaInicio,
+        LocalDateTime fechaFin
 ) {}
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
@@ -9,7 +9,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MovimientoInventarioService {
@@ -17,7 +17,7 @@ public interface MovimientoInventarioService {
     MovimientoInventarioResponseDTO registrarMovimiento(MovimientoInventarioDTO dto);
 
     Page<MovimientoInventarioResponseDTO> filtrar(
-            LocalDate fechaInicio, LocalDate fechaFin,
+            LocalDateTime fechaInicio, LocalDateTime fechaFin,
             Long productoId, Long almacenId,
             TipoMovimiento tipoMovimiento, ClasificacionMovimientoInventario clasificacion,
             Pageable pageable);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -44,9 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -222,24 +220,19 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     @Transactional(readOnly = true)
     @Override
     public Page<MovimientoInventarioResponseDTO> filtrar(
-            LocalDate fechaInicio, LocalDate fechaFin,
+            LocalDateTime fechaInicio, LocalDateTime fechaFin,
             Long productoId, Long almacenId,
             TipoMovimiento tipoMovimiento, ClasificacionMovimientoInventario clasificacion,
             Pageable pageable) {
-        LocalDateTime inicio = (fechaInicio != null) ? fechaInicio.atStartOfDay() : null;
-        LocalDateTime fin = (fechaFin != null) ? fechaFin.atTime(LocalTime.MAX) : null;
         Page<MovimientoInventario> page = repository.filtrar(
-                inicio, fin, productoId, almacenId, tipoMovimiento, clasificacion, pageable);
+                fechaInicio, fechaFin, productoId, almacenId, tipoMovimiento, clasificacion, pageable);
         return page.map(mapper::safeToResponseDTO);
     }
 
     @Override
     public List<MovimientoInventarioResponseDTO> consultarMovimientos(MovimientoInventarioFiltroDTO filtro) {
-        LocalDateTime inicio = filtro.fechaInicio() != null ? filtro.fechaInicio().atStartOfDay() : null;
-        LocalDateTime fin = filtro.fechaFin() != null ? filtro.fechaFin().atTime(23, 59, 59) : null;
-
         List<MovimientoInventario> lista = repository.buscarMovimientos(
-                inicio, fin,
+                filtro.fechaInicio(), filtro.fechaFin(),
                 filtro.productoId(),
                 filtro.almacenId(),
                 filtro.tipoMovimiento(),

--- a/src/main/java/com/willyes/clemenintegra/shared/util/DateParser.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/util/DateParser.java
@@ -1,0 +1,50 @@
+package com.willyes.clemenintegra.shared.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public final class DateParser {
+
+    private static final DateTimeFormatter DATE = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    private DateParser() {
+    }
+
+    public static LocalDateTime parseStart(String s) {
+        return parse(s, true);
+    }
+
+    public static LocalDateTime parseEnd(String s) {
+        return parse(s, false);
+    }
+
+    private static LocalDateTime parse(String s, boolean start) {
+        if (s == null || s.isBlank()) {
+            throw new IllegalArgumentException("Fecha requerida");
+        }
+        if (s.contains("Z") || s.contains("+")) {
+            throw new IllegalArgumentException("No se permiten zonas horarias");
+        }
+        if (s.contains("T")) {
+            String timePart = s.substring(s.indexOf('T') + 1);
+            if (timePart.contains("-")) {
+                throw new IllegalArgumentException("No se permiten zonas horarias");
+            }
+            try {
+                return LocalDateTime.parse(s, DATE_TIME);
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException("Formato de fecha inválido");
+            }
+        } else {
+            try {
+                LocalDate d = LocalDate.parse(s, DATE);
+                return start ? d.atStartOfDay() : d.atTime(23, 59, 59);
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException("Formato de fecha inválido");
+            }
+        }
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/LoteProductoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/LoteProductoControllerTest.java
@@ -1,0 +1,88 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LoteProductoController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class LoteProductoControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private LoteProductoService service;
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void listarAceptaFormatos() throws Exception {
+        Page<LoteProductoResponseDTO> empty = new PageImpl<>(List.of(), PageRequest.of(0,10), 0);
+        when(service.listarTodos(any(), any(), any(), any(), any(), any(), any())).thenReturn(empty);
+
+        mvc.perform(get("/api/lotes")
+                .param("fechaInicio", "2025-08-01")
+                .param("fechaFin", "2025-08-31T23:59:59")
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<LocalDateTime> inicio = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> fin = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(service).listarTodos(any(), any(), any(), any(), inicio.capture(), fin.capture(), any());
+        assertEquals(LocalDateTime.of(2025,8,1,0,0,0), inicio.getValue());
+        assertEquals(LocalDateTime.of(2025,8,31,23,59,59), fin.getValue());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void listarFaltaParametroRetorna400() throws Exception {
+        mvc.perform(get("/api/lotes")
+                .param("fechaInicio", "2025-08-01")
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void listarRangoInvalidoRetorna400() throws Exception {
+        mvc.perform(get("/api/lotes")
+                .param("fechaInicio", "2025-08-31")
+                .param("fechaFin", "2025-08-01")
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void listarZonaHorariaRetorna400() throws Exception {
+        mvc.perform(get("/api/lotes")
+                .param("fechaInicio", "2025-08-01T00:00:00Z")
+                .param("fechaFin", "2025-08-31T23:59:59")
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerTest.java
@@ -1,0 +1,110 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MovimientoInventarioController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MovimientoInventarioControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private MovimientoInventarioService service;
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void filtrarAceptaSoloFecha() throws Exception {
+        Page<MovimientoInventarioResponseDTO> empty = new PageImpl<>(List.of(), PageRequest.of(0,10), 0);
+        when(service.filtrar(any(), any(), any(), any(), any(), any(), any())).thenReturn(empty);
+
+        mvc.perform(get("/api/movimientos/filtrar")
+                .param("fechaInicio", "2025-08-01")
+                .param("fechaFin", "2025-08-31")
+                .param("page", "0")
+                .param("size", "10")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<LocalDateTime> inicio = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> fin = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(service).filtrar(inicio.capture(), fin.capture(), any(), any(), any(), any(), any());
+        assertEquals(LocalDateTime.of(2025,8,1,0,0,0), inicio.getValue());
+        assertEquals(LocalDateTime.of(2025,8,31,23,59,59), fin.getValue());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void filtrarAceptaFechaHora() throws Exception {
+        Page<MovimientoInventarioResponseDTO> empty = new PageImpl<>(List.of(), PageRequest.of(0,10), 0);
+        when(service.filtrar(any(), any(), any(), any(), any(), any(), any())).thenReturn(empty);
+
+        mvc.perform(get("/api/movimientos/filtrar")
+                .param("fechaInicio", "2025-08-01T00:00:00")
+                .param("fechaFin", "2025-08-31T23:59:59")
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<LocalDateTime> inicio = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> fin = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(service).filtrar(inicio.capture(), fin.capture(), any(), any(), any(), any(), any());
+        assertEquals(LocalDateTime.of(2025,8,1,0,0,0), inicio.getValue());
+        assertEquals(LocalDateTime.of(2025,8,31,23,59,59), fin.getValue());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void filtrarFaltaParametroRetorna400() throws Exception {
+        mvc.perform(get("/api/movimientos/filtrar")
+                .param("fechaInicio", "2025-08-01")
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void filtrarRangoInvalidoRetorna400() throws Exception {
+        mvc.perform(get("/api/movimientos/filtrar")
+                .param("fechaInicio", "2025-08-31")
+                .param("fechaFin", "2025-08-01")
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void filtrarZonaHorariaRetorna400() throws Exception {
+        mvc.perform(get("/api/movimientos/filtrar")
+                .param("fechaInicio", "2025-08-01T00:00:00Z")
+                .param("fechaFin", "2025-08-31T23:59:59")
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary
- restore LocalDateTime date filtering and add DateParser utility for parsing `YYYY-MM-DD` and `YYYY-MM-DDTHH:mm:ss`
- update controllers/services to parse String dates, validate ranges, and query using LocalDateTime
- add controller tests for date-only/date-time inputs and error cases

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab68805e4c833384031691f91da518