### PR TITLE
Propagar orden en movimientos desde solicitud

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -156,6 +156,14 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                         solicitud.getCantidad(), dto.cantidad());
             }
 
+            // Si la solicitud está vinculada a una orden de producción y el DTO no la
+            // proporciona explícitamente, se usa la de la solicitud. Esto garantiza que los
+            // movimientos ejecutados a partir de una solicitud queden asociados a la orden
+            // correspondiente para el cálculo de insumos consumidos.
+            if (ordenProduccion == null && solicitud.getOrdenProduccion() != null) {
+                ordenProduccion = solicitud.getOrdenProduccion();
+            }
+
             final Long userActualId = usuario.getId();
             Usuario responsable = solicitud.getUsuarioResponsable();
             Long responsableId = responsable != null ? responsable.getId() : null;


### PR DESCRIPTION
## Summary
- Asociar automáticamente la orden de producción al registrar movimientos basados en una solicitud
- Garantizar que el consumo de insumos se calcule correctamente para cada orden

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc937e9ed88333a78eed3e64fa9a4d