### PR TITLE
chore: drop stock_actual column

### DIFF
--- a/DIAGNOSTICO_STOCK.md
+++ b/DIAGNOSTICO_STOCK.md
@@ -1,32 +1,8 @@
-# Diagnóstico de gestión de stock
+# Gestión de stock
 
-Este documento resume los hallazgos sobre el uso actual de `productos.stock_actual` en el backend y propone una proyección de `stockDisponible` basada en lotes.
+El campo `stock_actual` de la tabla `productos` fue eliminado. El stock disponible se calcula dinámicamente sumando los lotes disponibles (`stock_lote - stock_reservado`).
 
-## Endpoints afectados
-- `GET /api/productos` y variantes (`/buscar`, `/categoria/{nombre}`, `/terminados`, etc.) desde `ProductoController`.
-- `GET /api/productos/{id}` en `ProductoController`.
-- `POST /api/movimientos` en `MovimientoInventarioController` (valida stock del producto y del lote).
-- `GET /api/reportes/stock-actual` en `ReporteInventarioController`.
-- Servicios de alertas y reportes que dependen de `ProductoServiceImpl` y `LoteProductoServiceImpl`.
-
-## Clases involucradas
-- **Entity/Repository**: `Producto`, `ProductoRepository`, `LoteProductoRepository`.
-- **Service**: `ProductoServiceImpl`, `MovimientoInventarioServiceImpl`, `LoteProductoServiceImpl`, `AlertaInventarioServiceImpl`, `OrdenProduccionServiceImpl`.
-- **Controller**: `ProductoController`, `MovimientoInventarioController`, `ReporteInventarioController`.
-- **DTO/Mapper**: `ProductoResponseDTO`, `AlertaInventarioResponseDTO`, `ProductoAlertaResponseDTO`, `ProductoMapper`.
-
-## Uso actual de `stock_actual`
-- Se expone directamente en `ProductoResponseDTO` y se consulta para validar salidas en `MovimientoInventarioController`.
-- Servicios como `AlertaInventarioServiceImpl` y `LoteProductoServiceImpl` comparan `stock_actual` contra `stock_minimo`.
-- Reportes generan columnas basadas en `productos.stock_actual`.
-- No se encontraron triggers ni jobs que sincronicen el campo con los lotes.
-
-## Riesgos de cambio
-- Frontend depende de `stockActual` en listados y detalle de productos; deberá migrar a `stockDisponible`.
-- Cualquier lógica externa que actualice `productos.stock_actual` podría quedar desfasada.
-
-## Consideraciones de rendimiento
-- Se recomienda calcular el stock disponible vía query agregada sobre `lotes_productos`:
+## Consulta de stock disponible
 
 ```sql
 SELECT p.id AS producto_id,
@@ -38,12 +14,6 @@ WHERE p.id IN (:ids)
 GROUP BY p.id;
 ```
 
-- Índices sugeridos:
-  - `lotes_productos(productos_id, estado, agotado)`
-  - `lotes_productos(productos_id, estado, agotado, fecha_vencimiento)` para consultas por vencimiento
-  - `lotes_productos(productos_id, estado, agotado, fecha_vencimiento, fecha_fabricacion, id)` para selección FEFO
-  - `lotes_productos(productos_id, almacenes_id)` para cortes por almacén
-
 ## Índice FEFO y escala
 
 Para optimizar la asignación multi-lote se recomienda mantener un índice compuesto que respete el orden FEFO:
@@ -54,4 +24,3 @@ ON lotes_productos (productos_id, estado, agotado, fecha_vencimiento, fecha_fabr
 ```
 
 Las reservas consumen cantidades con la misma escala definida en `stock_lote` y `stock_reservado` (DECIMAL), sin redondeos adicionales.
-

--- a/src/main/resources/db/migration/V20250911__drop_stock_actual_from_productos.sql
+++ b/src/main/resources/db/migration/V20250911__drop_stock_actual_from_productos.sql
@@ -1,0 +1,1 @@
+ALTER TABLE productos DROP COLUMN stock_actual;


### PR DESCRIPTION
## Summary
- drop obsolete stock_actual column from productos
- document stock management now based on lotes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d60ca2608333a120ae66d9a0db9c