### PR TITLE
feat: patch endpoint to update formula status

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
@@ -145,6 +145,14 @@ public class FormulaProductoController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @PatchMapping("/{id}/estado")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<FormulaProductoResponse> actualizarEstado(@PathVariable Long id,
+                                                                    @RequestParam EstadoFormula estado) {
+        FormulaProducto actualizado = formulaService.actualizarEstado(id, estado);
+        return ResponseEntity.ok(bomMapper.toResponseDTO(actualizado));
+    }
+
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.bom.service;
 
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResponse;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -14,4 +15,6 @@ public interface FormulaProductoService {
     void eliminar(Long id);
 
     FormulaProductoResponse obtenerFormulaActivaPorProducto(Long productoId, BigDecimal cantidad);
+
+    FormulaProducto actualizarEstado(Long id, EstadoFormula estado);
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -42,6 +42,15 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
     }
 
     @Override
+    public FormulaProducto actualizarEstado(Long id, EstadoFormula estado) {
+        FormulaProducto formula = formulaRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Fórmula no encontrada"));
+        formula.setEstado(estado);
+        formula.setActivo(estado == EstadoFormula.APROBADA);
+        return formulaRepository.save(formula);
+    }
+
+    @Override
     public FormulaProductoResponse obtenerFormulaActivaPorProducto(Long productoId, BigDecimal cantidad) {
         FormulaProducto formula = formulaRepository
                 .findByProductoIdAndEstadoAndActivoTrue(productoId, EstadoFormula.APROBADA)


### PR DESCRIPTION
## Summary
- add endpoint to update a formula's state
- allow service to persist state changes and activate approved formulas

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f018087483339f8df3b1d622c78a