### PR TITLE
Return updated order state when starting production stage

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -121,9 +121,13 @@ public class OrdenProduccionController {
 
     @PatchMapping("/{ordenId}/etapas/{etapaId}/iniciar")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_OPERARIO_PRODUCCION')")
-    public ResponseEntity<EtapaProduccionResponse> iniciarEtapa(@PathVariable Long ordenId, @PathVariable Long etapaId) {
+    public ResponseEntity<OrdenProduccionResponseDTO> iniciarEtapa(@PathVariable Long ordenId, @PathVariable Long etapaId) {
         Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
-        return ResponseEntity.ok(ProduccionMapper.toResponse(service.iniciarEtapa(ordenId, etapaId, usuario.getId())));
+        service.iniciarEtapa(ordenId, etapaId, usuario.getId());
+        return service.buscarPorId(ordenId)
+                .map(ProduccionMapper::toResponse)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @PatchMapping("/{ordenId}/etapas/{etapaId}/finalizar")


### PR DESCRIPTION
## Summary
- Update `OrdenProduccionController.iniciarEtapa` to fetch the order after stage start and return an `OrdenProduccionResponseDTO` with its current state.

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc049749c833381b7ef6e1e4c2992