### PR TITLE
Crea lote al iniciar etapa de producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
@@ -7,6 +7,7 @@ public class OrdenProduccionResponseDTO {
     public Long id;
     public String codigoOrden;
     public String loteProduccion;
+    public Long loteId;
     public LocalDateTime fechaInicio;
     public LocalDateTime fechaFin;
     public BigDecimal cantidadProgramada;

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
@@ -27,6 +27,7 @@ public class ProduccionMapper {
         dto.id = entidad.getId();
         dto.codigoOrden = entidad.getCodigoOrden();
         dto.loteProduccion = entidad.getLoteProduccion();
+        dto.loteId = entidad.getLoteId();
         dto.fechaInicio = entidad.getFechaInicio();
         dto.fechaFin = entidad.getFechaFin();
         dto.cantidadProgramada = entidad.getCantidadProgramada();

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
@@ -22,6 +22,9 @@ public class OrdenProduccion {
 
     private String loteProduccion;
 
+    @Column(name = "lote_producto_id")
+    private Long loteId;
+
     @Column(nullable = false)
     private LocalDateTime fechaInicio;
     private LocalDateTime fechaFin;

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -150,6 +150,14 @@ class OrdenProduccionServiceImplTest {
         when(catalogResolver.getAlmacenBodegaPrincipalId()).thenReturn(1L);
         when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(5L);
 
+        when(almacenRepository.findById(2L)).thenReturn(Optional.of(Almacen.builder().id(2L).build()));
+        when(almacenRepository.findById(7L)).thenReturn(Optional.of(Almacen.builder().id(7L).build()));
+        when(loteProductoRepository.save(any())).thenAnswer(inv -> {
+            LoteProducto l = inv.getArgument(0);
+            if (l.getId() == null) l.setId(1L);
+            return l;
+        });
+
         MotivoMovimiento motivoDev = new MotivoMovimiento();
         motivoDev.setId(30L);
         when(motivoMovimientoRepository.findById(30L)).thenReturn(Optional.of(motivoDev));
@@ -809,7 +817,11 @@ class OrdenProduccionServiceImplTest {
 
     @Test
     void iniciarPrimerEtapaActualizaEstadoOrden() {
-        OrdenProduccion orden = OrdenProduccion.builder().id(1L).estado(EstadoProduccion.CREADA).build();
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .id(1L)
+                .estado(EstadoProduccion.CREADA)
+                .producto(Producto.builder().id(10).tipoAnalisis(TipoAnalisisCalidad.NINGUNO).build())
+                .build();
         EtapaProduccion etapa = EtapaProduccion.builder().id(2L).ordenProduccion(orden).estado(EstadoEtapa.PENDIENTE).secuencia(1).build();
         Usuario usuario = new Usuario(); usuario.setId(5L); usuario.setNombreCompleto("John Doe");
         when(repository.findById(1L)).thenReturn(Optional.of(orden));
@@ -830,7 +842,7 @@ class OrdenProduccionServiceImplTest {
                 .id(1L)
                 .estado(EstadoProduccion.EN_PROCESO)
                 .cantidadProgramada(BigDecimal.ONE)
-                .producto(Producto.builder().id(10).build())
+                .producto(Producto.builder().id(10).tipoAnalisis(TipoAnalisisCalidad.NINGUNO).build())
                 .build();
         EtapaProduccion etapa = EtapaProduccion.builder()
                 .id(2L)
@@ -899,7 +911,11 @@ class OrdenProduccionServiceImplTest {
 
     @Test
     void iniciarEtapaIdempotenteNoRepiteConsumo() {
-        OrdenProduccion orden = OrdenProduccion.builder().id(1L).estado(EstadoProduccion.EN_PROCESO).producto(Producto.builder().id(10).build()).build();
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .id(1L)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .producto(Producto.builder().id(10).tipoAnalisis(TipoAnalisisCalidad.NINGUNO).build())
+                .build();
         EtapaProduccion etapa = EtapaProduccion.builder().id(2L).ordenProduccion(orden).estado(EstadoEtapa.PENDIENTE).secuencia(1).build();
         Usuario usuario = new Usuario(); usuario.setId(5L); usuario.setNombreCompleto("John Doe");
         when(repository.findById(1L)).thenReturn(Optional.of(orden));
@@ -920,7 +936,7 @@ class OrdenProduccionServiceImplTest {
                 .id(1L)
                 .estado(EstadoProduccion.EN_PROCESO)
                 .cantidadProgramada(BigDecimal.TEN)
-                .producto(Producto.builder().id(10).build())
+                .producto(Producto.builder().id(10).tipoAnalisis(TipoAnalisisCalidad.NINGUNO).build())
                 .build();
         EtapaProduccion etapa = EtapaProduccion.builder()
                 .id(2L)


### PR DESCRIPTION
## Summary
- Genera y asocia un lote de producto al iniciar la primera etapa de una orden
- Expone el identificador del lote en las respuestas de orden de producción
- Mapea y persiste el ID del lote en la entidad de orden de producción

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eccb9f608333882353d1da19715f