### PR TITLE
fix(inventarios): consumo SALIDA_PRODUCCION y validaciones

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerTest.java
@@ -1,0 +1,54 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MovimientoInventarioController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MovimientoInventarioControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    MovimientoInventarioService service;
+
+    @MockBean
+    ProductoRepository productoRepository;
+
+    @MockBean
+    LoteProductoRepository loteProductoRepository;
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    void registrarConClasificacionInvalida_devuelve400() throws Exception {
+        String json = """
+            {
+                "cantidad": 1,
+                "tipoMovimiento": "SALIDA",
+                "clasificacionMovimientoInventario": "SALIDAD_PRODUCCION",
+                "productoId": 1,
+                "loteProductoId": 1,
+                "almacenOrigenId": 1,
+                "tipoMovimientoDetalleId": 1
+            }
+            """;
+
+        mockMvc.perform(post("/api/movimientos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -20,6 +20,7 @@ import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.model.MotivoMovimiento;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.bom.model.DetalleFormula;
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
@@ -354,6 +355,8 @@ class OrdenProduccionServiceImplTest {
         assertEquals(BigDecimal.valueOf(2), movs.get(1).cantidad());
         assertTrue(movs.stream().allMatch(m -> m.ordenProduccionId().equals(1L)));
         assertTrue(movs.stream().allMatch(m -> m.usuarioId().equals(5L)));
+        assertTrue(movs.stream().allMatch(m -> m.tipoMovimiento() == TipoMovimiento.SALIDA));
+        assertTrue(movs.stream().allMatch(m -> m.clasificacionMovimientoInventario() == ClasificacionMovimientoInventario.SALIDA_PRODUCCION));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- validate SALIDA_PRODUCCION movements require tipoMovimiento=SALIDA
- add debug logs for movimiento requests and stock discounts
- cover SALIDA_PRODUCCION scenarios with unit and controller tests

## Testing
- `mvn -q test` *(fails: Network is unreachable during parent POM resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1c54ddd08333b5e03a4a5157db7b