### PR TITLE
feat: log entrada movimiento de PT

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -102,5 +102,11 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     boolean existsByOrdenProduccionIdAndClasificacion(Long ordenProduccionId, ClasificacionMovimientoInventario clasificacion);
 
+    boolean existsByTipoMovimientoAndProductoIdAndLoteIdAndOrdenProduccionId(
+            TipoMovimiento tipoMovimiento,
+            Long productoId,
+            Long loteId,
+            Long ordenProduccionId);
+
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,5 @@ spring.web.cors.allow-credentials=true
 
 inventory.almacen.pt.id=2
 inventory.almacen.cuarentena.id=7
+inventory.motivo.entradaPt=ENTRADA_PRODUCTO_TERMINADO
+inventory.tipoDetalle.entradaId=1


### PR DESCRIPTION
## Summary
- configura ids para motivo y tipo detalle de entradas de PT
- registra movimiento de entrada de producto terminado al cerrar la OP
- agrega validaciones de idempotencia y pruebas

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c19f3e1a5c833391a54c6bd77b51b8