### PR TITLE
Actualizar atención de solicitudes en movimientos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/AtencionDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/AtencionDTO.java
@@ -1,0 +1,52 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import java.math.BigDecimal;
+
+public class AtencionDTO {
+
+    private Long detalleId;
+    private Long loteId;
+    private BigDecimal cantidad;
+    private Integer almacenOrigenId;
+    private Integer almacenDestinoId;
+
+    public Long getDetalleId() {
+        return detalleId;
+    }
+
+    public void setDetalleId(Long detalleId) {
+        this.detalleId = detalleId;
+    }
+
+    public Long getLoteId() {
+        return loteId;
+    }
+
+    public void setLoteId(Long loteId) {
+        this.loteId = loteId;
+    }
+
+    public BigDecimal getCantidad() {
+        return cantidad;
+    }
+
+    public void setCantidad(BigDecimal cantidad) {
+        this.cantidad = cantidad;
+    }
+
+    public Integer getAlmacenOrigenId() {
+        return almacenOrigenId;
+    }
+
+    public void setAlmacenOrigenId(Integer almacenOrigenId) {
+        this.almacenOrigenId = almacenOrigenId;
+    }
+
+    public Integer getAlmacenDestinoId() {
+        return almacenDestinoId;
+    }
+
+    public void setAlmacenDestinoId(Integer almacenDestinoId) {
+        this.almacenDestinoId = almacenDestinoId;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
@@ -50,53 +50,6 @@ public record MovimientoInventarioDTO(
 
 
 ) {
-    public static class AtencionDTO {
-        private Long detalleId;
-        private Long loteId;
-        private BigDecimal cantidad;
-        private Integer almacenOrigenId;
-        private Integer almacenDestinoId;
-
-        public Long getDetalleId() {
-            return detalleId;
-        }
-
-        public void setDetalleId(Long detalleId) {
-            this.detalleId = detalleId;
-        }
-
-        public Long getLoteId() {
-            return loteId;
-        }
-
-        public void setLoteId(Long loteId) {
-            this.loteId = loteId;
-        }
-
-        public BigDecimal getCantidad() {
-            return cantidad;
-        }
-
-        public void setCantidad(BigDecimal cantidad) {
-            this.cantidad = cantidad;
-        }
-
-        public Integer getAlmacenOrigenId() {
-            return almacenOrigenId;
-        }
-
-        public void setAlmacenOrigenId(Integer almacenOrigenId) {
-            this.almacenOrigenId = almacenOrigenId;
-        }
-
-        public Integer getAlmacenDestinoId() {
-            return almacenDestinoId;
-        }
-
-        public void setAlmacenDestinoId(Integer almacenDestinoId) {
-            this.almacenDestinoId = almacenDestinoId;
-        }
-    }
 }
 
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -51,6 +51,10 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     @Query("select l from LoteProducto l where l.id = :id")
     Optional<LoteProducto> findByIdForUpdate(@Param("id") Long id);
 
+    @Lock(jakarta.persistence.LockModeType.PESSIMISTIC_WRITE)
+    @Query("select l from LoteProducto l where l.id = :id")
+    Optional<LoteProducto> findByIdWithLock(@Param("id") Long id);
+
     List<LoteProducto> findByProductoIdAndAlmacenIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
             Long productoId,
             Integer almacenId,

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoDetalleRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoDetalleRepository.java
@@ -1,12 +1,18 @@
 package com.willyes.clemenintegra.inventario.repository;
 
 import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import jakarta.persistence.LockModeType;
+
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SolicitudMovimientoDetalleRepository extends JpaRepository<SolicitudMovimientoDetalle, Long> {
@@ -38,5 +44,18 @@ public interface SolicitudMovimientoDetalleRepository extends JpaRepository<Soli
             group by d.solicitudMovimiento.ordenProduccion.id
             """)
     List<OpDetalleCount> countByOpIds(@Param("opIds") List<Long> opIds);
+
+    @Override
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<SolicitudMovimientoDetalle> findById(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<SolicitudMovimientoDetalle> findFirstBySolicitudMovimientoIdAndLoteIdAndEstadoInOrderByIdAsc(
+            Long solicitudId,
+            Long loteId,
+            Collection<EstadoSolicitudMovimientoDetalle> estados
+    );
+
+    long countBySolicitudMovimientoIdAndEstadoNot(Long solicitudId, EstadoSolicitudMovimientoDetalle estado);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
@@ -5,14 +5,18 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimient
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
+import jakarta.persistence.LockModeType;
+
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface SolicitudMovimientoRepository extends JpaRepository<SolicitudMovimiento, Long>, JpaSpecificationExecutor<SolicitudMovimiento> {
     List<SolicitudMovimiento> findByEstado(EstadoSolicitudMovimiento estado);
@@ -56,6 +60,24 @@ public interface SolicitudMovimientoRepository extends JpaRepository<SolicitudMo
             "left join fetch det.almacenDestino detAd " +
             "where s.id = :id")
     java.util.Optional<SolicitudMovimiento> findWithDetalles(@Param("id") Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select distinct s from SolicitudMovimiento s " +
+            "left join fetch s.producto p " +
+            "left join fetch p.unidadMedida um " +
+            "left join fetch s.lote l " +
+            "left join fetch s.almacenOrigen ao " +
+            "left join fetch s.almacenDestino ad " +
+            "left join fetch s.usuarioSolicitante us " +
+            "left join fetch s.ordenProduccion op " +
+            "left join fetch s.motivoMovimiento mm " +
+            "left join fetch s.tipoMovimientoDetalle tmd " +
+            "left join fetch s.detalles det " +
+            "left join fetch det.lote detLote " +
+            "left join fetch det.almacenOrigen detAo " +
+            "left join fetch det.almacenDestino detAd " +
+            "where s.id = :id")
+    Optional<SolicitudMovimiento> findByIdWithLock(@Param("id") Long id);
 
     @Override
     @EntityGraph(attributePaths = {"usuarioSolicitante", "ordenProduccion"})


### PR DESCRIPTION
## Summary
- crear DTO independiente para atenciones de solicitudes y utilizarlo en los movimientos
- consumir stock reservado y actualizar detalles/cabecera de la solicitud al registrar el movimiento, devolviendo la información en la respuesta
- añadir consultas con bloqueo pesimista para lotes y detalles de solicitud

## Testing
- mvn -q -DskipTests compile *(falla: Network is unreachable al resolver el parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cae892f98c8333812afd9c27318211