### PR TITLE
refactor: unify report endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ El código ha sido refactorizado mediante **Codex Workspace**, mejorando la legi
 
 ## API REST Principal
 ### Inventario
-- **Productos** `/api/productos` – CRUD y `/reporte-stock` (Excel).
-- **Lotes** `/api/lotes` – CRUD, `/reporte-vencimiento` y `/reporte-alertas` (Excel).
-- **Movimientos** `/api/movimientos` – registrar y consultar con filtros `productoId`, `almacenId`, `tipoMovimiento`, `clasificacion`, `fechaInicio`, `fechaFin`. Exportación en `/reporte-excel`.
+- **Productos** `/api/productos` – CRUD.
+- **Lotes** `/api/lotes` – CRUD.
+- **Movimientos** `/api/movimientos` – registrar y consultar con filtros `productoId`, `almacenId`, `tipoMovimiento`, `clasificacion`, `fechaInicio`, `fechaFin`.
 - **Ajustes de inventario** `/api/inventario/ajustes` – listar, crear y eliminar.
 - **Reportes** `/api/reportes` – alta/baja rotación (`fechaInicio`, `fechaFin`), productos más costosos (`categoria`), trazabilidad por lote (`codigoLote`), productos en retención o liberación (`estadoLote`, `desde`, `hasta`), no conformidades (`tipo`, `area`, `desde`, `hasta`), CAPA (`estado`, `desde`, `hasta`), stock actual, productos por vencer, alertas de inventario y movimientos. Todos devuelven Excel.
+
+Los antiguos endpoints `/api/productos/reporte-stock`, `/api/lotes/reporte-vencimiento`, `/api/lotes/reporte-alertas` y `/api/movimientos/reporte-excel` fueron eliminados en favor de las rutas unificadas bajo `/api/reportes`.
 
 ### Producción
 - **Órdenes de producción** `/api/produccion/ordenes` – CRUD.

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
@@ -10,10 +10,7 @@ import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
 import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,8 +22,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.io.IOException;
