### PR TITLE
Add configuration for PT entry classification

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -116,6 +116,9 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     @Value("${inventory.solicitud.estados.concluyentes}")
     private String estadosSolicitudConcluyentesConf;
 
+    @Value("${inventory.mov.clasificacion.entradaPt}")
+    private String clasificacionEntradaPtConf;
+
     private String generarCodigoOrden() {
         String fecha = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         String prefijo = "OP-CLEMEN-" + fecha;
@@ -488,7 +491,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             MotivoMovimiento motivoEntrada = motivoMovimientoRepository.findById(motivoEntradaId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MOTIVO_ENTRADA_PT_INEXISTENTE"));
 
-            ClasificacionMovimientoInventario clasifEntrada = motivoEntrada.getMotivo();
+            ClasificacionMovimientoInventario clasifEntrada;
+            try {
+                clasifEntrada = ClasificacionMovimientoInventario.valueOf(clasificacionEntradaPtConf);
+            } catch (IllegalArgumentException ex) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CLASIFICACION_ENTRADA_PT_INVALIDA");
+            }
 
             Long tipoDetalleEntradaId = catalogResolver.getTipoDetalleEntradaId();
             TipoMovimientoDetalle tipoDetalleEntrada = tipoMovimientoDetalleRepository.findById(tipoDetalleEntradaId)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,6 +39,7 @@ spring.web.cors.allow-credentials=true
 inventory.almacen.pt.id=2
 inventory.almacen.cuarentena.id=7
 inventory.motivo.entradaPt=ENTRADA_PRODUCTO_TERMINADO
+inventory.mov.clasificacion.entradaPt=ENTRADA_PRODUCTO_TERMINADO
 inventory.tipoDetalle.entradaId=9
 inventory.motivo.transferenciaCalidad=TRANSFERENCIA_GENERAL
 inventory.tipoDetalle.transferenciaId=2

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -135,6 +135,7 @@ class OrdenProduccionServiceImplTest {
 
         ReflectionTestUtils.setField(service, "estadosSolicitudPendientesConf", "PENDIENTE,AUTORIZADA,RESERVADA");
         ReflectionTestUtils.setField(service, "estadosSolicitudConcluyentesConf", "ATENDIDA,EJECUTADA,CANCELADA,RECHAZADO");
+        ReflectionTestUtils.setField(service, "clasificacionEntradaPtConf", "ENTRADA_PRODUCTO_TERMINADO");
 
         when(catalogResolver.getAlmacenPtId()).thenReturn(2L);
         when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -14,6 +14,7 @@ inventory.almacen.cuarentena.id=7
 inventory.motivo.transferenciaCalidad=TRANSFERENCIA_GENERAL
 inventory.tipoDetalle.transferenciaId=2
 inventory.lote.estadoLiberado=DISPONIBLE
+inventory.mov.clasificacion.entradaPt=ENTRADA_PRODUCTO_TERMINADO
 inventory.mov.clasificacion.liberacionCalidad=LIBERACION_CALIDAD
 inventory.almacen.obsoletos.id=3
 inventory.motivo.rechazoCalidad=TRANSFERENCIA_GENERAL


### PR DESCRIPTION
## Summary
- add `inventory.mov.clasificacion.entradaPt` to application configs
- wire order production service to use configurable PT entry classification
- set test configuration for new property

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dbb1368483339b0374d11b38dc3a