### PR TITLE
Validate non-empty purchase order details

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -44,6 +44,10 @@ public class OrdenCompraController {
         // 1. Validar proveedor
         Proveedor proveedor = proveedorRepository.findById(dto.getProveedorId())
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Proveedor no encontrado"));
+
+        if (dto.getDetalles() == null || dto.getDetalles().isEmpty()) {
+            throw new ResponseStatusException(BAD_REQUEST, "Debe registrar al menos un detalle");
+        }
         
         // 2. Crear orden y detalles dentro de la misma transacción
         OrdenCompra orden = OrdenCompra.builder()

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraRequestDTO.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -17,6 +18,6 @@ public class OrdenCompraRequestDTO {
 
     private String observaciones;
 
-    @NotNull
+    @NotEmpty
     private List<OrdenCompraDetalleRequestDTO> detalles;
 }


### PR DESCRIPTION
## Summary
- Require a non-empty details list for purchase orders
- Reject creation requests that lack at least one detail line

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4214c4f70833381344af03cf6012a