### PR TITLE
feat: expose product category in production order DTO

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
@@ -18,6 +18,7 @@ public class OrdenProduccionResponseDTO {
     public BigDecimal unidadesProducidas;
     public String estado;
     public String nombreProducto;
+    public String categoriaProducto;
     public String unidadMedida;
     public String unidadMedidaSimbolo;
     public String unidadMedidaBaseSimbolo;

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
@@ -39,6 +39,11 @@ public class ProduccionMapper {
         dto.fechaUltimoCierre = entidad.getFechaUltimoCierre();
         dto.estado = entidad.getEstado().name();
         dto.nombreProducto = entidad.getProducto() != null ? entidad.getProducto().getNombre() : null;
+        dto.categoriaProducto = entidad.getProducto() != null
+                && entidad.getProducto().getCategoriaProducto() != null
+                && entidad.getProducto().getCategoriaProducto().getTipo() != null
+                ? entidad.getProducto().getCategoriaProducto().getTipo().name()
+                : null;
         dto.unidadMedida = entidad.getUnidadMedida() != null ? entidad.getUnidadMedida().getNombre() : null;
         dto.unidadMedidaSimbolo = entidad.getUnidadMedida() != null ? entidad.getUnidadMedida().getSimbolo() : null;
         dto.nombreResponsable = entidad.getResponsable() != null ? entidad.getResponsable().getNombreCompleto() : null;

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -200,6 +200,15 @@ class OrdenProduccionControllerTest {
 
     @Test
     @WithMockUser(authorities = {"ROL_JEFE_PRODUCCION"})
+    void obtenerOrdenIncluyeCategoriaProducto() throws Exception {
+        OrdenProduccion op = crearOrdenConProducto(10);
+        mockMvc.perform(get("/api/produccion/ordenes/" + op.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.categoriaProducto").value("PRODUCTO_TERMINADO"));
+    }
+
+    @Test
+    @WithMockUser(authorities = {"ROL_JEFE_PRODUCCION"})
     void finalizarOrden() throws Exception {
         OrdenProduccion op = crearOrdenConProducto(10);
         mockMvc.perform(put("/api/produccion/ordenes/" + op.getId() + "/finalizar")


### PR DESCRIPTION
## Summary
- include `categoriaProducto` field in production order responses
- map product category type in `ProduccionMapper`
- test retrieving order exposes `categoriaProducto`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc88125f6c83339c24565d6a3aec89