### PR TITLE
Permitir entradas sin validar disponibilidad de lote

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -605,18 +605,21 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
 
         BigDecimal reservadoActual = Optional.ofNullable(loteOrigen.getStockReservado()).orElse(BigDecimal.ZERO);
-        if (solicitud != null && solicitud.getEstado() == EstadoSolicitudMovimiento.RESERVADA) {
-            if (reservadoActual.compareTo(cantidad) < 0) {
-                log.warn("RESERVA_INSUFICIENTE: loteId={} reservado={} solicitado={} productoId={}",
-                        loteOrigen.getId(), reservadoActual, cantidad, producto.getId());
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVA_INSUFICIENTE");
-            }
-        } else {
-            BigDecimal disponible = loteOrigen.getStockLote().subtract(reservadoActual);
-            if (disponible.compareTo(cantidad) < 0) {
-                log.warn("Stock insuficiente en lote: loteId={} disponible={} solicitado={} productoId={}",
-                        loteOrigen.getId(), disponible, cantidad, producto.getId());
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE");
+        if (EnumSet.of(TipoMovimiento.SALIDA, TipoMovimiento.TRANSFERENCIA,
+                TipoMovimiento.DEVOLUCION, TipoMovimiento.AJUSTE).contains(tipo)) {
+            if (solicitud != null && solicitud.getEstado() == EstadoSolicitudMovimiento.RESERVADA) {
+                if (reservadoActual.compareTo(cantidad) < 0) {
+                    log.warn("RESERVA_INSUFICIENTE: loteId={} reservado={} solicitado={} productoId={}",
+                            loteOrigen.getId(), reservadoActual, cantidad, producto.getId());
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVA_INSUFICIENTE");
+                }
+            } else {
+                BigDecimal disponible = loteOrigen.getStockLote().subtract(reservadoActual);
+                if (disponible.compareTo(cantidad) < 0) {
+                    log.warn("Stock insuficiente en lote: loteId={} disponible={} solicitado={} productoId={}",
+                            loteOrigen.getId(), disponible, cantidad, producto.getId());
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE");
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Excluir movimientos de entrada de la validación de stock del lote
- Añadir prueba que verifica incremento de stock sin validar disponibilidad

## Testing
- `mvn -q -Dtest=MovimientoInventarioServiceImplTest#entradaConLoteExistenteIncrementaStockSinValidarDisponibilidad test` *(fails: Non-resolvable parent POM)*
- `mvn -q -Dtest=OrdenProduccionServiceImplTest#variosCierresParcialesAcumulan+cierreTotalSubproduccionFinalizaOrden test` *(fails: Non-resolvable parent POM)*


------
https://chatgpt.com/codex/tasks/task_e_68c5fd3e04248333b4fbdfda1d6413c5