### PR TITLE
Convertir ID de insumo a Long para búsquedas FIFO

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -528,7 +528,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 for (DetalleFormula insumo : formula.getDetalles()) {
                     Long insumoId = insumo.getInsumo().getId().longValue();
                     BigDecimal requerida = insumo.getCantidadNecesaria().multiply(orden.getCantidadProgramada());
-                    List<LoteProducto> lotes = loteProductoRepository.findDisponiblesFifo(insumo.getInsumo().getId());
+                    List<LoteProducto> lotes = loteProductoRepository.findDisponiblesFifo(
+                            insumo.getInsumo().getId().longValue());
                     BigDecimal disponible = lotes.stream()
                             .map(LoteProducto::getStockLote)
                             .reduce(BigDecimal.ZERO, BigDecimal::add);

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -340,8 +340,8 @@ class OrdenProduccionServiceImplTest {
                 .thenReturn(Optional.of(motivo));
         when(tipoMovimientoDetalleRepository.findByDescripcion("SALIDA_PRODUCCION"))
                 .thenReturn(Optional.of(detalle));
-        when(loteProductoRepository.findDisponiblesFifo(100)).thenReturn(List.of(lote1));
-        when(loteProductoRepository.findDisponiblesFifo(200)).thenReturn(List.of(lote2));
+        when(loteProductoRepository.findDisponiblesFifo(100L)).thenReturn(List.of(lote1));
+        when(loteProductoRepository.findDisponiblesFifo(200L)).thenReturn(List.of(lote2));
         when(movimientoInventarioService.registrarMovimiento(any())).thenReturn(new MovimientoInventarioResponseDTO());
         when(solicitudMovimientoRepository.findWithDetalles(1L, null, null, null)).thenReturn(List.of());
         when(etapaProduccionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -425,7 +425,7 @@ class OrdenProduccionServiceImplTest {
                 .thenReturn(Optional.of(motivo));
         when(tipoMovimientoDetalleRepository.findByDescripcion("SALIDA_PRODUCCION"))
                 .thenReturn(Optional.of(detalle));
-        when(loteProductoRepository.findDisponiblesFifo(100)).thenReturn(List.of(lote));
+        when(loteProductoRepository.findDisponiblesFifo(100L)).thenReturn(List.of(lote));
 
         assertThrows(ResponseStatusException.class, () -> service.iniciarEtapa(1L, 2L));
         verify(movimientoInventarioService, never()).registrarMovimiento(any());


### PR DESCRIPTION
## Summary
- Convertir los identificadores de insumos a `Long` al obtener lotes disponibles en OrdenProduccionServiceImpl.
- Actualizar stubs de tests para usar literales `Long` al mockear `findDisponiblesFifo`.

## Testing
- `mvn -q test` *(falla: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf277dbd008333821bc7310e553d6a