### PR TITLE
feat: exigir orden producción en entrada PT y centralizar catálogos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/config/InventoryCatalogProperties.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/config/InventoryCatalogProperties.java
@@ -12,12 +12,29 @@ public class InventoryCatalogProperties {
     private final Almacen almacen = new Almacen();
     private final Motivo motivo = new Motivo();
     private final TipoDetalle tipoDetalle = new TipoDetalle();
+    private final Produccion produccion = new Produccion();
 
     @Data
     public static class Almacen {
         private final IdHolder pt = new IdHolder();
         private final IdHolder cuarentena = new IdHolder();
         private final IdHolder obsoletos = new IdHolder();
+    }
+
+    @Data
+    public static class Produccion {
+        private final AlmacenProduccion almacen = new AlmacenProduccion();
+    }
+
+    @Data
+    public static class AlmacenProduccion {
+        private final Origen origen = new Origen();
+    }
+
+    @Data
+    public static class Origen {
+        private Long bodegaPrincipal;
+        private Long preBodegaProduccion;
     }
 
     @Data

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogHealthIndicator.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogHealthIndicator.java
@@ -26,6 +26,8 @@ public class InventoryCatalogHealthIndicator implements HealthIndicator {
         details.put("almacenPt", checkAlmacen(resolver.getAlmacenPtId()));
         details.put("almacenCuarentena", checkAlmacen(resolver.getAlmacenCuarentenaId()));
         details.put("almacenObsoletos", checkAlmacen(resolver.getAlmacenObsoletosId()));
+        details.put("almacenBodegaPrincipal", checkAlmacen(resolver.getAlmacenBodegaPrincipalId()));
+        details.put("almacenPreBodegaProduccion", checkAlmacen(resolver.getAlmacenPreBodegaProduccionId()));
 
         details.put("motivoEntradaPt", checkMotivo(resolver.getMotivoIdEntradaPt()));
         details.put("motivoTransferenciaCalidad", checkMotivo(resolver.getMotivoIdTransferenciaCalidad()));

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogResolver.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogResolver.java
@@ -23,6 +23,8 @@ public class InventoryCatalogResolver {
     private Long almacenPtId;
     private Long almacenCuarentenaId;
     private Long almacenObsoletosId;
+    private Long almacenBodegaPrincipalId;
+    private Long almacenPreBodegaProduccionId;
 
     private Long motivoEntradaPtId;
     private Long motivoTransferenciaCalidadId;
@@ -38,6 +40,8 @@ public class InventoryCatalogResolver {
         almacenPtId = validateAlmacen(properties.getAlmacen().getPt().getId());
         almacenCuarentenaId = validateAlmacen(properties.getAlmacen().getCuarentena().getId());
         almacenObsoletosId = validateAlmacen(properties.getAlmacen().getObsoletos().getId());
+        almacenBodegaPrincipalId = validateAlmacen(properties.getProduccion().getAlmacen().getOrigen().getBodegaPrincipal());
+        almacenPreBodegaProduccionId = validateAlmacen(properties.getProduccion().getAlmacen().getOrigen().getPreBodegaProduccion());
 
         motivoEntradaPtId = resolveMotivo(properties.getMotivo().getEntradaPt());
         motivoTransferenciaCalidadId = resolveMotivo(properties.getMotivo().getTransferenciaCalidad());
@@ -51,8 +55,8 @@ public class InventoryCatalogResolver {
         tipoDetalleTransferenciaId = validateTipoDetalle(properties.getTipoDetalle().getTransferenciaId());
         tipoDetalleSalidaId = validateTipoDetalle(properties.getTipoDetalle().getSalidaId());
 
-        log.info("Inventory catalogs loaded pt={} cuarentena={} obsoletos={} motivoEntradaPt={} motivoTransferenciaCalidad={} motivoDevolucion={} motivoAjuste={} tipoDetalleEntrada={} tipoDetalleTransferencia={} tipoDetalleSalida={}",
-                almacenPtId, almacenCuarentenaId, almacenObsoletosId,
+        log.info("Inventory catalogs loaded pt={} cuarentena={} obsoletos={} bodegaPrincipal={} preBodegaProduccion={} motivoEntradaPt={} motivoTransferenciaCalidad={} motivoDevolucion={} motivoAjuste={} tipoDetalleEntrada={} tipoDetalleTransferencia={} tipoDetalleSalida={}",
+                almacenPtId, almacenCuarentenaId, almacenObsoletosId, almacenBodegaPrincipalId, almacenPreBodegaProduccionId,
                 motivoEntradaPtId, motivoTransferenciaCalidadId, motivoDevolucionDesdeProduccionId,
                 motivoAjusteRechazoId, tipoDetalleEntradaId, tipoDetalleTransferenciaId, tipoDetalleSalidaId);
     }
@@ -85,6 +89,8 @@ public class InventoryCatalogResolver {
     public Long getAlmacenPtId() { return almacenPtId; }
     public Long getAlmacenCuarentenaId() { return almacenCuarentenaId; }
     public Long getAlmacenObsoletosId() { return almacenObsoletosId; }
+    public Long getAlmacenBodegaPrincipalId() { return almacenBodegaPrincipalId; }
+    public Long getAlmacenPreBodegaProduccionId() { return almacenPreBodegaProduccionId; }
 
     public Long getMotivoIdEntradaPt() { return motivoEntradaPtId; }
     public Long getMotivoIdTransferenciaCalidad() { return motivoTransferenciaCalidadId; }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -321,9 +321,9 @@ public class LoteProductoServiceImpl implements LoteProductoService {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CLASIFICACION_RECHAZO_INVALIDA");
         }
 
-        Long motivoId = catalogResolver.getMotivoIdTransferenciaCalidad();
+        Long motivoId = catalogResolver.getMotivoIdAjusteRechazo();
         MotivoMovimiento motivo = motivoMovimientoRepository.findById(motivoId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MOTIVO_TRANSFERENCIA_INEXISTENTE"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MOTIVO_AJUSTE_RECHAZO_INEXISTENTE"));
         Long tipoDetalleTransferenciaId = catalogResolver.getTipoDetalleTransferenciaId();
         TipoMovimientoDetalle tipoDetalle = tipoMovimientoDetalleRepository.findById(tipoDetalleTransferenciaId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "TIPO_DETALLE_TRANSFERENCIA_INEXISTENTE"));

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -74,6 +74,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     private final MovimientoInventarioMapper mapper;
     private final UsuarioService usuarioService;
     private final SolicitudMovimientoRepository solicitudMovimientoRepository;
+    private final InventoryCatalogResolver catalogResolver;
 
     @Resource
     private final EntityManager entityManager;
@@ -90,6 +91,13 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
         if (dto.tipoMovimientoDetalleId() == null) {
             throw new IllegalArgumentException("tipo_movimiento_detalle_id es obligatorio"); // [Codex Edit]
+        }
+
+        if (dto.tipoMovimiento() == TipoMovimiento.ENTRADA
+                && Objects.equals(dto.motivoMovimientoId(), catalogResolver.getMotivoIdEntradaPt())
+                && dto.ordenProduccionId() == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "ENTRADA_PT_REQUIERE_ORDEN_PRODUCCION_ID");
         }
 
         MovimientoInventario movimiento = mapper.toEntity(dto);

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -124,15 +124,10 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     }
 
     private List<Long> obtenerAlmacenesOrigen(Producto insumo) {
-        if (insumo == null || insumo.getCategoriaProducto() == null
-                || insumo.getCategoriaProducto().getTipo() == null) {
-            return List.of();
-        }
-        return switch (insumo.getCategoriaProducto().getTipo()) {
-            case MATERIA_PRIMA -> List.of(1L);
-            case MATERIAL_EMPAQUE -> List.of(5L);
-            default -> List.of();
-        };
+        return List.of(
+                catalogResolver.getAlmacenBodegaPrincipalId(),
+                catalogResolver.getAlmacenPreBodegaProduccionId()
+        );
     }
 
     private String generarCodigoLote(Producto producto) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,5 +49,7 @@ inventory.mov.clasificacion.rechazoCalidad=RECHAZO_CALIDAD
 inventory.tipoDetalle.salidaId=8
 inventory.motivo.devolucionDesdeProduccion=DEVOLUCION_DESDE_PRODUCCION
 inventory.motivo.ajusteRechazo=AJUSTE_NEGATIVO
+inventory.produccion.almacen.origen.bodegaPrincipal=1
+inventory.produccion.almacen.origen.preBodegaProduccion=5
 inventory.solicitud.estados.pendientes=PENDIENTE,AUTORIZADA,RESERVADA
 inventory.solicitud.estados.concluyentes=ATENDIDA,EJECUTADA,CANCELADA,RECHAZADO

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -144,6 +144,8 @@ class OrdenProduccionServiceImplTest {
         when(catalogResolver.getTipoDetalleTransferenciaId()).thenReturn(null);
         when(catalogResolver.getAlmacenObsoletosId()).thenReturn(3L);
         when(catalogResolver.getMotivoIdTransferenciaCalidad()).thenReturn(12L);
+        when(catalogResolver.getAlmacenBodegaPrincipalId()).thenReturn(1L);
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(5L);
 
         MotivoMovimiento motivoDev = new MotivoMovimiento();
         motivoDev.setId(30L);


### PR DESCRIPTION
## Summary
- validar rechazo QA usando motivo `ajusteRechazo`
- requerir `orden_produccion_id` para movimientos de entrada de PT
- obtener almacenes origen de producción desde catálogos configurables

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c3dd52008333a084a397b8e8155f