### PR TITLE
refactor: reuse date variables in cierre

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -611,11 +611,9 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 default -> throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "PRODUCTO_SIN_TIPO_ANALISIS");
             }
 
-            LocalDateTime fechaFabricacion = dto.getFechaFabricacion();
             if (fechaFabricacion == null || fechaFabricacion.isAfter(LocalDateTime.now())) {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "FECHA_INVALIDA");
             }
-            LocalDateTime fechaVencimiento = dto.getFechaVencimiento();
             if (fechaVencimiento != null && fechaVencimiento.isBefore(fechaFabricacion)) {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "FECHA_INVALIDA");
             }


### PR DESCRIPTION
## Summary
- avoid redeclaring manufacturing/expiration dates in `registrarCierre`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3064367d48333bf82d12c519ccfb2