### PR TITLE
Add endpoint to filter order history by purchase order

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/HistorialEstadoOrdenController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/HistorialEstadoOrdenController.java
@@ -26,6 +26,13 @@ public class HistorialEstadoOrdenController {
                 .collect(Collectors.toList());
     }
 
+    @GetMapping("/orden/{ordenId}")
+    public List<HistorialEstadoOrdenResponse> listarPorOrden(@PathVariable Long ordenId) {
+        return service.listarPorOrden(ordenId).stream()
+                .map(HistorialEstadoOrdenMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
     @PostMapping
     public ResponseEntity<HistorialEstadoOrdenResponse> crear(@RequestBody HistorialEstadoOrdenRequest request) {
         OrdenCompra orden = new OrdenCompra(); orden.setId(request.ordenCompraId != null ? request.ordenCompraId.intValue() : null);

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/HistorialEstadoOrdenRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/HistorialEstadoOrdenRepository.java
@@ -3,6 +3,9 @@ package com.willyes.clemenintegra.inventario.repository;
 import com.willyes.clemenintegra.inventario.model.HistorialEstadoOrden;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface HistorialEstadoOrdenRepository extends JpaRepository<HistorialEstadoOrden, Long> {
+    List<HistorialEstadoOrden> findByOrdenCompra_Id(Long ordenId);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/HistorialEstadoOrdenService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/HistorialEstadoOrdenService.java
@@ -6,5 +6,6 @@ import java.util.List;
 
 public interface HistorialEstadoOrdenService {
     List<HistorialEstadoOrden> listarTodos();
+    List<HistorialEstadoOrden> listarPorOrden(Long ordenId);
     HistorialEstadoOrden guardar(HistorialEstadoOrden historial);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/HistorialEstadoOrdenServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/HistorialEstadoOrdenServiceImpl.java
@@ -17,6 +17,10 @@ public class HistorialEstadoOrdenServiceImpl implements HistorialEstadoOrdenServ
         return repository.findAll();
     }
 
+    public List<HistorialEstadoOrden> listarPorOrden(Long ordenId) {
+        return repository.findByOrdenCompra_Id(ordenId);
+    }
+
     public HistorialEstadoOrden guardar(HistorialEstadoOrden historial) {
         return repository.save(historial);
     }


### PR DESCRIPTION
## Summary
- allow repository lookup of history by purchase order id
- support filtering order history by purchase order in service and controller

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4333d655883339ae21b7eadfb0025