### PR TITLE
Use BigDecimal for production quantities and expose unit

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 
 @Getter
 @Setter
@@ -23,11 +24,11 @@ public class OrdenProduccionRequestDTO {
     private LocalDateTime fechaFin;
 
     @NotNull
-    @Min(1)
-    private Integer cantidadProgramada;
+    @DecimalMin(value = "0.0", inclusive = false)
+    private BigDecimal cantidadProgramada;
 
-    @Min(0)
-    private Integer cantidadProducida;
+    @DecimalMin(value = "0.0")
+    private BigDecimal cantidadProducida;
 
     @NotBlank
     private String estado;
@@ -37,4 +38,6 @@ public class OrdenProduccionRequestDTO {
 
     @NotNull
     private Long responsableId;
+
+    private String unidadMedida;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
@@ -9,12 +9,13 @@ public class OrdenProduccionResponseDTO {
     public String loteProduccion;
     public LocalDateTime fechaInicio;
     public LocalDateTime fechaFin;
-    public Integer cantidadProgramada;
-    public Integer cantidadProducida;
+    public BigDecimal cantidadProgramada;
+    public BigDecimal cantidadProducida;
     public BigDecimal cantidadProducidaAcumulada;
     public BigDecimal cantidadRestante;
     public LocalDateTime fechaUltimoCierre;
     public String estado;
     public String nombreProducto;
+    public String unidadMedida;
     public String nombreResponsable;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/OrdenProduccionMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/OrdenProduccionMapper.java
@@ -19,6 +19,7 @@ public class OrdenProduccionMapper {
         orden.setCantidadProducida(dto.getCantidadProducida());
         orden.setEstado(EstadoProduccion.valueOf(dto.getEstado()));
         orden.setProducto(producto);
+        orden.setUnidadMedida(producto.getUnidadMedida());
         orden.setResponsable(responsable);
         return orden;
     }

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
@@ -18,6 +18,7 @@ public class ProduccionMapper {
                 .cantidadProducida(dto.getCantidadProducida())
                 .estado(EstadoProduccion.valueOf(dto.getEstado()))
                 .producto(producto)
+                .unidadMedida(producto.getUnidadMedida())
                 .responsable(responsable)
                 .build();
     }
@@ -33,12 +34,13 @@ public class ProduccionMapper {
         dto.cantidadProducida = entidad.getCantidadProducida();
         dto.cantidadProducidaAcumulada = entidad.getCantidadProducidaAcumulada();
         if (entidad.getCantidadProgramada() != null && entidad.getCantidadProducidaAcumulada() != null) {
-            dto.cantidadRestante = BigDecimal.valueOf(entidad.getCantidadProgramada())
+            dto.cantidadRestante = entidad.getCantidadProgramada()
                     .subtract(entidad.getCantidadProducidaAcumulada());
         }
         dto.fechaUltimoCierre = entidad.getFechaUltimoCierre();
         dto.estado = entidad.getEstado().name();
         dto.nombreProducto = entidad.getProducto() != null ? entidad.getProducto().getNombre() : null;
+        dto.unidadMedida = entidad.getUnidadMedida() != null ? entidad.getUnidadMedida().getNombre() : null;
         dto.nombreResponsable = entidad.getResponsable() != null ? entidad.getResponsable().getNombreCompleto() : null;
         return dto;
     }

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.produccion.model;
 
 import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import jakarta.persistence.*;
@@ -25,11 +26,11 @@ public class OrdenProduccion {
     private LocalDateTime fechaInicio;
     private LocalDateTime fechaFin;
 
-    @Column(nullable = false)
-    private Integer cantidadProgramada;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal cantidadProgramada;
 
-    @Column(nullable = true)
-    private Integer cantidadProducida;
+    @Column(nullable = true, precision = 10, scale = 2)
+    private BigDecimal cantidadProducida;
 
     @Column(name = "cantidad_producida_acumulada", precision = 10, scale = 2)
     private BigDecimal cantidadProducidaAcumulada;
@@ -43,6 +44,10 @@ public class OrdenProduccion {
     @ManyToOne
     @JoinColumn(name = "producto_id")
     private Producto producto;
+
+    @ManyToOne
+    @JoinColumn(name = "unidad_medida_id")
+    private UnidadMedida unidadMedida;
 
     @ManyToOne
     @JoinColumn(name = "responsable_id")

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -93,7 +93,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         boolean stockSuficiente = true;
         Integer maxProducible = null;
 
-        BigDecimal cantidadProgramada = BigDecimal.valueOf(orden.getCantidadProgramada());
+        BigDecimal cantidadProgramada = orden.getCantidadProgramada();
 
         for (DetalleFormula insumo : formula.getDetalles()) {
             Long insumoId = insumo.getInsumo().getId().longValue();
@@ -234,7 +234,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CANTIDAD_INVALIDA");
             }
 
-            BigDecimal programada = BigDecimal.valueOf(orden.getCantidadProgramada());
+            BigDecimal programada = orden.getCantidadProgramada();
             BigDecimal acumulada = Optional.ofNullable(orden.getCantidadProducidaAcumulada()).orElse(BigDecimal.ZERO);
             BigDecimal nuevaAcumulada = acumulada.add(dto.getCantidad());
 
@@ -260,7 +260,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             }
 
             orden.setCantidadProducidaAcumulada(nuevaAcumulada);
-            orden.setCantidadProducida(nuevaAcumulada.intValue());
+            orden.setCantidadProducida(nuevaAcumulada);
             orden.setFechaUltimoCierre(LocalDateTime.now());
 
             CierreProduccion cierre = ProduccionMapper.toEntity(dto, orden);
@@ -337,7 +337,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CANTIDAD_INVALIDA");
         }
 
-        if (cantidadProducida.compareTo(BigDecimal.valueOf(orden.getCantidadProgramada())) > 0) {
+        if (cantidadProducida.compareTo(orden.getCantidadProgramada()) > 0) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CANTIDAD_EXCEDE_PROGRAMADA");
         }
 
@@ -345,7 +345,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ORDEN_SIN_PRODUCTO");
         }
 
-        orden.setCantidadProducida(cantidadProducida.intValue());
+        orden.setCantidadProducida(cantidadProducida);
         orden.setEstado(EstadoProduccion.FINALIZADA);
         orden.setFechaFin(LocalDateTime.now());
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -80,7 +80,7 @@ class OrdenProduccionControllerTest {
         ordenRepository.save(OrdenProduccion.builder()
                 .codigoOrden("ORD-A1")
                 .fechaInicio(LocalDateTime.of(2023,1,1,0,0))
-                .cantidadProgramada(10)
+                .cantidadProgramada(BigDecimal.valueOf(10))
                 .estado(EstadoProduccion.CREADA)
                 .responsable(responsable1)
                 .build());
@@ -88,7 +88,7 @@ class OrdenProduccionControllerTest {
         ordenRepository.save(OrdenProduccion.builder()
                 .codigoOrden("ORD-B2")
                 .fechaInicio(LocalDateTime.of(2023,2,1,0,0))
-                .cantidadProgramada(20)
+                .cantidadProgramada(BigDecimal.valueOf(20))
                 .estado(EstadoProduccion.EN_PROCESO)
                 .responsable(responsable2)
                 .build());
@@ -96,7 +96,7 @@ class OrdenProduccionControllerTest {
         ordenRepository.save(OrdenProduccion.builder()
                 .codigoOrden("X-ORD")
                 .fechaInicio(LocalDateTime.of(2023,3,1,0,0))
-                .cantidadProgramada(30)
+                .cantidadProgramada(BigDecimal.valueOf(30))
                 .estado(EstadoProduccion.CREADA)
                 .responsable(responsable1)
                 .build());
@@ -190,9 +190,10 @@ class OrdenProduccionControllerTest {
         return ordenRepository.save(OrdenProduccion.builder()
                 .codigoOrden("ORD-FIN")
                 .fechaInicio(LocalDateTime.now())
-                .cantidadProgramada(programada)
+                .cantidadProgramada(BigDecimal.valueOf(programada))
                 .estado(EstadoProduccion.EN_PROCESO)
                 .producto(producto)
+                .unidadMedida(producto.getUnidadMedida())
                 .responsable(responsable1)
                 .build());
     }


### PR DESCRIPTION
## Summary
- Switch production order quantities to `BigDecimal` and persist unit of measure
- Include unit data in order requests/responses with updated mapping
- Adjust service logic and tests for decimal quantities

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d212dbb8833383a2c47b83dd7f53