### PR TITLE
feat(inventarios/producción): reservas FEFO y lotes agotados

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/model/LoteProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/LoteProducto.java
@@ -41,6 +41,15 @@ public class LoteProducto {
     @Column(name = "stock_lote", nullable = false, precision = 10, scale = 2)
     private BigDecimal stockLote;
 
+    @Column(name = "agotado", nullable = false)
+    private boolean agotado = false;
+
+    @Column(name = "stock_reservado", nullable = false, precision = 18, scale = 6)
+    private BigDecimal stockReservado = BigDecimal.ZERO;
+
+    @Column(name = "fecha_agotado")
+    private LocalDateTime fechaAgotado;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "estado", nullable = false, length = 20)
     private EstadoLote estado;

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/enums/EstadoSolicitudMovimiento.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/enums/EstadoSolicitudMovimiento.java
@@ -4,5 +4,8 @@ public enum EstadoSolicitudMovimiento {
     PENDIENTE,
     AUTORIZADA,
     RECHAZADO,
-    EJECUTADA
+    EJECUTADA,
+    RESERVADA,
+    ATENDIDA,
+    CANCELADA
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventarioConsultaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventarioConsultaServiceImpl.java
@@ -40,7 +40,8 @@ public class InventarioConsultaServiceImpl implements InventarioConsultaService 
         }
 
         // CODEx: uso actual de la consulta FIFO disponible
-        List<LoteDisponibleDTO> lotesDisponibles = loteProductoRepository.findDisponiblesFifo(productoId)
+        List<LoteDisponibleDTO> lotesDisponibles = loteProductoRepository
+                .findDisponiblesFifo(productoId, List.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO))
                 .stream()
                 .map(lp -> LoteDisponibleDTO.builder()
                         .loteProductoId(lp.getId())

--- a/src/main/resources/db/migration/V20250908__lotes_agotado_reservado.sql
+++ b/src/main/resources/db/migration/V20250908__lotes_agotado_reservado.sql
@@ -1,0 +1,14 @@
+-- NUEVAS columnas para disponibilidad y rastro de agotamiento
+ALTER TABLE lotes_productos
+  ADD COLUMN agotado TINYINT(1) NOT NULL DEFAULT 0 AFTER stock_lote,
+  ADD COLUMN stock_reservado DECIMAL(18,6) NOT NULL DEFAULT 0 AFTER agotado,
+  ADD COLUMN fecha_agotado DATETIME NULL AFTER stock_reservado;
+
+-- Índice para FEFO eficiente
+CREATE INDEX idx_fefo_disponibles
+  ON lotes_productos (producto_id, estado, fecha_vencimiento, agotado, stock_lote, stock_reservado);
+
+-- Backfill: marcar agotados los lotes sin stock
+UPDATE lotes_productos
+SET agotado = 1, fecha_agotado = IFNULL(fecha_agotado, NOW())
+WHERE stock_lote <= 0;

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -340,8 +340,6 @@ class OrdenProduccionServiceImplTest {
                 .thenReturn(Optional.of(motivo));
         when(tipoMovimientoDetalleRepository.findByDescripcion("SALIDA_PRODUCCION"))
                 .thenReturn(Optional.of(detalle));
-        when(loteProductoRepository.findDisponiblesFifo(100L)).thenReturn(List.of(lote1));
-        when(loteProductoRepository.findDisponiblesFifo(200L)).thenReturn(List.of(lote2));
         when(movimientoInventarioService.registrarMovimiento(any())).thenReturn(new MovimientoInventarioResponseDTO());
         when(solicitudMovimientoRepository.findWithDetalles(1L, null, null, null)).thenReturn(List.of());
         when(etapaProduccionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -425,7 +423,6 @@ class OrdenProduccionServiceImplTest {
                 .thenReturn(Optional.of(motivo));
         when(tipoMovimientoDetalleRepository.findByDescripcion("SALIDA_PRODUCCION"))
                 .thenReturn(Optional.of(detalle));
-        when(loteProductoRepository.findDisponiblesFifo(100L)).thenReturn(List.of(lote));
 
         assertThrows(ResponseStatusException.class, () -> service.iniciarEtapa(1L, 2L));
         verify(movimientoInventarioService, never()).registrarMovimiento(any());


### PR DESCRIPTION
## Summary
- track exhausted inventory and reservations per lot
- enforce FEFO pick excluding agotados/reservados
- reserve inputs on OP creation and consume from reservations on stage start

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf38a7cc6c8333ab87a5c26c188a43