### PR TITLE
Considera almacenes de detalles en validación de stock

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -34,11 +34,13 @@ import org.springframework.web.server.ResponseStatusException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Objects;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/movimientos")
@@ -99,6 +101,29 @@ public class MovimientoInventarioController {
 
                 if (preBodegaId != null) {
                     almacenesFiltrados.removeIf(id -> Objects.equals(id, preBodegaId));
+                }
+
+                if (almacenesFiltrados.isEmpty() && solicitudMovimiento != null) {
+                    Set<Long> almacenesDesdeDetalles = new LinkedHashSet<>();
+                    if (solicitudMovimiento.getDetalles() != null) {
+                        for (SolicitudMovimientoDetalle detalle : solicitudMovimiento.getDetalles()) {
+                            if (detalle != null
+                                    && detalle.getAlmacenOrigen() != null
+                                    && detalle.getAlmacenOrigen().getId() != null) {
+                                almacenesDesdeDetalles.add(detalle.getAlmacenOrigen().getId().longValue());
+                            }
+                        }
+                    }
+                    if (preBodegaId != null) {
+                        almacenesDesdeDetalles.removeIf(id -> Objects.equals(id, preBodegaId));
+                    }
+                    if (!almacenesDesdeDetalles.isEmpty()) {
+                        almacenesFiltrados.addAll(almacenesDesdeDetalles);
+                    }
+                }
+
+                if (!almacenesFiltrados.isEmpty()) {
+                    almacenesFiltrados = new ArrayList<>(new LinkedHashSet<>(almacenesFiltrados));
                 }
 
                 if (almacenesFiltrados.isEmpty()) {


### PR DESCRIPTION
## Summary
- toma los almacenes de origen de la solicitud cuando no se definieron en el DTO ni en la solicitud principal
- excluye Pre-Bodega y evita duplicados antes de validar stock
- garantiza que la validación de stock considere todos los lotes asignados en la solicitud

## Testing
- `mvn -q -DskipTests compile` *(falla: sin acceso a https://repo.maven.apache.org/maven2)*

------
https://chatgpt.com/codex/tasks/task_e_68d269ea83208333a2f4ea264f8088b5