### PR TITLE
Fix Long/Integer mismatch in LoteProductoServiceImpl

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -433,7 +433,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
 
         Long almacenPtId = catalogResolver.getAlmacenPtId();
         Long almacenCuarentenaId = catalogResolver.getAlmacenCuarentenaId();
-        if (lote.getAlmacen().getId().equals(almacenPtId)
+        if (almacenPtId.equals(lote.getAlmacen().getId().longValue())
                 && lote.getEstado() == estadoLiberado
                 && lote.getFechaLiberacion() != null
                 && lote.getUsuarioLiberador() != null) {
@@ -445,8 +445,8 @@ public class LoteProductoServiceImpl implements LoteProductoService {
             }
         }
 
-        if (!lote.getAlmacen().getId().equals(almacenCuarentenaId) || lote.getEstado() != EstadoLote.EN_CUARENTENA) {
-            Long almacenId = lote.getAlmacen().getId();
+        if (!almacenCuarentenaId.equals(lote.getAlmacen().getId().longValue()) || lote.getEstado() != EstadoLote.EN_CUARENTENA) {
+            Long almacenId = Long.valueOf(lote.getAlmacen().getId());
             EstadoLote estadoLote = lote.getEstado();
             log.warn("Intento de liberar lote {} fuera de cuarentena: almacenId={} estado={}", loteId, almacenId, estadoLote);
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,


### PR DESCRIPTION
## Summary
- Normalize `Almacen` ID comparisons to avoid Integer/Long mismatch during lote liberación

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c404cec28083339a5c3a4d22d31472