### PR TITLE
feat(producción): consumo de insumos al iniciar etapa 1 (SALIDA_PRODUCCION) con idempotencia, FEFO y trazabilidad

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -100,5 +100,7 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
                                              @Param("productoId") Long productoId,
                                              @Param("detalleId") Long detalleId);
 
+    boolean existsByOrdenProduccionIdAndClasificacion(Long ordenProduccionId, ClasificacionMovimientoInventario clasificacion);
+
 }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -123,8 +123,7 @@ public class OrdenProduccionController {
     @PatchMapping("/{ordenId}/etapas/{etapaId}/iniciar")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_OPERARIO_PRODUCCION')")
     public ResponseEntity<OrdenProduccionResponseDTO> iniciarEtapa(@PathVariable Long ordenId, @PathVariable Long etapaId) {
-        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
-        service.iniciarEtapa(ordenId, etapaId, usuario.getId());
+        service.iniciarEtapa(ordenId, etapaId);
         return service.buscarPorId(ordenId)
                 .map(ProduccionMapper::toResponse)
                 .map(ResponseEntity::ok)

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -36,7 +36,7 @@ public interface OrdenProduccionService {
 
     void clonarEtapas(Long ordenId);
 
-    com.willyes.clemenintegra.produccion.model.EtapaProduccion iniciarEtapa(Long ordenId, Long etapaId, Long usuarioId);
+    com.willyes.clemenintegra.produccion.model.EtapaProduccion iniciarEtapa(Long ordenId, Long etapaId);
 
     com.willyes.clemenintegra.produccion.model.EtapaProduccion finalizarEtapa(Long ordenId, Long etapaId, Long usuarioId);
 


### PR DESCRIPTION
## Summary
- Consume BOM inputs when starting the first production stage, selecting FEFO lots and linking movements to the order and user
- Added repository check to ensure idempotent consumption for an order
- Updated tests for stage consumption, idempotence, and stock safeguards

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0501f51c83339cac9fc4ad097421