### PR TITLE
Ajusta creación de solicitudes de OP a estado pendiente

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -133,7 +133,6 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                 .usuarioSolicitante(solicitante)
                 .usuarioResponsable(responsable)
                 .observaciones(dto.getObservaciones())
-                .estado(EstadoSolicitudMovimiento.PENDIENTE)
                 .build();
 
         SolicitudMovimiento guardada = repository.save(solicitud);


### PR DESCRIPTION
## Summary
- Evita fijar explícitamente el estado de las solicitudes al registrarlas desde el servicio estándar, dejando que @PrePersist asigne PENDIENTE.
- Reutiliza SolicitudMovimientoService al reservar insumos de una OP y limpia la lógica para construir los detalles y reservas sin forzar estado.

## Testing
- mvn -q test *(falla: no se pudo resolver el parent POM por falta de acceso a Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cb88c98083338f288cd610e1c174