### PR TITLE
Handle null repository results in stock query

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/StockQueryService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/StockQueryService.java
@@ -9,6 +9,8 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -20,8 +22,12 @@ public class StockQueryService {
         if (ids == null || ids.isEmpty()) {
             return Collections.emptyMap();
         }
-        List<StockDisponibleProjection> rows = productoRepository.calcularStockDisponiblePorProducto(ids);
+        List<StockDisponibleProjection> rows = Optional
+                .ofNullable(productoRepository.calcularStockDisponiblePorProducto(ids))
+                .orElse(Collections.emptyList());
         return rows.stream()
+                .filter(Objects::nonNull)
+                .filter(row -> row.getProductoId() != null && row.getStockDisponible() != null)
                 .collect(Collectors.toMap(StockDisponibleProjection::getProductoId,
                                           StockDisponibleProjection::getStockDisponible));
     }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/StockQueryServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/StockQueryServiceTest.java
@@ -1,0 +1,39 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StockQueryServiceTest {
+
+    @Mock
+    private ProductoRepository productoRepository;
+
+    private StockQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new StockQueryService(productoRepository);
+    }
+
+    @Test
+    void obtenerStockDisponibleReturnsEmptyMapWhenRepositoryReturnsNull() {
+        List<Long> ids = List.of(1L, 2L);
+        when(productoRepository.calcularStockDisponiblePorProducto(ids)).thenReturn(null);
+
+        Map<Long, BigDecimal> result = service.obtenerStockDisponible(ids);
+
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- guard against null repository results when querying stock
- add unit test for null repository response in stock query service

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ea97c684833384f27cc468d0d937