### PR TITLE
feat: expose lote retrieval for production orders

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -149,4 +149,11 @@ public class OrdenProduccionController {
                                                                    Pageable pageable) {
         return service.listarMovimientos(id, pageable);
     }
+
+    @GetMapping("/{id}/lote")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<LoteProductoResponse> obtenerLote(@PathVariable Long id) {
+        LoteProductoResponse lote = service.obtenerLote(id);
+        return lote != null ? ResponseEntity.ok(lote) : ResponseEntity.notFound().build();
+    }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/LoteProductoResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/LoteProductoResponse.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import com.willyes.clemenintegra.inventario.dto.AlmacenResponseDTO;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoteProductoResponse {
+    private Long id;
+    private String codigoLote;
+    private EstadoLote estado;
+    private AlmacenResponseDTO almacen;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.produccion.dto.CierreProduccionRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.CierreProduccionResponseDTO;
 import com.willyes.clemenintegra.produccion.dto.EtapaProduccionResponse;
 import com.willyes.clemenintegra.produccion.dto.InsumoOPDTO;
+import com.willyes.clemenintegra.produccion.dto.LoteProductoResponse;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
@@ -41,6 +42,8 @@ public interface OrdenProduccionService {
     com.willyes.clemenintegra.produccion.model.EtapaProduccion finalizarEtapa(Long ordenId, Long etapaId, Long usuarioId);
 
     List<InsumoOPDTO> listarInsumos(Long id);
+
+    LoteProductoResponse obtenerLote(Long ordenId);
 
     Page<MovimientoInventarioResponseDTO> listarMovimientos(Long id, Pageable pageable);
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -38,6 +38,8 @@ import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
+import com.willyes.clemenintegra.produccion.dto.LoteProductoResponse;
+import com.willyes.clemenintegra.inventario.dto.AlmacenResponseDTO;
 import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
@@ -1001,6 +1003,21 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             ));
         }
         return lista;
+    }
+
+    @Override
+    public LoteProductoResponse obtenerLote(Long ordenId) {
+        return repository.findById(ordenId)
+                .filter(op -> op.getProducto() != null && op.getProducto().getId() != null)
+                .flatMap(op -> loteProductoRepository.findByOrdenProduccionIdAndProductoId(
+                        ordenId, op.getProducto().getId().longValue()))
+                .map(lote -> LoteProductoResponse.builder()
+                        .id(lote.getId())
+                        .codigoLote(lote.getCodigoLote())
+                        .estado(lote.getEstado())
+                        .almacen(new AlmacenResponseDTO(lote.getAlmacen()))
+                        .build())
+                .orElse(null);
     }
 
     public Page<MovimientoInventarioResponseDTO> listarMovimientos(Long id, Pageable pageable) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -4,6 +4,9 @@ import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.service.OrdenProduccionService;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import com.willyes.clemenintegra.produccion.dto.LoteProductoResponse;
+import com.willyes.clemenintegra.inventario.dto.AlmacenResponseDTO;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -17,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -81,6 +85,24 @@ class OrdenProduccionControllerTest {
                 .content(json))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.errors[0].field").value("tipo"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void obtenerLote_ok() throws Exception {
+        AlmacenResponseDTO almacen = AlmacenResponseDTO.builder().id(1).nombre("A1").build();
+        LoteProductoResponse lote = LoteProductoResponse.builder()
+                .id(7L)
+                .codigoLote("L1")
+                .estado(EstadoLote.DISPONIBLE)
+                .almacen(almacen)
+                .build();
+        when(service.obtenerLote(5L)).thenReturn(lote);
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}/lote", 5))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(7))
+                .andExpect(jsonPath("$.codigoLote").value("L1"));
     }
 }
 


### PR DESCRIPTION
## Summary
- add LoteProductoResponse DTO
- allow OrdenProduccionService to retrieve lot information
- expose `/api/produccion/ordenes/{id}/lote` endpoint and tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f160b7f08333b63a7bae45de6763