### PR TITLE
Ajusta almacenes de origen por categoría

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogResolver.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogResolver.java
@@ -104,9 +104,13 @@ public class InventoryCatalogResolver {
     public Long getAlmacenPtId() { return almacenPtId; }
     public Long getAlmacenCuarentenaId() { return almacenCuarentenaId; }
     public Long getAlmacenObsoletosId() { return almacenObsoletosId; }
-    public Long getAlmacenMateriaPrimaId() { return almacenMateriaPrimaId; }
-    public Long getAlmacenMaterialEmpaqueId() { return almacenMaterialEmpaqueId; }
-    public Long getAlmacenSuministrosId() { return almacenSuministrosId; }
+    public Long getAlmacenOrigenMateriaPrimaId() { return almacenMateriaPrimaId; }
+    public Long getAlmacenOrigenMaterialEmpaqueId() { return almacenMaterialEmpaqueId; }
+    public Long getAlmacenOrigenSuministrosId() { return almacenSuministrosId; }
+
+    public Long getAlmacenMateriaPrimaId() { return getAlmacenOrigenMateriaPrimaId(); }
+    public Long getAlmacenMaterialEmpaqueId() { return getAlmacenOrigenMaterialEmpaqueId(); }
+    public Long getAlmacenSuministrosId() { return getAlmacenOrigenSuministrosId(); }
     public Long getAlmacenPreBodegaProduccionId() { return almacenPreBodegaProduccionId; }
 
     public Long getMotivoIdEntradaProductoTerminado() { return motivoEntradaPtId; }


### PR DESCRIPTION
## Summary
- actualiza el resolver de catálogos para exponer getters específicos de almacén de origen
- utiliza los nuevos getters en la lógica de orden de producción y mantiene la exclusión de la pre-bodega
- amplía las pruebas unitarias para comprobar los almacenes usados al validar stock y reservar insumos

## Testing
- `mvn -q -DskipITs test` *(falla: no hay acceso a Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d19005b9d48333b5d37c2652dc7de0