### PR TITLE
chore/produccion: auditar usuario en cierres; listar etapas por OP; calcular insumos consumidos; exponer movimientos por OP; sort seguro en cierres

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -411,7 +411,9 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         for (DetalleFormula det : formula.getDetalles()) {
             BigDecimal requerida = det.getCantidadNecesaria().multiply(orden.getCantidadProgramada());
             Long insumoId = det.getInsumo().getId().longValue();
-            BigDecimal consumida = movimientoInventarioRepository.sumaCantidadPorOrdenYProducto(id, insumoId, TipoMovimiento.SALIDA);
+            BigDecimal consumida = Optional.ofNullable(
+                    movimientoInventarioRepository.sumaCantidadPorOrdenYProducto(id, insumoId, TipoMovimiento.SALIDA)
+            ).orElse(BigDecimal.ZERO);
             BigDecimal faltante = requerida.subtract(consumida);
             if (faltante.compareTo(BigDecimal.ZERO) < 0) {
                 faltante = BigDecimal.ZERO;


### PR DESCRIPTION
## Summary
- handle null inventory movement sums when calculating consumed inputs
- cover cierre audit and invalid sort scenarios with unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a6b5b8dc8333a434fc3d1217e695