### PR TITLE
Filtrar consumos por detalle de movimiento

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -95,10 +95,10 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     Page<MovimientoInventario> findByOrdenProduccionId(Long ordenProduccionId, Pageable pageable);
 
-    @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m where m.ordenProduccion.id = :ordenId and m.producto.id = :productoId and m.tipoMovimiento = :tipo")
+    @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m where m.ordenProduccion.id = :ordenId and m.producto.id = :productoId and m.tipoMovimientoDetalle.id = :detalleId")
     BigDecimal sumaCantidadPorOrdenYProducto(@Param("ordenId") Long ordenId,
                                              @Param("productoId") Long productoId,
-                                             @Param("tipo") TipoMovimiento tipo);
+                                             @Param("detalleId") Long detalleId);
 
 }
 


### PR DESCRIPTION
## Summary
- Filtra la suma de consumos de inventario por orden y producto usando `tipoMovimientoDetalle` en lugar de `TipoMovimiento`.
- Ajusta `listarInsumos` para recuperar el detalle `SALIDA_PRODUCCION` y usar su id al consultar consumos.
- Añade prueba que verifica el uso del nuevo filtro de detalle en `listarInsumos`.

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bca8a79e8c8333bb845784bd2c17a1