### PR TITLE
Generar atenciones automáticas por detalle de solicitud

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImplTest.java
@@ -9,6 +9,7 @@ import com.willyes.clemenintegra.shared.service.UsuarioService;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,7 +21,11 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -178,5 +183,113 @@ class MovimientoInventarioServiceImplTest {
         assertThat(resultado.get(0).lote()).isEqualTo(loteDestino);
         assertThat(resultado.get(0).cantidad()).isEqualByComparingTo(new BigDecimal("10.00"));
         assertThat(loteOrigen.getStockLote()).isEqualByComparingTo(new BigDecimal("0.00"));
+    }
+
+    @Test
+    void atiendeSolicitudConMultiplesDetallesDelMismoLoteSinExcederPendiente() {
+        Almacen origen = new Almacen();
+        origen.setId(3);
+
+        Producto producto = new Producto();
+        producto.setId(500);
+        producto.setTipoAnalisisCalidad(TipoAnalisisCalidad.NINGUNO);
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(600L);
+        lote.setProducto(producto);
+        lote.setAlmacen(origen);
+        lote.setStockLote(new BigDecimal("150.00"));
+        lote.setStockReservado(new BigDecimal("100.000000"));
+
+        SolicitudMovimiento solicitud = SolicitudMovimiento.builder()
+                .id(700L)
+                .estado(EstadoSolicitudMovimiento.AUTORIZADA)
+                .tipoMovimiento(TipoMovimiento.SALIDA)
+                .producto(producto)
+                .lote(lote)
+                .almacenOrigen(origen)
+                .fechaSolicitud(LocalDateTime.now())
+                .detalles(new java.util.ArrayList<>())
+                .build();
+
+        SolicitudMovimientoDetalle detalle12 = SolicitudMovimientoDetalle.builder()
+                .id(710L)
+                .solicitudMovimiento(solicitud)
+                .lote(lote)
+                .cantidad(new BigDecimal("12.000000"))
+                .cantidadAtendida(BigDecimal.ZERO)
+                .estado(EstadoSolicitudMovimientoDetalle.PENDIENTE)
+                .almacenOrigen(origen)
+                .build();
+
+        SolicitudMovimientoDetalle detalle88 = SolicitudMovimientoDetalle.builder()
+                .id(711L)
+                .solicitudMovimiento(solicitud)
+                .lote(lote)
+                .cantidad(new BigDecimal("88.000000"))
+                .cantidadAtendida(BigDecimal.ZERO)
+                .estado(EstadoSolicitudMovimientoDetalle.PENDIENTE)
+                .almacenOrigen(origen)
+                .build();
+
+        solicitud.getDetalles().add(detalle12);
+        solicitud.getDetalles().add(detalle88);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("100.000000"),
+                TipoMovimiento.SALIDA,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                null,
+                producto.getId(),
+                lote.getId(),
+                origen.getId(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                123L,
+                solicitud.getId(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                EstadoLote.DISPONIBLE,
+                Boolean.FALSE,
+                List.of()
+        );
+
+        when(loteProductoRepository.findByIdForUpdate(lote.getId())).thenReturn(Optional.of(lote));
+        when(loteProductoRepository.save(any(LoteProducto.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(solicitudMovimientoDetalleRepository.findById(detalle12.getId())).thenReturn(Optional.of(detalle12));
+        when(solicitudMovimientoDetalleRepository.findById(detalle88.getId())).thenReturn(Optional.of(detalle88));
+        when(solicitudMovimientoDetalleRepository.save(any(SolicitudMovimientoDetalle.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(reservaLoteRepository.sumPendienteActivaByLoteId(eq(lote.getId()), eq(EstadoReservaLote.ACTIVA)))
+                .thenReturn(BigDecimal.ZERO);
+
+        assertThatCode(() -> ReflectionTestUtils.invokeMethod(
+                service,
+                "atenderSolicitudMovimiento",
+                dto,
+                solicitud
+        )).doesNotThrowAnyException();
+
+        ArgumentCaptor<SolicitudMovimientoDetalle> detalleCaptor = ArgumentCaptor.forClass(SolicitudMovimientoDetalle.class);
+        ArgumentCaptor<BigDecimal> cantidadCaptor = ArgumentCaptor.forClass(BigDecimal.class);
+
+        verify(reservaLoteService, times(2)).consumirReserva(
+                eq(solicitud),
+                detalleCaptor.capture(),
+                eq(lote),
+                cantidadCaptor.capture()
+        );
+
+        assertThat(detalleCaptor.getAllValues()).extracting(SolicitudMovimientoDetalle::getId)
+                .containsExactly(detalle12.getId(), detalle88.getId());
+        assertThat(cantidadCaptor.getAllValues())
+                .containsExactly(new BigDecimal("12.000000"), new BigDecimal("88.000000"));
     }
 }


### PR DESCRIPTION
## Summary
- dividir las atenciones implícitas según los detalles pendientes de la solicitud y limitar la cantidad por detalle para evitar excedentes
- registrar una prueba unitaria que cubre el consumo de múltiples detalles del mismo lote al atender una solicitud

## Testing
- `mvn -q -Dtest=MovimientoInventarioServiceImplTest test` *(falla: no se pudo resolver el parent POM de Spring Boot por falta de acceso a Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d1df1e2da48333a79d557c3bc1a995