### PR TITLE
Fix LoteProducto repository derived query

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -51,7 +51,7 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     @Query("select l from LoteProducto l where l.id = :id")
     Optional<LoteProducto> findByIdForUpdate(@Param("id") Long id);
 
-    List<LoteProducto> findByProductoIdAndAlmacenesIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
+    List<LoteProducto> findByProductoIdAndAlmacenIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
             Long productoId,
             Integer almacenId,
             Collection<EstadoLote> estados);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -954,7 +954,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
 
         List<LoteProducto> candidatos = loteProductoRepository
-                .findByProductoIdAndAlmacenesIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
+                .findByProductoIdAndAlmacenIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
                         productoId,
                         almacenOrigenId,
                         List.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO));

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImplTest.java
@@ -786,7 +786,7 @@ class MovimientoInventarioServiceImplTest {
                 loteInicial.getCodigoLote(), producto.getId(), destino.getId())).thenReturn(Optional.empty());
         when(loteProductoRepository.findByCodigoLoteAndProductoIdAndAlmacenId(
                 loteAdicional.getCodigoLote(), producto.getId(), destino.getId())).thenReturn(Optional.empty());
-        when(loteProductoRepository.findByProductoIdAndAlmacenesIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
+        when(loteProductoRepository.findByProductoIdAndAlmacenIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
                 producto.getId().longValue(), origen.getId(),
                 List.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO)))
                 .thenReturn(List.of(loteInicial, loteAdicional));
@@ -854,7 +854,7 @@ class MovimientoInventarioServiceImplTest {
         when(entityManager.getReference(Almacen.class, destino.getId())).thenReturn(destino);
         when(loteProductoRepository.findById(loteInicial.getId())).thenReturn(Optional.of(loteInicial));
         when(loteProductoRepository.findById(loteAdicional.getId())).thenReturn(Optional.of(loteAdicional));
-        when(loteProductoRepository.findByProductoIdAndAlmacenesIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
+        when(loteProductoRepository.findByProductoIdAndAlmacenIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
                 producto.getId().longValue(), origen.getId(),
                 List.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO)))
                 .thenReturn(List.of(loteInicial, loteAdicional));


### PR DESCRIPTION
## Summary
- rename the LoteProductoRepository derived query so it navigates the almacen property instead of a nonexistent almacenesId field
- update MovimientoInventarioServiceImpl and its unit tests to call the renamed repository method

## Testing
- mvn -q -DskipTests compile *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cabdfc16348333a9312376ffac0264