### PR TITLE
feat(productos): expone rendimiento mapeado desde rendimientoUnidad y alinea unidades con fórmula; migración SQL incluida

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoResponse.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.bom.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -10,6 +11,8 @@ public class FormulaProductoResponse {
     public String estado;
     public LocalDateTime fechaCreacion;
     public String creadoPorNombre;
+    public BigDecimal cantidadBaseFormula;
+    public String unidadBaseFormula;
     public List<DetalleFormulaResponse> detalles;
     public List<DocumentoFormulaResponseDTO> documentos;
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -49,6 +49,9 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                         "No existe fórmula activa aprobada para este producto."));
 
         FormulaProductoResponse response = bomMapper.toResponseDTO(formula);
+        response.unidadBaseFormula = formula.getProducto() != null && formula.getProducto().getUnidadMedida() != null
+                ? formula.getProducto().getUnidadMedida().getSimbolo() : null;
+        response.cantidadBaseFormula = BigDecimal.ONE;
 
         BigDecimal cantidadProduccion = (cantidad != null && cantidad.compareTo(BigDecimal.ZERO) > 0)
                 ? cantidad

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResponseDTO.java
@@ -3,7 +3,7 @@ package com.willyes.clemenintegra.inventario.dto;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.willyes.clemenintegra.inventario.model.Producto;
-import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.dto.UnidadMedidaResponseDTO;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -25,7 +25,8 @@ public class ProductoResponseDTO {
     private BigDecimal stockMinimoProveedor;
     private Boolean activo;
     private String tipoAnalisisCalidad;
-    private String unidadMedida;
+    private BigDecimal rendimiento;
+    private UnidadMedidaResponseDTO unidadMedida;
     private String categoria;
     private LocalDateTime fechaCreacion;
     // PROD-DETAIL-IDS BEGIN
@@ -48,7 +49,13 @@ public class ProductoResponseDTO {
         this.stockMinimoProveedor = producto.getStockMinimoProveedor();
         this.activo = producto.isActivo();
         this.tipoAnalisisCalidad = producto.getTipoAnalisis() != null ? producto.getTipoAnalisis().name() : null;
-        this.unidadMedida = producto.getUnidadMedida() != null ? producto.getUnidadMedida().getNombre() : null;
+        this.rendimiento = producto.getRendimientoUnidad() != null ? producto.getRendimientoUnidad() : BigDecimal.ZERO;
+        this.unidadMedida = producto.getUnidadMedida() != null
+                ? new UnidadMedidaResponseDTO(
+                        producto.getUnidadMedida().getId(),
+                        producto.getUnidadMedida().getNombre(),
+                        producto.getUnidadMedida().getSimbolo())
+                : null;
         this.categoria = producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getNombre() : null;
         this.fechaCreacion = producto.getFechaCreacion();
         // PROD-DETAIL-IDS BEGIN
@@ -81,8 +88,10 @@ public class ProductoResponseDTO {
     public void setActivo(Boolean activo) {this.activo = activo;}
     public String getTipoAnalisisCalidad() {return tipoAnalisisCalidad;}
     public void setTipoAnalisisCalidad(String tipoAnalisisCalidad) {this.tipoAnalisisCalidad = tipoAnalisisCalidad;}
-    public String getUnidadMedida() {return unidadMedida;}
-    public void setUnidadMedida(String unidadMedida) {this.unidadMedida = unidadMedida;}
+    public BigDecimal getRendimiento() {return rendimiento;}
+    public void setRendimiento(BigDecimal rendimiento) {this.rendimiento = rendimiento;}
+    public UnidadMedidaResponseDTO getUnidadMedida() {return unidadMedida;}
+    public void setUnidadMedida(UnidadMedidaResponseDTO unidadMedida) {this.unidadMedida = unidadMedida;}
     public String getCategoria() {return categoria;}
     public void setCategoria(String categoria) {this.categoria = categoria;}
     public LocalDateTime getFechaCreacion() {return fechaCreacion;}

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
@@ -1,11 +1,13 @@
 package com.willyes.clemenintegra.inventario.mapper;
 
 import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.UnidadMedidaResponseDTO;
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import org.mapstruct.*;
+import java.math.BigDecimal;
 
 @Mapper(componentModel = "spring")
 public interface ProductoMapper {
@@ -19,19 +21,17 @@ public interface ProductoMapper {
     }
 
     @Mapping(source = "codigoSku", target = "sku")
-    @Mapping(target = "unidadMedida", expression = "java(producto.getUnidadMedida() != null ? producto.getUnidadMedida().getNombre() : null)")
+    @Mapping(target = "unidadMedida", source = "unidadMedida")
     @Mapping(target = "categoria", expression = "java(producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getNombre() : null)")
     @Mapping(target = "tipoAnalisisCalidad", expression = "java(producto.getTipoAnalisis() != null ? producto.getTipoAnalisis().name() : null)")
+    @Mapping(target = "rendimiento", source = "rendimientoUnidad")
     // PROD-DETAIL-IDS BEGIN
     @Mapping(target = "unidadMedidaId", expression = "java(producto.getUnidadMedida() != null ? producto.getUnidadMedida().getId() : null)")
     @Mapping(target = "categoriaProductoId", expression = "java(producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getId() : null)")
         // PROD-DETAIL-IDS END
     ProductoResponseDTO toDto(Producto producto);
 
-    @Named("mapUnidadMedida")
-    default String mapUnidadMedida(UnidadMedida unidadMedida) {
-        return (unidadMedida != null) ? unidadMedida.getNombre() : null;
-    }
+    UnidadMedidaResponseDTO toUnidadMedidaDto(UnidadMedida unidadMedida);
 
     @Named("mapCategoriaProducto")
     default String mapCategoriaProducto(CategoriaProducto categoriaProducto) {
@@ -49,6 +49,13 @@ public interface ProductoMapper {
     @Named("mapTipoAnalisisCalidadString")
     default String mapTipoAnalisisCalidadString(TipoAnalisisCalidad valor) {
         return valor != null ? valor.name() : null;
+    }
+
+    @AfterMapping
+    default void setDefaultRendimiento(@MappingTarget ProductoResponseDTO dto) {
+        if (dto.getRendimiento() == null) {
+            dto.setRendimiento(BigDecimal.ZERO);
+        }
     }
 
 }

--- a/src/main/resources/db/migration/V2025_09_01__add_rendimiento_unidad_and_seed.sql
+++ b/src/main/resources/db/migration/V2025_09_01__add_rendimiento_unidad_and_seed.sql
@@ -1,0 +1,6 @@
+ALTER TABLE productos ADD COLUMN IF NOT EXISTS rendimiento_unidad DECIMAL(19,6) NULL;
+UPDATE productos SET rendimiento_unidad = 0 WHERE rendimiento_unidad IS NULL;
+UPDATE productos
+SET rendimiento_unidad = 4.000000
+WHERE LOWER(nombre) LIKE LOWER('%jarabe vitamina c%250%')
+  AND (rendimiento_unidad IS NULL OR rendimiento_unidad = 0);

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoControllerTest.java
@@ -1,0 +1,86 @@
+package com.willyes.clemenintegra.bom.controller;
+
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FormulaProductoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private FormulaProductoRepository formulaRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void setup() {
+        formulaRepository.deleteAll();
+        productoRepository.deleteAll();
+        unidadMedidaRepository.deleteAll();
+        categoriaProductoRepository.deleteAll();
+        usuarioRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(authorities = {"ROL_JEFE_PRODUCCION"})
+    void getFormulaActivaIncludesUnidadBase() throws Exception {
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Litro").simbolo("L").build());
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Jarabes").tipo(TipoCategoria.PRODUCTO_TERMINADO).build());
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("user").clave("pwd").nombreCompleto("User").correo("u@t.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION).activo(true).bloqueado(false).build());
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU1").nombre("Prod").descripcionProducto("d")
+                .stockActual(BigDecimal.ZERO).stockMinimo(BigDecimal.ZERO)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .unidadMedida(unidad).categoriaProducto(categoria).creadoPor(usuario)
+                .build());
+
+        FormulaProducto formula = FormulaProducto.builder()
+                .producto(producto)
+                .estado(EstadoFormula.APROBADA)
+                .fechaCreacion(LocalDateTime.now())
+                .activo(true)
+                .creadoPor(usuario)
+                .detalles(Collections.emptyList())
+                .build();
+        formulaRepository.save(formula);
+
+        mockMvc.perform(get("/api/bom/formulas/activa").param("productoId", producto.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.unidadBaseFormula").value("L"))
+                .andExpect(jsonPath("$.cantidadBaseFormula").value(1));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoControllerTest.java
@@ -1,0 +1,75 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProductoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void setup() {
+        productoRepository.deleteAll();
+        unidadMedidaRepository.deleteAll();
+        categoriaProductoRepository.deleteAll();
+        usuarioRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(authorities = {"ROL_JEFE_CALIDAD"})
+    void getProductoIncludesRendimientoAndUnidadMedida() throws Exception {
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Litro").simbolo("L").build());
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Jarabes").tipo(TipoCategoria.PRODUCTO_TERMINADO).build());
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("user").clave("pwd").nombreCompleto("User Test").correo("u@t.com")
+                .rol(RolUsuario.ROL_JEFE_CALIDAD).activo(true).bloqueado(false).build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU1")
+                .nombre("Producto1")
+                .descripcionProducto("desc")
+                .stockActual(BigDecimal.ZERO)
+                .stockMinimo(BigDecimal.ZERO)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .rendimientoUnidad(new BigDecimal("4"))
+                .build());
+
+        mockMvc.perform(get("/api/productos/" + producto.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rendimiento").value(4))
+                .andExpect(jsonPath("$.unidadMedida.simbolo").value("L"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapperTest.java
@@ -1,0 +1,34 @@
+package com.willyes.clemenintegra.inventario.mapper;
+
+import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductoMapperTest {
+
+    private final ProductoMapper mapper = Mappers.getMapper(ProductoMapper.class);
+
+    @Test
+    void mapsRendimientoAndUnidadMedida() {
+        UnidadMedida unidad = UnidadMedida.builder()
+                .id(1L)
+                .nombre("Litro")
+                .simbolo("L")
+                .build();
+        Producto producto = new Producto();
+        producto.setRendimientoUnidad(new BigDecimal("2.5"));
+        producto.setUnidadMedida(unidad);
+
+        ProductoResponseDTO dto = mapper.toDto(producto);
+
+        assertEquals(new BigDecimal("2.5"), dto.getRendimiento());
+        assertNotNull(dto.getUnidadMedida());
+        assertEquals("L", dto.getUnidadMedida().getSimbolo());
+    }
+}


### PR DESCRIPTION
## Summary
- expose product `rendimiento` mapped from `rendimientoUnidad` and return full `unidadMedida`
- include base unit info in active formula responses
- add flyway migration and tests for products and formulas

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f0947cd4833396dbf6e998d944de