### PR TITLE
Ajusta consulta de stock y agrega prueba para almacenes

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -61,11 +61,12 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
             SELECT p.id AS productoId,
                    COALESCE(SUM(CASE WHEN lp.estado IN ('DISPONIBLE','LIBERADO')
                                      AND lp.agotado = false
+                                     AND lp.almacenes_id IN (?2)
                                      AND (lp.stock_lote - COALESCE(lp.stock_reservado, 0)) > 0
                                      THEN (lp.stock_lote - COALESCE(lp.stock_reservado, 0)) ELSE 0 END), 0) AS stockDisponible
             FROM productos p
             LEFT JOIN lotes_productos lp ON lp.productos_id = p.id
-            WHERE p.id IN (?1) AND lp.almacenes_id IN (?2) AND lp.agotado = false
+            WHERE p.id IN (?1)
             GROUP BY p.id
             """, nativeQuery = true)
     List<StockDisponibleProjection> calcularStockDisponiblePorProductoEnAlmacenes(List<Long> ids, List<Long> almacenes);

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/StockQueryServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/StockQueryServiceTest.java
@@ -1,0 +1,113 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class StockQueryServiceTest {
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private StockQueryService stockQueryService;
+
+    @BeforeEach
+    void setUp() {
+        stockQueryService = new StockQueryService(productoRepository);
+    }
+
+    @Test
+    void devuelveProductoConStockCeroCuandoNoHayLotesEnAlmacenFiltrado() {
+        UnidadMedida unidad = entityManager.persistAndFlush(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("u")
+                .build());
+
+        CategoriaProducto categoria = entityManager.persistAndFlush(CategoriaProducto.builder()
+                .nombre("Insumos")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        Usuario usuario = entityManager.persistAndFlush(Usuario.builder()
+                .nombreUsuario("operador")
+                .clave("secreto")
+                .nombreCompleto("Operador Principal")
+                .correo("operador@example.com")
+                .rol(RolUsuario.ROL_ALMACENISTA)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        Producto producto = new Producto();
+        producto.setCodigoSku("INS-001");
+        producto.setNombre("Insumo 1");
+        producto.setDescripcionProducto("Insumo de prueba");
+        producto.setStockMinimo(BigDecimal.ZERO);
+        producto.setActivo(true);
+        producto.setTipoAnalisisCalidad(TipoAnalisisCalidad.NINGUNO);
+        producto.setUnidadMedida(unidad);
+        producto.setCategoriaProducto(categoria);
+        producto.setCreadoPor(usuario);
+        producto = entityManager.persistAndFlush(producto);
+
+        Almacen almacenFiltrado = entityManager.persistAndFlush(Almacen.builder()
+                .nombre("Principal")
+                .ubicacion("Zona A")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        Almacen almacenAlterno = entityManager.persistAndFlush(Almacen.builder()
+                .nombre("Secundario")
+                .ubicacion("Zona B")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.SATELITE)
+                .build());
+
+        entityManager.persistAndFlush(LoteProducto.builder()
+                .codigoLote("LOTE-EXT")
+                .producto(producto)
+                .almacen(almacenAlterno)
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(new BigDecimal("5.00"))
+                .stockReservado(BigDecimal.ZERO.setScale(6))
+                .agotado(false)
+                .build());
+
+        Long productoId = producto.getId().longValue();
+        Long almacenFiltradoId = almacenFiltrado.getId().longValue();
+
+        Map<Long, BigDecimal> stockPorProducto = stockQueryService.obtenerStockDisponible(
+                List.of(productoId),
+                List.of(almacenFiltradoId)
+        );
+
+        assertThat(stockPorProducto).containsOnlyKeys(productoId);
+        assertThat(stockPorProducto.get(productoId)).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+}
+


### PR DESCRIPTION
## Summary
- actualiza la consulta nativa para mantener el filtro de almacenes dentro del CASE y preservar el LEFT JOIN
- agrega una prueba de integración para StockQueryService que verifica que se devuelva stock cero cuando no hay lotes en el almacén filtrado

## Testing
- mvn -q test *(falla: Non-resolvable parent POM por falta de acceso a Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d2075421ec83339afb75a1931cfa55