### PR TITLE
feat: assign order ID to purchase order details

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ El código ha sido refactorizado mediante **Codex Workspace**, mejorando la legi
 - **Lotes** `/api/lotes` – CRUD.
   - `/api/lotes/por-evaluar` lista los lotes aún pendientes de evaluación. Cada elemento incluye el arreglo `evaluaciones` con los tipos de evaluación ya realizados.
 - **Movimientos** `/api/movimientos` – registrar y consultar con filtros `productoId`, `almacenId`, `tipoMovimiento`, `clasificacion`, `fechaInicio`, `fechaFin`.
+- **Órdenes de compra** `/api/ordenes-compra` – crear una orden con sus detalles.
+  - En la creación, el servidor asigna automáticamente la orden a cada detalle, por lo que no se requiere `ordenCompraId` en los elementos enviados.
 - **Ajustes de inventario** `/api/inventario/ajustes` – listar, crear y eliminar.
 - **Reportes** `/api/reportes` – alta/baja rotación (`fechaInicio`, `fechaFin`), productos más costosos (`categoria`), trazabilidad por lote (`codigoLote`), productos en retención o liberación (`estadoLote`, `desde`, `hasta`), no conformidades (`tipo`, `area`, `desde`, `hasta`), CAPA (`estado`, `desde`, `hasta`), stock actual, productos por vencer, alertas de inventario y movimientos. Todos devuelven Excel.
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraDetalleController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraDetalleController.java
@@ -33,9 +33,10 @@ public class OrdenCompraDetalleController {
                 .collect(Collectors.toList());
     }
 
-    @PostMapping
-    public ResponseEntity<OrdenCompraDetalleResponse> crear(@RequestBody OrdenCompraDetalleRequestDTO request) {
-        OrdenCompra orden = ordenCompraRepository.findById(request.getOrdenCompraId())
+    @PostMapping("/{ordenCompraId}")
+    public ResponseEntity<OrdenCompraDetalleResponse> crear(@PathVariable Long ordenCompraId,
+                                                            @RequestBody OrdenCompraDetalleRequestDTO request) {
+        OrdenCompra orden = ordenCompraRepository.findById(ordenCompraId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Orden de compra no encontrada"));
 
         Producto producto = productoRepository.findById(request.getProductoId())

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDetalleRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDetalleRequestDTO.java
@@ -10,6 +10,10 @@ import java.math.BigDecimal;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+/**
+ * Datos para crear un detalle de orden de compra.
+ * El identificador de la orden es asignado por el servidor.
+ */
 public class OrdenCompraDetalleRequestDTO {
     @NotNull
     @DecimalMin(value = "0.01")
@@ -23,8 +27,5 @@ public class OrdenCompraDetalleRequestDTO {
 
     @NotNull
     private Long productoId;
-
-    @NotNull
-    private Long ordenCompraId;
 
 }


### PR DESCRIPTION
## Summary
- drop `ordenCompraId` from order detail creation DTO and document server-side assignment
- map order detail creation endpoint with order ID path variable
- document in README that the server assigns the purchase order to each detail

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c41cc7cb04833385b27819a302a446