### PR TITLE
Handle unit defaults in production orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Los antiguos endpoints `/api/productos/reporte-stock`, `/api/lotes/reporte-venci
 
 ### Producción
 - **Órdenes de producción** `/api/produccion/ordenes` – CRUD.
+  - El campo `unidadMedidaSimbolo` indica la unidad de la `cantidadProgramada`
+    (por ejemplo, "kg" o "L"). Si no se envía, la API utilizará la unidad
+    definida para el producto asociado.
 
 ### Calidad
 - **Evaluaciones de calidad** `/api/calidad/evaluaciones` – CRUD de evaluaciones.

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
@@ -39,5 +39,11 @@ public class OrdenProduccionRequestDTO {
     @NotNull
     private Long responsableId;
 
+    /**
+     * Símbolo de la unidad de medida en la que se expresa la cantidad programada
+     * (por ejemplo, "kg" o "L"). Si se omite, se utilizará la unidad definida
+     * para el producto.
+     */
+    @NotBlank
     private String unidadMedidaSimbolo;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -202,6 +202,10 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         BigDecimal cantidadBase = dto.getCantidadProgramada();
         String unidadBase = dto.getUnidadMedidaSimbolo();
         String unidadProducto = producto.getUnidadMedida() != null ? producto.getUnidadMedida().getSimbolo() : unidadBase;
+        if (unidadBase == null || unidadBase.isBlank()) {
+            unidadBase = unidadProducto;
+            dto.setUnidadMedidaSimbolo(unidadBase);
+        }
         BigDecimal cantidadConvertida = unidadConversionService.convertir(cantidadBase, unidadBase, unidadProducto);
 
         OrdenProduccion orden = ordenProduccionMapper.toEntity(dto, producto, responsable);


### PR DESCRIPTION
## Summary
- require unit symbol in `OrdenProduccionRequestDTO` and document expected format
- default to product's unit when request omits `unidadMedidaSimbolo`
- document unit requirement in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.willyes.clemenintegra:inventario:1.0.0: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b5da7777288333a22b653f1963e566