### PR TITLE
Calcula unidades producidas en ordenes

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/model/Producto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/Producto.java
@@ -43,6 +43,13 @@ public class Producto {
     @Column(name = "stock_minimo_proveedor")
     private BigDecimal stockMinimoProveedor;
 
+    /**
+     * Rendimiento de producción expresado en la unidad del producto.
+     * Representa, por ejemplo, el volumen por unidad de empaque.
+     */
+    @Column(name = "rendimiento_unidad")
+    private BigDecimal rendimientoUnidad;
+
     @Column(name = "activo", nullable = false)
     private boolean activo = true;
 
@@ -110,6 +117,8 @@ public class Producto {
     public void setCategoriaProducto(CategoriaProducto categoriaProducto) {this.categoriaProducto = categoriaProducto;}
     public Usuario getCreadoPor() {return creadoPor;}
     public void setCreadoPor(Usuario creadoPor) {this.creadoPor = creadoPor;}
+    public BigDecimal getRendimientoUnidad() {return rendimientoUnidad;}
+    public void setRendimientoUnidad(BigDecimal rendimientoUnidad) {this.rendimientoUnidad = rendimientoUnidad;}
 
 }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
@@ -15,6 +15,7 @@ public class OrdenProduccionResponseDTO {
     public BigDecimal cantidadProducidaAcumulada;
     public BigDecimal cantidadRestante;
     public LocalDateTime fechaUltimoCierre;
+    public BigDecimal unidadesProducidas;
     public String estado;
     public String nombreProducto;
     public String unidadMedida;

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ResultadoValidacionOrdenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ResultadoValidacionOrdenDTO.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.math.BigDecimal;
 
 @Data
 @NoArgsConstructor
@@ -17,4 +18,5 @@ public class ResultadoValidacionOrdenDTO {
     private Integer unidadesMaximasProducibles;
     private List<InsumoFaltanteDTO> insumosFaltantes;
     private OrdenProduccionResponseDTO orden;
+    private BigDecimal unidadesProducidas;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -206,14 +206,22 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         }
         BigDecimal cantidadConvertida = unidadConversionService.convertir(cantidadBase, unidadBase, unidadProducto);
 
+        BigDecimal unidadesProducidas = unidadConversionService.dividirNormalizado(
+                cantidadConvertida,
+                unidadProducto,
+                producto.getRendimientoUnidad(),
+                unidadProducto);
+
         OrdenProduccion orden = ProduccionMapper.toEntity(dto, producto, responsable);
         orden.setCantidadProgramada(cantidadConvertida);
 
         ResultadoValidacionOrdenDTO resultado = guardarConValidacionStock(orden);
+        resultado.setUnidadesProducidas(unidadesProducidas);
         if (resultado.getOrden() != null) {
             resultado.getOrden().cantidadProgramadaBase = cantidadBase;
             resultado.getOrden().unidadMedidaBaseSimbolo = unidadBase;
             resultado.getOrden().unidadMedidaSimbolo = unidadProducto;
+            resultado.getOrden().unidadesProducidas = unidadesProducidas;
         }
         return resultado;
     }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/UnidadConversionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/UnidadConversionService.java
@@ -35,4 +35,17 @@ public class UnidadConversionService {
         // Sin conversión conocida
         return cantidad;
     }
+
+    /**
+     * Normaliza las unidades de ambas cantidades antes de dividirlas.
+     * Si las unidades ya coinciden, se realiza la división directamente.
+     */
+    public BigDecimal dividirNormalizado(BigDecimal numerador, String unidadNumerador,
+                                         BigDecimal divisor, String unidadDivisor) {
+        BigDecimal cantidadNormalizada = convertir(numerador, unidadNumerador, unidadDivisor);
+        if (divisor == null || divisor.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return cantidadNormalizada.divide(divisor, 6, RoundingMode.HALF_UP);
+    }
 }


### PR DESCRIPTION
## Summary
- add rendimientoUnidad field to Producto model for unit yield tracking
- compute produced units in OrdenProduccionServiceImpl and expose via DTOs
- extend UnidadConversionService with helper to normalize units before division

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5df69db1c83338f2a8e5ae722f91e