### PR TITLE
Soporte de paginación y filtros en listado de órdenes de producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -5,15 +5,20 @@ import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.produccion.dto.*;
 import com.willyes.clemenintegra.produccion.mapper.ProduccionMapper;
 import com.willyes.clemenintegra.produccion.model.*;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.service.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/produccion/ordenes")
@@ -23,10 +28,15 @@ public class OrdenProduccionController {
     private final OrdenProduccionService service;
 
     @GetMapping
-    public List<OrdenProduccionResponseDTO> listarTodas() {
-        return service.listarTodas().stream()
-                .map(ProduccionMapper::toResponse)
-                .collect(Collectors.toList());
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public Page<OrdenProduccionResponseDTO> listar(
+            @RequestParam(required = false) String codigo,
+            @RequestParam(required = false) EstadoProduccion estado,
+            @RequestParam(required = false) String responsable,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaInicio,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaFin,
+            @PageableDefault(size = 10, sort = "fechaInicio", direction = Sort.Direction.DESC) Pageable pageable) {
+        return service.listarPaginado(codigo, estado, responsable, fechaInicio, fechaFin, pageable);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
@@ -2,10 +2,11 @@ package com.willyes.clemenintegra.produccion.repository;
 
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.Optional;
 
-public interface OrdenProduccionRepository extends JpaRepository<OrdenProduccion, Long> {
+public interface OrdenProduccionRepository extends JpaRepository<OrdenProduccion, Long>, JpaSpecificationExecutor<OrdenProduccion> {
 
     Optional<OrdenProduccion> findByLoteProduccion(String loteProduccion);
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -1,8 +1,14 @@
 package com.willyes.clemenintegra.produccion.service;
 
 import com.willyes.clemenintegra.produccion.dto.OrdenProduccionRequestDTO;
+import com.willyes.clemenintegra.produccion.dto.OrdenProduccionResponseDTO;
 import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +19,11 @@ public interface OrdenProduccionService {
     List<OrdenProduccion> listarTodas();
     Optional<OrdenProduccion> buscarPorId(Long id);
     void eliminar(Long id);
+
+    Page<OrdenProduccionResponseDTO> listarPaginado(String codigo,
+                                                    EstadoProduccion estado,
+                                                    String responsable,
+                                                    LocalDateTime fechaInicio,
+                                                    LocalDateTime fechaFin,
+                                                    Pageable pageable);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -17,6 +17,8 @@ import com.willyes.clemenintegra.produccion.mapper.OrdenProduccionMapper;
 import com.willyes.clemenintegra.produccion.mapper.ProduccionMapper;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.service.spec.OrdenProduccionSpecifications;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoRequestDTO;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
@@ -25,6 +27,9 @@ import com.willyes.clemenintegra.shared.model.Usuario;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -166,6 +171,22 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         return guardarConValidacionStock(orden);
     }
 
+
+    @Override
+    public Page<OrdenProduccionResponseDTO> listarPaginado(String codigo,
+                                                           EstadoProduccion estado,
+                                                           String responsable,
+                                                           LocalDateTime fechaInicio,
+                                                           LocalDateTime fechaFin,
+                                                           Pageable pageable) {
+        Specification<OrdenProduccion> spec = OrdenProduccionSpecifications.and(
+                OrdenProduccionSpecifications.byCodigo(codigo),
+                OrdenProduccionSpecifications.byEstado(estado),
+                OrdenProduccionSpecifications.byResponsable(responsable),
+                OrdenProduccionSpecifications.byFechaBetween(fechaInicio, fechaFin)
+        );
+        return repository.findAll(spec, pageable).map(ProduccionMapper::toResponse);
+    }
 
     public List<OrdenProduccion> listarTodas() {
         return repository.findAll();

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/spec/OrdenProduccionSpecifications.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/spec/OrdenProduccionSpecifications.java
@@ -1,0 +1,64 @@
+package com.willyes.clemenintegra.produccion.service.spec;
+
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import jakarta.persistence.criteria.JoinType;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+
+/**
+ * Utilidades para construir Specification de {@link OrdenProduccion} de forma
+ * null-safe.
+ */
+public final class OrdenProduccionSpecifications {
+
+    private OrdenProduccionSpecifications() {
+    }
+
+    public static Specification<OrdenProduccion> byCodigo(String codigo) {
+        return (root, query, cb) -> {
+            if (codigo == null || codigo.isBlank()) return cb.conjunction();
+            return cb.like(cb.upper(root.get("codigoOrden")), "%" + codigo.trim().toUpperCase() + "%");
+        };
+    }
+
+    public static Specification<OrdenProduccion> byEstado(EstadoProduccion estado) {
+        return (root, query, cb) -> estado == null ? cb.conjunction() : cb.equal(root.get("estado"), estado);
+    }
+
+    public static Specification<OrdenProduccion> byResponsable(String responsable) {
+        return (root, query, cb) -> {
+            if (responsable == null || responsable.isBlank()) return cb.conjunction();
+            var r = root.join("responsable", JoinType.LEFT);
+            String like = "%" + responsable.trim().toUpperCase() + "%";
+            return cb.or(
+                    cb.like(cb.upper(r.get("nombreUsuario")), like),
+                    cb.like(cb.upper(r.get("nombreCompleto")), like)
+            );
+        };
+    }
+
+    public static Specification<OrdenProduccion> byFechaBetween(LocalDateTime inicio, LocalDateTime fin) {
+        return (root, query, cb) -> {
+            if (inicio == null && fin == null) return cb.conjunction();
+            if (inicio != null && fin != null) return cb.between(root.get("fechaInicio"), inicio, fin);
+            if (inicio != null) return cb.greaterThanOrEqualTo(root.get("fechaInicio"), inicio);
+            return cb.lessThanOrEqualTo(root.get("fechaInicio"), fin);
+        };
+    }
+
+    @SafeVarargs
+    public static Specification<OrdenProduccion> and(Specification<OrdenProduccion>... specs) {
+        Specification<OrdenProduccion> result = Specification.where(null);
+        if (specs != null) {
+            for (Specification<OrdenProduccion> spec : specs) {
+                if (spec != null) {
+                    result = (result == null) ? Specification.where(spec) : result.and(spec);
+                }
+            }
+        }
+        return result == null ? (root, query, cb) -> cb.conjunction() : result;
+    }
+}
+

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -1,0 +1,134 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OrdenProduccionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private OrdenProduccionRepository ordenRepository;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    private Usuario responsable1;
+    private Usuario responsable2;
+
+    @BeforeEach
+    void setup() {
+        ordenRepository.deleteAll();
+        usuarioRepository.deleteAll();
+
+        responsable1 = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("juan")
+                .clave("pwd")
+                .nombreCompleto("Juan Perez")
+                .correo("juan@ex.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        responsable2 = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("maria")
+                .clave("pwd")
+                .nombreCompleto("Maria Gomez")
+                .correo("maria@ex.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        ordenRepository.save(OrdenProduccion.builder()
+                .codigoOrden("ORD-A1")
+                .fechaInicio(LocalDateTime.of(2023,1,1,0,0))
+                .cantidadProgramada(10)
+                .estado(EstadoProduccion.CREADA)
+                .responsable(responsable1)
+                .build());
+
+        ordenRepository.save(OrdenProduccion.builder()
+                .codigoOrden("ORD-B2")
+                .fechaInicio(LocalDateTime.of(2023,2,1,0,0))
+                .cantidadProgramada(20)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .responsable(responsable2)
+                .build());
+
+        ordenRepository.save(OrdenProduccion.builder()
+                .codigoOrden("X-ORD")
+                .fechaInicio(LocalDateTime.of(2023,3,1,0,0))
+                .cantidadProgramada(30)
+                .estado(EstadoProduccion.CREADA)
+                .responsable(responsable1)
+                .build());
+    }
+
+    @Test
+    @WithMockUser(authorities = {"ROL_JEFE_PRODUCCION"})
+    void listarSinFiltros() throws Exception {
+        mockMvc.perform(get("/api/produccion/ordenes").param("page","0").param("size","10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(3));
+    }
+
+    @Test
+    @WithMockUser(authorities = {"ROL_JEFE_PRODUCCION"})
+    void filtrarPorEstado() throws Exception {
+        mockMvc.perform(get("/api/produccion/ordenes").param("estado","CREADA"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    @WithMockUser(authorities = {"ROL_JEFE_PRODUCCION"})
+    void filtrarPorRangoFechas() throws Exception {
+        mockMvc.perform(get("/api/produccion/ordenes")
+                .param("fechaInicio","2023-02-01T00:00:00")
+                .param("fechaFin","2023-03-31T00:00:00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    @WithMockUser(authorities = {"ROL_JEFE_PRODUCCION"})
+    void filtrosCombinados() throws Exception {
+        mockMvc.perform(get("/api/produccion/ordenes")
+                .param("codigo","A1")
+                .param("responsable","juan")
+                .param("estado","CREADA")
+                .param("fechaInicio","2023-01-01T00:00:00")
+                .param("fechaFin","2023-01-31T23:59:59"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0].codigoOrden").value("ORD-A1"));
+    }
+
+    @Test
+    @WithMockUser(authorities = {"ROL_JEFE_PRODUCCION"})
+    void ordenarAscendente() throws Exception {
+        mockMvc.perform(get("/api/produccion/ordenes").param("sort","fechaInicio,asc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].codigoOrden").value("ORD-A1"));
+    }
+}
+

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,10 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
+spring.flyway.enabled=false


### PR DESCRIPTION
## Resumen
- Se habilitó el repositorio de órdenes para Specifications.
- Se implementaron filtros dinámicos y paginación en el servicio de órdenes.
- Se expuso un endpoint paginado con filtros en el controlador, agregando reglas de seguridad.

## Testing
- `mvn -q test` *(falló: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5954b58488333a1e01250e51e1fe1