### PR TITLE
feat: add comprador role and restrict purchase orders

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -37,6 +37,7 @@ public class OrdenCompraController {
     private final OrdenCompraMapper mapper;
 
     @PostMapping
+    @PreAuthorize("hasAuthority('ROL_COMPRADOR')")
     public ResponseEntity<OrdenCompra> crear(@RequestBody OrdenCompraRequestDTO dto) {
         // 1. Validar proveedor
         Proveedor proveedor = proveedorRepository.findById(dto.getProveedorId())

--- a/src/main/java/com/willyes/clemenintegra/shared/model/enums/RolUsuario.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/model/enums/RolUsuario.java
@@ -10,6 +10,7 @@ public enum RolUsuario {
     ROL_LIDER_HOMEOPATICOS,
     ROL_LIDER_ALIMENTOS,
     ROL_CONTADOR,
+    ROL_COMPRADOR,
     ROL_SUPER_ADMIN
 }
 

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
                     ).permitAll();
 
                     auth.requestMatchers(
-                            "/api/productos/**", "/api/ordenes-compra/**",
+                            "/api/productos/**",
                             "/api/motivos/**", "/api/lotes/**", "/api/almacenes/**",
                             "/api/proveedores/**", "/api/unidades/**",
                             "/api/inventario/bitacora/**",
@@ -86,6 +86,12 @@ public class SecurityConfig {
                             RolUsuario.ROL_ANALISTA_CALIDAD.name(),
                             RolUsuario.ROL_MICROBIOLOGO.name(),
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers("/api/ordenes-compra/**").hasAnyAuthority(
+                            RolUsuario.ROL_COMPRADOR.name(),
+                            RolUsuario.ROL_JEFE_ALMACENES.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 

--- a/src/main/resources/db/migration/V20250912__asignar_rol_comprador.sql
+++ b/src/main/resources/db/migration/V20250912__asignar_rol_comprador.sql
@@ -1,0 +1,6 @@
+-- Asignar rol comprador a usuarios existentes e insertar usuario por defecto
+UPDATE usuarios SET rol = 'ROL_COMPRADOR' WHERE nombre_usuario IN ('comprador');
+
+INSERT INTO usuarios (id, nombre_usuario, clave, nombre_completo, correo, rol, activo, bloqueado)
+VALUES (100, 'comprador', '$2a$10$E6Qdl7/xZsmqilMaha3qHOrMIOLjmzT9gDC11FXGeUXLEVp3G5UpG', 'Usuario Comprador', 'comprador@demo.com', 'ROL_COMPRADOR', true, false)
+ON DUPLICATE KEY UPDATE rol = VALUES(rol);


### PR DESCRIPTION
## Summary
- add `ROL_COMPRADOR` enum and seed default user
- protect OrdenCompra creation to comprador role and adjust security config

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c407276ea08333bed48edb9e4e9444