### PR TITLE
Expose inventory order endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ El código ha sido refactorizado mediante **Codex Workspace**, mejorando la legi
 - **Lotes** `/api/lotes` – CRUD.
   - `/api/lotes/por-evaluar` lista los lotes aún pendientes de evaluación. Cada elemento incluye el arreglo `evaluaciones` con los tipos de evaluación ya realizados.
 - **Movimientos** `/api/movimientos` – registrar y consultar con filtros `productoId`, `almacenId`, `tipoMovimiento`, `clasificacion`, `fechaInicio`, `fechaFin`.
-- **Órdenes de compra** `/api/ordenes-compra` – crear una orden con sus detalles.
+- **Órdenes de compra** `/api/inventario/ordenes` – crear una orden con sus detalles.
   - En la creación, el servidor asigna automáticamente la orden a cada detalle, por lo que no se requiere `ordenCompraId` en los elementos enviados.
 - **Ajustes de inventario** `/api/inventario/ajustes` – listar, crear y eliminar.
 - **Reportes** `/api/reportes` – alta/baja rotación (`fechaInicio`, `fechaFin`), productos más costosos (`categoria`), trazabilidad por lote (`codigoLote`), productos en retención o liberación (`estadoLote`, `desde`, `hasta`), no conformidades (`tipo`, `area`, `desde`, `hasta`), CAPA (`estado`, `desde`, `hasta`), stock actual, productos por vencer, alertas de inventario y movimientos. Todos devuelven Excel.

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static org.springframework.http.HttpStatus.*;
 
 @RestController
-@RequestMapping("/api/ordenes-compra")
+@RequestMapping("/api/inventario/ordenes")
 @RequiredArgsConstructor
 public class OrdenCompraController {
 

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -90,7 +90,7 @@ public class SecurityConfig {
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
-                    auth.requestMatchers("/api/ordenes-compra/**").hasAnyAuthority(
+                    auth.requestMatchers("/api/inventario/ordenes/**").hasAnyAuthority(
                             RolUsuario.ROL_COMPRADOR.name(),
                             RolUsuario.ROL_JEFE_ALMACENES.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()


### PR DESCRIPTION
## Summary
- move purchase order controller under `/api/inventario/ordenes`
- secure new path for authorized roles
- document inventory order route in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c43073f2408333bf67ca6ad19a13d3