### PR TITLE
Allow unauthenticated access to error path

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -156,6 +156,7 @@ public class SecurityConfig {
                     );
 
                     // Mantener esta regla genérica al final
+                    auth.requestMatchers("/error").permitAll();
                     auth.requestMatchers("/api/**").authenticated();
                     auth.anyRequest().authenticated();
                 })


### PR DESCRIPTION
## Summary
- allow unrestricted access to `/error` so unknown routes return 404 instead of 401

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*
- `mvn -q -DskipTests spring-boot:run` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c44f55f65c8333a80e245f6334a677