### PR TITLE
feat: reserva FEFO multi-lote con encabezado único

### DIFF
--- a/DIAGNOSTICO_STOCK.md
+++ b/DIAGNOSTICO_STOCK.md
@@ -41,5 +41,17 @@ GROUP BY p.id;
 - Índices sugeridos:
   - `lotes_productos(productos_id, estado, agotado)`
   - `lotes_productos(productos_id, estado, agotado, fecha_vencimiento)` para consultas por vencimiento
+  - `lotes_productos(productos_id, estado, agotado, fecha_vencimiento, fecha_fabricacion, id)` para selección FEFO
   - `lotes_productos(productos_id, almacenes_id)` para cortes por almacén
+
+## Índice FEFO y escala
+
+Para optimizar la asignación multi-lote se recomienda mantener un índice compuesto que respete el orden FEFO:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_lotes_productos_fefo
+ON lotes_productos (productos_id, estado, agotado, fecha_vencimiento, fecha_fabricacion, id);
+```
+
+Las reservas consumen cantidades con la misma escala definida en `stock_lote` y `stock_reservado` (DECIMAL), sin redondeos adicionales.
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/SolicitudMovimiento.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/SolicitudMovimiento.java
@@ -9,6 +9,8 @@ import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "solicitudes_movimiento")
@@ -92,6 +94,10 @@ public class SolicitudMovimiento {
     private LocalDateTime fechaResolucion;
 
     private String observaciones;
+
+    @OneToMany(mappedBy = "solicitudMovimiento", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<SolicitudMovimientoDetalle> detalles = new ArrayList<>();
 
     @PrePersist
     public void prePersist() {

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/SolicitudMovimientoDetalle.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/SolicitudMovimientoDetalle.java
@@ -1,0 +1,41 @@
+package com.willyes.clemenintegra.inventario.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "solicitudes_movimiento_detalle")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class SolicitudMovimientoDetalle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "solicitud_movimiento_id", nullable = false)
+    private SolicitudMovimiento solicitudMovimiento;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lote_id", nullable = false)
+    private LoteProducto lote;
+
+    @Column(nullable = false, precision = 18, scale = 6)
+    private BigDecimal cantidad;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "almacen_origen_id")
+    private Almacen almacenOrigen;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "almacen_destino_id")
+    private Almacen almacenDestino;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoDetalleRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoDetalleRepository.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SolicitudMovimientoDetalleRepository extends JpaRepository<SolicitudMovimientoDetalle, Long> {
+}
+

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
@@ -26,6 +26,10 @@ public interface SolicitudMovimientoRepository extends JpaRepository<SolicitudMo
             "left join fetch s.almacenDestino ad " +
             "left join fetch s.usuarioSolicitante us " +
             "left join fetch s.ordenProduccion op " +
+            "left join fetch s.detalles det " +
+            "left join fetch det.lote detLote " +
+            "left join fetch det.almacenOrigen detAo " +
+            "left join fetch det.almacenDestino detAd " +
             "where (:ordenId is null or op.id = :ordenId) " +
             "and (:estados is null or s.estado in :estados) " +
             "and (:desde is null or s.fechaSolicitud >= :desde) " +
@@ -46,6 +50,10 @@ public interface SolicitudMovimientoRepository extends JpaRepository<SolicitudMo
             "left join fetch s.ordenProduccion op " +
             "left join fetch s.motivoMovimiento mm " +
             "left join fetch s.tipoMovimientoDetalle tmd " +
+            "left join fetch s.detalles det " +
+            "left join fetch det.lote detLote " +
+            "left join fetch det.almacenOrigen detAo " +
+            "left join fetch det.almacenDestino detAd " +
             "where s.id = :id")
     java.util.Optional<SolicitudMovimiento> findWithDetalles(@Param("id") Long id);
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventarioConsultaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventarioConsultaServiceImpl.java
@@ -43,7 +43,7 @@ public class InventarioConsultaServiceImpl implements InventarioConsultaService 
 
         // CODEx: uso actual de la consulta FIFO disponible
         List<LoteDisponibleDTO> lotesDisponibles = loteProductoRepository
-                .findDisponiblesFifo(productoId, List.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO))
+                .findDisponiblesFefo(productoId, List.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO), null)
                 .stream()
                 .map(lp -> LoteDisponibleDTO.builder()
                         .loteProductoId(lp.getId())

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -144,7 +144,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
             Long solicitudAlmacenOrigenId = solicitud.getAlmacenOrigen() != null ? Long.valueOf(solicitud.getAlmacenOrigen().getId()) : null;
             Long dtoAlmacenOrigenId = dto.almacenOrigenId() != null ? dto.almacenOrigenId().longValue() : null;
-            if (!Objects.equals(solicitudAlmacenOrigenId, dtoAlmacenOrigenId)) {
+            if (solicitudAlmacenOrigenId != null && !Objects.equals(solicitudAlmacenOrigenId, dtoAlmacenOrigenId)) {
                 log.warn("MISMATCH_ALMACEN_ORIGEN_ID: esperado={}, recibido={}", solicitudAlmacenOrigenId, dto.almacenOrigenId());
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MISMATCH_ALMACEN_ORIGEN_ID");
             }


### PR DESCRIPTION
## Summary
- asignar insumos por lotes siguiendo FEFO con bloqueo pesimista y actualización atómica
- registrar un encabezado de solicitud de movimiento con detalles por lote
- permitir consumo de reservas al iniciar la primera etapa
- documentar índice FEFO recomendado y escala de reserva

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c18cc2e1208333b732363bbb7e5336