### PR TITLE
Convertir cantidad programada a unidad del producto

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
@@ -8,6 +8,7 @@ public class DetalleFormulaResponse {
     public java.math.BigDecimal stockActual;
     public String estadoStock;
     public String unidad;
+    public String unidadSimbolo;
     public Boolean obligatorio;
     // LÍNEA CODEx: nuevos campos para exponer disponibilidad detallada de lotes
     public DisponibilidadInsumoDTO disponibilidad;

--- a/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
@@ -37,6 +37,7 @@ public interface BomMapper {
 
     @Mapping(target = "insumoNombre", source = "insumo", qualifiedByName = "mapProductoNombre")
     @Mapping(target = "unidad", source = "unidadMedida", qualifiedByName = "mapUnidadNombre")
+    @Mapping(target = "unidadSimbolo", source = "unidadMedida", qualifiedByName = "mapUnidadSimbolo")
     DetalleFormulaResponse toResponseDTO(DetalleFormula detalle);
 
     //@Mapping(target = "id", ignore = true)
@@ -55,6 +56,11 @@ public interface BomMapper {
     @Named("mapUnidadNombre")
     default String mapUnidadNombre(UnidadMedida unidad) {
         return (unidad != null) ? unidad.getNombre() : null;
+    }
+
+    @Named("mapUnidadSimbolo")
+    default String mapUnidadSimbolo(UnidadMedida unidad) {
+        return (unidad != null) ? unidad.getSimbolo() : null;
     }
 
     @Named("mapNombreUsuario")

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -50,10 +50,7 @@ public class OrdenProduccionController {
     @PostMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<ResultadoValidacionOrdenDTO> crear(@RequestBody OrdenProduccionRequestDTO request) {
-        Producto producto = new Producto(); producto.setId(request.getProductoId().intValue());
-        Usuario responsable = new Usuario(); responsable.setId(request.getResponsableId());
-        OrdenProduccion entidad = ProduccionMapper.toEntity(request, producto, responsable);
-        ResultadoValidacionOrdenDTO resultado = service.guardarConValidacionStock(entidad);
+        ResultadoValidacionOrdenDTO resultado = service.crearOrden(request);
         HttpStatus status = resultado.isEsValida() ? HttpStatus.CREATED : HttpStatus.BAD_REQUEST;
         return new ResponseEntity<>(resultado, status);
     }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionResponseDTO.java
@@ -11,4 +11,5 @@ public class CierreProduccionResponseDTO {
     public Boolean cerradaIncompleta;
     public String turno;
     public String observacion;
+    public String unidadMedidaSimbolo;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/InsumoFaltanteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/InsumoFaltanteDTO.java
@@ -16,5 +16,6 @@ public class InsumoFaltanteDTO {
     private String nombre;
     private BigDecimal requerido;
     private BigDecimal disponible;
+    private String unidadSimbolo;
 }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
@@ -39,5 +39,5 @@ public class OrdenProduccionRequestDTO {
     @NotNull
     private Long responsableId;
 
-    private String unidadMedida;
+    private String unidadMedidaSimbolo;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
@@ -10,6 +10,7 @@ public class OrdenProduccionResponseDTO {
     public LocalDateTime fechaInicio;
     public LocalDateTime fechaFin;
     public BigDecimal cantidadProgramada;
+    public BigDecimal cantidadProgramadaBase;
     public BigDecimal cantidadProducida;
     public BigDecimal cantidadProducidaAcumulada;
     public BigDecimal cantidadRestante;
@@ -17,5 +18,7 @@ public class OrdenProduccionResponseDTO {
     public String estado;
     public String nombreProducto;
     public String unidadMedida;
+    public String unidadMedidaSimbolo;
+    public String unidadMedidaBaseSimbolo;
     public String nombreResponsable;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
@@ -41,6 +41,7 @@ public class ProduccionMapper {
         dto.estado = entidad.getEstado().name();
         dto.nombreProducto = entidad.getProducto() != null ? entidad.getProducto().getNombre() : null;
         dto.unidadMedida = entidad.getUnidadMedida() != null ? entidad.getUnidadMedida().getNombre() : null;
+        dto.unidadMedidaSimbolo = entidad.getUnidadMedida() != null ? entidad.getUnidadMedida().getSimbolo() : null;
         dto.nombreResponsable = entidad.getResponsable() != null ? entidad.getResponsable().getNombreCompleto() : null;
         return dto;
     }
@@ -65,6 +66,10 @@ public class ProduccionMapper {
         dto.cerradaIncompleta = entidad.getCerradaIncompleta();
         dto.turno = entidad.getTurno();
         dto.observacion = entidad.getObservacion();
+        dto.unidadMedidaSimbolo = entidad.getOrdenProduccion() != null
+                && entidad.getOrdenProduccion().getUnidadMedida() != null
+                ? entidad.getOrdenProduccion().getUnidadMedida().getSimbolo()
+                : null;
         return dto;
     }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/UnidadConversionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/UnidadConversionService.java
@@ -1,0 +1,38 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import org.springframework.stereotype.Service;
+
+/**
+ * Servicio utilitario para convertir cantidades entre unidades básicas.
+ * Solo maneja conversiones simples entre pares comunes (g↔kg, ml↔l).
+ */
+@Service
+public class UnidadConversionService {
+
+    public BigDecimal convertir(BigDecimal cantidad, String origen, String destino) {
+        if (cantidad == null || origen == null || destino == null) {
+            return cantidad;
+        }
+        if (origen.equalsIgnoreCase(destino)) {
+            return cantidad;
+        }
+        // Masa
+        if (origen.equalsIgnoreCase("g") && destino.equalsIgnoreCase("kg")) {
+            return cantidad.divide(BigDecimal.valueOf(1000), 6, RoundingMode.HALF_UP);
+        }
+        if (origen.equalsIgnoreCase("kg") && destino.equalsIgnoreCase("g")) {
+            return cantidad.multiply(BigDecimal.valueOf(1000));
+        }
+        // Volumen
+        if (origen.equalsIgnoreCase("ml") && destino.equalsIgnoreCase("l")) {
+            return cantidad.divide(BigDecimal.valueOf(1000), 6, RoundingMode.HALF_UP);
+        }
+        if (origen.equalsIgnoreCase("l") && destino.equalsIgnoreCase("ml")) {
+            return cantidad.multiply(BigDecimal.valueOf(1000));
+        }
+        // Sin conversión conocida
+        return cantidad;
+    }
+}


### PR DESCRIPTION
## Summary
- Agregada `UnidadConversionService` para convertir cantidades entre unidades comunes
- Conversión de `cantidadProgramada` a la unidad del producto y exposición de cantidades base y convertidas en respuestas de órdenes
- Inclusión de símbolos de unidad en mapeos y DTOs de fórmulas, faltantes e informes de producción

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d3bdc1dc8333906ef0fd93157e4d