### PR TITLE
Add safeguards for quality evaluations and tests

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -1,0 +1,204 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.ArchivoEvaluacionDTO;
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import com.willyes.clemenintegra.calidad.mapper.EvaluacionCalidadMapper;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EvaluacionCalidadServiceImplTest {
+
+    @Mock
+    private EvaluacionCalidadRepository repository;
+    @Mock
+    private LoteProductoRepository loteRepository;
+    @Mock
+    private EvaluacionCalidadMapper mapper;
+    @Mock
+    private UsuarioService usuarioService;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private InventoryCatalogResolver catalogResolver;
+    @Mock
+    private AlmacenRepository almacenRepository;
+
+    private EvaluacionCalidadServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EvaluacionCalidadServiceImpl(repository, loteRepository, mapper,
+                usuarioService, usuarioRepository, catalogResolver, almacenRepository);
+    }
+
+    @Test
+    void registrarEvaluacionMicroNoModificaAlmacen() throws Exception {
+        Usuario user = buildUsuario(1L, RolUsuario.ROL_MICROBIOLOGO);
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(user);
+
+        LoteProducto lote = buildLoteEnCuarentena(5L, 7);
+        when(loteRepository.findById(5L)).thenReturn(Optional.of(lote), Optional.of(lote));
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(repository.existsByLoteProductoIdAndTipoEvaluacion(5L, TipoEvaluacion.MICROBIOLOGICO)).thenReturn(false);
+        mockMapperToEntity();
+        mockMapperToResponse();
+        when(repository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        MultipartFile archivo = buildArchivoMock();
+        EvaluacionCalidadRequestDTO dto = baseRequest(5L, TipoEvaluacion.MICROBIOLOGICO);
+
+        service.crear(dto, List.of(archivo));
+
+        verify(loteRepository, never()).saveAndFlush(any());
+        assertThat(lote.getAlmacen().getId()).isEqualTo(7);
+    }
+
+    @Test
+    void registrarEvaluacionFisicoQuimicoNoModificaAlmacen() throws Exception {
+        Usuario user = buildUsuario(2L, RolUsuario.ROL_ANALISTA_CALIDAD);
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(user);
+
+        LoteProducto lote = buildLoteEnCuarentena(8L, 7);
+        when(loteRepository.findById(8L)).thenReturn(Optional.of(lote), Optional.of(lote));
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(repository.existsByLoteProductoIdAndTipoEvaluacion(8L, TipoEvaluacion.FISICO_QUIMICO)).thenReturn(false);
+        mockMapperToEntity();
+        mockMapperToResponse();
+        when(repository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        MultipartFile archivo = buildArchivoMock();
+        EvaluacionCalidadRequestDTO dto = baseRequest(8L, TipoEvaluacion.FISICO_QUIMICO);
+
+        service.crear(dto, List.of(archivo));
+
+        verify(loteRepository, never()).saveAndFlush(any());
+        assertThat(lote.getAlmacen().getId()).isEqualTo(7);
+    }
+
+    @Test
+    void registrarEvaluacionMicroRestauraSiOtroProcesoMueveElLote() throws Exception {
+        Usuario user = buildUsuario(3L, RolUsuario.ROL_MICROBIOLOGO);
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(user);
+
+        LoteProducto loteInicial = buildLoteEnCuarentena(15L, 7);
+        LoteProducto loteMutado = buildLoteEnCuarentena(15L, 1);
+        when(loteRepository.findById(15L)).thenReturn(Optional.of(loteInicial), Optional.of(loteMutado));
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(almacenRepository.findById(7L)).thenReturn(Optional.of(new Almacen(7)));
+        when(repository.existsByLoteProductoIdAndTipoEvaluacion(15L, TipoEvaluacion.MICROBIOLOGICO)).thenReturn(false);
+        mockMapperToEntity();
+        mockMapperToResponse();
+        when(repository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        MultipartFile archivo = buildArchivoMock();
+        EvaluacionCalidadRequestDTO dto = baseRequest(15L, TipoEvaluacion.MICROBIOLOGICO);
+
+        service.crear(dto, List.of(archivo));
+
+        ArgumentCaptor<LoteProducto> captor = ArgumentCaptor.forClass(LoteProducto.class);
+        verify(loteRepository).saveAndFlush(captor.capture());
+        assertThat(captor.getValue().getAlmacen().getId()).isEqualTo(7);
+    }
+
+    @Test
+    void registrarEvaluacionMicroCorrigeAlmacenSiYaNoEstaEnCuarentena() throws Exception {
+        Usuario user = buildUsuario(4L, RolUsuario.ROL_MICROBIOLOGO);
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(user);
+
+        LoteProducto loteFuera = buildLoteEnCuarentena(20L, 1);
+        when(loteRepository.findById(20L)).thenReturn(Optional.of(loteFuera), Optional.of(loteFuera));
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(almacenRepository.findById(7L)).thenReturn(Optional.of(new Almacen(7)));
+        when(repository.existsByLoteProductoIdAndTipoEvaluacion(20L, TipoEvaluacion.MICROBIOLOGICO)).thenReturn(false);
+        mockMapperToEntity();
+        mockMapperToResponse();
+        when(repository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        MultipartFile archivo = buildArchivoMock();
+        EvaluacionCalidadRequestDTO dto = baseRequest(20L, TipoEvaluacion.MICROBIOLOGICO);
+
+        service.crear(dto, List.of(archivo));
+
+        verify(loteRepository).saveAndFlush(loteFuera);
+        assertThat(loteFuera.getAlmacen().getId()).isEqualTo(7);
+    }
+
+    private void mockMapperToEntity() {
+        when(mapper.toEntity(any(), any(), any())).thenAnswer(invocation -> {
+            EvaluacionCalidadRequestDTO dto = invocation.getArgument(0);
+            LoteProducto lote = invocation.getArgument(1);
+            Usuario user = invocation.getArgument(2);
+            return EvaluacionCalidad.builder()
+                    .loteProducto(lote)
+                    .usuarioEvaluador(user)
+                    .tipoEvaluacion(dto.getTipoEvaluacion())
+                    .resultado(dto.getResultado())
+                    .observaciones(dto.getObservaciones())
+                    .build();
+        });
+    }
+
+    private void mockMapperToResponse() {
+        when(mapper.toResponseDTO(any())).thenReturn(new com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO());
+    }
+
+    private Usuario buildUsuario(Long id, RolUsuario rol) {
+        Usuario usuario = new Usuario();
+        usuario.setId(id);
+        usuario.setRol(rol);
+        return usuario;
+    }
+
+    private LoteProducto buildLoteEnCuarentena(Long id, Integer almacenId) {
+        LoteProducto lote = new LoteProducto();
+        lote.setId(id);
+        lote.setEstado(com.willyes.clemenintegra.inventario.model.enums.EstadoLote.EN_CUARENTENA);
+        lote.setAlmacen(new Almacen(almacenId));
+        lote.setProducto(new com.willyes.clemenintegra.inventario.model.Producto());
+        return lote;
+    }
+
+    private MultipartFile buildArchivoMock() throws Exception {
+        MultipartFile archivo = mock(MultipartFile.class);
+        when(archivo.isEmpty()).thenReturn(false);
+        when(archivo.getOriginalFilename()).thenReturn("resultado.pdf");
+        doNothing().when(archivo).transferTo(any(java.io.File.class));
+        return archivo;
+    }
+
+    private EvaluacionCalidadRequestDTO baseRequest(Long loteId, TipoEvaluacion tipo) {
+        return EvaluacionCalidadRequestDTO.builder()
+                .loteProductoId(loteId)
+                .tipoEvaluacion(tipo)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .observaciones("ok")
+                .archivosAdjuntos(List.of(ArchivoEvaluacionDTO.builder().nombreVisible("doc").build()))
+                .build();
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoCalidadServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoCalidadServiceTest.java
@@ -1,0 +1,165 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.*;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoteProductoCalidadServiceTest {
+
+    @Mock
+    private LoteProductoRepository loteRepo;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private LoteProductoMapper loteProductoMapper;
+    @Mock
+    private UsuarioService usuarioService;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private EvaluacionCalidadRepository evaluacionRepository;
+    @Mock
+    private StockQueryService stockQueryService;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock
+    private InventoryCatalogResolver catalogResolver;
+
+    private LoteProductoServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LoteProductoServiceImpl(loteRepo, productoRepository, almacenRepository, loteProductoMapper,
+                usuarioService, loteProductoRepository, evaluacionRepository, stockQueryService,
+                movimientoInventarioRepository, motivoMovimientoRepository, tipoMovimientoDetalleRepository,
+                catalogResolver);
+        ReflectionTestUtils.setField(service, "estadoLiberadoConf", "LIBERADO");
+        ReflectionTestUtils.setField(service, "clasificacionLiberacionConf", "LIBERACION_CALIDAD");
+        ReflectionTestUtils.setField(service, "clasificacionRechazoCalidad", "RECHAZO_CALIDAD");
+    }
+
+    @Test
+    void liberarLotePorCalidadMueveLoteAPrincipal() {
+        Usuario jefe = buildUsuario(RolUsuario.ROL_JEFE_CALIDAD);
+
+        Producto producto = new Producto();
+        producto.setTipoAnalisisCalidad(TipoAnalisisCalidad.AMBOS);
+        LoteProducto lote = buildLote(42L, 7, producto);
+
+        when(loteProductoRepository.findByIdForUpdate(42L)).thenReturn(Optional.of(lote));
+        when(catalogResolver.getAlmacenPtId()).thenReturn(1L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(catalogResolver.getMotivoIdTransferenciaCalidad()).thenReturn(55L);
+        when(catalogResolver.getTipoDetalleTransferenciaId()).thenReturn(66L);
+        when(motivoMovimientoRepository.findById(55L)).thenReturn(Optional.of(MotivoMovimiento.builder()
+                .id(55L)
+                .motivo(ClasificacionMovimientoInventario.LIBERACION_CALIDAD)
+                .build()));
+        when(tipoMovimientoDetalleRepository.findById(66L)).thenReturn(Optional.of(TipoMovimientoDetalle.builder()
+                .id(66L)
+                .descripcion("Transferencia")
+                .build()));
+        when(almacenRepository.findById(1L)).thenReturn(Optional.of(new Almacen(1)));
+        when(movimientoInventarioRepository.existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(
+                eq(TipoMovimiento.TRANSFERENCIA), eq(42L), eq(7L), eq(1L), eq(ClasificacionMovimientoInventario.LIBERACION_CALIDAD)))
+                .thenReturn(false);
+        when(evaluacionRepository.findByLoteProductoId(42L)).thenReturn(List.of(
+                buildEvaluacion(TipoEvaluacion.MICROBIOLOGICO),
+                buildEvaluacion(TipoEvaluacion.FISICO_QUIMICO)));
+        when(loteProductoMapper.toResponseDTO(any())).thenAnswer(invocation -> {
+            LoteProducto value = invocation.getArgument(0);
+            return LoteProductoResponseDTO.builder()
+                    .id(value.getId())
+                    .estado(value.getEstado())
+                    .build();
+        });
+        when(loteRepo.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(movimientoInventarioRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        LoteProductoResponseDTO respuesta = service.liberarLotePorCalidad(42L, jefe);
+
+        assertThat(lote.getEstado()).isEqualTo(EstadoLote.LIBERADO);
+        assertThat(lote.getAlmacen().getId()).isEqualTo(1);
+        assertThat(respuesta.getEstado()).isEqualTo(EstadoLote.LIBERADO);
+        verify(movimientoInventarioRepository).save(any(MovimientoInventario.class));
+    }
+
+    @Test
+    void liberarLotePorCalidadFallaSiAlmacenNoEsCuarentena() {
+        Usuario jefe = buildUsuario(RolUsuario.ROL_JEFE_CALIDAD);
+        Producto producto = new Producto();
+        producto.setTipoAnalisisCalidad(TipoAnalisisCalidad.MICROBIOLOGICO);
+        LoteProducto lote = buildLote(77L, 1, producto);
+
+        when(loteProductoRepository.findByIdForUpdate(77L)).thenReturn(Optional.of(lote));
+        when(catalogResolver.getAlmacenPtId()).thenReturn(1L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+
+        assertThatThrownBy(() -> service.liberarLotePorCalidad(77L, jefe))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    private Usuario buildUsuario(RolUsuario rol) {
+        Usuario usuario = new Usuario();
+        usuario.setRol(rol);
+        usuario.setId(10L);
+        return usuario;
+    }
+
+    private LoteProducto buildLote(Long id, Integer almacenId, Producto producto) {
+        LoteProducto lote = new LoteProducto();
+        lote.setId(id);
+        lote.setAlmacen(new Almacen(almacenId));
+        lote.setEstado(EstadoLote.EN_CUARENTENA);
+        lote.setStockLote(BigDecimal.TEN);
+        lote.setStockReservado(BigDecimal.ZERO);
+        lote.setProducto(producto);
+        lote.setFechaLiberacion(null);
+        lote.setUsuarioLiberador(null);
+        lote.setFechaVencimiento(LocalDateTime.now().plusDays(5));
+        return lote;
+    }
+
+    private EvaluacionCalidad buildEvaluacion(TipoEvaluacion tipo) {
+        return EvaluacionCalidad.builder()
+                .tipoEvaluacion(tipo)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- audit and restore the quarantine warehouse when registering or updating quality evaluations, logging any anomalies and preventing silent transfers before approval
- exercise the evaluation flow with new unit tests that verify microbiological and physicochemical submissions keep lots in quarantine and recover if another process moves them
- cover the quality release path to ensure the jefe de calidad transfer moves lots to the main warehouse and errors when the lot is already outside quarantine

## Testing
- mvn test *(fails: unable to download parent POM because Maven Central is unreachable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d574bfef2c83338dc25a2b148fab8a