### PR TITLE
Añade scheduler para marcar lotes vencidos automáticamente

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/ClemenIntegraApplication.java
+++ b/src/main/java/com/willyes/clemenintegra/ClemenIntegraApplication.java
@@ -2,8 +2,10 @@ package com.willyes.clemenintegra;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.willyes.clemenintegra")
+@EnableScheduling
 public class ClemenIntegraApplication {
     public static void main(String[] args) {
         SpringApplication.run(ClemenIntegraApplication.class, args);

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -29,6 +29,8 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     Optional<LoteProducto> findByCodigoLoteAndProductoIdAndAlmacenId(String codigoLote, Integer productoId, Integer almacenId);
     List<LoteProducto> findByEstadoIn(List<EstadoLote> estados);
     List<LoteProducto> findByEstadoInAndProducto_TipoAnalisisIn(List<EstadoLote> estados, List<TipoAnalisisCalidad> tipos);
+    List<LoteProducto> findByFechaVencimientoBeforeAndEstadoNotIn(LocalDateTime fecha,
+                                                                  List<EstadoLote> estados);
     Optional<LoteProducto> findFirstByProductoIdAndEstadoAndStockLoteGreaterThanOrderByFechaVencimientoAsc(
             Integer productoId,
             EstadoLote estado,

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteVencimientoScheduler.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteVencimientoScheduler.java
@@ -1,0 +1,31 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class LoteVencimientoScheduler {
+
+    private final LoteProductoRepository loteProductoRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void actualizarLotesVencidos() {
+        LocalDateTime hoy = LocalDate.now().atStartOfDay();
+        List<LoteProducto> lotes = loteProductoRepository
+                .findByFechaVencimientoBeforeAndEstadoNotIn(hoy,
+                        List.of(EstadoLote.VENCIDO, EstadoLote.RECHAZADO));
+        for (LoteProducto lote : lotes) {
+            lote.setEstado(EstadoLote.VENCIDO);
+            loteProductoRepository.save(lote);
+        }
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/LoteVencimientoSchedulerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/LoteVencimientoSchedulerTest.java
@@ -1,0 +1,114 @@
+package com.willyes.clemenintegra.inventario;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.*;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.inventario.service.LoteVencimientoScheduler;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class LoteVencimientoSchedulerTest {
+
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private AlmacenRepository almacenRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private LoteVencimientoScheduler scheduler;
+
+    @BeforeEach
+    void setup() {
+        loteProductoRepository.deleteAll();
+        productoRepository.deleteAll();
+        almacenRepository.deleteAll();
+        categoriaProductoRepository.deleteAll();
+        unidadMedidaRepository.deleteAll();
+        usuarioRepository.deleteAll();
+    }
+
+    @Test
+    void lotesVencidosSeMarcanComoVencidos() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("user")
+                .clave("pwd")
+                .nombreCompleto("User Test")
+                .correo("user@test.com")
+                .rol(RolUsuario.ROL_JEFE_CALIDAD)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Litro")
+                .simbolo("L")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Cat")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU1")
+                .nombre("Prod1")
+                .descripcionProducto("desc")
+                .stockActual(BigDecimal.ONE)
+                .stockMinimo(BigDecimal.ZERO)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Alm1")
+                .ubicacion("Loc")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        LoteProducto vencido = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("L1")
+                .fechaFabricacion(LocalDateTime.now().minusDays(10))
+                .fechaVencimiento(LocalDateTime.now().minusDays(1))
+                .stockLote(BigDecimal.ONE)
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(producto)
+                .almacen(almacen)
+                .build());
+
+        LoteProducto vigente = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("L2")
+                .fechaFabricacion(LocalDateTime.now())
+                .fechaVencimiento(LocalDateTime.now().plusDays(5))
+                .stockLote(BigDecimal.ONE)
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(producto)
+                .almacen(almacen)
+                .build());
+
+        scheduler.actualizarLotesVencidos();
+
+        assertEquals(EstadoLote.VENCIDO, loteProductoRepository.findById(vencido.getId()).orElseThrow().getEstado());
+        assertEquals(EstadoLote.DISPONIBLE, loteProductoRepository.findById(vigente.getId()).orElseThrow().getEstado());
+    }
+}


### PR DESCRIPTION
## Summary
- Habilita `@EnableScheduling` en la aplicación
- Añade `LoteVencimientoScheduler` que marca lotes expirados como VENCIDO
- Agrega método de repositorio para consultar lotes vencidos
- Cubre transición automática con prueba unitaria

## Testing
- `mvn test` *(falla: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baf4a1345883339c1bce8a843221cb