### PR TITLE
feat: query latest lote by prefix

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
@@ -12,4 +12,6 @@ public interface OrdenProduccionRepository extends JpaRepository<OrdenProduccion
 
     Long countByCodigoOrdenStartingWith(String prefijo);
 
+    Optional<OrdenProduccion> findTopByLoteProduccionStartingWithOrderByLoteProduccionDesc(String prefix);
+
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepositoryTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.willyes.clemenintegra.produccion.repository;
+
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class OrdenProduccionRepositoryTest {
+
+    @Autowired
+    private OrdenProduccionRepository repository;
+
+    @Test
+    void obtieneLoteConMayorConsecutivoParaPrefijo() {
+        repository.save(crearOrden("OP-1", "20231101-001"));
+        repository.save(crearOrden("OP-2", "20231101-003"));
+        repository.save(crearOrden("OP-3", "20231101-002"));
+        repository.save(crearOrden("OP-4", "20231102-001"));
+
+        Optional<OrdenProduccion> resultado = repository
+                .findTopByLoteProduccionStartingWithOrderByLoteProduccionDesc("20231101");
+
+        assertThat(resultado).isPresent();
+        assertThat(resultado.get().getLoteProduccion()).isEqualTo("20231101-003");
+    }
+
+    private OrdenProduccion crearOrden(String codigo, String lote) {
+        return OrdenProduccion.builder()
+                .codigoOrden(codigo)
+                .loteProduccion(lote)
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(BigDecimal.ONE)
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.CREADA)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- add finder method for last lote by prefix
- test repository method to ensure highest lote is returned

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.willyes.clemenintegra:inventario:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4b69a41c8333bdbbf9d219cb94aa