### PR TITLE
fix: rename FEFO projection aliases

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -51,12 +51,12 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     Optional<LoteProducto> findByIdForUpdate(@Param("id") Long id);
 
     @Query(value = """
-        SELECT lp.id AS lote_producto_id,
-               lp.codigo_lote AS codigo_lote,
-               (lp.stock_lote - lp.stock_reservado) AS stock_lote,
-               lp.fecha_vencimiento AS fecha_vencimiento,
-               lp.almacenes_id AS almacen_id,
-               a.nombre AS nombre_almacen
+        SELECT lp.id AS loteProductoId,
+               lp.codigo_lote AS codigoLote,
+               (lp.stock_lote - lp.stock_reservado) AS stockLote,
+               lp.fecha_vencimiento AS fechaVencimiento,
+               lp.almacenes_id AS almacenId,
+               a.nombre AS nombreAlmacen
         FROM lotes_productos lp
         LEFT JOIN almacenes a ON lp.almacenes_id = a.id
         WHERE lp.productos_id = :productoId


### PR DESCRIPTION
## Summary
- rename aliases in `findFefoDisponibles` to camelCase so projection mapping works

## Testing
- `mvn -DskipTests package` *(fails: Non-resolvable parent POM)*
- `mvn spring-boot:run -DskipTests` *(fails: Non-resolvable parent POM)*
- `curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8080/api/produccion/ordenes` *(000)*

------
https://chatgpt.com/codex/tasks/task_e_68c21607fb4c8333a1275b0f9bff781b