### PR TITLE
feat: allow dd/MM/yyyy date inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ LoteProducto toEntity(LoteProductoRequestDTO dto, Producto producto, Almacen alm
 
 Al trabajar con `LocalDateTime` se evita la pérdida de información al registrar movimientos o cambios de estado. **No se debe volver a utilizar `LocalDate`** en estos contextos, ya que comprometería la precisión temporal que requiere el sistema.
 
+### Formato de fechas desde el frontend
+Si el usuario ingresa la fecha mediante un control que sólo muestra `dd/mm/aaaa`, el frontend puede construir el `LocalDateTime` antes de enviarlo:
+
+```javascript
+const fecha = document.getElementById('fecha').value; // "2025-09-10" u "10/09/2025"
+const fechaCompleta = `${fecha}T00:00:00`;           // "2025-09-10T00:00:00"
+```
+
+El utilitario `DateParser` acepta tanto `yyyy-MM-dd` como `dd/MM/yyyy` y convierte cualquiera de ellos a `LocalDateTime`, usando `00:00:00` o `23:59:59` según se invoque `parseStart` o `parseEnd`.
+
 ## Requisitos de Compilación y Despliegue
 - JDK 21
 - Maven 3.8+

--- a/src/main/java/com/willyes/clemenintegra/shared/util/DateParser.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/util/DateParser.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeParseException;
 public final class DateParser {
 
     private static final DateTimeFormatter DATE = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter DATE_SLASH = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     private static final DateTimeFormatter DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     private DateParser() {
@@ -43,7 +44,12 @@ public final class DateParser {
                 LocalDate d = LocalDate.parse(s, DATE);
                 return start ? d.atStartOfDay() : d.atTime(23, 59, 59);
             } catch (DateTimeParseException e) {
-                throw new IllegalArgumentException("Formato de fecha inválido");
+                try {
+                    LocalDate d = LocalDate.parse(s, DATE_SLASH);
+                    return start ? d.atStartOfDay() : d.atTime(23, 59, 59);
+                } catch (DateTimeParseException ex) {
+                    throw new IllegalArgumentException("Formato de fecha inválido");
+                }
             }
         }
     }

--- a/src/test/java/com/willyes/clemenintegra/shared/util/DateParserTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/util/DateParserTest.java
@@ -1,0 +1,19 @@
+package com.willyes.clemenintegra.shared.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DateParserTest {
+
+    @Test
+    void parseStartAcceptsIsoAndSlashFormats() {
+        LocalDateTime iso = DateParser.parseStart("2025-09-10");
+        assertEquals(LocalDateTime.of(2025, 9, 10, 0, 0, 0), iso);
+
+        LocalDateTime slash = DateParser.parseStart("10/09/2025");
+        assertEquals(LocalDateTime.of(2025, 9, 10, 0, 0, 0), slash);
+    }
+}


### PR DESCRIPTION
## Summary
- allow DateParser to parse dates in `dd/MM/yyyy` format
- document how frontend can send full `LocalDateTime` while showing only the date
- cover DateParser ISO vs slash formats with unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e6ff2aa88333b936b05159b41168