### PR TITLE
Compute lote fechas from etapas

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
@@ -1,0 +1,28 @@
+package com.willyes.clemenintegra.inventario.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "vida_util_productos")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class VidaUtilProducto {
+
+    @Id
+    @Column(name = "producto_id")
+    @EqualsAndHashCode.Include
+    private Integer productoId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "producto_id", foreignKey = @ForeignKey(name = "fk_vida_util_productos_producto"))
+    private Producto producto;
+
+    @Column(name = "semanas_vigencia", nullable = false)
+    private Integer semanasVigencia;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/VidaUtilProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/VidaUtilProductoRepository.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.VidaUtilProducto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VidaUtilProductoRepository extends JpaRepository<VidaUtilProducto, Integer> {
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/CierreProduccionRequestDTO.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -18,10 +17,6 @@ public class CierreProduccionRequestDTO {
     @NotNull
     private TipoCierre tipo;
     private String codigoLote;
-    @NotNull
-    private LocalDateTime fechaFabricacion;
-    @NotNull
-    private LocalDateTime fechaVencimiento;
     private Boolean cerradaIncompleta;
     private String turno;
     private String observacion;


### PR DESCRIPTION
## Summary
- Stop requiring fabrication and expiration dates in CierreProduccionRequestDTO
- Infer lote dates from first production stage and product shelf life
- Introduce VidaUtilProducto entity and repository with semanas_vigencia
- Add service tests for fecha de etapa and vida útil based vencimiento

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d1ece1bc8333befc7834e3e12092