### PR TITLE
Filter pre-bodega stock when validating movements

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerTest.java
@@ -13,6 +13,7 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
 import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import com.willyes.clemenintegra.inventario.service.StockQueryService;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,11 +29,13 @@ import org.springframework.http.ResponseEntity;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,6 +52,8 @@ class MovimientoInventarioControllerTest {
     private SolicitudMovimientoRepository solicitudMovimientoRepository;
     @Mock
     private StockQueryService stockQueryService;
+    @Mock
+    private InventoryCatalogResolver inventoryCatalogResolver;
 
     @InjectMocks
     private MovimientoInventarioController controller;
@@ -56,9 +61,12 @@ class MovimientoInventarioControllerTest {
     private Producto producto;
     private LoteProducto lote;
     private SolicitudMovimiento solicitud;
+    private static final long PRE_BODEGA_ID = 999L;
 
     @BeforeEach
     void setUp() {
+        when(inventoryCatalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(PRE_BODEGA_ID);
+
         producto = new Producto();
         producto.setId(1);
 
@@ -93,7 +101,7 @@ class MovimientoInventarioControllerTest {
                 null,
                 producto.getId(),
                 lote.getId(),
-                null,
+                100,
                 null,
                 null,
                 null,
@@ -113,7 +121,8 @@ class MovimientoInventarioControllerTest {
         when(productoRepository.findById(producto.getId().longValue())).thenReturn(Optional.of(producto));
         when(loteProductoRepository.findById(lote.getId())).thenReturn(Optional.of(lote));
         when(solicitudMovimientoRepository.findWithDetalles(solicitud.getId())).thenReturn(Optional.of(solicitud));
-        when(stockQueryService.obtenerStockDisponible(anyLong())).thenReturn(BigDecimal.ONE);
+        when(stockQueryService.obtenerStockDisponible(anyList(), anyList()))
+                .thenReturn(Map.of(producto.getId().longValue(), BigDecimal.ONE));
         when(movimientoInventarioService.registrarMovimiento(any(MovimientoInventarioDTO.class)))
                 .thenReturn(MovimientoInventarioResponseDTO.builder().id(200L).build());
 
@@ -136,7 +145,7 @@ class MovimientoInventarioControllerTest {
                 null,
                 producto.getId(),
                 lote.getId(),
-                null,
+                100,
                 null,
                 null,
                 null,
@@ -156,7 +165,8 @@ class MovimientoInventarioControllerTest {
         when(productoRepository.findById(producto.getId().longValue())).thenReturn(Optional.of(producto));
         when(loteProductoRepository.findById(lote.getId())).thenReturn(Optional.of(lote));
         when(solicitudMovimientoRepository.findWithDetalles(solicitud.getId())).thenReturn(Optional.of(solicitud));
-        when(stockQueryService.obtenerStockDisponible(anyLong())).thenReturn(BigDecimal.ONE);
+        when(stockQueryService.obtenerStockDisponible(anyList(), anyList()))
+                .thenReturn(Map.of(producto.getId().longValue(), BigDecimal.ONE));
         when(movimientoInventarioService.registrarMovimiento(any(MovimientoInventarioDTO.class)))
                 .thenReturn(MovimientoInventarioResponseDTO.builder().id(201L).build());
 
@@ -164,6 +174,45 @@ class MovimientoInventarioControllerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         verify(movimientoInventarioService).registrarMovimiento(dto);
+    }
+
+    @Test
+    void registrarSalidaConStockSoloEnPreBodegaDebeResponderConflict() {
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                BigDecimal.valueOf(2),
+                TipoMovimiento.SALIDA,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                null,
+                producto.getId(),
+                lote.getId(),
+                (int) PRE_BODEGA_ID,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(productoRepository.findById(producto.getId().longValue())).thenReturn(Optional.of(producto));
+        when(loteProductoRepository.findById(lote.getId())).thenReturn(Optional.of(lote));
+
+        ResponseEntity<?> response = controller.registrar(dto);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody()).isInstanceOf(Map.class);
+        assertThat(((Map<?, ?>) response.getBody()).get("message"))
+                .isEqualTo("No hay suficiente stock disponible");
+        verify(movimientoInventarioService, never()).registrarMovimiento(any(MovimientoInventarioDTO.class));
     }
 }
 


### PR DESCRIPTION
## Summary
- inject the inventory catalog resolver into the inventory movement controller to build origin warehouse filters and exclude the pre-bodega when validating stock
- switch stock checks to use the warehouse-aware query and fail fast if no valid warehouses remain or filtered stock is insufficient
- expand controller unit tests to cover the pre-bodega rejection scenario and updated stock validation behaviour

## Testing
- `mvn -q test` *(fails: unable to reach Maven Central to resolve spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68d17e0f900883339f479b3e1127a4ae