### PR TITLE
feat: allow alternate purchase order path

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static org.springframework.http.HttpStatus.*;
 
 @RestController
-@RequestMapping("/api/inventario/ordenes")
+@RequestMapping({"/api/inventario/ordenes", "/api/ordenes-compra"})
 @RequiredArgsConstructor
 public class OrdenCompraController {
 

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -96,6 +96,12 @@ public class SecurityConfig {
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
+                    auth.requestMatchers("/api/ordenes-compra/**").hasAnyAuthority(
+                            RolUsuario.ROL_COMPRADOR.name(),
+                            RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
                     auth.requestMatchers("/api/movimientos/**", "/api/categorias/**",
                             "/api/inventario/alertas/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_ALMACENES.name(),


### PR DESCRIPTION
## Summary
- support purchase order endpoints under `/api/ordenes-compra`
- secure new purchase order route for authorized roles

## Testing
- `mvn -q test -Dtest=OrdenCompraControllerTokenTest` *(fails: Non-resolvable parent POM; Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68c44f2fcfe083338c9824e83907d3b9