### PR TITLE
Add items count per OP to solicitud listing

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoDetalleRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoDetalleRepository.java
@@ -17,6 +17,12 @@ public interface SolicitudMovimientoDetalleRepository extends JpaRepository<Soli
         Long getCnt();
     }
 
+    interface OpDetalleCount {
+        Long getOpId();
+
+        Long getCnt();
+    }
+
     @Query("""
             select d.solicitudMovimiento.id as solicitudId, count(d.id) as cnt
             from SolicitudMovimientoDetalle d
@@ -24,5 +30,13 @@ public interface SolicitudMovimientoDetalleRepository extends JpaRepository<Soli
             group by d.solicitudMovimiento.id
             """)
     List<SolicitudDetalleCount> countBySolicitudIds(@Param("ids") List<Long> ids);
+
+    @Query("""
+            select d.solicitudMovimiento.ordenProduccion.id as opId, count(d.id) as cnt
+            from SolicitudMovimientoDetalle d
+            where d.solicitudMovimiento.ordenProduccion.id in :opIds
+            group by d.solicitudMovimiento.ordenProduccion.id
+            """)
+    List<OpDetalleCount> countByOpIds(@Param("opIds") List<Long> opIds);
 }
 


### PR DESCRIPTION
## Summary
- add a repository projection and query to count detalle rows grouped by orden de producción
- populate the listado DTOs with the aggregated item totals per OP while keeping the legacy `items` field in sync

## Testing
- mvn -q -DskipTests package *(fails: network is unreachable while downloading the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c9650e66c8833399e74ccdeaead2fd