### PR TITLE
Allow buyer role to access suppliers API

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -82,6 +82,7 @@ public class SecurityConfig {
                             RolUsuario.ROL_ALMACENISTA.name(),
                             RolUsuario.ROL_JEFE_ALMACENES.name(),
                             RolUsuario.ROL_CONTADOR.name(),
+                            RolUsuario.ROL_COMPRADOR.name(),
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
                             RolUsuario.ROL_ANALISTA_CALIDAD.name(),
                             RolUsuario.ROL_MICROBIOLOGO.name(),

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ProveedorControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ProveedorControllerSecurityTest.java
@@ -1,0 +1,50 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.inventario.repository.ProveedorRepository;
+import com.willyes.clemenintegra.inventario.mapper.ProveedorMapper;
+import com.willyes.clemenintegra.inventario.service.ProveedorService;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ProveedorController.class)
+@Import(SecurityConfig.class)
+class ProveedorControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean private ProveedorRepository proveedorRepository;
+    @MockBean private ProveedorMapper proveedorMapper;
+    @MockBean private ProveedorService proveedorService;
+    @MockBean private UsuarioRepository usuarioRepository;
+    @MockBean private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean private UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void compradorPuedeAccederProveedores() throws Exception {
+        Page emptyPage = new PageImpl<>(Collections.emptyList());
+        given(proveedorService.listar(any(Pageable.class))).willReturn(emptyPage);
+        mockMvc.perform(get("/api/proveedores"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- Permit `ROL_COMPRADOR` to access inventory, product, and supplier endpoints
- Add Spring MVC test verifying buyers can reach `/api/proveedores`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c414cc7d4083338556173e1654a33f