-import java.io.ByteArrayOutputStream;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -52,34 +47,6 @@ public class LoteProductoController {
     public ResponseEntity<List<LoteProductoResponseDTO>> listarPorEstado(@PathVariable String estado) {
         List<LoteProductoResponseDTO> lotes = service.obtenerLotesPorEstado(estado);
         return ResponseEntity.ok(lotes);
-    }
-
-    @GetMapping("/reporte-vencimiento")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ANALISTA_CALIDAD', 'ROL_JEFE_CALIDAD', 'ROL_SUPER_ADMIN')")
-    public ResponseEntity<byte[]> exportarLotesPorVencer() throws IOException {
-        Workbook workbook = service.generarReporteLotesPorVencerExcel();
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        workbook.write(bos);
-        workbook.close();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.parseMediaType(
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
-        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=lotes_por_vencer.xlsx");
-
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(bos.toByteArray());
-    }
-
-    @GetMapping("/reporte-alertas")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ANALISTA_CALIDAD', 'ROL_JEFE_CALIDAD', 'ROL_SUPER_ADMIN')")
-    public ResponseEntity<byte[]> exportarAlertasActivas() {
-        ByteArrayOutputStream stream = service.generarReporteAlertasActivasExcel();
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=alertas_activas.xlsx")
-                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
-                .body(stream.toByteArray());
     }
 
     @GetMapping

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -11,8 +11,6 @@ import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.tomcat.util.http.fileupload.ByteArrayOutputStream;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +26,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -172,27 +169,6 @@ public class MovimientoInventarioController {
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
-    }
-
-    @GetMapping("/reporte-excel")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_JEFE_PRODUCCION', 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD')")
-    public ResponseEntity<byte[]> exportarReporteMovimientos() throws IOException {
-        byte[] contenido;
-
-        try (Workbook workbook = service.generarReporteMovimientosExcel();
-             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            workbook.write(bos);
-            contenido = bos.toByteArray();
-        }
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
-        headers.setContentDisposition(ContentDisposition
-                .attachment()
-                .filename("reporte_movimientos.xlsx")
-                .build());
-
-        return new ResponseEntity<>(contenido, headers, HttpStatus.OK);
     }
 
     @GetMapping

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -3,17 +3,11 @@ package com.willyes.clemenintegra.inventario.controller;
 import com.willyes.clemenintegra.inventario.dto.*;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.repository.*;
-import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import com.willyes.clemenintegra.inventario.service.ProductoService;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.servlet.ServletOutputStream;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -42,9 +36,6 @@ public class ProductoController {
     private final MovimientoInventarioRepository movimientoInventarioRepository;
     private final UnidadMedidaRepository unidadMedidaRepository;
     private final UsuarioRepository usuarioRepository;
-    private final MovimientoInventarioService service;
-    private final ProductoRepository productoRepo;
-    private final LoteProductoRepository loteRepo;
 
     @GetMapping("/buscar")
     @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION')")
@@ -195,22 +186,6 @@ public class ProductoController {
         Pageable sanitized = PaginationUtil.sanitize(pageable, List.of("fechaCreacion", "id", "nombre"), "fechaCreacion");
         Page<ProductoResponseDTO> productos = productoService.listarTodos(nombre, codigoSku, categoriaProductoId, activo, sanitized);
         return ResponseEntity.ok(productos);
-    }
-
-    @GetMapping("/reporte-stock")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_SUPER_ADMIN')")
-    @Operation(summary = "Exportar reporte de stock actual de productos a Excel")
-    @ApiResponse(responseCode = "200", description = "Reporte generado correctamente")
-    public void exportarStockActual(HttpServletResponse response) throws IOException {
-        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        response.setHeader("Content-Disposition", "attachment; filename=stock_actual.xlsx");
-
-        Workbook workbook = productoService.generarReporteStockActualExcel();
-        try (ServletOutputStream out = response.getOutputStream()) {
-            workbook.write(out);
-            out.flush();
-        }
-        workbook.close();
     }
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioController.java
@@ -156,7 +156,7 @@ public class ReporteInventarioController {
     }
 
     @GetMapping("/productos-por-vencer")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportarLotesPorVencer() throws IOException {
         Workbook workbook = loteProductoService.generarReporteLotesPorVencerExcel();
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -169,7 +169,7 @@ public class ReporteInventarioController {
     }
 
     @GetMapping("/alertas-inventario")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportarAlertasInventario() {
         ByteArrayOutputStream stream = loteProductoService.generarReporteAlertasActivasExcel();
         return ResponseEntity.ok()
@@ -179,7 +179,7 @@ public class ReporteInventarioController {
     }
 
     @GetMapping("/movimientos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportarReporteMovimientos() throws IOException {
         byte[] contenido;
         try (Workbook workbook = movimientoService.generarReporteMovimientosExcel();

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -126,6 +126,9 @@ public class SecurityConfig {
                     auth.requestMatchers("/api/reportes/**").hasAnyAuthority(
                             RolUsuario.ROL_ALMACENISTA.name(),
                             RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_ANALISTA_CALIDAD.name(),
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioControllerTest.java
@@ -1,0 +1,86 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.willyes.clemenintegra.inventario.service.ReporteInventarioService;
+import com.willyes.clemenintegra.inventario.service.ProductoService;
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReporteInventarioController.class)
+@EnableMethodSecurity
+class ReporteInventarioControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReporteInventarioService service;
+    @MockBean
+    private ProductoService productoService;
+    @MockBean
+    private LoteProductoService loteProductoService;
+    @MockBean
+    private MovimientoInventarioService movimientoService;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void stockActualEndpoint() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        when(productoService.generarReporteStockActualExcel()).thenReturn(wb);
+
+        mockMvc.perform(get("/api/reportes/stock-actual"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=stock_actual.xlsx"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void productosPorVencerEndpoint() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        when(loteProductoService.generarReporteLotesPorVencerExcel()).thenReturn(wb);
+
+        mockMvc.perform(get("/api/reportes/productos-por-vencer"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=lotes_por_vencer.xlsx"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void alertasInventarioEndpoint() throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        bos.write(1);
+        when(loteProductoService.generarReporteAlertasActivasExcel()).thenReturn(bos);
+
+        mockMvc.perform(get("/api/reportes/alertas-inventario"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=alertas_activas.xlsx"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void movimientosEndpoint() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        when(movimientoService.generarReporteMovimientosExcel()).thenReturn(wb);
+
+        mockMvc.perform(get("/api/reportes/movimientos"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=reporte_movimientos.xlsx"));
+    }
+}


### PR DESCRIPTION
## Summary
- consolidate inventory report generation behind `/api/reportes`
- remove legacy report routes from producto, lote and movimiento controllers
- align security roles for unified report endpoints and document the change

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.willyes.clemenintegra:inventario:1.0.0: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68ab992b88188333b0aacd163290ac8c