### PR TITLE
Restringir nombre de etapa por orden en producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/model/EtapaProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/EtapaProduccion.java
@@ -8,6 +8,10 @@ import java.util.List;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
 
 @Entity
+@Table(name = "etapa_produccion",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"orden_produccion_id", "nombre_etapa"})
+        })
 @Getter
 @Setter
 @NoArgsConstructor
@@ -18,7 +22,7 @@ public class EtapaProduccion {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "nombre_etapa", nullable = false, unique = true)
+    @Column(name = "nombre_etapa", nullable = false)
     private String nombre;
 
     @Column(nullable = false)

--- a/src/main/resources/db/migration/V2025_09_04__etapa_produccion_unique_compuesta.sql
+++ b/src/main/resources/db/migration/V2025_09_04__etapa_produccion_unique_compuesta.sql
@@ -1,0 +1,5 @@
+ALTER TABLE etapa_produccion
+    DROP INDEX nombre_etapa;
+
+ALTER TABLE etapa_produccion
+    ADD CONSTRAINT uk_orden_nombre_etapa UNIQUE (orden_produccion_id, nombre_etapa);

--- a/src/test/java/com/willyes/clemenintegra/produccion/repository/EtapaProduccionRepositoryTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/repository/EtapaProduccionRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.willyes.clemenintegra.produccion.repository;
+
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class EtapaProduccionRepositoryTest {
+
+    @Autowired
+    private OrdenProduccionRepository ordenRepository;
+
+    @Autowired
+    private EtapaProduccionRepository etapaRepository;
+
+    @Test
+    void permiteNombresRepetidosEnDistintasOrdenes() {
+        OrdenProduccion orden1 = crearOrden("OP-1");
+        OrdenProduccion orden2 = crearOrden("OP-2");
+        ordenRepository.save(orden1);
+        ordenRepository.save(orden2);
+
+        EtapaProduccion e1 = EtapaProduccion.builder()
+                .nombre("Mezcla")
+                .secuencia(1)
+                .ordenProduccion(orden1)
+                .build();
+        EtapaProduccion e2 = EtapaProduccion.builder()
+                .nombre("Mezcla")
+                .secuencia(1)
+                .ordenProduccion(orden2)
+                .build();
+
+        etapaRepository.save(e1);
+        etapaRepository.save(e2);
+
+        assertThat(etapaRepository.count()).isEqualTo(2);
+    }
+
+    private OrdenProduccion crearOrden(String codigo) {
+        return OrdenProduccion.builder()
+                .codigoOrden(codigo)
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(BigDecimal.ONE)
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.CREADA)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Allow repeated stage names across different orders by scoping uniqueness to each `orden_produccion`
- Add Flyway migration for composite unique constraint on `orden_produccion_id` and `nombre_etapa`
- Introduce test ensuring duplicated stage names in different orders are persisted

## Testing
- ⚠️ `mvn -q test` *(failed: Non-resolvable parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bafdc9d020833396e58ca8f6db7153