### PR TITLE
Ajuste de stock disponible excluyendo lotes agotados

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/dto/LoteResumenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/LoteResumenDTO.java
@@ -13,7 +13,7 @@ public class LoteResumenDTO {
     private String codigoLote;
     private EstadoLote estado;
     private String almacenNombre;
-    private BigDecimal stockLote;
+    private BigDecimal stockDisponible;
     private LocalDateTime fechaVencimiento;
     private LocalDateTime fechaLiberacion;
     private String nombreUsuarioLiberador;

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -119,7 +119,7 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                 java.time.LocalDateTime ahora = java.time.LocalDateTime.now();
                 for (LoteResumenDTO lote : lotes) {
                     if (lote.getFechaVencimiento() != null && lote.getFechaVencimiento().isBefore(ahora)) {
-                        BigDecimal st = lote.getStockLote();
+                        BigDecimal st = lote.getStockDisponible();
                         vencidoExtra = vencidoExtra.add(st);
                         totales.put(lote.getEstado(), totales.get(lote.getEstado()).subtract(st));
                     }

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -83,20 +83,20 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     @Query("""
       select lp.estado as estado, coalesce(sum(lp.stockLote - lp.stockReservado),0)
       from LoteProducto lp
-      where lp.producto.id = :productoId and (lp.stockLote - lp.stockReservado) > 0
+      where lp.producto.id = :productoId and (lp.stockLote - lp.stockReservado) > 0 and lp.agotado = false
       group by lp.estado
     """)
     List<Object[]> sumarPorEstado(@Param("productoId") Long productoId);
 
     @Query("""
      select new com.willyes.clemenintegra.bom.dto.LoteResumenDTO(
-        lp.id, lp.codigoLote, lp.estado, a.nombre, lp.stockLote,
+        lp.id, lp.codigoLote, lp.estado, a.nombre, (lp.stockLote - lp.stockReservado),
         lp.fechaVencimiento, lp.fechaLiberacion, u.nombreCompleto
      )
      from LoteProducto lp
      left join lp.almacen a
      left join lp.usuarioLiberador u
-     where lp.producto.id = :productoId and lp.stockLote > 0
+     where lp.producto.id = :productoId and (lp.stockLote - lp.stockReservado) > 0 and lp.agotado = false
      order by lp.estado asc, lp.fechaVencimiento asc
     """)
     List<com.willyes.clemenintegra.bom.dto.LoteResumenDTO> listarLotesPorProducto(@Param("productoId") Long productoId);

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -1,0 +1,130 @@
+package com.willyes.clemenintegra.bom.service;
+
+import com.willyes.clemenintegra.bom.dto.FormulaProductoResponse;
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.*;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class FormulaProductoServiceImplTest {
+
+    @Autowired
+    private FormulaProductoServiceImpl service;
+    @Autowired
+    private FormulaProductoRepository formulaRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private AlmacenRepository almacenRepository;
+
+    @BeforeEach
+    void setup() {
+        loteProductoRepository.deleteAll();
+        formulaRepository.deleteAll();
+        productoRepository.deleteAll();
+        unidadMedidaRepository.deleteAll();
+        categoriaProductoRepository.deleteAll();
+        usuarioRepository.deleteAll();
+        almacenRepository.deleteAll();
+    }
+
+    @Test
+    void disponibilidadExcluyeAgotadosYReservados() {
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Kg").simbolo("kg").build());
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Mat").tipo(TipoCategoria.MATERIA_PRIMA).build());
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("user").clave("pwd").nombreCompleto("User")
+                .correo("u@t.com").rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true).bloqueado(false).build());
+
+        Producto insumo = productoRepository.save(Producto.builder()
+                .codigoSku("INS1").nombre("Insumo1").descripcionProducto("d")
+                .stockMinimo(BigDecimal.ZERO).tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .unidadMedida(unidad).categoriaProducto(categoria).creadoPor(usuario)
+                .build());
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("PROD1").nombre("Producto1").descripcionProducto("d")
+                .stockMinimo(BigDecimal.ZERO).tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .unidadMedida(unidad).categoriaProducto(categoria).creadoPor(usuario)
+                .build());
+
+        DetalleFormula detalle = DetalleFormula.builder()
+                .insumo(insumo)
+                .unidadMedida(unidad)
+                .cantidadNecesaria(BigDecimal.ONE)
+                .obligatorio(true)
+                .build();
+        FormulaProducto formula = FormulaProducto.builder()
+                .producto(producto)
+                .estado(EstadoFormula.APROBADA)
+                .activo(true)
+                .fechaCreacion(LocalDateTime.now())
+                .creadoPor(usuario)
+                .detalles(List.of(detalle))
+                .build();
+        detalle.setFormula(formula);
+        formulaRepository.save(formula);
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Main").ubicacion("U")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("L1")
+                .producto(insumo)
+                .almacen(almacen)
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(new BigDecimal("10"))
+                .stockReservado(new BigDecimal("3"))
+                .agotado(false)
+                .build());
+
+        loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("L2")
+                .producto(insumo)
+                .almacen(almacen)
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(new BigDecimal("5"))
+                .stockReservado(BigDecimal.ZERO)
+                .agotado(true)
+                .fechaAgotado(LocalDateTime.now())
+                .build());
+
+        FormulaProductoResponse resp = service.obtenerFormulaActivaPorProducto(producto.getId().longValue(), BigDecimal.ONE);
+
+        BigDecimal esperado = new BigDecimal("7");
+        assertEquals(0, esperado.compareTo(resp.detalles.get(0).stockDisponible));
+        assertEquals(1, resp.detalles.get(0).lotes.size());
+        assertEquals("L1", resp.detalles.get(0).lotes.get(0).getCodigoLote());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Filtrar lotes agotados y stock reservado en consultas de disponibilidad
- Exponer `stockDisponible` en `LoteResumenDTO` y utilizarlo en la lógica de fórmula
- Añadir prueba de servicio para validar exclusión de lotes agotados y reservas

## Testing
- `mvn -q -e -Dtest=FormulaProductoServiceImplTest test` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b60327a0833390e8674e2fe051e7