### PR TITLE
Allow buyer role to search products

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -38,7 +38,7 @@ public class ProductoController {
     private final UsuarioRepository usuarioRepository;
 
     @GetMapping("/buscar")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
     public ResponseEntity<Page<ProductoOptionDTO>> buscarProductos(
             @RequestParam(name = "q", required = false) String q,
             @PageableDefault(size = 10, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoControllerSecurityTest.java
@@ -1,0 +1,50 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.service.ProductoService;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ProductoController.class)
+@Import(SecurityConfig.class)
+class ProductoControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean private ProductoService productoService;
+    @MockBean private ProductoRepository productoRepository;
+    @MockBean private MovimientoInventarioRepository movimientoInventarioRepository;
+    @MockBean private UnidadMedidaRepository unidadMedidaRepository;
+    @MockBean private UsuarioRepository usuarioRepository;
+    @MockBean private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean private UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void compradorPuedeBuscarProductos() throws Exception {
+        given(productoService.buscarOpciones(anyString(), any(Pageable.class))).willReturn(Page.empty());
+        mockMvc.perform(get("/api/productos/buscar"))
+                .andExpect(status().isOk());
+    }
+}
+


### PR DESCRIPTION
## Summary
- permit buyer role to access product search endpoint
- add security test verifying buyer access to product search

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.willyes.clemenintegra:inventario:1.0.0 due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c418dbe7208333bf21b395d1a35272