### PR TITLE
fix: remove invalid variable from debug log

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -492,7 +492,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "FORMULA_NO_ENCONTRADA"));
 
         Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
-        log.debug("OP-ETAPA iniciar ordenId={}, secuencia={}, user={}", ordenId, etapa.getSecuencia(), usuario.getId());
+        log.debug("OP-reserva iniciar ordenId={}, user={}", ordenId, usuario.getId());
 
         MotivoMovimiento motivo = motivoMovimientoRepository
                 .findByMotivo(ClasificacionMovimientoInventario.SALIDA_PRODUCCION)


### PR DESCRIPTION
## Summary
- correct debug log in reservarInsumosParaOP to avoid referencing undefined variable

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf45b8bbfc83338602e61db5d1f43a