### PR TITLE
Corrige consulta de stock masiva en productos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -51,9 +51,9 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
                                      THEN (lp.stock_lote - lp.stock_reservado) ELSE 0 END), 0) AS stock_disponible
             FROM productos p
             LEFT JOIN lotes_productos lp ON lp.productos_id = p.id
-            WHERE p.id IN (:ids)
+            WHERE p.id IN (?1)
             GROUP BY p.id
             """, nativeQuery = true)
-    List<StockDisponibleProjection> calcularStockDisponiblePorProducto(@Param("ids") List<Long> ids);
+    List<StockDisponibleProjection> calcularStockDisponiblePorProducto(List<Long> ids);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/StockQueryService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/StockQueryService.java
@@ -22,8 +22,12 @@ public class StockQueryService {
         if (ids == null || ids.isEmpty()) {
             return Collections.emptyMap();
         }
+        List<Long> uniques = ids.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
         List<StockDisponibleProjection> rows = Optional
-                .ofNullable(productoRepository.calcularStockDisponiblePorProducto(ids))
+                .ofNullable(productoRepository.calcularStockDisponiblePorProducto(uniques))
                 .orElse(Collections.emptyList());
         return rows.stream()
                 .filter(Objects::nonNull)


### PR DESCRIPTION
## Summary
- Usa parámetro posicional en `ProductoRepository.calcularStockDisponiblePorProducto` para permitir consultas con listas de IDs
- Depura `StockQueryService.obtenerStockDisponible` deduplicando IDs antes de consultar el repositorio

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2044a3f7c83338bcbdb27fc4a0140