### PR TITLE
Permitir movimiento de lote en cuarentena para producto terminado

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -566,8 +566,13 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                     return new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_ENCONTRADO");
                 });
 
-        if (EnumSet.of(EstadoLote.EN_CUARENTENA, EstadoLote.RETENIDO,
-                EstadoLote.RECHAZADO, EstadoLote.VENCIDO).contains(loteOrigen.getEstado())) {
+        boolean estadoBloqueado = EnumSet.of(EstadoLote.RETENIDO,
+                        EstadoLote.RECHAZADO, EstadoLote.VENCIDO)
+                .contains(loteOrigen.getEstado())
+                || (loteOrigen.getEstado() == EstadoLote.EN_CUARENTENA
+                && producto.getCategoriaProducto().getTipo() != TipoCategoria.PRODUCTO_TERMINADO);
+
+        if (estadoBloqueado) {
             log.warn(
                     "procesarMovimientoConLoteExistente: estado de lote inválido loteId={} estado={} productoId={}",
                     loteOrigen.getId(), loteOrigen.getEstado(), producto.getId());


### PR DESCRIPTION
## Summary
- Ajuste de validación de estado de lote para permitir movimientos cuando el lote está en cuarentena y el producto es terminado
- Pruebas para movimientos permitidos y bloqueados según estado del lote

## Testing
- `mvn -q test` *(falló: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c30d75eff883338d6e820d91cc2c85