### PR TITLE
feat: log purchase order state changes

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraService.java
@@ -2,9 +2,12 @@ package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.OrdenCompraResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.OrdenCompraMapper;
+import com.willyes.clemenintegra.inventario.model.HistorialEstadoOrden;
 import com.willyes.clemenintegra.inventario.model.OrdenCompra;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
+import com.willyes.clemenintegra.inventario.repository.HistorialEstadoOrdenRepository;
 import com.willyes.clemenintegra.inventario.repository.OrdenCompraRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Service
@@ -19,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 public class OrdenCompraService {
 
     private final OrdenCompraRepository ordenCompraRepository;
+    private final HistorialEstadoOrdenRepository historialEstadoOrdenRepository;
     private final OrdenCompraMapper mapper;
 
     /**
@@ -69,6 +74,27 @@ public class OrdenCompraService {
             orden.setEstado(nuevoEstado);
             ordenCompraRepository.save(orden);
         }
+    }
+
+    public HistorialEstadoOrden cambiarEstado(Long ordenId, EstadoOrdenCompra estado, Long usuarioId, String observaciones) {
+        OrdenCompra orden = ordenCompraRepository.findById(ordenId)
+                .orElseThrow(() -> new IllegalArgumentException("Orden de compra no encontrada"));
+
+        orden.setEstado(estado);
+        ordenCompraRepository.save(orden);
+
+        Usuario usuario = new Usuario();
+        usuario.setId(usuarioId);
+
+        HistorialEstadoOrden historial = HistorialEstadoOrden.builder()
+                .ordenCompra(orden)
+                .estado(estado)
+                .fechaCambio(LocalDateTime.now())
+                .cambiadoPor(usuario)
+                .observaciones(observaciones)
+                .build();
+
+        return historialEstadoOrdenRepository.save(historial);
     }
 
     // Métodos adicionales futuros: crear, editar, anular, etc.


### PR DESCRIPTION
## Summary
- add method to change purchase order status and store state history
- inject history repository into order service

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c431e06b74833396fc7ed74a92b2c7