### PR TITLE
feat: add units and decimal ranges to quality specs

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EspecificacionCalidadDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EspecificacionCalidadDTO.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,13 +19,15 @@ public class EspecificacionCalidadDTO {
     @Size(max = 45, message = "El parámetro no puede exceder 45 caracteres")
     private String parametro;
 
-    @NotBlank(message = "El valor mínimo es obligatorio")
-    @Size(max = 45, message = "El valor mínimo no puede exceder 45 caracteres")
-    private String valorMinimo;
+    @NotNull(message = "El valor mínimo es obligatorio")
+    private BigDecimal valorMinimo;
 
-    @NotBlank(message = "El valor máximo es obligatorio")
-    @Size(max = 45, message = "El valor máximo no puede exceder 45 caracteres")
-    private String valorMaximo;
+    @NotNull(message = "El valor máximo es obligatorio")
+    private BigDecimal valorMaximo;
+
+    @NotBlank(message = "La unidad es obligatoria")
+    @Size(max = 45, message = "La unidad no puede exceder 45 caracteres")
+    private String unidad;
 
     @NotBlank(message = "El método de ensayo es obligatorio")
     @Size(max = 100, message = "El método de ensayo no puede exceder 100 caracteres")

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EspecificacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EspecificacionCalidadMapper.java
@@ -14,6 +14,7 @@ public class EspecificacionCalidadMapper {
                 .parametro(entity.getParametro())
                 .valorMinimo(entity.getValorMinimo())
                 .valorMaximo(entity.getValorMaximo())
+                .unidad(entity.getUnidad())
                 .metodoEnsayo(entity.getMetodoEnsayo())
                 .productoId(entity.getProducto().getId().longValue())
                 .build();
@@ -25,6 +26,7 @@ public class EspecificacionCalidadMapper {
                 .parametro(dto.getParametro())
                 .valorMinimo(dto.getValorMinimo())
                 .valorMaximo(dto.getValorMaximo())
+                .unidad(dto.getUnidad())
                 .metodoEnsayo(dto.getMetodoEnsayo())
                 .producto(producto)
                 .build();

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/EspecificacionCalidad.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/EspecificacionCalidad.java
@@ -4,6 +4,8 @@ import com.willyes.clemenintegra.inventario.model.Producto;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "especificaciones_calidad")
 @Data
@@ -19,11 +21,14 @@ public class EspecificacionCalidad {
     @Column(name = "parametro", length = 45, nullable = false)
     private String parametro;
 
-    @Column(name = "valor_minimo", length = 45, nullable = false)
-    private String valorMinimo;
+    @Column(name = "valor_minimo", precision = 10, scale = 2, nullable = false)
+    private BigDecimal valorMinimo;
 
-    @Column(name = "valor_maximo", length = 45, nullable = false)
-    private String valorMaximo;
+    @Column(name = "valor_maximo", precision = 10, scale = 2, nullable = false)
+    private BigDecimal valorMaximo;
+
+    @Column(name = "unidad", length = 45, nullable = false)
+    private String unidad;
 
     @Column(name = "metodo_ensayo", length = 100, nullable = false)
     private String metodoEnsayo;

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EspecificacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EspecificacionCalidadServiceImpl.java
@@ -43,6 +43,7 @@ public class EspecificacionCalidadServiceImpl implements EspecificacionCalidadSe
         existing.setParametro(dto.getParametro());
         existing.setValorMinimo(dto.getValorMinimo());
         existing.setValorMaximo(dto.getValorMaximo());
+        existing.setUnidad(dto.getUnidad());
         existing.setMetodoEnsayo(dto.getMetodoEnsayo());
         existing.setProducto(prod);
         return mapper.toDTO(repository.save(existing));

--- a/src/main/resources/db/migration/V4__update_especificaciones_calidad.sql
+++ b/src/main/resources/db/migration/V4__update_especificaciones_calidad.sql
@@ -1,0 +1,6 @@
+ALTER TABLE especificaciones_calidad
+    MODIFY COLUMN valor_minimo DECIMAL(10,2) NOT NULL;
+ALTER TABLE especificaciones_calidad
+    MODIFY COLUMN valor_maximo DECIMAL(10,2) NOT NULL;
+ALTER TABLE especificaciones_calidad
+    ADD COLUMN unidad VARCHAR(45) NOT NULL;


### PR DESCRIPTION
## Summary
- store quality specification limits as `BigDecimal`
- include unit field in quality specs DTO, mapper, service
- migrate database to decimal columns with unit

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.willyes.clemenintegra:inventario:1.0.0: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.2.3 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d1020f8c83339ffd370b54b5d080