### PR TITLE
feat(producción): endpoint de finalización sin requerir productoId

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -81,4 +81,12 @@ public class OrdenProduccionController {
         service.eliminar(id);
         return ResponseEntity.noContent().build();
     }
+
+    @PutMapping("/{id}/finalizar")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<OrdenProduccionResponseDTO> finalizar(@PathVariable Long id,
+                                                               @RequestBody FinalizarOrdenRequestDTO request) {
+        OrdenProduccion orden = service.finalizar(id, request.getCantidadProducida());
+        return ResponseEntity.ok(ProduccionMapper.toResponse(orden));
+    }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/FinalizarOrdenRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/FinalizarOrdenRequestDTO.java
@@ -1,0 +1,15 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinalizarOrdenRequestDTO {
+    private BigDecimal cantidadProducida;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 
 import java.util.List;
 import java.util.Optional;
+import java.math.BigDecimal;
 
 public interface OrdenProduccionService {
     ResultadoValidacionOrdenDTO guardarConValidacionStock(OrdenProduccion orden);
@@ -19,6 +20,8 @@ public interface OrdenProduccionService {
     List<OrdenProduccion> listarTodas();
     Optional<OrdenProduccion> buscarPorId(Long id);
     void eliminar(Long id);
+
+    OrdenProduccion finalizar(Long id, BigDecimal cantidadProducida);
 
     Page<OrdenProduccionResponseDTO> listarPaginado(String codigo,
                                                     EstadoProduccion estado,


### PR DESCRIPTION
## Resumen
- Agrega DTO `FinalizarOrdenRequestDTO` para recibir solo `cantidadProducida`
- Implementa servicio `finalizar` que toma el producto desde la orden, valida cantidad y estado, y establece `fechaFin`
- Expone endpoint `PUT /api/produccion/ordenes/{id}/finalizar` protegido con roles de producción
- Añade pruebas `MockMvc` para flujos de finalización válidos y errores

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ae6daa748333ac7b8a6fc0ac3151