### PR TITLE
Permitir buscar unidad de medida por símbolo en fórmulas

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
@@ -79,7 +79,8 @@ public class FormulaProductoController {
         if (request.getInsumos() != null) {
             List<DetalleFormula> detalles = request.getInsumos().stream().map(dto -> {
                 Producto productoInsumo = productoService.findById(dto.getProductoId());
-                UnidadMedida unidad = unidadMedidaRepository.findByNombre(dto.getUnidadMedida())
+                UnidadMedida unidad = unidadMedidaRepository
+                        .findByNombreIgnoreCaseOrSimboloIgnoreCase(dto.getUnidadMedida(), dto.getUnidadMedida())
                         .orElseThrow(() -> new IllegalArgumentException("Unidad de medida no encontrada: " + dto.getUnidadMedida()));
 
                 DetalleFormula detalle = new DetalleFormula();

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/UnidadMedidaRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/UnidadMedidaRepository.java
@@ -10,5 +10,12 @@ import java.util.Optional;
 public interface UnidadMedidaRepository extends JpaRepository<UnidadMedida, Long> {
     Optional<UnidadMedida> findByNombre(String nombre);
 
+    /**
+     * Busca una unidad de medida por su nombre o símbolo, ignorando mayúsculas/minúsculas.
+     * Permite que los consumidores usen indistintamente el nombre completo ("Gramo")
+     * o el símbolo ("g") al referirse a la unidad.
+     */
+    Optional<UnidadMedida> findByNombreIgnoreCaseOrSimboloIgnoreCase(String nombre, String simbolo);
+
 }
 

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoControllerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -23,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -82,5 +84,50 @@ class FormulaProductoControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.unidadBaseFormula").value("L"))
                 .andExpect(jsonPath("$.cantidadBaseFormula").value(1));
+    }
+
+    @Test
+    @WithMockUser(authorities = {"ROL_SUPER_ADMIN"})
+    void crearFormulaAceptaSimboloDeUnidad() throws Exception {
+        UnidadMedida unidadProducto = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Litro").simbolo("L").build());
+        UnidadMedida unidadInsumo = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Gramo").simbolo("g").build());
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Jarabes").tipo(TipoCategoria.PRODUCTO_TERMINADO).build());
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("admin").clave("pwd").nombreCompleto("Admin").correo("a@t.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN).activo(true).bloqueado(false).build());
+        Producto insumo = productoRepository.save(Producto.builder()
+                .codigoSku("INS1").nombre("Insumo1").descripcionProducto("d")
+                .stockActual(BigDecimal.ZERO).stockMinimo(BigDecimal.ZERO)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .unidadMedida(unidadInsumo).categoriaProducto(categoria).creadoPor(usuario)
+                .build());
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("PROD1").nombre("Producto1").descripcionProducto("d")
+                .stockActual(BigDecimal.ZERO).stockMinimo(BigDecimal.ZERO)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .unidadMedida(unidadProducto).categoriaProducto(categoria).creadoPor(usuario)
+                .build());
+
+        String formulaJson = "{" +
+                "\"productoId\":" + producto.getId() + "," +
+                "\"version\":\"1.0\"," +
+                "\"estado\":\"BORRADOR\"," +
+                "\"creadoPorId\":" + usuario.getId() + "," +
+                "\"insumos\":[{" +
+                "\"productoId\":" + insumo.getId() + "," +
+                "\"cantidad\":5," +
+                "\"unidadMedida\":\"g\"," +
+                "\"tipo\":\"OBLIGATORIO\"}]" +
+                "}";
+
+        MockMultipartFile formulaPart = new MockMultipartFile(
+                "formula", "", "application/json", formulaJson.getBytes());
+
+        mockMvc.perform(multipart("/api/bom/formulas").file(formulaPart))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.detalles[0].unidadSimbolo").value("g"));
     }
 }


### PR DESCRIPTION
## Summary
- allow unit lookup by name or symbol
- use new lookup when creating formulas
- add test ensuring formulas accept unit symbols

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ea3d46d4833395452c1580906727