### PR TITLE
feat: support sku alias for products

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ El código ha sido refactorizado mediante **Codex Workspace**, mejorando la legi
 ## API REST Principal
 ### Inventario
 - **Productos** `/api/productos` – CRUD.
+  - El identificador de catálogo se expone ahora como `sku`. Por compatibilidad, las peticiones aún aceptan y las respuestas incluyen el alias `codigoSku`.
 - **Lotes** `/api/lotes` – CRUD.
 - **Movimientos** `/api/movimientos` – registrar y consultar con filtros `productoId`, `almacenId`, `tipoMovimiento`, `clasificacion`, `fechaInicio`, `fechaFin`.
 - **Ajustes de inventario** `/api/inventario/ajustes` – listar, crear y eliminar.

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -176,7 +176,8 @@ public class ProductoController {
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD')")
     public ResponseEntity<Page<ProductoResponseDTO>> obtenerTodos(
             @RequestParam(required = false) String nombre,
-            @RequestParam(required = false) String codigoSku,
+            @RequestParam(required = false) String sku,
+            @RequestParam(required = false, name = "codigoSku") String codigoSkuLegacy,
             @RequestParam(required = false) Long categoriaProductoId,
             @RequestParam(required = false) Boolean activo,
             @PageableDefault(size = 10, sort = "fechaCreacion", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -184,7 +185,8 @@ public class ProductoController {
             return ResponseEntity.badRequest().build();
         }
         Pageable sanitized = PaginationUtil.sanitize(pageable, List.of("fechaCreacion", "id", "nombre"), "fechaCreacion");
-        Page<ProductoResponseDTO> productos = productoService.listarTodos(nombre, codigoSku, categoriaProductoId, activo, sanitized);
+        String finalSku = sku != null ? sku : codigoSkuLegacy;
+        Page<ProductoResponseDTO> productos = productoService.listarTodos(nombre, finalSku, categoriaProductoId, activo, sanitized);
         return ResponseEntity.ok(productos);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import lombok.AllArgsConstructor;
@@ -22,12 +24,17 @@ public class MovimientoInventarioResponseDTO {
     private BigDecimal cantidad;
     private Long productoId;
     private String nombreProducto;
-    private String codigoSku;
+    @JsonProperty("sku")
+    @JsonAlias("codigoSku")
+    private String sku;
     private Long loteId;
     private String codigoLote;
     private String nombreAlmacenOrigen;
     private String nombreAlmacenDestino;
     private String nombreUsuarioRegistrador;
 
+
+    @JsonProperty("codigoSku")
+    public String getCodigoSku() {return sku;}
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoConEstadoLoteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoConEstadoLoteDTO.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,8 +11,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProductoConEstadoLoteDTO {
     private Long productoId;
-    private String codigoSku;
+    @JsonProperty("sku")
+    @JsonAlias("codigoSku")
+    private String sku;
     private String nombre;
     private String estadoLote;
+
+    @JsonProperty("codigoSku")
+    public String getCodigoSku() {return sku;}
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoConLotesDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoConLotesDTO.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,7 +13,12 @@ import java.util.List;
 @NoArgsConstructor
 public class ProductoConLotesDTO {
     private Long productoId;
-    private String codigoSku;
+    @JsonProperty("sku")
+    @JsonAlias("codigoSku")
+    private String sku;
     private String nombre;
     private List<LoteSimpleDTO> lotes;
+
+    @JsonProperty("codigoSku")
+    public String getCodigoSku() {return sku;}
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoOptionDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoOptionDTO.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 @Data
@@ -9,11 +11,16 @@ import lombok.*;
 public class ProductoOptionDTO {
     private Long id;
     private String nombre;
-    private String codigoSku;
+    @JsonProperty("sku")
+    @JsonAlias("codigoSku")
+    private String sku;
     // Texto listo para pintar en el autocomplete (NOMBRE (SKU))
     public String getEtiqueta() {
-        return (codigoSku == null || codigoSku.isBlank())
+        return (sku == null || sku.isBlank())
                 ? (nombre == null ? "" : nombre)
-                : (nombre == null ? codigoSku : nombre + " (" + codigoSku + ")");
+                : (nombre == null ? sku : nombre + " (" + sku + ")");
     }
+
+    @JsonProperty("codigoSku")
+    public String getCodigoSku() {return sku;}
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoRequestDTO.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
@@ -14,7 +16,9 @@ public class ProductoRequestDTO {
 
     @NotBlank
     @Size(max = 50)
-    private String codigoSku;
+    @JsonProperty("sku")
+    @JsonAlias("codigoSku")
+    private String sku;
 
     @NotBlank
     @Size(max = 100)

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResponseDTO.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import lombok.*;
@@ -13,7 +15,9 @@ import java.time.LocalDateTime;
 @Builder
 public class ProductoResponseDTO {
     private Long id;
-    private String codigoSku;
+    @JsonProperty("sku")
+    @JsonAlias("codigoSku")
+    private String sku;
     private String nombre;
     private String descripcionProducto;
     private BigDecimal stockActual;
@@ -36,7 +40,7 @@ public class ProductoResponseDTO {
 
     public ProductoResponseDTO(Producto producto) {
         this.id = producto.getId().longValue();
-        this.codigoSku = producto.getCodigoSku();
+        this.sku = producto.getCodigoSku();
         this.nombre = producto.getNombre();
         this.descripcionProducto = producto.getDescripcionProducto();
         this.stockActual = producto.getStockActual();
@@ -59,8 +63,10 @@ public class ProductoResponseDTO {
 
     public Long getId() {return id;}
     public void setId(Long id) {this.id = id;}
-    public String getCodigoSku() {return codigoSku;}
-    public void setCodigoSku(String codigoSku) {this.codigoSku = codigoSku;}
+    public String getSku() {return sku;}
+    public void setSku(String sku) {this.sku = sku;}
+    @JsonProperty("codigoSku")
+    public String getCodigoSku() {return sku;}
     public String getNombre() {return nombre;}
     public void setNombre(String nombre) {this.nombre = nombre;}
     public String getDescripcionProducto() {return descripcionProducto;}

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
@@ -51,7 +51,7 @@ public interface MovimientoInventarioMapper {
         var p = m.getProducto();
         dto.setProductoId(p != null ? (p.getId() == null ? null : Long.valueOf(p.getId())) : null);
         dto.setNombreProducto(p != null ? p.getNombre() : null);
-        dto.setCodigoSku(p != null ? p.getCodigoSku() : null);
+        dto.setSku(p != null ? p.getCodigoSku() : null);
 
         var l = m.getLote();
         dto.setLoteId(l != null ? l.getId() : null);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ProductoService {
-    Page<ProductoResponseDTO> listarTodos(String nombre, String codigoSku, Long categoriaProductoId, Boolean activo, Pageable pageable);
+    Page<ProductoResponseDTO> listarTodos(String nombre, String sku, Long categoriaProductoId, Boolean activo, Pageable pageable);
     List<ProductoResponseDTO> buscarPorCategoria(String categoria);
     List<ProductoResponseDTO> findByCategoriaTipo(String tipo);
     List<ProductoResponseDTO> findByCategoriaTipoIn(List<String> tipos);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/spec/ProductoSpecifications.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/spec/ProductoSpecifications.java
@@ -14,7 +14,7 @@ public final class ProductoSpecifications {
                 : cb.like(cb.upper(root.get("nombre")), "%" + q.trim().toUpperCase() + "%");
     }
 
-    public static Specification<Producto> codigoSkuContains(String sku) {
+    public static Specification<Producto> skuContains(String sku) {
         return (root, cq, cb) -> (sku == null || sku.isBlank())
                 ? cb.conjunction()
                 : cb.like(cb.upper(root.get("codigoSku")), "%" + sku.trim().toUpperCase() + "%");


### PR DESCRIPTION
## Summary
- expose `sku` field in product-related DTOs with `codigoSku` as JSON alias
- allow products endpoint to filter by `sku` while keeping `codigoSku` for compatibility
- document SKU naming convention

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9b4e3cac83338dc8ddf5f96888da