### PR TITLE
feat: plantillas de etapas de producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaPlantillaController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaPlantillaController.java
@@ -1,0 +1,67 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.dto.*;
+import com.willyes.clemenintegra.produccion.mapper.EtapaPlantillaMapper;
+import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
+import com.willyes.clemenintegra.produccion.service.EtapaPlantillaService;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/produccion/plantillas")
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+public class EtapaPlantillaController {
+
+    private final EtapaPlantillaService service;
+    private final EtapaPlantillaMapper mapper;
+
+    @GetMapping("/{productoId}")
+    public List<EtapaPlantillaResponse> listar(@PathVariable Integer productoId) {
+        return service.listarPorProducto(productoId).stream()
+                .map(mapper::toResponse)
+                .toList();
+    }
+
+    @PostMapping("/{productoId}")
+    public ResponseEntity<EtapaPlantillaResponse> crear(@PathVariable Integer productoId,
+                                                         @RequestBody EtapaPlantillaRequest request) {
+        Producto producto = new Producto();
+        producto.setId(productoId);
+        EtapaPlantilla entidad = mapper.toEntity(request);
+        entidad.setProducto(producto);
+        return ResponseEntity.ok(mapper.toResponse(service.crear(entidad)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<EtapaPlantillaResponse> actualizar(@PathVariable Long id,
+                                                             @RequestBody EtapaPlantillaRequest request) {
+        EtapaPlantilla entidad = mapper.toEntity(request);
+        return ResponseEntity.ok(mapper.toResponse(service.actualizar(id, entidad)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        service.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{productoId}/reordenar")
+    public ResponseEntity<Void> reordenar(@PathVariable Integer productoId,
+                                          @RequestBody List<EtapaPlantillaReordenRequest> cambios) {
+        service.reordenar(productoId, cambios);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{productoId}/preview")
+    public List<EtapaPlantillaResponse> preview(@PathVariable Integer productoId) {
+        return service.preview(productoId).stream()
+                .map(mapper::toResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaPlantillaReordenRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaPlantillaReordenRequest.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+public class EtapaPlantillaReordenRequest {
+    public Long id;
+    public Integer secuencia;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaPlantillaRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaPlantillaRequest.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+public class EtapaPlantillaRequest {
+    public String nombre;
+    public Integer secuencia;
+    public Boolean activo;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaPlantillaResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/EtapaPlantillaResponse.java
@@ -1,0 +1,9 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+public class EtapaPlantillaResponse {
+    public Long id;
+    public Integer productoId;
+    public String nombre;
+    public Integer secuencia;
+    public Boolean activo;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/EtapaPlantillaMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/EtapaPlantillaMapper.java
@@ -1,0 +1,15 @@
+package com.willyes.clemenintegra.produccion.mapper;
+
+import com.willyes.clemenintegra.produccion.dto.EtapaPlantillaRequest;
+import com.willyes.clemenintegra.produccion.dto.EtapaPlantillaResponse;
+import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface EtapaPlantillaMapper {
+    EtapaPlantilla toEntity(EtapaPlantillaRequest request);
+
+    @Mapping(target = "productoId", source = "producto.id")
+    EtapaPlantillaResponse toResponse(EtapaPlantilla entity);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaPlantillaRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaPlantillaRepository.java
@@ -5,5 +5,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface EtapaPlantillaRepository extends JpaRepository<EtapaPlantilla, Long> {
+    List<EtapaPlantilla> findByProductoIdOrderBySecuenciaAsc(Integer productoId);
+
     List<EtapaPlantilla> findByProductoIdAndActivoTrueOrderBySecuenciaAsc(Integer productoId);
+
+    boolean existsByProductoIdAndSecuencia(Integer productoId, Integer secuencia);
+
+    boolean existsByProductoIdAndNombreIgnoreCase(Integer productoId, String nombre);
+
+    boolean existsByProductoIdAndSecuenciaAndIdNot(Integer productoId, Integer secuencia, Long id);
+
+    boolean existsByProductoIdAndNombreIgnoreCaseAndIdNot(Integer productoId, String nombre, Long id);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/EtapaPlantillaService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/EtapaPlantillaService.java
@@ -1,0 +1,14 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
+import com.willyes.clemenintegra.produccion.dto.EtapaPlantillaReordenRequest;
+import java.util.List;
+
+public interface EtapaPlantillaService {
+    List<EtapaPlantilla> listarPorProducto(Integer productoId);
+    List<EtapaPlantilla> preview(Integer productoId);
+    EtapaPlantilla crear(EtapaPlantilla etapa);
+    EtapaPlantilla actualizar(Long id, EtapaPlantilla etapa);
+    void eliminar(Long id);
+    void reordenar(Integer productoId, List<EtapaPlantillaReordenRequest> cambios);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/EtapaPlantillaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/EtapaPlantillaServiceImpl.java
@@ -1,0 +1,103 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.EtapaPlantillaReordenRequest;
+import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
+import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EtapaPlantillaServiceImpl implements EtapaPlantillaService {
+
+    private final EtapaPlantillaRepository repository;
+
+    private void validarUnicidad(Integer productoId, String nombre, Integer secuencia, Long id) {
+        if (id == null) {
+            if (repository.existsByProductoIdAndSecuencia(productoId, secuencia)) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Secuencia ya usada");
+            }
+            if (repository.existsByProductoIdAndNombreIgnoreCase(productoId, nombre)) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Nombre ya usado");
+            }
+        } else {
+            if (repository.existsByProductoIdAndSecuenciaAndIdNot(productoId, secuencia, id)) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Secuencia ya usada");
+            }
+            if (repository.existsByProductoIdAndNombreIgnoreCaseAndIdNot(productoId, nombre, id)) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Nombre ya usado");
+            }
+        }
+    }
+
+    @Override
+    public List<EtapaPlantilla> listarPorProducto(Integer productoId) {
+        return repository.findByProductoIdOrderBySecuenciaAsc(productoId);
+    }
+
+    @Override
+    public List<EtapaPlantilla> preview(Integer productoId) {
+        return repository.findByProductoIdAndActivoTrueOrderBySecuenciaAsc(productoId);
+    }
+
+    @Override
+    public EtapaPlantilla crear(EtapaPlantilla etapa) {
+        Integer productoId = etapa.getProducto().getId();
+        validarUnicidad(productoId, etapa.getNombre(), etapa.getSecuencia(), null);
+        return repository.save(etapa);
+    }
+
+    @Override
+    public EtapaPlantilla actualizar(Long id, EtapaPlantilla etapa) {
+        EtapaPlantilla existente = repository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Etapa no encontrada"));
+        Integer productoId = existente.getProducto().getId();
+        validarUnicidad(productoId, etapa.getNombre(), etapa.getSecuencia(), id);
+        existente.setNombre(etapa.getNombre());
+        existente.setSecuencia(etapa.getSecuencia());
+        existente.setActivo(etapa.getActivo());
+        return repository.save(existente);
+    }
+
+    @Override
+    public void eliminar(Long id) {
+        repository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public void reordenar(Integer productoId, List<EtapaPlantillaReordenRequest> cambios) {
+        List<EtapaPlantilla> existentes = repository.findByProductoIdOrderBySecuenciaAsc(productoId);
+        Map<Long, EtapaPlantilla> mapa = existentes.stream()
+                .collect(Collectors.toMap(EtapaPlantilla::getId, Function.identity()));
+        Map<Long, Integer> originales = existentes.stream()
+                .collect(Collectors.toMap(EtapaPlantilla::getId, EtapaPlantilla::getSecuencia));
+
+        for (EtapaPlantillaReordenRequest c : cambios) {
+            EtapaPlantilla e = mapa.get(c.id);
+            if (e == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Etapa no encontrada");
+            }
+            e.setSecuencia(c.secuencia);
+        }
+
+        Set<Integer> secuencias = new HashSet<>();
+        for (EtapaPlantilla e : existentes) {
+            if (!secuencias.add(e.getSecuencia())) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Secuencia duplicada");
+            }
+        }
+
+        List<EtapaPlantilla> modificadas = existentes.stream()
+                .filter(e -> !Objects.equals(originales.get(e.getId()), e.getSecuencia()))
+                .toList();
+        repository.saveAll(modificadas);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/EtapaPlantillaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/EtapaPlantillaServiceImplTest.java
@@ -1,0 +1,94 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.produccion.dto.EtapaPlantillaReordenRequest;
+import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
+import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EtapaPlantillaServiceImplTest {
+
+    @Mock EtapaPlantillaRepository repository;
+    EtapaPlantillaServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EtapaPlantillaServiceImpl(repository);
+    }
+
+    @Test
+    void crearGuarda() {
+        Producto prod = new Producto(); prod.setId(1);
+        EtapaPlantilla etapa = EtapaPlantilla.builder()
+                .nombre("E1").secuencia(1).activo(true).producto(prod).build();
+        when(repository.existsByProductoIdAndSecuencia(1,1)).thenReturn(false);
+        when(repository.existsByProductoIdAndNombreIgnoreCase(1,"E1")).thenReturn(false);
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        EtapaPlantilla res = service.crear(etapa);
+        assertEquals("E1", res.getNombre());
+        verify(repository).save(etapa);
+    }
+
+    @Test
+    void crearSecuenciaDuplicada() {
+        Producto prod = new Producto(); prod.setId(1);
+        EtapaPlantilla etapa = EtapaPlantilla.builder()
+                .nombre("E1").secuencia(1).producto(prod).build();
+        when(repository.existsByProductoIdAndSecuencia(1,1)).thenReturn(true);
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.crear(etapa));
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, ex.getStatusCode());
+    }
+
+    @Test
+    void actualizarModifica() {
+        Producto prod = new Producto(); prod.setId(1);
+        EtapaPlantilla existente = EtapaPlantilla.builder()
+                .id(5L).nombre("E1").secuencia(1).activo(true).producto(prod).build();
+        when(repository.findById(5L)).thenReturn(Optional.of(existente));
+        when(repository.existsByProductoIdAndSecuenciaAndIdNot(1,2,5L)).thenReturn(false);
+        when(repository.existsByProductoIdAndNombreIgnoreCaseAndIdNot(1,"E2",5L)).thenReturn(false);
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        EtapaPlantilla cambios = EtapaPlantilla.builder().nombre("E2").secuencia(2).activo(false).build();
+        EtapaPlantilla res = service.actualizar(5L, cambios);
+        assertEquals("E2", res.getNombre());
+        assertEquals(2, res.getSecuencia());
+        assertFalse(res.getActivo());
+        verify(repository).save(existente);
+    }
+
+    @Test
+    void reordenarActualizaSoloCambios() {
+        EtapaPlantilla e1 = EtapaPlantilla.builder().id(1L).secuencia(1).build();
+        EtapaPlantilla e2 = EtapaPlantilla.builder().id(2L).secuencia(2).build();
+        EtapaPlantilla e3 = EtapaPlantilla.builder().id(3L).secuencia(3).build();
+        when(repository.findByProductoIdOrderBySecuenciaAsc(1)).thenReturn(List.of(e1,e2,e3));
+
+        EtapaPlantillaReordenRequest r1 = new EtapaPlantillaReordenRequest(); r1.id=1L; r1.secuencia=2;
+        EtapaPlantillaReordenRequest r2 = new EtapaPlantillaReordenRequest(); r2.id=2L; r2.secuencia=1;
+        service.reordenar(1, List.of(r1,r2));
+
+        ArgumentCaptor<List<EtapaPlantilla>> captor = ArgumentCaptor.forClass(List.class);
+        verify(repository).saveAll(captor.capture());
+        List<EtapaPlantilla> guardadas = captor.getValue();
+        assertEquals(2, guardadas.size());
+        assertEquals(2, e1.getSecuencia());
+        assertEquals(1, e2.getSecuencia());
+    }
+}


### PR DESCRIPTION
## Summary
- expose CRUD, preview and batch reorder endpoints for EtapaPlantilla under /api/produccion/plantillas
- enforce uniqueness of stage names and sequences per product
- add service layer and unit tests for creation, update and reordering

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c5fb49e88333a985f854af357022