### PR TITLE
feat: expose lote production dates

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/LoteProductoResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/LoteProductoResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -14,6 +15,8 @@ import lombok.NoArgsConstructor;
 public class LoteProductoResponse {
     private Long id;
     private String codigoLote;
+    private LocalDateTime fechaFabricacion;
+    private LocalDateTime fechaVencimiento;
     private EstadoLote estado;
     private AlmacenResponseDTO almacen;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -970,6 +970,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 .map(lote -> LoteProductoResponse.builder()
                         .id(lote.getId())
                         .codigoLote(lote.getCodigoLote())
+                        .fechaFabricacion(lote.getFechaFabricacion())
+                        .fechaVencimiento(lote.getFechaVencimiento())
                         .estado(lote.getEstado())
                         .almacen(new AlmacenResponseDTO(lote.getAlmacen()))
                         .build())

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -91,9 +92,13 @@ class OrdenProduccionControllerTest {
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     void obtenerLote_ok() throws Exception {
         AlmacenResponseDTO almacen = AlmacenResponseDTO.builder().id(1).nombre("A1").build();
+        LocalDateTime fabricacion = LocalDateTime.of(2024, 1, 1, 10, 0);
+        LocalDateTime vencimiento = LocalDateTime.of(2024, 6, 1, 10, 0);
         LoteProductoResponse lote = LoteProductoResponse.builder()
                 .id(7L)
                 .codigoLote("L1")
+                .fechaFabricacion(fabricacion)
+                .fechaVencimiento(vencimiento)
                 .estado(EstadoLote.DISPONIBLE)
                 .almacen(almacen)
                 .build();
@@ -102,7 +107,9 @@ class OrdenProduccionControllerTest {
         mockMvc.perform(get("/api/produccion/ordenes/{id}/lote", 5))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(7))
-                .andExpect(jsonPath("$.codigoLote").value("L1"));
+                .andExpect(jsonPath("$.codigoLote").value("L1"))
+                .andExpect(jsonPath("$.fechaFabricacion").value(fabricacion.toString()))
+                .andExpect(jsonPath("$.fechaVencimiento").value(vencimiento.toString()));
     }
 }
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -1434,6 +1434,8 @@ class OrdenProduccionServiceImplTest {
         LoteProducto lote = LoteProducto.builder()
                 .id(7L)
                 .codigoLote("L1")
+                .fechaFabricacion(LocalDateTime.of(2024, 1, 1, 10, 0))
+                .fechaVencimiento(LocalDateTime.of(2024, 6, 1, 10, 0))
                 .estado(EstadoLote.DISPONIBLE)
                 .almacen(almacen)
                 .build();
@@ -1445,6 +1447,8 @@ class OrdenProduccionServiceImplTest {
         assertNotNull(dto);
         assertEquals(7L, dto.getId());
         assertEquals("L1", dto.getCodigoLote());
+        assertEquals(LocalDateTime.of(2024, 1, 1, 10, 0), dto.getFechaFabricacion());
+        assertEquals(LocalDateTime.of(2024, 6, 1, 10, 0), dto.getFechaVencimiento());
         assertEquals(EstadoLote.DISPONIBLE, dto.getEstado());
         assertEquals(1, dto.getAlmacen().getId());
     }


### PR DESCRIPTION
## Summary
- include fabrication and expiration dates in lote response
- map lote dates when retrieving an order's lote
- extend controller and service tests for new date fields

## Testing
- `mvn -q -Dtest=OrdenProduccionControllerTest,OrdenProduccionServiceImplTest test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent 3.2.3 – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f7580a1883339c3793881aed5cd6