### PR TITLE
Renombrar getter de motivo entrada PT a Producto Terminado

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogHealthIndicator.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogHealthIndicator.java
@@ -29,7 +29,7 @@ public class InventoryCatalogHealthIndicator implements HealthIndicator {
         details.put("almacenBodegaPrincipal", checkAlmacen(resolver.getAlmacenBodegaPrincipalId()));
         details.put("almacenPreBodegaProduccion", checkAlmacen(resolver.getAlmacenPreBodegaProduccionId()));
 
-        details.put("motivoEntradaPt", checkMotivo(resolver.getMotivoIdEntradaPt()));
+        details.put("motivoEntradaPt", checkMotivo(resolver.getMotivoIdEntradaProductoTerminado()));
         details.put("motivoTransferenciaCalidad", checkMotivo(resolver.getMotivoIdTransferenciaCalidad()));
         details.put("motivoDevolucionDesdeProduccion", checkMotivo(resolver.getMotivoIdDevolucionDesdeProduccion()));
         Long ajuste = resolver.getMotivoIdAjusteRechazo();

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogResolver.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogResolver.java
@@ -99,7 +99,7 @@ public class InventoryCatalogResolver {
     public Long getAlmacenBodegaPrincipalId() { return almacenBodegaPrincipalId; }
     public Long getAlmacenPreBodegaProduccionId() { return almacenPreBodegaProduccionId; }
 
-    public Long getMotivoIdEntradaPt() { return motivoEntradaPtId; }
+    public Long getMotivoIdEntradaProductoTerminado() { return motivoEntradaPtId; }
     public Long getMotivoIdTransferenciaCalidad() { return motivoTransferenciaCalidadId; }
     public Long getMotivoIdDevolucionDesdeProduccion() { return motivoDevolucionDesdeProduccionId; }
     public Long getMotivoIdAjusteRechazo() { return motivoAjusteRechazoId; }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -94,7 +94,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
 
         if (dto.tipoMovimiento() == TipoMovimiento.ENTRADA
-                && Objects.equals(dto.motivoMovimientoId(), catalogResolver.getMotivoIdEntradaPt())
+                && Objects.equals(dto.motivoMovimientoId(), catalogResolver.getMotivoIdEntradaProductoTerminado())
                 && dto.ordenProduccionId() == null) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                     "ENTRADA_PT_REQUIERE_ORDEN_PRODUCCION_ID");

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -484,7 +484,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 }
             }
 
-            Long motivoEntradaId = catalogResolver.getMotivoIdEntradaPt();
+            Long motivoEntradaId = catalogResolver.getMotivoIdEntradaProductoTerminado();
             MotivoMovimiento motivoEntrada = motivoMovimientoRepository.findById(motivoEntradaId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MOTIVO_ENTRADA_PT_INEXISTENTE"));
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImplTest.java
@@ -279,7 +279,7 @@ class MovimientoInventarioServiceImplTest {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken("user", "pass"));
 
-        when(catalogResolver.getMotivoIdEntradaPt()).thenReturn(11L);
+        when(catalogResolver.getMotivoIdEntradaProductoTerminado()).thenReturn(11L);
 
         MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
                 null, new BigDecimal("1"), TipoMovimiento.ENTRADA,

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -138,7 +138,7 @@ class OrdenProduccionServiceImplTest {
 
         when(catalogResolver.getAlmacenPtId()).thenReturn(2L);
         when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
-        when(catalogResolver.getMotivoIdEntradaPt()).thenReturn(11L);
+        when(catalogResolver.getMotivoIdEntradaProductoTerminado()).thenReturn(11L);
         when(catalogResolver.getTipoDetalleEntradaId()).thenReturn(9L);
         when(catalogResolver.getMotivoIdDevolucionDesdeProduccion()).thenReturn(30L);
         when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(8L);


### PR DESCRIPTION
## Summary
- Renombra `getMotivoIdEntradaPt` a `getMotivoIdEntradaProductoTerminado` en `InventoryCatalogResolver`
- Ajusta llamadas en servicios y pruebas que utilizaban el viejo nombre

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d993db8883339cc2709179478ab9