### PR TITLE
Generar código automático para órdenes de compra

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -50,6 +49,8 @@ public class OrdenCompraController {
                 .fechaOrden(LocalDateTime.now())
                 .observaciones(dto.getObservaciones())
                 .build();
+
+        orden.setCodigoOrden(ordenCompraService.generarCodigoOrdenCompra());
 
         ordenCompraRepository.save(orden); // Necesario para generar el ID
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraRequestDTO.java
@@ -13,15 +13,10 @@ import java.util.List;
 public class OrdenCompraRequestDTO {
 
     @NotNull
-    public String codigoOrden;
-
-    @NotNull
     private Long proveedorId;
 
     private String observaciones;
 
     @NotNull
     private List<OrdenCompraDetalleRequestDTO> detalles;
-
-    public String getCodigoOrden() {return codigoOrden;}
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/OrdenCompraMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/OrdenCompraMapper.java
@@ -21,7 +21,6 @@ public interface OrdenCompraMapper {
         entity.setEstado(estado);
         entity.setFechaOrden(java.time.LocalDateTime.now());
         entity.setObservaciones(dto.getObservaciones());
-        entity.setCodigoOrden(dto.getCodigoOrden());
         return entity;
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/OrdenCompraRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/OrdenCompraRepository.java
@@ -23,4 +23,6 @@ public interface OrdenCompraRepository extends JpaRepository<OrdenCompra, Long> 
 
     Page<OrdenCompra> findByEstado(EstadoOrdenCompra estado, Pageable pageable);
 
+    Long countByCodigoOrdenStartingWith(String prefijo);
+
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +38,13 @@ public class OrdenCompraService {
     public Page<OrdenCompraResponseDTO> listarPorEstado(EstadoOrdenCompra estado, Pageable pageable) {
         return ordenCompraRepository.findByEstado(estado, pageable)
                 .map(mapper::toDTO);
+    }
+
+    public String generarCodigoOrdenCompra() {
+        String fecha = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String prefijo = "OC-CLEMEN-" + fecha;
+        Long contador = ordenCompraRepository.countByCodigoOrdenStartingWith(prefijo);
+        return prefijo + "-" + String.format("%02d", contador + 1);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Permite contar órdenes de compra existentes por prefijo para generar códigos secuenciales.
- Añade lógica de generación de código de orden de compra en el servicio.
- Asigna automáticamente el código generado al crear la orden de compra.
- Elimina el requerimiento de código de la solicitud y ajusta mapeo correspondiente.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c408c9288c8333b8c64b85c5631054