### PR TITLE
Implement auto-split logic for FEFO transfers

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
@@ -38,7 +38,9 @@ public record MovimientoInventarioDTO(
          * Estado inicial sugerido por el cliente. Este valor se ignora en el
          * proceso de registro del movimiento.
          */
-        EstadoLote estadoLote
+        EstadoLote estadoLote,
+
+        Boolean autoSplit
 
 
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,6 +50,11 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     @Lock(jakarta.persistence.LockModeType.PESSIMISTIC_WRITE)
     @Query("select l from LoteProducto l where l.id = :id")
     Optional<LoteProducto> findByIdForUpdate(@Param("id") Long id);
+
+    List<LoteProducto> findByProductoIdAndAlmacenesIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
+            Long productoId,
+            Integer almacenId,
+            Collection<EstadoLote> estados);
 
     @Query(value = """
         SELECT lp.id AS loteProductoId,

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -666,8 +666,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     null,
                     null,
                     null,
-                    lote.getEstado()
-            );
+                    lote.getEstado(),
+                    null);
             movimientoInventarioService.registrarMovimiento(movDto);
             log.info("OP-cierre entrada PT op={}, producto={}, lote={}, cantidad={}, usuario={}, destino={}, motivoId={}, tipoDetalleId={}",
                     orden.getId(), orden.getProducto().getId(), lote.getId(), cantidad, usuario.getId(), destino.getId(), motivoEntrada.getId(), tipoDetalleEntrada.getId());
@@ -947,8 +947,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                                 null,
                                 null,
                                 null,
-                                detRes.getLote().getEstado()
-                        );
+                                detRes.getLote().getEstado(),
+                                null);
                         movimientoInventarioService.registrarMovimiento(movDto);
                     }
                 }


### PR DESCRIPTION
## Summary
- add an autoSplit flag to inventory movement DTOs and update production code to pass the new parameter
- implement FEFO-based auto-split planning in MovimientoInventarioServiceImpl, including multi-lot handling and repository support
- extend MovimientoInventarioServiceImpl tests with auto-split scenarios and ensure existing cases use the new return type

## Testing
- mvn -q -DskipITs test *(fails: unable to resolve parent POM because external Maven repository is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68caae46f16c8333bba133b5a8da8880