### PR TITLE
feat: default Pre-Bodega destino for OP solicitudes

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -237,6 +237,10 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             }
         }
 
+        if (dto.almacenDestinoId() == null && solicitud != null && solicitud.getAlmacenDestino() != null) {
+            almacenDestino = solicitud.getAlmacenDestino();
+        }
+
         // Detección automática de devolución interna
         boolean devolucionInterna = false;
         if (tipoMovimiento == TipoMovimiento.TRANSFERENCIA && almacenOrigen != null && almacenDestino != null) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -820,6 +820,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                         .lote(new LoteProducto(lote.getLoteProductoId()))
                         .cantidad(usar)
                         .almacenOrigen(lote.getAlmacenId() != null ? new Almacen(lote.getAlmacenId()) : null)
+                        .almacenDestino(solicitud.getAlmacenDestino())
                         .build();
                 detallesSolicitud.add(detSolicitud);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,8 @@ spring.web.cors.allowed-headers=*
 spring.web.cors.exposed-headers=*
 spring.web.cors.allow-credentials=true
 
+app.inventario.prebodega.id=6
+
 inventory.almacen.pt.id=2
 inventory.almacen.cuarentena.id=7
 inventory.motivo.entradaPt=ENTRADA_PRODUCTO_TERMINADO


### PR DESCRIPTION
## Summary
- add configurable Pre-Bodega Producción id with default value 6
- assign the default destination warehouse when creating OP-linked solicitudes (including their detalles)
- reuse the solicitud destination when executing a movimiento if the DTO omits almacenDestinoId

## Testing
- mvn -q -DskipTests package *(fails: network is unreachable while resolving Maven parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e3f3043c8333a25a8a8123a59f68