### PR TITLE
Handle pending reservation error with ProblemDetail

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -63,6 +63,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.ErrorResponseException;
+import org.springframework.http.ProblemDetail;
 import org.springframework.core.env.Environment;
 
 import java.math.BigDecimal;
@@ -486,9 +488,11 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             }
 
             if (!pendientes.isEmpty()) {
-                Map<String, Object> body = Map.of("detalles", pendientes.stream().limit(20).toList());
                 log.warn("OP-cierre reservas pendientes op={}, detallesPendientes={}", orden.getId(), pendientes.size());
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVAS_PENDIENTES_OP", null, body);
+                ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "RESERVAS_PENDIENTES_OP");
+                problem.setProperty("detalles", pendientes.stream().limit(20).toList());
+                throw new ErrorResponseException(HttpStatus.UNPROCESSABLE_ENTITY, problem, null);
             }
 
             if (solicitudesPend.isEmpty()) {


### PR DESCRIPTION
## Summary
- replace deprecated ResponseStatusException constructor in `OrdenProduccionServiceImpl`
- use ProblemDetail and ErrorResponseException to include pending reservations details

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ba78bb9c83339fb17f008ee9529f