### PR TITLE
Add SQL migration and JPA entities for OC receptions

### DIFF
--- a/scripts/sql/20251006_recepcion_oc.sql
+++ b/scripts/sql/20251006_recepcion_oc.sql
@@ -1,0 +1,59 @@
+-- Script de migración para recepciones de orden de compra
+
+CREATE TABLE IF NOT EXISTS recepciones_oc (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    codigo VARCHAR(32) NOT NULL,
+    fecha_recepcion DATE NOT NULL,
+    orden_compra_id INT NOT NULL,
+    almacen_destino_id INT NOT NULL,
+    proveedor_id INT NULL,
+    usuario_id BIGINT NOT NULL,
+    observaciones VARCHAR(500) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_recepciones_oc_codigo (codigo),
+    UNIQUE KEY uk_recepciones_oc_orden_fecha (orden_compra_id, fecha_recepcion),
+    KEY idx_recepciones_oc_orden_compra (orden_compra_id),
+    KEY idx_recepciones_oc_almacen_destino (almacen_destino_id),
+    KEY idx_recepciones_oc_proveedor (proveedor_id),
+    KEY idx_recepciones_oc_usuario (usuario_id),
+    CONSTRAINT fk_recepciones_oc_orden_compra FOREIGN KEY (orden_compra_id) REFERENCES ordenes_compra (id),
+    CONSTRAINT fk_recepciones_oc_almacen_destino FOREIGN KEY (almacen_destino_id) REFERENCES almacenes (id),
+    CONSTRAINT fk_recepciones_oc_proveedor FOREIGN KEY (proveedor_id) REFERENCES proveedores (id),
+    CONSTRAINT fk_recepciones_oc_usuario FOREIGN KEY (usuario_id) REFERENCES usuarios (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS recepciones_oc_detalles (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    recepcion_oc_id BIGINT UNSIGNED NOT NULL,
+    orden_compra_detalle_id BIGINT NOT NULL,
+    productos_id INT NOT NULL,
+    lotes_productos_id BIGINT NULL,
+    cantidad_recibida DECIMAL(18,6) NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_recepciones_oc_detalles_recepcion (recepcion_oc_id),
+    KEY idx_recepciones_oc_detalles_orden_compra_detalle (orden_compra_detalle_id),
+    KEY idx_recepciones_oc_detalles_producto (productos_id),
+    KEY idx_recepciones_oc_detalles_lote (lotes_productos_id),
+    CONSTRAINT fk_recepciones_oc_detalles_recepcion FOREIGN KEY (recepcion_oc_id) REFERENCES recepciones_oc (id),
+    CONSTRAINT fk_recepciones_oc_detalles_orden_compra_detalle FOREIGN KEY (orden_compra_detalle_id) REFERENCES orden_compra_detalle (id),
+    CONSTRAINT fk_recepciones_oc_detalles_producto FOREIGN KEY (productos_id) REFERENCES productos (id),
+    CONSTRAINT fk_recepciones_oc_detalles_lote FOREIGN KEY (lotes_productos_id) REFERENCES lotes_productos (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS secuencias_recepcion (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    anio INT NOT NULL,
+    prefijo VARCHAR(16) NOT NULL,
+    secuencia_actual BIGINT UNSIGNED NOT NULL,
+    actualizado_en DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_secuencias_recepcion_anio_prefijo (anio, prefijo)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE movimientos_inventario
+    ADD COLUMN recepcion_oc_id BIGINT UNSIGNED NULL,
+    ADD COLUMN codigo_recepcion VARCHAR(32) NULL,
+    ADD KEY idx_movimientos_inventario_recepcion_oc (recepcion_oc_id),
+    ADD KEY idx_movimientos_inventario_codigo_recepcion (codigo_recepcion),
+    ADD CONSTRAINT fk_movimientos_inventario_recepcion_oc FOREIGN KEY (recepcion_oc_id) REFERENCES recepciones_oc (id);

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/RecepcionOC.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/RecepcionOC.java
@@ -1,0 +1,75 @@
+package com.willyes.clemenintegra.inventario.model;
+
+import com.willyes.clemenintegra.shared.model.Usuario;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "recepciones_oc", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_recepciones_oc_codigo", columnNames = "codigo"),
+        @UniqueConstraint(name = "uk_recepciones_oc_orden_fecha", columnNames = {"orden_compra_id", "fecha_recepcion"})
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class RecepcionOC {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(name = "codigo", nullable = false, length = 32)
+    private String codigo;
+
+    @Column(name = "fecha_recepcion", nullable = false)
+    private LocalDate fechaRecepcion;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "orden_compra_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_recepciones_oc_orden_compra"))
+    private OrdenCompra ordenCompra;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "almacen_destino_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_recepciones_oc_almacen_destino"))
+    private Almacen almacenDestino;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "proveedor_id",
+            foreignKey = @ForeignKey(name = "fk_recepciones_oc_proveedor"))
+    private Proveedor proveedor;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "usuario_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_recepciones_oc_usuario"))
+    private Usuario usuario;
+
+    @Column(name = "observaciones", length = 500)
+    private String observaciones;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "recepcionOc", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RecepcionOCDetalle> detalles = new ArrayList<>();
+
+    public RecepcionOC(Long id) {
+        this.id = id;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/RecepcionOCDetalle.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/RecepcionOCDetalle.java
@@ -1,0 +1,48 @@
+package com.willyes.clemenintegra.inventario.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "recepciones_oc_detalles")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class RecepcionOCDetalle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "recepcion_oc_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_recepciones_oc_detalles_recepcion"))
+    private RecepcionOC recepcionOc;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "orden_compra_detalle_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_recepciones_oc_detalles_orden_compra_detalle"))
+    private OrdenCompraDetalle ordenCompraDetalle;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "productos_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_recepciones_oc_detalles_producto"))
+    private Producto producto;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lotes_productos_id",
+            foreignKey = @ForeignKey(name = "fk_recepciones_oc_detalles_lote"))
+    private LoteProducto lote;
+
+    @Column(name = "cantidad_recibida", nullable = false, precision = 18, scale = 6)
+    private BigDecimal cantidadRecibida;
+
+    public RecepcionOCDetalle(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/RecepcionOCDetalleRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/RecepcionOCDetalleRepository.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.RecepcionOCDetalle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecepcionOCDetalleRepository extends JpaRepository<RecepcionOCDetalle, Long> {
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/RecepcionOCRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/RecepcionOCRepository.java
@@ -1,0 +1,14 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.RecepcionOC;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface RecepcionOCRepository extends JpaRepository<RecepcionOC, Long> {
+
+    Optional<RecepcionOC> findByOrdenCompraIdAndFechaRecepcion(Integer ordenCompraId, LocalDate fechaRecepcion);
+
+    Optional<RecepcionOC> findByCodigo(String codigo);
+}


### PR DESCRIPTION
## Summary
- add manual SQL script to define reception tables, sequence tracker, and new references on inventory movements
- introduce JPA entities for purchase order receptions and their details
- create Spring Data repositories for the new entities with lookup helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42ad9b4188333bf431bc1fc4ef297