### PR TITLE
Refactor FEFO query to projection

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteFefoDisponibleProjection.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteFefoDisponibleProjection.java
@@ -1,0 +1,16 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Proyección para la consulta FEFO de lotes disponibles.
+ */
+public interface LoteFefoDisponibleProjection {
+    Long getLoteProductoId();
+    String getCodigoLote();
+    BigDecimal getStockLote();
+    LocalDateTime getFechaVencimiento();
+    Integer getAlmacenId();
+    String getNombreAlmacen();
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -51,14 +51,22 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     Optional<LoteProducto> findByIdForUpdate(@Param("id") Long id);
 
     @Query(value = """
-       SELECT * FROM v_lotes_stock_disponible
-       WHERE productos_id = :productoId
-         AND estado IN ('DISPONIBLE','LIBERADO')
-         AND stock_disponible > 0
-       ORDER BY fecha_vencimiento ASC
-       LIMIT :limit
-     """, nativeQuery = true)
-    List<LoteProducto> findFefoDisponibles(@Param("productoId") Long productoId, @Param("limit") int limit);
+        SELECT lp.id AS lote_producto_id,
+               lp.codigo_lote AS codigo_lote,
+               (lp.stock_lote - lp.stock_reservado) AS stock_lote,
+               lp.fecha_vencimiento AS fecha_vencimiento,
+               lp.almacenes_id AS almacen_id,
+               a.nombre AS nombre_almacen
+        FROM lotes_productos lp
+        LEFT JOIN almacenes a ON lp.almacenes_id = a.id
+        WHERE lp.productos_id = :productoId
+          AND lp.estado IN ('DISPONIBLE','LIBERADO')
+          AND (lp.stock_lote - lp.stock_reservado) > 0
+        ORDER BY lp.fecha_vencimiento ASC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection> findFefoDisponibles(
+            @Param("productoId") Long productoId, @Param("limit") int limit);
 
     @Modifying
     @Query(value = """

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventarioConsultaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventarioConsultaServiceImpl.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.DisponibilidadProductoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteDisponibleDTO;
+import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
@@ -46,12 +47,12 @@ public class InventarioConsultaServiceImpl implements InventarioConsultaService 
                 .findFefoDisponibles(productoId, Integer.MAX_VALUE)
                 .stream()
                 .map(lp -> LoteDisponibleDTO.builder()
-                        .loteProductoId(lp.getId())
+                        .loteProductoId(lp.getLoteProductoId())
                         .codigoLote(lp.getCodigoLote())
                         .stockLote(lp.getStockLote())
                         .fechaVencimiento(lp.getFechaVencimiento())
-                        .almacenId(lp.getAlmacen() != null ? lp.getAlmacen().getId() : null)
-                        .nombreAlmacen(lp.getAlmacen() != null ? lp.getAlmacen().getNombre() : null)
+                        .almacenId(lp.getAlmacenId())
+                        .nombreAlmacen(lp.getNombreAlmacen())
                         .build())
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## Summary
- Replace `findFefoDisponibles` native query with explicit selection including `codigo_lote` alias
- Introduce `LoteFefoDisponibleProjection` for FEFO lot view
- Update inventory and production services to consume the projection

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c21370ab188333a6e3007fde858bfd