### PR TITLE
Add QA release, rejection and default tests

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/calidad/service/LoteProductoCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/LoteProductoCalidadServiceImplTest.java
@@ -1,0 +1,244 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.*;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.inventario.service.LoteProductoServiceImpl;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoteProductoCalidadServiceImplTest {
+
+    @Mock LoteProductoRepository loteRepo;
+    @Mock LoteProductoRepository loteProductoRepository;
+    @Mock ProductoRepository productoRepository;
+    @Mock AlmacenRepository almacenRepository;
+    @Mock LoteProductoMapper loteProductoMapper;
+    @Mock UsuarioService usuarioService;
+    @Mock EvaluacionCalidadRepository evaluacionRepository;
+    @Mock InventoryCatalogResolver catalogResolver;
+    @Mock MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock StockQueryService stockQueryService;
+
+    LoteProductoServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LoteProductoServiceImpl(
+                loteRepo,
+                productoRepository,
+                almacenRepository,
+                loteProductoMapper,
+                usuarioService,
+                loteProductoRepository,
+                evaluacionRepository,
+                stockQueryService,
+                movimientoInventarioRepository,
+                motivoMovimientoRepository,
+                tipoMovimientoDetalleRepository,
+                catalogResolver
+        );
+        ReflectionTestUtils.setField(service, "estadoLiberadoConf", "DISPONIBLE");
+        ReflectionTestUtils.setField(service, "clasificacionLiberacionConf", "LIBERACION_CALIDAD");
+        ReflectionTestUtils.setField(service, "clasificacionRechazoCalidad", "RECHAZO_CALIDAD");
+        when(loteProductoMapper.toResponseDTO(any())).thenAnswer(inv -> {
+            LoteProducto l = inv.getArgument(0);
+            LoteProductoResponseDTO dto = new LoteProductoResponseDTO();
+            dto.setId(l.getId());
+            dto.setEstado(l.getEstado());
+            dto.setAlmacenId(l.getAlmacen().getId());
+            return dto;
+        });
+    }
+
+    private LoteProducto buildLote(EstadoLote estado, Almacen almacen, Producto producto) {
+        return LoteProducto.builder()
+                .id(1L)
+                .codigoLote("L1")
+                .producto(producto)
+                .almacen(almacen)
+                .estado(estado)
+                .stockLote(BigDecimal.ONE)
+                .build();
+    }
+
+    @Test
+    void liberacionCambiaEstadoYCreaTransferencia() {
+        Usuario jefe = new Usuario(); jefe.setRol(RolUsuario.ROL_JEFE_CALIDAD); jefe.setId(10L);
+        Producto producto = Producto.builder().id(1).tipoAnalisisCalidad(TipoAnalisisCalidad.AMBOS).build();
+        Almacen cuarentena = Almacen.builder().id(7L).build();
+        Almacen pt = Almacen.builder().id(2L).build();
+        LoteProducto lote = buildLote(EstadoLote.EN_CUARENTENA, cuarentena, producto);
+
+        when(loteProductoRepository.findByIdForUpdate(1L)).thenReturn(java.util.Optional.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(1L)).thenReturn(List.of(
+                EvaluacionCalidad.builder().tipoEvaluacion(TipoEvaluacion.FISICO_QUIMICO).resultado(ResultadoEvaluacion.CONFORME).build(),
+                EvaluacionCalidad.builder().tipoEvaluacion(TipoEvaluacion.MICROBIOLOGICO).resultado(ResultadoEvaluacion.CONFORME).build()
+        ));
+        when(catalogResolver.getMotivoIdTransferenciaCalidad()).thenReturn(12L);
+        when(motivoMovimientoRepository.findById(12L)).thenReturn(java.util.Optional.of(new MotivoMovimiento()));
+        when(catalogResolver.getTipoDetalleTransferenciaId()).thenReturn(9L);
+        when(tipoMovimientoDetalleRepository.findById(9L)).thenReturn(java.util.Optional.of(new TipoMovimientoDetalle()));
+        when(catalogResolver.getAlmacenPtId()).thenReturn(2L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(almacenRepository.findById(2L)).thenReturn(java.util.Optional.of(pt));
+        when(movimientoInventarioRepository.existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(any(), anyLong(), anyLong(), anyLong(), any())).thenReturn(false);
+        when(movimientoInventarioRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        LoteProductoResponseDTO result = service.liberarLotePorCalidad(1L, jefe);
+
+        assertEquals(EstadoLote.DISPONIBLE, lote.getEstado());
+        assertEquals(pt.getId(), lote.getAlmacen().getId());
+        assertEquals(EstadoLote.DISPONIBLE, result.getEstado());
+        ArgumentCaptor<MovimientoInventario> movCaptor = ArgumentCaptor.forClass(MovimientoInventario.class);
+        verify(movimientoInventarioRepository).save(movCaptor.capture());
+        assertEquals(TipoMovimiento.TRANSFERENCIA, movCaptor.getValue().getTipoMovimiento());
+    }
+
+    @Test
+    void liberacionIdempotenteNoDuplicaMovimiento() {
+        Usuario jefe = new Usuario(); jefe.setRol(RolUsuario.ROL_JEFE_CALIDAD); jefe.setId(10L);
+        Producto producto = Producto.builder().id(1).tipoAnalisisCalidad(TipoAnalisisCalidad.AMBOS).build();
+        Almacen cuarentena = Almacen.builder().id(7L).build();
+        Almacen pt = Almacen.builder().id(2L).build();
+        LoteProducto lote = buildLote(EstadoLote.EN_CUARENTENA, cuarentena, producto);
+
+        when(loteProductoRepository.findByIdForUpdate(1L)).thenReturn(java.util.Optional.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(1L)).thenReturn(List.of(
+                EvaluacionCalidad.builder().tipoEvaluacion(TipoEvaluacion.FISICO_QUIMICO).resultado(ResultadoEvaluacion.CONFORME).build(),
+                EvaluacionCalidad.builder().tipoEvaluacion(TipoEvaluacion.MICROBIOLOGICO).resultado(ResultadoEvaluacion.CONFORME).build()
+        ));
+        when(catalogResolver.getMotivoIdTransferenciaCalidad()).thenReturn(12L);
+        when(motivoMovimientoRepository.findById(12L)).thenReturn(java.util.Optional.of(new MotivoMovimiento()));
+        when(catalogResolver.getTipoDetalleTransferenciaId()).thenReturn(9L);
+        when(tipoMovimientoDetalleRepository.findById(9L)).thenReturn(java.util.Optional.of(new TipoMovimientoDetalle()));
+        when(catalogResolver.getAlmacenPtId()).thenReturn(2L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(almacenRepository.findById(2L)).thenReturn(java.util.Optional.of(pt));
+        when(movimientoInventarioRepository.existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(any(), anyLong(), anyLong(), anyLong(), any()))
+                .thenReturn(false).thenReturn(true);
+        when(movimientoInventarioRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.liberarLotePorCalidad(1L, jefe);
+        service.liberarLotePorCalidad(1L, jefe);
+
+        verify(movimientoInventarioRepository, times(1)).save(any());
+    }
+
+    @Test
+    void liberacionFallaSiFaltanEvaluacionesRequeridas() {
+        Usuario jefe = new Usuario(); jefe.setRol(RolUsuario.ROL_JEFE_CALIDAD); jefe.setId(10L);
+        Producto producto = Producto.builder().id(1).tipoAnalisisCalidad(TipoAnalisisCalidad.AMBOS).build();
+        Almacen cuarentena = Almacen.builder().id(7L).build();
+        LoteProducto lote = buildLote(EstadoLote.EN_CUARENTENA, cuarentena, producto);
+
+        when(loteProductoRepository.findByIdForUpdate(1L)).thenReturn(java.util.Optional.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(1L)).thenReturn(List.of(
+                EvaluacionCalidad.builder().tipoEvaluacion(TipoEvaluacion.FISICO_QUIMICO).resultado(ResultadoEvaluacion.CONFORME).build()
+        ));
+        when(catalogResolver.getMotivoIdTransferenciaCalidad()).thenReturn(12L);
+        when(motivoMovimientoRepository.findById(12L)).thenReturn(java.util.Optional.of(new MotivoMovimiento()));
+        when(catalogResolver.getTipoDetalleTransferenciaId()).thenReturn(9L);
+        when(tipoMovimientoDetalleRepository.findById(9L)).thenReturn(java.util.Optional.of(new TipoMovimientoDetalle()));
+        when(catalogResolver.getAlmacenPtId()).thenReturn(2L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(almacenRepository.findById(2L)).thenReturn(java.util.Optional.of(Almacen.builder().id(2L).build()));
+        when(movimientoInventarioRepository.existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(any(), anyLong(), anyLong(), anyLong(), any())).thenReturn(false);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.liberarLotePorCalidad(1L, jefe));
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+        assertEquals("Falta evaluación requerida", ex.getReason());
+        verify(movimientoInventarioRepository, never()).save(any());
+    }
+
+    @Test
+    void rechazoMueveAObsoletosConMotivoAjuste() {
+        Usuario jefe = new Usuario(); jefe.setId(20L); jefe.setRol(RolUsuario.ROL_JEFE_CALIDAD);
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(jefe);
+        Producto producto = Producto.builder().id(1).tipoAnalisisCalidad(TipoAnalisisCalidad.AMBOS).build();
+        Almacen cuarentena = Almacen.builder().id(7L).build();
+        Almacen obsoletos = Almacen.builder().id(3L).build();
+        LoteProducto lote = buildLote(EstadoLote.EN_CUARENTENA, cuarentena, producto);
+
+        when(loteProductoRepository.findByIdForUpdate(1L)).thenReturn(java.util.Optional.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(1L)).thenReturn(List.of(new EvaluacionCalidad()));
+        when(catalogResolver.getMotivoIdAjusteRechazo()).thenReturn(30L);
+        MotivoMovimiento motivo = new MotivoMovimiento(); motivo.setId(30L);
+        when(motivoMovimientoRepository.findById(30L)).thenReturn(java.util.Optional.of(motivo));
+        when(catalogResolver.getTipoDetalleTransferenciaId()).thenReturn(9L);
+        when(tipoMovimientoDetalleRepository.findById(9L)).thenReturn(java.util.Optional.of(new TipoMovimientoDetalle()));
+        when(catalogResolver.getAlmacenObsoletosId()).thenReturn(3L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(almacenRepository.findById(3L)).thenReturn(java.util.Optional.of(obsoletos));
+        when(movimientoInventarioRepository.existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(any(), anyLong(), anyLong(), anyLong(), any())).thenReturn(false);
+        when(movimientoInventarioRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        LoteProductoResponseDTO result = service.rechazarLote(1L);
+
+        assertEquals(EstadoLote.RECHAZADO, lote.getEstado());
+        assertEquals(obsoletos.getId(), lote.getAlmacen().getId());
+        ArgumentCaptor<MovimientoInventario> movCaptor = ArgumentCaptor.forClass(MovimientoInventario.class);
+        verify(movimientoInventarioRepository).save(movCaptor.capture());
+        assertEquals(motivo.getId(), movCaptor.getValue().getMotivoMovimiento().getId());
+        assertEquals(TipoMovimiento.TRANSFERENCIA, movCaptor.getValue().getTipoMovimiento());
+        assertEquals(EstadoLote.RECHAZADO, result.getEstado());
+    }
+
+    @Test
+    void rechazoIdempotente() {
+        Usuario jefe = new Usuario(); jefe.setId(20L); jefe.setRol(RolUsuario.ROL_JEFE_CALIDAD);
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(jefe);
+        Producto producto = Producto.builder().id(1).tipoAnalisisCalidad(TipoAnalisisCalidad.AMBOS).build();
+        Almacen cuarentena = Almacen.builder().id(7L).build();
+        Almacen obsoletos = Almacen.builder().id(3L).build();
+        LoteProducto lote = buildLote(EstadoLote.EN_CUARENTENA, cuarentena, producto);
+
+        when(loteProductoRepository.findByIdForUpdate(1L)).thenReturn(java.util.Optional.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(1L)).thenReturn(List.of(new EvaluacionCalidad()));
+        when(catalogResolver.getMotivoIdAjusteRechazo()).thenReturn(30L);
+        MotivoMovimiento motivo = new MotivoMovimiento(); motivo.setId(30L);
+        when(motivoMovimientoRepository.findById(30L)).thenReturn(java.util.Optional.of(motivo));
+        when(catalogResolver.getTipoDetalleTransferenciaId()).thenReturn(9L);
+        when(tipoMovimientoDetalleRepository.findById(9L)).thenReturn(java.util.Optional.of(new TipoMovimientoDetalle()));
+        when(catalogResolver.getAlmacenObsoletosId()).thenReturn(3L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(almacenRepository.findById(3L)).thenReturn(java.util.Optional.of(obsoletos));
+        when(movimientoInventarioRepository.existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(any(), anyLong(), anyLong(), anyLong(), any()))
+                .thenReturn(false).thenReturn(true);
+        when(movimientoInventarioRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.rechazarLote(1L);
+        service.rechazarLote(1L);
+
+        verify(movimientoInventarioRepository, times(1)).save(any());
+        assertEquals(EstadoLote.RECHAZADO, lote.getEstado());
+        assertEquals(obsoletos.getId(), lote.getAlmacen().getId());
+    }
+}
+

--- a/src/test/java/com/willyes/clemenintegra/inventario/model/LoteProductoDefaultsTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/model/LoteProductoDefaultsTest.java
@@ -1,0 +1,30 @@
+package com.willyes.clemenintegra.inventario.model;
+
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoteProductoDefaultsTest {
+
+    @Test
+    void loteBuilderDefaultsSeAplican() {
+        LoteProducto lote = LoteProducto.builder()
+                .codigoLote("L1")
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(new BigDecimal("10.129"))
+                .build();
+
+        assertFalse(lote.isAgotado());
+        assertEquals(new BigDecimal("0.000000"), lote.getStockReservado());
+
+        ReflectionTestUtils.invokeMethod(lote, "normalizeDefaults");
+
+        assertEquals(new BigDecimal("10.12"), lote.getStockLote());
+        assertEquals(new BigDecimal("0.000000"), lote.getStockReservado());
+    }
+}
+

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -546,6 +546,152 @@ class OrdenProduccionServiceImplTest {
     }
 
     @Test
+    void entradaPtSinOrdenDevuelve422() {
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .id(1L)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .cantidadProgramada(BigDecimal.TEN)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .loteProduccion("L1")
+                .producto(Producto.builder().id(1).tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                        .unidadMedida(UnidadMedida.builder().simbolo("G").build()).build())
+                .build();
+        when(repository.findById(1L)).thenReturn(Optional.of(orden));
+        Usuario usuario = new Usuario(); usuario.setId(5L); usuario.setNombreCompleto("Jane Doe");
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(cierreProduccionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(almacenRepository.findById(2L)).thenReturn(Optional.of(Almacen.builder().id(2L).build()));
+        when(almacenRepository.findById(7L)).thenReturn(Optional.of(Almacen.builder().id(7L).build()));
+        LoteProducto lote = LoteProducto.builder()
+                .id(1L)
+                .almacen(Almacen.builder().id(2L).build())
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(BigDecimal.ZERO)
+                .build();
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(lote));
+        when(loteProductoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        MotivoMovimiento motivo = new MotivoMovimiento(); motivo.setId(11L);
+        when(motivoMovimientoRepository.findById(11L)).thenReturn(Optional.of(motivo));
+        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle(); tipoDetalle.setId(9L);
+        when(tipoMovimientoDetalleRepository.findById(9L)).thenReturn(Optional.of(tipoDetalle));
+        when(movimientoInventarioRepository.findByTipoMovimientoAndMotivoMovimientoIdAndOrdenProduccionIdAndProductoIdAndLoteId(
+                any(), anyLong(), anyLong(), anyLong(), anyLong())).thenReturn(Optional.empty());
+        when(movimientoInventarioService.registrarMovimiento(any()))
+                .thenThrow(new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ENTRADA_PT_REQUIERE_ORDEN_PRODUCCION_ID"));
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(BigDecimal.ONE)
+                .tipo(TipoCierre.PARCIAL)
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
+                .build();
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.registrarCierre(1L, dto));
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, ex.getStatusCode());
+        assertEquals("ENTRADA_PT_REQUIERE_ORDEN_PRODUCCION_ID", ex.getReason());
+    }
+
+    @Test
+    void entradaPtConOrdenPasa() {
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .id(1L)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .cantidadProgramada(BigDecimal.TEN)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .loteProduccion("L1")
+                .producto(Producto.builder().id(1).tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                        .unidadMedida(UnidadMedida.builder().simbolo("G").build()).build())
+                .build();
+        when(repository.findById(1L)).thenReturn(Optional.of(orden));
+        Usuario usuario = new Usuario(); usuario.setId(5L); usuario.setNombreCompleto("Jane Doe");
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(cierreProduccionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(almacenRepository.findById(2L)).thenReturn(Optional.of(Almacen.builder().id(2L).build()));
+        when(almacenRepository.findById(7L)).thenReturn(Optional.of(Almacen.builder().id(7L).build()));
+        LoteProducto lote = LoteProducto.builder()
+                .id(1L)
+                .almacen(Almacen.builder().id(2L).build())
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(BigDecimal.ZERO)
+                .build();
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(lote));
+        when(loteProductoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        MotivoMovimiento motivo = new MotivoMovimiento(); motivo.setId(11L);
+        when(motivoMovimientoRepository.findById(11L)).thenReturn(Optional.of(motivo));
+        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle(); tipoDetalle.setId(9L);
+        when(tipoMovimientoDetalleRepository.findById(9L)).thenReturn(Optional.of(tipoDetalle));
+        when(movimientoInventarioRepository.findByTipoMovimientoAndMotivoMovimientoIdAndOrdenProduccionIdAndProductoIdAndLoteId(
+                any(), anyLong(), anyLong(), anyLong(), anyLong())).thenReturn(Optional.empty());
+        when(movimientoInventarioService.registrarMovimiento(any())).thenReturn(new MovimientoInventarioResponseDTO());
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(BigDecimal.ONE)
+                .tipo(TipoCierre.PARCIAL)
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
+                .build();
+
+        service.registrarCierre(1L, dto);
+
+        ArgumentCaptor<MovimientoInventarioDTO> captor = ArgumentCaptor.forClass(MovimientoInventarioDTO.class);
+        verify(movimientoInventarioService).registrarMovimiento(captor.capture());
+        assertEquals(1L, captor.getValue().ordenProduccionId());
+        assertEquals(TipoMovimiento.ENTRADA, captor.getValue().tipoMovimiento());
+    }
+
+    @Test
+    void entradaPtDuplicadaMismaCantidadEsIdempotente() {
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .id(1L)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .cantidadProgramada(BigDecimal.TEN)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .loteProduccion("L1")
+                .producto(Producto.builder().id(1).tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                        .unidadMedida(UnidadMedida.builder().simbolo("G").build()).build())
+                .build();
+        when(repository.findById(1L)).thenReturn(Optional.of(orden));
+        Usuario usuario = new Usuario(); usuario.setId(5L); usuario.setNombreCompleto("Jane Doe");
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(cierreProduccionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(almacenRepository.findById(2L)).thenReturn(Optional.of(Almacen.builder().id(2L).build()));
+        when(almacenRepository.findById(7L)).thenReturn(Optional.of(Almacen.builder().id(7L).build()));
+        LoteProducto lote = LoteProducto.builder()
+                .id(1L)
+                .almacen(Almacen.builder().id(2L).build())
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(BigDecimal.ZERO)
+                .build();
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(lote));
+        when(loteProductoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        MotivoMovimiento motivo = new MotivoMovimiento(); motivo.setId(11L);
+        when(motivoMovimientoRepository.findById(11L)).thenReturn(Optional.of(motivo));
+        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle(); tipoDetalle.setId(9L);
+        when(tipoMovimientoDetalleRepository.findById(9L)).thenReturn(Optional.of(tipoDetalle));
+        MovimientoInventario existente = MovimientoInventario.builder()
+                .id(33L)
+                .cantidad(BigDecimal.ONE)
+                .build();
+        when(movimientoInventarioRepository.findByTipoMovimientoAndMotivoMovimientoIdAndOrdenProduccionIdAndProductoIdAndLoteId(
+                any(), anyLong(), anyLong(), anyLong(), anyLong()))
+                .thenReturn(Optional.empty()).thenReturn(Optional.of(existente));
+        when(movimientoInventarioService.registrarMovimiento(any())).thenReturn(new MovimientoInventarioResponseDTO());
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(BigDecimal.ONE)
+                .tipo(TipoCierre.PARCIAL)
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
+                .build();
+
+        service.registrarCierre(1L, dto);
+        service.registrarCierre(1L, dto);
+
+        verify(movimientoInventarioService, times(1)).registrarMovimiento(any());
+        assertEquals(BigDecimal.ONE, orden.getCantidadProducidaAcumulada());
+    }
+
+    @Test
     void registrarCierreUmDecimalesExcedidos() {
         OrdenProduccion orden = OrdenProduccion.builder()
                 .estado(EstadoProduccion.EN_PROCESO)


### PR DESCRIPTION
## Summary
- cover lote quality release with transfer creation, idempotence and missing evaluations
- exercise rejection moves to obsoletos with proper motive and idempotence
- test builder defaults on `LoteProducto` and guard scenarios for `entrada PT`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cd2422108333a7a148924e5702f1