### PR TITLE
Filtrar stock de insumos por almacenes válidos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -55,5 +55,17 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
             GROUP BY p.id
             """, nativeQuery = true)
     List<StockDisponibleProjection> calcularStockDisponiblePorProducto(List<Long> ids);
+
+    @Query(value = """
+            SELECT p.id AS productoId,
+                   COALESCE(SUM(CASE WHEN lp.estado IN ('DISPONIBLE','LIBERADO')
+                                     AND (lp.stock_lote - COALESCE(lp.stock_reservado, 0)) > 0
+                                     THEN (lp.stock_lote - COALESCE(lp.stock_reservado, 0)) ELSE 0 END), 0) AS stockDisponible
+            FROM productos p
+            LEFT JOIN lotes_productos lp ON lp.productos_id = p.id
+            WHERE p.id IN (?1) AND lp.almacenes_id IN (?2)
+            GROUP BY p.id
+            """, nativeQuery = true)
+    List<StockDisponibleProjection> calcularStockDisponiblePorProductoEnAlmacenes(List<Long> ids, List<Long> almacenes);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/StockQueryService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/StockQueryService.java
@@ -36,6 +36,25 @@ public class StockQueryService {
                                           StockDisponibleProjection::getStockDisponible));
     }
 
+    public Map<Long, BigDecimal> obtenerStockDisponible(List<Long> ids, List<Long> almacenes) {
+        if (ids == null || ids.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        if (almacenes == null || almacenes.isEmpty()) {
+            return obtenerStockDisponible(ids);
+        }
+        List<Long> uniqueIds = ids.stream().filter(Objects::nonNull).distinct().toList();
+        List<Long> uniqueAlmacenes = almacenes.stream().filter(Objects::nonNull).distinct().toList();
+        List<StockDisponibleProjection> rows = Optional
+                .ofNullable(productoRepository.calcularStockDisponiblePorProductoEnAlmacenes(uniqueIds, uniqueAlmacenes))
+                .orElse(Collections.emptyList());
+        return rows.stream()
+                .filter(Objects::nonNull)
+                .filter(row -> row.getProductoId() != null && row.getStockDisponible() != null)
+                .collect(Collectors.toMap(StockDisponibleProjection::getProductoId,
+                                          StockDisponibleProjection::getStockDisponible));
+    }
+
     public BigDecimal obtenerStockDisponible(Long id) {
         return obtenerStockDisponible(List.of(id)).getOrDefault(id, BigDecimal.ZERO);
     }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -237,8 +237,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 .toList();
         Map<Long, Producto> productosInsumo = productoRepository.findAllById(insumoIds).stream()
                 .collect(Collectors.toMap(p -> p.getId().longValue(), p -> p));
-
-        Map<Long, BigDecimal> stockPorInsumo = stockQueryService.obtenerStockDisponible(insumoIds);
+        List<Long> almacenesValidos = obtenerAlmacenesOrigen(orden.getProducto());
+        Map<Long, BigDecimal> stockPorInsumo = stockQueryService.obtenerStockDisponible(insumoIds, almacenesValidos);
 
         for (DetalleFormula insumo : formula.getDetalles()) {
             Long insumoId = insumo.getInsumo().getId().longValue();

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -72,6 +72,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Map;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -1143,7 +1144,9 @@ class OrdenProduccionServiceImplTest {
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(1L, EstadoFormula.APROBADA))
                 .thenReturn(Optional.of(formula));
         when(productoRepository.findAllById(List.of(100L))).thenReturn(List.of(insumo));
-        when(stockQueryService.obtenerStockDisponible(eq(List.of(100L))))
+        when(catalogResolver.getAlmacenBodegaPrincipalId()).thenReturn(1L);
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(2L);
+        when(stockQueryService.obtenerStockDisponible(eq(List.of(100L)), eq(List.of(1L, 2L))))
                 .thenReturn(Map.of(100L, BigDecimal.valueOf(15)));
         when(repository.save(any())).thenAnswer(inv -> {
             OrdenProduccion o = inv.getArgument(0);
@@ -1167,8 +1170,52 @@ class OrdenProduccionServiceImplTest {
         ResultadoValidacionOrdenDTO resultado = spyService.guardarConValidacionStock(orden);
 
         assertTrue(resultado.isEsValida());
-        verify(stockQueryService, times(1)).obtenerStockDisponible(eq(List.of(100L)));
+        verify(stockQueryService, times(1)).obtenerStockDisponible(eq(List.of(100L)), eq(List.of(1L, 2L)));
         verify(stockQueryService, never()).obtenerStockDisponible(anyLong());
+    }
+
+    @Test
+    void guardarConValidacionStockSinStockEnAlmacenesPermitidos() {
+        Producto producto = new Producto();
+        producto.setId(1);
+
+        Usuario responsable = new Usuario();
+        responsable.setId(2L);
+
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .producto(producto)
+                .cantidadProgramada(BigDecimal.valueOf(5))
+                .responsable(responsable)
+                .build();
+
+        Producto insumo = new Producto();
+        insumo.setId(100);
+        insumo.setNombre("Insumo A");
+        UnidadMedida um = new UnidadMedida();
+        um.setSimbolo("kg");
+        insumo.setUnidadMedida(um);
+
+        DetalleFormula detalle = DetalleFormula.builder()
+                .insumo(insumo)
+                .cantidadNecesaria(BigDecimal.valueOf(2))
+                .build();
+
+        FormulaProducto formula = FormulaProducto.builder()
+                .detalles(List.of(detalle))
+                .build();
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(1L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+        when(productoRepository.findAllById(List.of(100L))).thenReturn(List.of(insumo));
+        when(catalogResolver.getAlmacenBodegaPrincipalId()).thenReturn(1L);
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(2L);
+        when(stockQueryService.obtenerStockDisponible(eq(List.of(100L)), eq(List.of(1L, 2L))))
+                .thenReturn(Collections.emptyMap());
+
+        ResultadoValidacionOrdenDTO resultado = service.guardarConValidacionStock(orden);
+
+        assertFalse(resultado.isEsValida());
+        assertEquals("Stock insuficiente para algunos insumos", resultado.getMensaje());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Añade consulta en `ProductoRepository` para calcular stock disponible por producto filtrado por almacenes
- Expone en `StockQueryService` un método sobrecargado que permite filtrar por almacenes
- Valida órdenes de producción usando únicamente stock de almacenes permitidos
- Agrega pruebas para caso sin stock en almacenes válidos

## Testing
- `mvn -q -Dtest=OrdenProduccionServiceImplTest test` *(falla: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cc0142b88333a51454b8971b2bd9