### PR TITLE
feat: validar reservas pendientes antes del cierre de OP

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -122,5 +122,19 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
             Long almacenDestinoId,
             ClasificacionMovimientoInventario clasificacion);
 
+    @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m " +
+            "where m.solicitudMovimiento.id = :solicitudId " +
+            "and m.producto.id = :productoId " +
+            "and m.lote.id = :loteId " +
+            "and m.tipoMovimiento = :tipoMov " +
+            "and (:tipoDetalleId is null or m.tipoMovimientoDetalle.id = :tipoDetalleId) " +
+            "and (:motivoId is null or m.motivoMovimiento.id = :motivoId)")
+    BigDecimal sumaPorSolicitudYTipo(@Param("solicitudId") Long solicitudId,
+                                     @Param("productoId") Long productoId,
+                                     @Param("loteId") Long loteId,
+                                     @Param("tipoMov") TipoMovimiento tipoMov,
+                                     @Param("tipoDetalleId") Long tipoDetalleId,
+                                     @Param("motivoId") Long motivoId);
+
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,3 +47,7 @@ inventory.mov.clasificacion.liberacionCalidad=LIBERACION_CALIDAD
 inventory.almacen.obsoletos.id=3
 inventory.motivo.rechazoCalidad=TRANSFERENCIA_GENERAL
 inventory.mov.clasificacion.rechazoCalidad=RECHAZO_CALIDAD
+inventory.tipoDetalle.salidaId=4
+inventory.motivo.devolucionDesdeProduccion=DEVOLUCION_DESDE_PRODUCCION
+inventory.solicitud.estados.pendientes=PENDIENTE,AUTORIZADA,RESERVADA
+inventory.solicitud.estados.concluyentes=ATENDIDA,EJECUTADA,CANCELADA,RECHAZADO


### PR DESCRIPTION
## Summary
- prevent closing production orders while linked inventory requests have unfulfilled reservations
- add query helper to aggregate movements by request and update configuration properties
- cover pending-reservation scenario with unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c1aac20a50833385d457ec675695d2