### PR TITLE
Handle null results in ProductoService.findByCategoriaTipo

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -32,9 +32,11 @@ import static com.willyes.clemenintegra.inventario.service.spec.ProductoSpecific
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -107,7 +109,8 @@ public class ProductoServiceImpl implements ProductoService {
 
     public List<ProductoResponseDTO> findByCategoriaTipo(String tipo) {
         TipoCategoria tipoEnum = TipoCategoria.valueOf(tipo); // conversión aquí
-        List<Producto> lista = productoRepository.findByCategoriaProducto_Tipo(tipoEnum);
+        List<Producto> lista = Optional.ofNullable(productoRepository.findByCategoriaProducto_Tipo(tipoEnum))
+                .orElse(Collections.emptyList());
         Map<Long, BigDecimal> stockMap = stockQueryService.obtenerStockDisponible(
                 lista.stream().map(p -> p.getId().longValue()).toList());
         return lista.stream()

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -1,0 +1,62 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.inventario.mapper.ProductoMapper;
+import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProductoServiceImplTest {
+
+    @Mock private ProductoRepository productoRepository;
+    @Mock private UnidadMedidaRepository unidadMedidaRepository;
+    @Mock private CategoriaProductoRepository categoriaProductoRepository;
+    @Mock private UsuarioRepository usuarioRepository;
+    @Mock private LoteProductoRepository loteProductoRepository;
+    @Mock private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock private ProductoMapper productoMapper;
+    @Mock private JwtTokenService jwtTokenService;
+    @Mock private StockQueryService stockQueryService;
+
+    private ProductoServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProductoServiceImpl(
+                productoRepository,
+                unidadMedidaRepository,
+                categoriaProductoRepository,
+                usuarioRepository,
+                loteProductoRepository,
+                movimientoInventarioRepository,
+                productoMapper,
+                jwtTokenService,
+                stockQueryService
+        );
+    }
+
+    @Test
+    void findByCategoriaTipoReturnsEmptyListWhenRepositoryReturnsNull() {
+        TipoCategoria tipoEnum = TipoCategoria.MATERIA_PRIMA;
+        when(productoRepository.findByCategoriaProducto_Tipo(tipoEnum)).thenReturn(null);
+        when(stockQueryService.obtenerStockDisponible(any())).thenReturn(Collections.emptyMap());
+
+        List<ProductoResponseDTO> result = assertDoesNotThrow(() -> service.findByCategoriaTipo(tipoEnum.name()));
+
+        assertTrue(result.isEmpty());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Ensure `findByCategoriaTipo` in `ProductoServiceImpl` safely handles null repository results using `Optional` and `Collections.emptyList`.
- Add unit test verifying the method returns an empty list rather than throwing `NullPointerException`.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e941902083338de5bf01201aeb31