### PR TITLE
Ensure idempotent PT entry movements

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -102,6 +102,13 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     boolean existsByOrdenProduccionIdAndClasificacion(Long ordenProduccionId, ClasificacionMovimientoInventario clasificacion);
 
+    java.util.Optional<MovimientoInventario> findByTipoMovimientoAndMotivoMovimientoIdAndOrdenProduccionIdAndProductoIdAndLoteId(
+            TipoMovimiento tipoMovimiento,
+            Long motivoMovimientoId,
+            Long ordenProduccionId,
+            Long productoId,
+            Long loteId);
+
     boolean existsByTipoMovimientoAndProductoIdAndLoteIdAndOrdenProduccionId(
             TipoMovimiento tipoMovimiento,
             Long productoId,

--- a/src/main/resources/db/migration/V20250909__movimientos_inventario_pt_unique.sql
+++ b/src/main/resources/db/migration/V20250909__movimientos_inventario_pt_unique.sql
@@ -1,0 +1,3 @@
+-- Unique index to prevent duplicate PT entry movements
+ALTER TABLE movimientos_inventario
+    ADD CONSTRAINT uk_mov_inv_entrada_pt UNIQUE (tipo_mov, motivos_movimiento_id, orden_produccion_id, productos_id, lotes_productos_id);


### PR DESCRIPTION
## Summary
- Guard against duplicate PT entry movements using a repository pre-check and conflict handling
- Add unique database constraint for PT entry key
- Extend unit tests for idempotent success and conflict scenarios

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.willyes.clemenintegra:inventario:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a4d0f0d48333b9e9f1abebf7bf5c