### PR TITLE
feat: initialize PT lot with validations

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/model/LoteProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/LoteProducto.java
@@ -41,9 +41,11 @@ public class LoteProducto {
     @Column(name = "stock_lote", nullable = false, precision = 10, scale = 2)
     private BigDecimal stockLote;
 
+    @Builder.Default
     @Column(name = "agotado", nullable = false)
     private boolean agotado = false;
 
+    @Builder.Default
     @Column(name = "stock_reservado", nullable = false, precision = 18, scale = 6)
     private BigDecimal stockReservado = BigDecimal.ZERO;
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long>, JpaSpecificationExecutor<LoteProducto> {
 
     Optional<LoteProducto> findByCodigoLoteAndProductoId(String codigoLote, Long productoId);
+    Optional<LoteProducto> findByOrdenProduccionIdAndProductoId(Long ordenProduccionId, Long productoId);
     boolean existsByProducto(Producto producto);
     boolean existsByCodigoLote(String codigoLote);
     List<LoteProducto> findByEstado(EstadoLote estado);

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionRequestDTO.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -16,6 +17,10 @@ public class CierreProduccionRequestDTO {
     private BigDecimal cantidad;
     @NotNull
     private TipoCierre tipo;
+    private String codigoLote;
+    @NotNull
+    private LocalDateTime fechaFabricacion;
+    private LocalDateTime fechaVencimiento;
     private Boolean cerradaIncompleta;
     private String turno;
     private String observacion;

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -138,6 +138,7 @@ class OrdenProduccionServiceImplTest {
         CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
                 .cantidad(BigDecimal.ONE)
                 .tipo(TipoCierre.PARCIAL)
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
                 .build();
         assertThrows(ResponseStatusException.class, () -> service.registrarCierre(1L, dto));
     }
@@ -153,6 +154,7 @@ class OrdenProduccionServiceImplTest {
         CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
                 .cantidad(BigDecimal.ONE)
                 .tipo(TipoCierre.PARCIAL)
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
                 .build();
         assertThrows(ResponseStatusException.class, () -> service.registrarCierre(1L, dto));
     }
@@ -175,7 +177,7 @@ class OrdenProduccionServiceImplTest {
         when(repository.save(any())).thenReturn(orden);
         when(almacenRepository.findById(2L)).thenReturn(Optional.of(Almacen.builder().id(2L).build()));
         when(almacenRepository.findById(7L)).thenReturn(Optional.of(Almacen.builder().id(7L).build()));
-        when(loteProductoRepository.findByCodigoLoteAndProductoId(anyString(), anyLong()))
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(anyLong(), anyLong()))
                 .thenReturn(Optional.of(LoteProducto.builder()
                         .id(1L)
                         .almacen(Almacen.builder().id(2L).build())
@@ -214,6 +216,7 @@ class OrdenProduccionServiceImplTest {
         CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
                 .cantidad(BigDecimal.ONE)
                 .tipo(TipoCierre.PARCIAL)
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
                 .observacion("obs")
                 .build();
 
@@ -243,7 +246,7 @@ class OrdenProduccionServiceImplTest {
         when(cierreProduccionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(almacenRepository.findById(2L)).thenReturn(Optional.of(Almacen.builder().id(2L).build()));
         when(almacenRepository.findById(7L)).thenReturn(Optional.of(Almacen.builder().id(7L).build()));
-        when(loteProductoRepository.findByCodigoLoteAndProductoId(anyString(), anyLong()))
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(anyLong(), anyLong()))
                 .thenReturn(Optional.of(LoteProducto.builder()
                         .id(1L)
                         .almacen(Almacen.builder().id(2L).build())
@@ -279,7 +282,7 @@ class OrdenProduccionServiceImplTest {
         when(cierreProduccionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(almacenRepository.findById(2L)).thenReturn(Optional.of(Almacen.builder().id(2L).build()));
         when(almacenRepository.findById(7L)).thenReturn(Optional.of(Almacen.builder().id(7L).build()));
-        when(loteProductoRepository.findByCodigoLoteAndProductoId(anyString(), anyLong()))
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(anyLong(), anyLong()))
                 .thenReturn(Optional.of(LoteProducto.builder()
                         .id(1L)
                         .almacen(Almacen.builder().id(2L).build())
@@ -291,6 +294,7 @@ class OrdenProduccionServiceImplTest {
         CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
                 .cantidad(BigDecimal.valueOf(5))
                 .tipo(TipoCierre.TOTAL)
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
                 .cerradaIncompleta(true)
                 .build();
 
@@ -322,7 +326,7 @@ class OrdenProduccionServiceImplTest {
                 .estado(EstadoLote.DISPONIBLE)
                 .stockLote(BigDecimal.ZERO)
                 .build();
-        when(loteProductoRepository.findByCodigoLoteAndProductoId(anyString(), anyLong()))
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(anyLong(), anyLong()))
                 .thenReturn(Optional.of(lote));
         when(loteProductoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(movimientoInventarioRepository.existsByTipoMovimientoAndProductoIdAndLoteIdAndOrdenProduccionId(
@@ -337,6 +341,7 @@ class OrdenProduccionServiceImplTest {
         CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
                 .cantidad(BigDecimal.ONE)
                 .tipo(TipoCierre.PARCIAL)
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
                 .build();
 
         service.registrarCierre(1L, dto);
@@ -377,7 +382,7 @@ class OrdenProduccionServiceImplTest {
                 .estado(EstadoLote.DISPONIBLE)
                 .stockLote(BigDecimal.ZERO)
                 .build();
-        when(loteProductoRepository.findByCodigoLoteAndProductoId(anyString(), anyLong()))
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(anyLong(), anyLong()))
                 .thenReturn(Optional.of(lote));
         when(loteProductoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(movimientoInventarioRepository.existsByTipoMovimientoAndProductoIdAndLoteIdAndOrdenProduccionId(
@@ -391,6 +396,7 @@ class OrdenProduccionServiceImplTest {
         CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
                 .cantidad(BigDecimal.ONE)
                 .tipo(TipoCierre.PARCIAL)
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
                 .build();
 
         ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.registrarCierre(1L, dto));


### PR DESCRIPTION
## Summary
- ensure LoteProducto builder defaults for stockReservado and agotado
- enrich cierre registration to create/update PT lot with validation, code generation, and logging
- extend CierreProduccionRequestDTO with lot fields
- adjust repository and tests for new lot lookup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a1639874833395392c71d42f9719