### PR TITLE
Agregar endpoint para cambiar estado de orden de compra

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.controller;
 
 import com.willyes.clemenintegra.inventario.dto.*;
 import com.willyes.clemenintegra.inventario.mapper.OrdenCompraMapper;
+import com.willyes.clemenintegra.inventario.mapper.HistorialEstadoOrdenMapper;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
 import com.willyes.clemenintegra.inventario.repository.*;
@@ -150,6 +151,18 @@ public class OrdenCompraController {
                 .map(mapper::toOrdenCompraConDetallesResponse)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}/estado")
+    public ResponseEntity<HistorialEstadoOrdenResponse> cambiarEstado(
+            @PathVariable Long id,
+            @RequestBody CambioEstadoOrdenRequest request) {
+        var historial = ordenCompraService.cambiarEstado(
+                id,
+                request.estado,
+                request.usuarioId,
+                request.observaciones);
+        return ResponseEntity.ok(HistorialEstadoOrdenMapper.toResponse(historial));
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/CambioEstadoOrdenRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/CambioEstadoOrdenRequest.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
+
+public class CambioEstadoOrdenRequest {
+    public EstadoOrdenCompra estado;
+    public Long usuarioId;
+    public String observaciones;
+}
+


### PR DESCRIPTION
## Summary
- Añadir DTO `CambioEstadoOrdenRequest` para recibir estado, usuario y observaciones
- Exponer endpoint `PUT /api/ordenes-compra/{id}/estado` que delega en `ordenCompraService.cambiarEstado` y devuelve `HistorialEstadoOrdenResponse`

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c43262f3a4833386e87ed447887f38