### PR TITLE
Implement Salida PT feature flag and endpoints

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/config/InventoryCatalogProperties.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/config/InventoryCatalogProperties.java
@@ -15,6 +15,7 @@ public class InventoryCatalogProperties {
     private final Produccion produccion = new Produccion();
     private final Mov mov = new Mov();
     private final Um um = new Um();
+    private final SalidaPt salidaPt = new SalidaPt();
 
     @Data
     public static class Almacen {
@@ -60,6 +61,11 @@ public class InventoryCatalogProperties {
         private Long transferenciaId;
         private Long salidaId;
         private Long salidaPtId;
+    }
+
+    @Data
+    public static class SalidaPt {
+        private boolean enabled = true;
     }
 
     @Data

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -76,9 +76,14 @@ public class MovimientoInventarioController {
             boolean isSalida = tipo == TipoMovimiento.SALIDA || tipo == TipoMovimiento.AJUSTE;
             boolean autoSplitSolicitado = Boolean.TRUE.equals(dto.autoSplit());
             boolean atencionesVacias = dto.atenciones() == null || dto.atenciones().isEmpty();
-            Long detalleSalidaPtId = Optional.ofNullable(inventoryCatalogResolver.getTipoDetalleSalidaPtId())
-                    .orElse(inventoryCatalogResolver.getTipoDetalleSalidaId());
-            boolean esSalidaPt = dto.tipoMovimiento() == TipoMovimiento.SALIDA
+            Long detalleSalidaPtId = inventoryCatalogResolver.isSalidaPtEnabled()
+                    ? inventoryCatalogResolver.getTipoDetalleSalidaPtId()
+                    : null;
+            if (detalleSalidaPtId == null) {
+                detalleSalidaPtId = inventoryCatalogResolver.getTipoDetalleSalidaId();
+            }
+            boolean esSalidaPt = inventoryCatalogResolver.isSalidaPtEnabled()
+                    && dto.tipoMovimiento() == TipoMovimiento.SALIDA
                     && detalleSalidaPtId != null
                     && Objects.equals(dto.tipoMovimientoDetalleId(), detalleSalidaPtId);
             boolean permitirLoteNulo = dto.loteProductoId() == null && autoSplitSolicitado && atencionesVacias;

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SalidaPtController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SalidaPtController.java
@@ -1,0 +1,91 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.LotePtDisponibleDTO;
+import com.willyes.clemenintegra.inventario.dto.SalidaPtConfigResponse;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+import java.math.BigDecimal;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/inventario")
+public class SalidaPtController {
+
+    private final InventoryCatalogResolver catalogResolver;
+    private final LoteProductoRepository loteProductoRepository;
+
+    public SalidaPtController(InventoryCatalogResolver catalogResolver,
+                              LoteProductoRepository loteProductoRepository) {
+        this.catalogResolver = catalogResolver;
+        this.loteProductoRepository = loteProductoRepository;
+    }
+
+    @GetMapping("/salida-pt/config")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
+    public ResponseEntity<SalidaPtConfigResponse> obtenerConfigSalidaPt() {
+        return ResponseEntity.ok(new SalidaPtConfigResponse(
+                catalogResolver.isSalidaPtEnabled(),
+                catalogResolver.getAlmacenPtId(),
+                catalogResolver.getTipoDetalleSalidaPtId()
+        ));
+    }
+
+    @GetMapping("/lotes/pt-disponibles")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
+    public ResponseEntity<List<LotePtDisponibleDTO>> listarLotesDisponiblesPt(
+            @RequestParam("productoId") Long productoId,
+            @RequestParam(value = "minCantidad", required = false) BigDecimal minCantidad
+    ) {
+        if (productoId == null || productoId <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "PRODUCTO_ID_REQUERIDO");
+        }
+        Long almacenPtId = catalogResolver.getAlmacenPtId();
+        if (catalogResolver.isSalidaPtEnabled() && (almacenPtId == null || almacenPtId <= 0)) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "CONFIG_FALTANTE");
+        }
+        if (almacenPtId == null || almacenPtId <= 0) {
+            return ResponseEntity.ok(List.of());
+        }
+
+        EnumSet<EstadoLote> estadosElegibles = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
+        List<LoteProducto> candidatos = loteProductoRepository.findFefoSalidaPt(
+                productoId,
+                almacenPtId,
+                estadosElegibles
+        );
+
+        BigDecimal umbral = minCantidad != null ? minCantidad : BigDecimal.ZERO;
+        List<LotePtDisponibleDTO> respuesta = candidatos.stream()
+                .map(lote -> {
+                    BigDecimal stock = lote.getStockLote() != null ? lote.getStockLote() : BigDecimal.ZERO;
+                    BigDecimal reservado = lote.getStockReservado() != null ? lote.getStockReservado() : BigDecimal.ZERO;
+                    BigDecimal disponible = stock.subtract(reservado);
+                    if (disponible.compareTo(BigDecimal.ZERO) < 0) {
+                        disponible = BigDecimal.ZERO;
+                    }
+                    return new LotePtDisponibleDTO(
+                            lote.getId(),
+                            lote.getCodigoLote(),
+                            disponible,
+                            lote.getFechaVencimiento()
+                    );
+                })
+                .filter(dto -> dto.stockDisponible() != null && dto.stockDisponible().compareTo(umbral) >= 0)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(respuesta);
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LotePtDisponibleDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LotePtDisponibleDTO.java
@@ -1,0 +1,12 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record LotePtDisponibleDTO(
+        Long id,
+        String codigoLote,
+        BigDecimal stockDisponible,
+        LocalDateTime fechaVencimiento
+) {
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/SalidaPtConfigResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/SalidaPtConfigResponse.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+public record SalidaPtConfigResponse(
+        boolean enabled,
+        Long almacenPtId,
+        Long tipoDetalleSalidaPtId
+) {
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogResolver.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/InventoryCatalogResolver.java
@@ -28,6 +28,7 @@ public class InventoryCatalogResolver {
     private final MotivoMovimientoRepository motivoRepository;
     private final TipoMovimientoDetalleRepository tipoDetalleRepository;
 
+    private boolean salidaPtEnabled;
     private Long almacenPtId;
     private Long almacenCuarentenaId;
     private Long almacenObsoletosId;
@@ -93,8 +94,14 @@ public class InventoryCatalogResolver {
         tipoDetalleEntradaId = validateTipoDetalle(properties.getTipoDetalle().getEntradaId());
         tipoDetalleTransferenciaId = validateTipoDetalle(properties.getTipoDetalle().getTransferenciaId());
         tipoDetalleSalidaId = validateTipoDetalle(properties.getTipoDetalle().getSalidaId());
+        salidaPtEnabled = properties.getSalidaPt().isEnabled();
         Long salidaPtConfig = properties.getTipoDetalle().getSalidaPtId();
-        if (salidaPtConfig != null) {
+        if (salidaPtEnabled) {
+            if (salidaPtConfig == null || salidaPtConfig <= 0) {
+                throw new IllegalStateException("CONFIG_FALTANTE (SALIDA_PT)");
+            }
+            tipoDetalleSalidaPtId = validateTipoDetalle(salidaPtConfig);
+        } else if (salidaPtConfig != null) {
             tipoDetalleSalidaPtId = validateTipoDetalle(salidaPtConfig);
         }
 
@@ -107,6 +114,9 @@ public class InventoryCatalogResolver {
                 motivoEntradaPtId, motivoTransferenciaCalidadId, motivoDevolucionDesdeProduccionId,
                 motivoAjusteRechazoId, tipoDetalleEntradaId, tipoDetalleTransferenciaId, tipoDetalleSalidaId,
                 getTipoDetalleSalidaPtId());
+
+        log.info("Salida PT enabled: {} almacenPtId={} tipoDetalleId={}",
+                salidaPtEnabled, almacenPtId, getTipoDetalleSalidaPtId());
     }
 
     private Long validateAlmacen(Long id) {
@@ -166,6 +176,10 @@ public class InventoryCatalogResolver {
 
     public Long getTipoDetalleSalidaPtId() {
         return tipoDetalleSalidaPtId != null ? tipoDetalleSalidaPtId : tipoDetalleSalidaId;
+    }
+
+    public boolean isSalidaPtEnabled() {
+        return salidaPtEnabled;
     }
 
     public Long resolveAlmacenPrincipal(Producto producto) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,7 +38,7 @@ spring.web.cors.allow-credentials=true
 
 app.inventario.prebodega.id=6
 
-# Configuración de correo saliente
+# ConfiguraciÃ³n de correo saliente
 spring.mail.host=${MAIL_HOST}
 spring.mail.port=${MAIL_PORT}
 spring.mail.username=${MAIL_USERNAME}
@@ -53,7 +53,7 @@ inventory.almacen.pt.id=2
 inventory.almacen.cuarentena.id=7
 inventory.almacen.obsoletos.id=3
 
-# --- PRODUCCI�N / ORIGENES ---
+# --- PRODUCCIÓN / ORIGENES ---
 inventory.produccion.almacen.origen.materiaPrima=1
 inventory.produccion.almacen.origen.materialEmpaque=5
 inventory.produccion.almacen.origen.suministros=4
@@ -70,6 +70,7 @@ inventory.tipoDetalle.entradaId=6
 inventory.tipoDetalle.transferenciaId=12
 inventory.tipoDetalle.salidaId=11
 inventory.tipoDetalle.salidaPtId=11
+inventory.salidaPt.enabled=true
 
 # --- CLASIFICACIONES DE MOVIMIENTO / IDs ESPECIALES ---
 inventory.mov.clasificacion.entradaPt=ENTRADA_PRODUCTO_TERMINADO

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -35,6 +36,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,7 +67,8 @@ class MovimientoInventarioControllerTest {
 
     @BeforeEach
     void setUp() {
-        when(inventoryCatalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(PRE_BODEGA_ID);
+        lenient().when(inventoryCatalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(PRE_BODEGA_ID);
+        lenient().when(inventoryCatalogResolver.isSalidaPtEnabled()).thenReturn(true);
 
         producto = new Producto();
         producto.setId(1);
@@ -221,7 +224,7 @@ class MovimientoInventarioControllerTest {
     @Test
     void postSalida_noForzaPt_cuandoDetalleNoEsPt() {
         when(inventoryCatalogResolver.getTipoDetalleSalidaPtId()).thenReturn(99L);
-        when(inventoryCatalogResolver.getTipoDetalleSalidaId()).thenReturn(33L);
+        lenient().when(inventoryCatalogResolver.getTipoDetalleSalidaId()).thenReturn(33L);
 
         MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
                 null,

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/SalidaPtControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/SalidaPtControllerTest.java
@@ -1,0 +1,95 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.LotePtDisponibleDTO;
+import com.willyes.clemenintegra.inventario.dto.SalidaPtConfigResponse;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SalidaPtControllerTest {
+
+    @Mock
+    private InventoryCatalogResolver catalogResolver;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+
+    @InjectMocks
+    private SalidaPtController controller;
+
+    @Test
+    void obtenerConfigSalidaPt_devuelveValoresDeResolver() {
+        when(catalogResolver.isSalidaPtEnabled()).thenReturn(true);
+        when(catalogResolver.getAlmacenPtId()).thenReturn(2L);
+        when(catalogResolver.getTipoDetalleSalidaPtId()).thenReturn(11L);
+
+        ResponseEntity<SalidaPtConfigResponse> response = controller.obtenerConfigSalidaPt();
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().enabled()).isTrue();
+        assertThat(response.getBody().almacenPtId()).isEqualTo(2L);
+        assertThat(response.getBody().tipoDetalleSalidaPtId()).isEqualTo(11L);
+    }
+
+    @Test
+    void listarLotesDisponiblesPt_filtraPorCantidadYEstado() {
+        when(catalogResolver.isSalidaPtEnabled()).thenReturn(true);
+        when(catalogResolver.getAlmacenPtId()).thenReturn(5L);
+
+        Producto producto = new Producto();
+        producto.setId(99);
+
+        Almacen almacenPt = new Almacen();
+        almacenPt.setId(5);
+
+        LoteProducto apto = new LoteProducto();
+        apto.setId(10L);
+        apto.setCodigoLote("PT-001");
+        apto.setProducto(producto);
+        apto.setAlmacen(almacenPt);
+        apto.setEstado(EstadoLote.DISPONIBLE);
+        apto.setStockLote(new BigDecimal("8.000"));
+        apto.setStockReservado(new BigDecimal("1.000000"));
+        apto.setFechaVencimiento(LocalDateTime.of(2025, 1, 1, 0, 0));
+
+        LoteProducto insuficiente = new LoteProducto();
+        insuficiente.setId(11L);
+        insuficiente.setCodigoLote("PT-002");
+        insuficiente.setProducto(producto);
+        insuficiente.setAlmacen(almacenPt);
+        insuficiente.setEstado(EstadoLote.LIBERADO);
+        insuficiente.setStockLote(new BigDecimal("1.000"));
+        insuficiente.setStockReservado(BigDecimal.ZERO.setScale(6));
+
+        when(loteProductoRepository.findFefoSalidaPt(eq(99L), eq(5L), any()))
+                .thenReturn(List.of(apto, insuficiente));
+
+        ResponseEntity<List<LotePtDisponibleDTO>> response = controller.listarLotesDisponiblesPt(99L, new BigDecimal("5"));
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).hasSize(1);
+        LotePtDisponibleDTO dto = response.getBody().get(0);
+        assertThat(dto.id()).isEqualTo(10L);
+        assertThat(dto.codigoLote()).isEqualTo("PT-001");
+        assertThat(dto.stockDisponible()).isEqualByComparingTo(new BigDecimal("7.000"));
+        assertThat(dto.fechaVencimiento()).isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceIntegrationTest.java
@@ -93,7 +93,7 @@ class MovimientoInventarioServiceIntegrationTest {
                 .unidadMedida(unidad)
                 .categoriaProducto(categoria)
                 .creadoPor(usuario)
-                .tipoAnalisisCalidad(TipoAnalisisCalidad.NINGUNO)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
                 .activo(true)
                 .build());
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -41,7 +41,7 @@ import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
-import com.willyes.clemenintegra.inventario.service.UnidadConversionService;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
 import com.willyes.clemenintegra.produccion.dto.InsumoFaltanteDTO;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Test;
@@ -530,8 +530,18 @@ class OrdenProduccionServiceImplTest {
                                                     BigDecimal stockLote,
                                                     Integer almacenId) implements LoteFefoDisponibleProjection {
         @Override
+        public Long getLoteProductoId() {
+            return loteProductoId;
+        }
+
+        @Override
         public String getCodigoLote() {
             return "LOT-" + loteProductoId;
+        }
+
+        @Override
+        public BigDecimal getStockLote() {
+            return stockLote;
         }
 
         @Override
@@ -542,6 +552,11 @@ class OrdenProduccionServiceImplTest {
         @Override
         public String getNombreAlmacen() {
             return null;
+        }
+
+        @Override
+        public Long getAlmacenId() {
+            return almacenId != null ? almacenId.longValue() : null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add the Salida PT feature toggle and configuration validation to `InventoryCatalogResolver`, wiring it to `application.properties`
- surface the new configuration and FEFO lot lookup endpoints plus supporting DTOs and controller security
- update movement processing to normalize PT origin handling, add logging, and expand the unit/integration/controller tests with lenient stubbing for the new scenarios

## Testing
- `mvn -q -Dtest=MovimientoInventarioServiceImplTest test`
- `mvn -q -Dtest=MovimientoInventarioControllerTest,SalidaPtControllerTest test`
- `mvn -q -Dtest=MovimientoInventarioServiceIntegrationTest test` *(fails: missing clemen.jwt.secret placeholder in Spring context)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b0ab863c83338e67774f91727c7d