### PR TITLE
feat: generar lote y asignar en inicio de producción

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepositoryTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepositoryTest.java
@@ -20,16 +20,16 @@ class OrdenProduccionRepositoryTest {
 
     @Test
     void obtieneLoteConMayorConsecutivoParaPrefijo() {
-        repository.save(crearOrden("OP-1", "20231101-001"));
-        repository.save(crearOrden("OP-2", "20231101-003"));
-        repository.save(crearOrden("OP-3", "20231101-002"));
-        repository.save(crearOrden("OP-4", "20231102-001"));
+        repository.save(crearOrden("OP-1", "2023110100-AAA"));
+        repository.save(crearOrden("OP-2", "2023110102-BBB"));
+        repository.save(crearOrden("OP-3", "2023110101-CCC"));
+        repository.save(crearOrden("OP-4", "2023110200-DDD"));
 
         Optional<OrdenProduccion> resultado = repository
                 .findTopByLoteProduccionStartingWithOrderByLoteProduccionDesc("20231101");
 
         assertThat(resultado).isPresent();
-        assertThat(resultado.get().getLoteProduccion()).isEqualTo("20231101-003");
+        assertThat(resultado.get().getLoteProduccion()).isEqualTo("2023110102-BBB");
     }
 
     private OrdenProduccion crearOrden(String codigo, String lote) {


### PR DESCRIPTION
## Summary
- genera código de lote `aaaammddXX-ABC` para productos terminados
- asigna el lote al iniciar la primera etapa si la orden aún no lo tiene
- actualiza pruebas del repositorio para nuevo formato de lotes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4c5e90448333a934f90caa252c2d