### PR TITLE
Fix SolicitudMovimientoDetalle count query to use solicitudMovimiento field

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoDetalleRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoDetalleRepository.java
@@ -18,10 +18,10 @@ public interface SolicitudMovimientoDetalleRepository extends JpaRepository<Soli
     }
 
     @Query("""
-            select d.solicitud.id as solicitudId, count(d.id) as cnt
+            select d.solicitudMovimiento.id as solicitudId, count(d.id) as cnt
             from SolicitudMovimientoDetalle d
-            where d.solicitud.id in :ids
-            group by d.solicitud.id
+            where d.solicitudMovimiento.id in :ids
+            group by d.solicitudMovimiento.id
             """)
     List<SolicitudDetalleCount> countBySolicitudIds(@Param("ids") List<Long> ids);
 }


### PR DESCRIPTION
## Summary
- update the `countBySolicitudIds` query to reference the `solicitudMovimiento` relationship when counting details
- verified no other repository queries use the outdated `d.solicitud` path

## Testing
- `mvn -q -DskipTests compile` *(fails: cannot reach Maven Central to resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c9616a32148333919ee1b24e9ed64e