### PR TITLE
feat(inventarios/solicitudes): GET detalle con prefill de SolicitudMovimiento

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
@@ -70,6 +70,12 @@ public class SolicitudMovimientoController {
         }
     }
 
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<SolicitudMovimientoResponseDTO> obtener(@PathVariable Long id) {
+        return ResponseEntity.ok(service.obtenerSolicitud(id));
+    }
+
     @PutMapping("/{id}/aprobar")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
     public ResponseEntity<SolicitudMovimientoResponseDTO> aprobar(@PathVariable Long id,

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/SolicitudMovimientoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/SolicitudMovimientoResponseDTO.java
@@ -16,6 +16,7 @@ public class SolicitudMovimientoResponseDTO {
     private TipoMovimiento tipoMovimiento;
     private Integer productoId;
     private String nombreProducto;
+    private String codigoSku;     // SKU del producto para prefill
     private Long loteProductoId;
     private String nombreLote;
     private BigDecimal cantidad;
@@ -24,6 +25,7 @@ public class SolicitudMovimientoResponseDTO {
     private Integer almacenDestinoId;
     private String nombreAlmacenDestino;
     private Long ordenProduccionId;
+    private String codigoOrden;   // Código de la OP (si aplica) para banner/prefill
     private Long motivoMovimientoId;
     private Long tipoMovimientoDetalleId;
     private String nombreSolicitante;

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
@@ -36,6 +36,19 @@ public interface SolicitudMovimientoRepository extends JpaRepository<SolicitudMo
                                                @Param("desde") LocalDateTime desde,
                                                @Param("hasta") LocalDateTime hasta);
 
+    @Query("select s from SolicitudMovimiento s " +
+            "left join fetch s.producto p " +
+            "left join fetch p.unidadMedida um " +
+            "left join fetch s.lote l " +
+            "left join fetch s.almacenOrigen ao " +
+            "left join fetch s.almacenDestino ad " +
+            "left join fetch s.usuarioSolicitante us " +
+            "left join fetch s.ordenProduccion op " +
+            "left join fetch s.motivoMovimiento mm " +
+            "left join fetch s.tipoMovimientoDetalle tmd " +
+            "where s.id = :id")
+    java.util.Optional<SolicitudMovimiento> findWithDetalles(@Param("id") Long id);
+
     @Override
     @EntityGraph(attributePaths = {"usuarioSolicitante", "ordenProduccion"})
     Page<SolicitudMovimiento> findAll(Specification<SolicitudMovimiento> spec, Pageable pageable);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoService.java
@@ -18,6 +18,7 @@ public interface SolicitudMovimientoService {
                                                           LocalDateTime inicio,
                                                           LocalDateTime fin,
                                                           Pageable pageable);
+    SolicitudMovimientoResponseDTO obtenerSolicitud(Long id);
     SolicitudMovimientoResponseDTO aprobarSolicitud(Long id, Long responsableId);
     SolicitudMovimientoResponseDTO rechazarSolicitud(Long id, Long responsableId, String observaciones);
     SolicitudMovimientoResponseDTO revertirAutorizacion(Long id, Long responsableId);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -41,6 +41,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import jakarta.persistence.EntityNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -186,6 +187,23 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
 
         return repository.findAll(spec, pageable)
                 .map(this::toListadoDTO);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SolicitudMovimientoResponseDTO obtenerSolicitud(Long id) {
+        var solicitud = repository.findWithDetalles(id)
+                .orElseGet(() -> repository.findById(id)
+                        .orElseThrow(() -> new EntityNotFoundException("Solicitud no encontrada: " + id)));
+
+        SolicitudMovimientoResponseDTO dto = toResponse(solicitud);
+        if (solicitud.getProducto() != null) {
+            dto.setCodigoSku(solicitud.getProducto().getCodigoSku());
+        }
+        if (solicitud.getOrdenProduccion() != null) {
+            dto.setCodigoOrden(solicitud.getOrdenProduccion().getCodigoOrden());
+        }
+        return dto;
     }
 
     @Override
@@ -488,6 +506,7 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                 .tipoMovimiento(s.getTipoMovimiento())
                 .productoId(s.getProducto() != null ? s.getProducto().getId() : null)
                 .nombreProducto(s.getProducto() != null ? s.getProducto().getNombre() : null)
+                .codigoSku(s.getProducto() != null ? s.getProducto().getCodigoSku() : null)
                 .loteProductoId(s.getLote() != null ? s.getLote().getId() : null)
                 .nombreLote(s.getLote() != null ? s.getLote().getCodigoLote() : null)
                 .cantidad(s.getCantidad())
@@ -496,6 +515,7 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                 .almacenDestinoId(s.getAlmacenDestino() != null ? s.getAlmacenDestino().getId() : null)
                 .nombreAlmacenDestino(s.getAlmacenDestino() != null ? s.getAlmacenDestino().getNombre() : null)
                 .ordenProduccionId(s.getOrdenProduccion() != null ? s.getOrdenProduccion().getId() : null)
+                .codigoOrden(s.getOrdenProduccion() != null ? s.getOrdenProduccion().getCodigoOrden() : null)
                 .motivoMovimientoId(s.getMotivoMovimiento() != null ? s.getMotivoMovimiento().getId() : null)
                 .tipoMovimientoDetalleId(s.getTipoMovimientoDetalle() != null ? s.getTipoMovimientoDetalle().getId() : null)
                 .nombreSolicitante(s.getUsuarioSolicitante() != null ? s.getUsuarioSolicitante().getNombreCompleto() : null)


### PR DESCRIPTION
## Summary
- add `codigoSku` and `codigoOrden` to `SolicitudMovimientoResponseDTO`
- expose `GET /api/inventarios/solicitudes/{id}` returning prefill data
- fetch related entities and map SKU/order code in service implementation

## Testing
- `mvn -q -e test` *(fails: Network is unreachable: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68ad927750c08333899d066993d0efea