### PR TITLE
Fix auto-split logging delimiter

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -856,7 +856,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             if (!consumidos.isEmpty()) {
                 String lotesLog = consumidos.stream()
                         .map(par -> String.format("{loteId=%d, cantidad=%s}", par.loteId(), par.cantidad()))
-                        .collect(Collectors.joining(", \"));
+                        .collect(Collectors.joining(", "));
                 log.info("AUTO_SPLIT_FEFO productoId={} opId={} almacenOrigenId={} lotes=[{}] total={}",
                         producto.getId(), dto.ordenProduccionId(),
                         almacenOrigen != null ? almacenOrigen.getId() : null,


### PR DESCRIPTION
## Summary
- replace the malformed delimiter in the auto-split logging joiner so the code compiles

## Testing
- `mvn -DskipTests package` *(fails: network is unreachable while downloading parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cab61e32988333b612eaf1b86723c7