### PR TITLE
feat: make lote optional in production order request

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
@@ -12,9 +12,6 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @Builder
 public class OrdenProduccionRequestDTO {
-    @NotBlank
-    private String loteProduccion;
-
     @NotNull
     @PastOrPresent
     private LocalDateTime fechaInicio;

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
@@ -11,7 +11,6 @@ public class ProduccionMapper {
 
     public static OrdenProduccion toEntity(OrdenProduccionRequestDTO dto, Producto producto, Usuario responsable) {
         return OrdenProduccion.builder()
-                .loteProduccion(dto.getLoteProduccion())
                 // La fecha de inicio se establecerá desde el servicio, ignorando valores del cliente
                 .fechaFin(dto.getFechaFin())
                 .cantidadProgramada(dto.getCantidadProgramada())

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -224,7 +224,6 @@ class OrdenProduccionServiceImplTest {
     @Test
     void crearOrdenInicializaCantidadesEnCero() {
         OrdenProduccionRequestDTO dto = OrdenProduccionRequestDTO.builder()
-                .loteProduccion("L1")
                 .fechaInicio(LocalDateTime.now())
                 .fechaFin(LocalDateTime.now().plusDays(1))
                 .cantidadProgramada(BigDecimal.TEN)


### PR DESCRIPTION
## Summary
- remove `loteProduccion` from `OrdenProduccionRequestDTO`
- stop mapping lot from request in `ProduccionMapper`
- adjust service test to build requests without lot

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb495f4be483339230330ddd740ed3