### PR TITLE
feat: ensure transactional availability query

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventarioConsultaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventarioConsultaServiceImpl.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ public class InventarioConsultaServiceImpl implements InventarioConsultaService 
     private final ProductoService productoService;
 
     @Override
+    @Transactional(readOnly = true)
     public DisponibilidadProductoResponseDTO obtenerDisponibilidadPorProducto(Long productoId) {
         Producto producto = productoService.findById(productoId);
 


### PR DESCRIPTION
## Summary
- mark `InventarioConsultaServiceImpl.obtenerDisponibilidadPorProducto` as `@Transactional(readOnly = true)`
- import Spring's `Transactional` annotation
- verified other `findDisponiblesFifo` usages run inside transactions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5263c090833383ec792008af5f87