### PR TITLE
Handle ResponseStatusException with original status

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -86,6 +87,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleAccessDenied(AccessDeniedException ex,
                                                                HttpServletRequest request) {
         return buildResponse(HttpStatus.FORBIDDEN, ex, "Acceso denegado", request.getRequestURI());
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponseDTO> handleResponseStatus(ResponseStatusException ex,
+                                                                HttpServletRequest request) {
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+        return buildResponse(status, ex, ex.getReason(), request.getRequestURI());
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/test/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,39 @@
+package com.willyes.clemenintegra.shared.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = GlobalExceptionHandlerTest.TestController.class)
+@Import(GlobalExceptionHandler.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RestController
+    static class TestController {
+        @GetMapping("/test")
+        public void endpoint() {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Error");
+        }
+    }
+
+    @Test
+    void responseStatusExceptionReturnsSameStatus() throws Exception {
+        mockMvc.perform(get("/test"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.status").value(422))
+                .andExpect(jsonPath("$.message").value("Error"));
+    }
+}


### PR DESCRIPTION
## Summary
- propagate HTTP status and reason from ResponseStatusException via GlobalExceptionHandler
- add MVC test verifying ResponseStatusException returns original 422 status

## Testing
- `mvn -q -Dtest=GlobalExceptionHandlerTest test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c30a2b006c8333b8fcfcc4e4641c51