### PR TITLE
Derivar almacén y estado de lote de PT según análisis

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,3 +35,6 @@ spring.web.cors.allowed-methods=GET,POST,PUT,DELETE,PATCH,OPTIONS
 spring.web.cors.allowed-headers=*
 spring.web.cors.exposed-headers=*
 spring.web.cors.allow-credentials=true
+
+inventory.almacen.pt.id=2
+inventory.almacen.cuarentena.id=7

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -8,3 +8,6 @@ spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 spring.flyway.enabled=false
+
+inventory.almacen.pt.id=2
+inventory.almacen.cuarentena.id=7


### PR DESCRIPTION
## Resumen
- Ajusta el cierre de órdenes de producción para asignar almacén y estado del lote de PT según el tipo de análisis del producto.
- Configura los IDs de almacén de PT y Cuarentena vía propiedades externas.
- Actualiza pruebas y configuración para reflejar los nuevos parámetros.

## Pruebas
- `mvn -q test` *(falló: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c19caa77808333ada76a4da802a6f2