### PR TITLE
Handle null origin in existing lot movement

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -580,7 +580,11 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
 
         // Declaración necesaria (si aún no está)
-        Almacen almacenOrigen = entityManager.getReference(Almacen.class, dto.almacenOrigenId());
+        Almacen almacenOrigen = origen != null
+                ? origen
+                : (dto.almacenOrigenId() != null
+                        ? entityManager.getReference(Almacen.class, dto.almacenOrigenId())
+                        : null);
 
         // Determinar si es una devolución interna
         boolean esDevolucionInterna =
@@ -588,7 +592,9 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                         dto.clasificacionMovimientoInventario() == ClasificacionMovimientoInventario.DEVOLUCION_DESDE_PRODUCCION;
 
         // Validar almacén del lote origen
-        if (!esDevolucionInterna && !loteOrigen.getAlmacen().getId().equals(almacenOrigen.getId())) {
+        if (!esDevolucionInterna
+                && almacenOrigen != null
+                && !loteOrigen.getAlmacen().getId().equals(almacenOrigen.getId())) {
             log.warn("Almacén origen no coincide: loteId={} almacenLoteId={} almacenOrigenId={}",
                     loteOrigen.getId(), loteOrigen.getAlmacen().getId(), almacenOrigen.getId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_PERTENECE_ALMACEN_ORIGEN");


### PR DESCRIPTION
## Summary
- Safely reuse provided origin warehouse or load lazily from DTO in `procesarMovimientoConLoteExistente`
- Guard origin warehouse validation to avoid NPE when origin is missing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact spring-boot-starter-parent from central)*

------
https://chatgpt.com/codex/tasks/task_e_68c315806c38833380415f5dcf4fdc09