### PR TITLE
Validar fechas de cierres de producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -61,6 +61,10 @@ import java.util.Optional;
 public class MovimientoInventarioServiceImpl implements MovimientoInventarioService {
 
     private static final Logger log = LoggerFactory.getLogger(MovimientoInventarioServiceImpl.class);
+    /** Nombre normalizado del almacén Pre-Bodega Producción */
+    private static final String PRE_BODEGA_PRODUCCION_NORMALIZADO =
+            java.text.Normalizer.normalize("Pre-Bodega Producción", java.text.Normalizer.Form.NFD)
+                    .replaceAll("\\p{M}", "").toLowerCase();
     private final AlmacenRepository almacenRepository;
     private final UsuarioRepository usuarioRepository;
     private final ProductoRepository productoRepository;
@@ -757,8 +761,8 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         String nombreOrigen = normalizar(almacenOrigen.getNombre());
         String nombreDestino = normalizar(almacenDestino.getNombre());
 
-        boolean origenPreBodega = "pre-bodega produccion".equals(nombreOrigen);
-        boolean destinoDiferente = !"pre-bodega produccion".equals(nombreDestino);
+        boolean origenPreBodega = PRE_BODEGA_PRODUCCION_NORMALIZADO.equals(nombreOrigen);
+        boolean destinoDiferente = !PRE_BODEGA_PRODUCCION_NORMALIZADO.equals(nombreDestino);
 
         return categoriaPermitida && origenPreBodega && destinoDiferente;
     }

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -20,6 +20,8 @@ import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,6 +29,8 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/produccion/ordenes")
 @RequiredArgsConstructor
+@Validated
+@Slf4j
 public class OrdenProduccionController {
 
     private final OrdenProduccionService service;
@@ -96,6 +100,7 @@ public class OrdenProduccionController {
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> registrarCierre(@PathVariable Long id,
                                                                      @Valid @RequestBody CierreProduccionRequestDTO request) {
+        log.debug("Registrar cierre recibido: ordenId={}, payload={}", id, request);
         OrdenProduccion orden = service.registrarCierre(id, request);
         return ResponseEntity.ok(ProduccionMapper.toResponse(orden));
     }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionRequestDTO.java
@@ -20,6 +20,7 @@ public class CierreProduccionRequestDTO {
     private String codigoLote;
     @NotNull
     private LocalDateTime fechaFabricacion;
+    @NotNull
     private LocalDateTime fechaVencimiento;
     private Boolean cerradaIncompleta;
     private String turno;

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -47,6 +47,7 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
@@ -413,6 +414,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
             if (dto.getCantidad() == null) {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CANTIDAD_INVALIDA");
+            }
+
+            LocalDateTime fechaFabricacion = dto.getFechaFabricacion();
+            LocalDateTime fechaVencimiento = dto.getFechaVencimiento();
+            if (fechaFabricacion != null && fechaVencimiento != null && fechaFabricacion.isAfter(fechaVencimiento)) {
+                throw new CustomBusinessException("La fecha de fabricación no puede ser posterior a la fecha de vencimiento");
             }
 
             BigDecimal cantidad = validarCantidad(dto.getCantidad(), orden.getProducto());

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -34,6 +36,15 @@ public class GlobalExceptionHandler {
         body.put("errors", ex.getBindingResult().getFieldErrors().stream()
                 .map(err -> Map.of("field", err.getField(), "message", err.getDefaultMessage()))
                 .toList());
+        return ResponseEntity.badRequest().body(body);
+    }
+
+    @ExceptionHandler({HttpMessageNotReadableException.class, DateTimeParseException.class})
+    public ResponseEntity<Map<String, String>> handleInvalidDateFormat(Exception ex) {
+        Map<String, String> body = Map.of(
+                "error", "Formato de fecha inválido",
+                "detalle", "Use 'YYYY-MM-DDTHH:mm:ss', ej. '2025-09-10T00:00:00'."
+        );
         return ResponseEntity.badRequest().body(body);
     }
 


### PR DESCRIPTION
## Summary
- Enforce required `fechaFabricacion` and `fechaVencimiento` in cierre de producción DTO
- Validate fabrication vs expiration dates and log cierre payloads
- Map parsing errors to 400 with a clear "Formato de fecha inválido" message
- Normalize "Pre-Bodega Producción" name for internal return detection

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3031bc5588333a553bb76e06bfb04