### PR TITLE
chore/produccion: robustecer cierres (sort y reglas), auditar usuario y exponer etapas/insumos/movimientos por OP

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
@@ -28,6 +28,7 @@ public record MovimientoInventarioDTO(
         Long tipoMovimientoDetalleId,
         Long solicitudMovimientoId,
         Long usuarioId,
+        Long ordenProduccionId,
         Long ordenCompraDetalleId,
         String codigoLote,
         LocalDateTime fechaVencimiento,

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
@@ -31,6 +31,8 @@ public class MovimientoInventarioResponseDTO {
     private String nombreAlmacenOrigen;
     private String nombreAlmacenDestino;
     private String nombreUsuarioRegistrador;
+    private String unidad;
+    private Long ordenProduccionId;
 
 
     @JsonProperty("codigoSku")

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
@@ -21,6 +21,7 @@ public interface MovimientoInventarioMapper {
     //@Mapping(target = "ordenCompraDetalle", ignore = true)
     //@Mapping(target = "fechaIngreso", ignore = true)
     @Mapping(target = "solicitudMovimiento", ignore = true)
+    @Mapping(target = "ordenProduccion", ignore = true)
     @Mapping(target = "clasificacion", source = "clasificacionMovimientoInventario")
     MovimientoInventario toEntity(MovimientoInventarioDTO dto);
 
@@ -35,6 +36,7 @@ public interface MovimientoInventarioMapper {
     @Mapping(target = "tipoMovimientoDetalleId", expression = "java(movimiento.getTipoMovimientoDetalle() != null ? movimiento.getTipoMovimientoDetalle().getId() : null)")
     @Mapping(target = "ordenCompraDetalleId", expression = "java(movimiento.getOrdenCompraDetalle() != null ? movimiento.getOrdenCompraDetalle().getId() : null)")
     @Mapping(target = "solicitudMovimientoId", expression = "java(movimiento.getSolicitudMovimiento() != null ? movimiento.getSolicitudMovimiento().getId() : null)")
+    @Mapping(target = "ordenProduccionId", expression = "java(movimiento.getOrdenProduccion() != null ? movimiento.getOrdenProduccion().getId() : null)")
     @Mapping(target = "clasificacionMovimientoInventario", source = "clasificacion")
     MovimientoInventarioDTO toDTO(MovimientoInventario movimiento);
 
@@ -73,6 +75,10 @@ public interface MovimientoInventarioMapper {
 
         var u = m.getRegistradoPor();
         dto.setNombreUsuarioRegistrador(u != null ? u.getNombreCompleto() : null);
+        dto.setOrdenProduccionId(m.getOrdenProduccion() != null ? m.getOrdenProduccion().getId() : null);
+        dto.setUnidad(m.getProducto() != null && m.getProducto().getUnidadMedida() != null
+                ? m.getProducto().getUnidadMedida().getNombre()
+                : null);
 
         return dto;
     }

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/MovimientoInventario.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/MovimientoInventario.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.inventario.model;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -80,6 +81,10 @@ public class MovimientoInventario {
             foreignKey = @ForeignKey(name = "fk_movimientos_inventario_motivos_movimiento1"))
     private MotivoMovimiento motivoMovimiento;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orden_produccion_id")
+    private OrdenProduccion ordenProduccion;
+
     @ManyToOne
     @JoinColumn(name = "tipos_movimiento_detalle_id", nullable = false,
             foreignKey = @ForeignKey(name = "fk_mov_inv_tipo_mov_detalle"))
@@ -134,6 +139,9 @@ public class MovimientoInventario {
     public void setOrdenCompraDetalle(OrdenCompraDetalle ordenCompraDetalle) {this.ordenCompraDetalle = ordenCompraDetalle;}
     public SolicitudMovimiento getSolicitudMovimiento() {return solicitudMovimiento;}
     public void setSolicitudMovimiento(SolicitudMovimiento solicitudMovimiento) {this.solicitudMovimiento = solicitudMovimiento;}
+
+    public OrdenProduccion getOrdenProduccion() {return ordenProduccion;}
+    public void setOrdenProduccion(OrdenProduccion ordenProduccion) {this.ordenProduccion = ordenProduccion;}
 }
 
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.math.BigDecimal;
 
 public interface MovimientoInventarioRepository extends JpaRepository<MovimientoInventario, Long> {
 
@@ -91,6 +92,13 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
     boolean existsByProductoId(Long productoId);
 
     boolean existsBySolicitudMovimientoId(Long solicitudMovimientoId);
+
+    Page<MovimientoInventario> findByOrdenProduccionId(Long ordenProduccionId, Pageable pageable);
+
+    @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m where m.ordenProduccion.id = :ordenId and m.producto.id = :productoId and m.tipoMovimiento = :tipo")
+    BigDecimal sumaCantidadPorOrdenYProducto(@Param("ordenId") Long ordenId,
+                                             @Param("productoId") Long productoId,
+                                             @Param("tipo") TipoMovimiento tipo);
 
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -12,6 +12,7 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import com.willyes.clemenintegra.inventario.repository.*;
@@ -106,6 +107,10 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         Usuario usuario = dto.usuarioId() != null
                 ? entityManager.getReference(Usuario.class, dto.usuarioId())
                 : usuarioService.obtenerUsuarioAutenticado();
+
+        OrdenProduccion ordenProduccion = dto.ordenProduccionId() != null
+                ? entityManager.getReference(OrdenProduccion.class, dto.ordenProduccionId())
+                : null;
 
         TipoMovimiento tipoMovimiento = dto.tipoMovimiento();
 
@@ -267,6 +272,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         movimiento.setLote(lote);
         movimiento.setAlmacenOrigen(almacenOrigen);
         movimiento.setAlmacenDestino(almacenDestino);
+        movimiento.setOrdenProduccion(ordenProduccion);
         movimiento.setProveedor(dto.proveedorId() != null
                 ? entityManager.getReference(Proveedor.class, dto.proveedorId()) : null);
         movimiento.setOrdenCompra(dto.ordenCompraId() != null

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.produccion.mapper.ProduccionMapper;
 import com.willyes.clemenintegra.produccion.model.*;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.service.*;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/produccion/ordenes")
@@ -100,5 +102,24 @@ public class OrdenProduccionController {
     public Page<CierreProduccionResponseDTO> listarCierres(@PathVariable Long id,
                                                           @PageableDefault(size = 10, sort = "fechaCierre", direction = Sort.Direction.DESC) Pageable pageable) {
         return service.listarCierres(id, pageable);
+    }
+
+    @GetMapping("/{id}/etapas")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public List<EtapaProduccionResponse> listarEtapas(@PathVariable Long id) {
+        return service.listarEtapas(id);
+    }
+
+    @GetMapping("/{id}/insumos")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public List<InsumoOPDTO> listarInsumos(@PathVariable Long id) {
+        return service.listarInsumos(id);
+    }
+
+    @GetMapping("/{id}/movimientos")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public Page<MovimientoInventarioResponseDTO> listarMovimientos(@PathVariable Long id,
+                                                                   Pageable pageable) {
+        return service.listarMovimientos(id, pageable);
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionResponseDTO.java
@@ -12,4 +12,6 @@ public class CierreProduccionResponseDTO {
     public String turno;
     public String observacion;
     public String unidadMedidaSimbolo;
+    public Long usuarioId;
+    public String usuarioNombre;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaProduccionResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaProduccionResponse.java
@@ -5,4 +5,7 @@ public class EtapaProduccionResponse {
     public String nombre;
     public Integer secuencia;
     public Long ordenProduccionId;
+    public String estado;
+    public java.time.LocalDateTime fechaInicio;
+    public java.time.LocalDateTime fechaFin;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/InsumoOPDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/InsumoOPDTO.java
@@ -1,0 +1,19 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InsumoOPDTO {
+    private Long idInsumo;
+    private String nombre;
+    private String unidad;
+    private BigDecimal cantidadRequerida;
+    private BigDecimal cantidadConsumida;
+    private BigDecimal faltante;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
@@ -70,6 +70,8 @@ public class ProduccionMapper {
                 && entidad.getOrdenProduccion().getUnidadMedida() != null
                 ? entidad.getOrdenProduccion().getUnidadMedida().getSimbolo()
                 : null;
+        dto.usuarioId = entidad.getUsuarioId();
+        dto.usuarioNombre = entidad.getUsuarioNombre();
         return dto;
     }
 
@@ -87,6 +89,9 @@ public class ProduccionMapper {
         dto.nombre = entidad.getNombre();
         dto.secuencia = entidad.getSecuencia();
         dto.ordenProduccionId = entidad.getOrdenProduccion() != null ? entidad.getOrdenProduccion().getId() : null;
+        dto.estado = entidad.getEstado() != null ? entidad.getEstado().name() : null;
+        dto.fechaInicio = entidad.getFechaInicio();
+        dto.fechaFin = entidad.getFechaFin();
         return dto;
     }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/CierreProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/CierreProduccion.java
@@ -8,7 +8,8 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "cierres_produccion")
+@Table(name = "cierres_produccion",
+       indexes = @Index(name = "idx_cierres_produccion_fecha", columnList = "fecha_cierre"))
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -40,6 +41,12 @@ public class CierreProduccion {
 
     @Column(name = "fecha_cierre", nullable = false)
     private LocalDateTime fechaCierre;
+
+    @Column(name = "usuario_id")
+    private Long usuarioId;
+
+    @Column(name = "usuario_nombre", length = 100)
+    private String usuarioNombre;
 
     @PrePersist
     public void prePersist() {

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/EtapaProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/EtapaProduccion.java
@@ -3,7 +3,9 @@ package com.willyes.clemenintegra.produccion.model;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
 
 @Entity
 @Getter
@@ -28,4 +30,12 @@ public class EtapaProduccion {
 
     @OneToMany(mappedBy = "etapaProduccion")
     private List<DetalleEtapa> detalles;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private EstadoEtapa estado = EstadoEtapa.PENDIENTE;
+
+    private LocalDateTime fechaInicio;
+    private LocalDateTime fechaFin;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/enums/EstadoEtapa.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/enums/EstadoEtapa.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.produccion.model.enums;
+
+public enum EstadoEtapa {
+    PENDIENTE,
+    EN_PROCESO,
+    FINALIZADA
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaProduccionRepository.java
@@ -2,5 +2,8 @@ package com.willyes.clemenintegra.produccion.repository;
 
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
-public interface EtapaProduccionRepository extends JpaRepository<EtapaProduccion, Long> {}
+public interface EtapaProduccionRepository extends JpaRepository<EtapaProduccion, Long> {
+    List<EtapaProduccion> findByOrdenProduccionIdOrderBySecuenciaAsc(Long ordenProduccionId);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -5,6 +5,9 @@ import com.willyes.clemenintegra.produccion.dto.OrdenProduccionResponseDTO;
 import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
 import com.willyes.clemenintegra.produccion.dto.CierreProduccionRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.CierreProduccionResponseDTO;
+import com.willyes.clemenintegra.produccion.dto.EtapaProduccionResponse;
+import com.willyes.clemenintegra.produccion.dto.InsumoOPDTO;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import org.springframework.data.domain.Page;
@@ -28,6 +31,12 @@ public interface OrdenProduccionService {
     OrdenProduccion registrarCierre(Long id, CierreProduccionRequestDTO dto);
 
     Page<CierreProduccionResponseDTO> listarCierres(Long id, Pageable pageable);
+
+    List<EtapaProduccionResponse> listarEtapas(Long id);
+
+    List<InsumoOPDTO> listarInsumos(Long id);
+
+    Page<MovimientoInventarioResponseDTO> listarMovimientos(Long id, Pageable pageable);
 
     Page<OrdenProduccionResponseDTO> listarPaginado(String codigo,
                                                     EstadoProduccion estado,

--- a/src/main/resources/db/migration/V2025_09_02__produccion_detalle_updates.sql
+++ b/src/main/resources/db/migration/V2025_09_02__produccion_detalle_updates.sql
@@ -1,0 +1,14 @@
+ALTER TABLE cierres_produccion
+    ADD COLUMN usuario_id BIGINT,
+    ADD COLUMN usuario_nombre VARCHAR(100),
+    ADD INDEX idx_cierres_produccion_fecha (fecha_cierre);
+
+ALTER TABLE movimientos_inventario
+    ADD COLUMN orden_produccion_id BIGINT NULL,
+    ADD INDEX idx_mov_inv_orden (orden_produccion_id),
+    ADD CONSTRAINT fk_mov_inv_orden FOREIGN KEY (orden_produccion_id) REFERENCES orden_produccion(id);
+
+ALTER TABLE etapa_produccion
+    ADD COLUMN estado VARCHAR(32) NOT NULL DEFAULT 'PENDIENTE',
+    ADD COLUMN fecha_inicio DATETIME NULL,
+    ADD COLUMN fecha_fin DATETIME NULL;

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -1,0 +1,115 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MotivoMovimientoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.TipoMovimientoDetalleRepository;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import com.willyes.clemenintegra.inventario.service.SolicitudMovimientoService;
+import com.willyes.clemenintegra.produccion.dto.CierreProduccionRequestDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.TipoCierre;
+import com.willyes.clemenintegra.produccion.repository.CierreProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrdenProduccionServiceImplTest {
+
+    @Mock FormulaProductoRepository formulaProductoRepository;
+    @Mock ProductoRepository productoRepository;
+    @Mock UsuarioRepository usuarioRepository;
+    @Mock SolicitudMovimientoService solicitudMovimientoService;
+    @Mock OrdenProduccionRepository repository;
+    @Mock MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock CierreProduccionRepository cierreProduccionRepository;
+    @Mock MovimientoInventarioService movimientoInventarioService;
+    @Mock LoteProductoRepository loteProductoRepository;
+    @Mock AlmacenRepository almacenRepository;
+    @Mock com.willyes.clemenintegra.produccion.service.UnidadConversionService unidadConversionService;
+    @Mock EtapaProduccionRepository etapaProduccionRepository;
+    @Mock MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock MovimientoInventarioMapper movimientoInventarioMapper;
+    @Mock UsuarioService usuarioService;
+
+    OrdenProduccionServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new OrdenProduccionServiceImpl(
+                formulaProductoRepository,
+                productoRepository,
+                usuarioRepository,
+                solicitudMovimientoService,
+                repository,
+                motivoMovimientoRepository,
+                tipoMovimientoDetalleRepository,
+                cierreProduccionRepository,
+                movimientoInventarioService,
+                loteProductoRepository,
+                almacenRepository,
+                unidadConversionService,
+                etapaProduccionRepository,
+                movimientoInventarioRepository,
+                movimientoInventarioMapper,
+                usuarioService
+        );
+    }
+
+    @Test
+    void listarCierresSortInvalido() {
+        Pageable pageable = PageRequest.of(0,10, Sort.by("fecha"));
+        assertThrows(ResponseStatusException.class, () -> service.listarCierres(1L, pageable));
+    }
+
+    @Test
+    void registrarCierreOrdenFinalizada() {
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .estado(EstadoProduccion.FINALIZADA)
+                .build();
+        when(repository.findById(1L)).thenReturn(Optional.of(orden));
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(BigDecimal.ONE)
+                .tipo(TipoCierre.PARCIAL)
+                .build();
+        assertThrows(ResponseStatusException.class, () -> service.registrarCierre(1L, dto));
+    }
+
+    @Test
+    void registrarCierreSinCantidadRestante() {
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .estado(EstadoProduccion.EN_PROCESO)
+                .cantidadProgramada(BigDecimal.TEN)
+                .cantidadProducidaAcumulada(BigDecimal.TEN)
+                .build();
+        when(repository.findById(1L)).thenReturn(Optional.of(orden));
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(BigDecimal.ONE)
+                .tipo(TipoCierre.PARCIAL)
+                .build();
+        assertThrows(ResponseStatusException.class, () -> service.registrarCierre(1L, dto));
+    }
+}


### PR DESCRIPTION
## Summary
- validar propiedad de sort en listado de cierres y agregar auditoría de usuario
- exponer etapas, insumos y movimientos asociados a una orden de producción
- relacionar movimientos con órdenes y ampliar DTOs y mapeos

## Testing
- `mvn -q -e test` *(failed: Non-resolvable parent POM)*


------
https://chatgpt.com/codex/tasks/task_e_68b724fd4fa0833381e876819be3f252