### PR TITLE
feat: add reception code services

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
@@ -39,6 +39,8 @@ public class MovimientoInventarioResponseDTO {
     private Long solicitudId;
     private EstadoSolicitudMovimiento estadoSolicitud;
     private List<SolicitudDetalleAtencionDTO> detallesSolicitud;
+    private Long recepcionOcId;
+    private String codigoRecepcion;
 
 
     @JsonProperty("codigoSku")

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
@@ -87,6 +87,9 @@ public interface MovimientoInventarioMapper {
             dto.setEstadoSolicitud(solicitud.getEstado());
         }
 
+        dto.setCodigoRecepcion(m.getCodigoRecepcion());
+        dto.setRecepcionOcId(m.getRecepcionOc() != null ? m.getRecepcionOc().getId() : null);
+
         return dto;
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/MovimientoInventario.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/MovimientoInventario.java
@@ -99,6 +99,13 @@ public class MovimientoInventario {
     @JoinColumn(name = "solicitud_movimiento_id")
     private SolicitudMovimiento solicitudMovimiento;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recepcion_oc_id", foreignKey = @ForeignKey(name = "fk_movimientos_inventario_recepcion_oc"))
+    private RecepcionOC recepcionOc;
+
+    @Column(name = "codigo_recepcion", length = 32)
+    private String codigoRecepcion;
+
     @PrePersist
     public void prePersist() {
         if (this.fechaIngreso == null) {
@@ -142,6 +149,10 @@ public class MovimientoInventario {
 
     public OrdenProduccion getOrdenProduccion() {return ordenProduccion;}
     public void setOrdenProduccion(OrdenProduccion ordenProduccion) {this.ordenProduccion = ordenProduccion;}
+    public RecepcionOC getRecepcionOc() {return recepcionOc;}
+    public void setRecepcionOc(RecepcionOC recepcionOc) {this.recepcionOc = recepcionOc;}
+    public String getCodigoRecepcion() {return codigoRecepcion;}
+    public void setCodigoRecepcion(String codigoRecepcion) {this.codigoRecepcion = codigoRecepcion;}
 }
 
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/SecuenciaRecepcion.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/SecuenciaRecepcion.java
@@ -1,0 +1,41 @@
+package com.willyes.clemenintegra.inventario.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "secuencias_recepcion", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_secuencias_recepcion_anio_prefijo", columnNames = {"anio", "prefijo"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SecuenciaRecepcion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "anio", nullable = false)
+    private Integer anio;
+
+    @Column(name = "prefijo", nullable = false, length = 16)
+    private String prefijo;
+
+    @Column(name = "secuencia_actual", nullable = false)
+    private Long secuenciaActual;
+
+    @Column(name = "actualizado_en", nullable = false)
+    private LocalDateTime actualizadoEn;
+
+    @PrePersist
+    public void prePersist() {
+        if (actualizadoEn == null) {
+            actualizadoEn = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SecuenciaRecepcionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SecuenciaRecepcionRepository.java
@@ -1,0 +1,19 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.SecuenciaRecepcion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+
+public interface SecuenciaRecepcionRepository extends JpaRepository<SecuenciaRecepcion, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from SecuenciaRecepcion s where s.anio = :anio and s.prefijo = :prefijo")
+    Optional<SecuenciaRecepcion> findByAnioAndPrefijoForUpdate(@Param("anio") int anio, @Param("prefijo") String prefijo);
+
+    Optional<SecuenciaRecepcion> findByAnioAndPrefijo(int anio, String prefijo);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/CodigoRecepcionService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/CodigoRecepcionService.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import java.time.LocalDate;
+
+public interface CodigoRecepcionService {
+
+    String generarCodigo(LocalDate fechaNegocio);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/CodigoRecepcionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/CodigoRecepcionServiceImpl.java
@@ -1,0 +1,72 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.model.SecuenciaRecepcion;
+import com.willyes.clemenintegra.inventario.repository.SecuenciaRecepcionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CodigoRecepcionServiceImpl implements CodigoRecepcionService {
+
+    private static final DateTimeFormatter PREFIJO_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
+    private final SecuenciaRecepcionRepository repository;
+    private final PlatformTransactionManager transactionManager;
+
+    @Override
+    @Transactional
+    public String generarCodigo(LocalDate fechaNegocio) {
+        if (fechaNegocio == null) {
+            throw new IllegalArgumentException("La fecha de negocio es obligatoria");
+        }
+        int anio = fechaNegocio.getYear();
+        String prefijo = fechaNegocio.format(PREFIJO_FORMATTER);
+
+        SecuenciaRecepcion secuencia = repository.findByAnioAndPrefijoForUpdate(anio, prefijo)
+                .orElse(null);
+        if (secuencia == null) {
+            crearSecuenciaInicial(anio, prefijo);
+            secuencia = repository.findByAnioAndPrefijoForUpdate(anio, prefijo)
+                    .orElseThrow(() -> new IllegalStateException("No fue posible inicializar la secuencia de recepción"));
+        }
+
+        long siguiente = secuencia.getSecuenciaActual() == null ? 1L : secuencia.getSecuenciaActual() + 1L;
+        secuencia.setSecuenciaActual(siguiente);
+        secuencia.setActualizadoEn(LocalDateTime.now());
+        String codigo = String.format("RC-%s-%02d", prefijo, siguiente);
+        log.debug("Secuencia recepción actualizada anio={} prefijo={} valor={}", anio, prefijo, siguiente);
+        return codigo;
+    }
+
+    private void crearSecuenciaInicial(int anio, String prefijo) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        template.execute(status -> {
+            try {
+                SecuenciaRecepcion nueva = SecuenciaRecepcion.builder()
+                        .anio(anio)
+                        .prefijo(prefijo)
+                        .secuenciaActual(0L)
+                        .build();
+                nueva.setActualizadoEn(LocalDateTime.now());
+                repository.saveAndFlush(nueva);
+            } catch (DataIntegrityViolationException ex) {
+                status.setRollbackOnly();
+                log.debug("Colisión creando secuencia recepción anio={} prefijo={}, reintentando", anio, prefijo, ex);
+            }
+            return null;
+        });
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -57,6 +57,8 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -74,6 +76,7 @@ import java.util.stream.Collectors;
 public class MovimientoInventarioServiceImpl implements MovimientoInventarioService {
 
     private static final Logger log = LoggerFactory.getLogger(MovimientoInventarioServiceImpl.class);
+    private static final ZoneId ZONA_BOGOTA = ZoneId.of("America/Bogota");
     /** Nombre normalizado del almacén Pre-Bodega Producción */
     private static final String PRE_BODEGA_PRODUCCION_NORMALIZADO =
             java.text.Normalizer.normalize("Pre-Bodega Producción", java.text.Normalizer.Form.NFD)
@@ -103,6 +106,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     private final InventoryCatalogResolver catalogResolver;
     private final ReservaLoteService reservaLoteService;
     private final ReservaLoteRepository reservaLoteRepository;
+    private final RecepcionOCService recepcionOCService;
     //private final Long motivoSalidaProdId = catalogResolver.getMotivoSalidaProduccionId();
     //private final Long tipoDetSalidaProdId = catalogResolver.getTipoDetalleSalidaProduccionId();
 
@@ -132,6 +136,11 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
 
         MovimientoInventario movimiento = mapper.toEntity(dto);
+        LocalDateTime fechaIngreso = movimiento.getFechaIngreso();
+        if (fechaIngreso == null) {
+            fechaIngreso = ZonedDateTime.now(ZONA_BOGOTA).toLocalDateTime();
+            movimiento.setFechaIngreso(fechaIngreso);
+        }
 
         boolean esOpDesdeDto = dto.ordenProduccionId() != null;
         TipoMovimiento tipoMovimiento = dto.tipoMovimiento();
@@ -460,6 +469,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
 
         OrdenCompra orden = null;
+        RecepcionOC recepcionCabecera = null;
         if (tipoMovimiento == TipoMovimiento.RECEPCION
                 && motivoMovimiento != null
                 && motivoMovimiento.getMotivo() == ClasificacionMovimientoInventario.RECEPCION_COMPRA) {
@@ -479,6 +489,22 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             if (!incluido) {
                 throw new IllegalArgumentException("El producto no pertenece a la orden de compra");
             }
+            Integer almacenDestinoIdRequerido = Objects.requireNonNull(almacenDestinoIdNormalizado,
+                    "Se requiere un almacén destino para la recepción");
+            LocalDate fechaNegocio = fechaIngreso.atZone(ZONA_BOGOTA).toLocalDate();
+            String observacionesCabecera = dto.destinoTexto() != null && !dto.destinoTexto().isBlank()
+                    ? dto.destinoTexto()
+                    : dto.docReferencia();
+            recepcionCabecera = recepcionOCService.findOrCreateCabecera(
+                    dto.ordenCompraId(),
+                    almacenDestinoIdRequerido,
+                    dto.proveedorId(),
+                    usuario.getId(),
+                    fechaNegocio,
+                    observacionesCabecera
+            );
+            movimiento.setRecepcionOc(recepcionCabecera);
+            movimiento.setCodigoRecepcion(recepcionCabecera.getCodigo());
         }
 
         BigDecimal cantidadSolicitada = dto.cantidad();
@@ -1899,6 +1925,8 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         copia.setTipoMovimientoDetalle(base.getTipoMovimientoDetalle());
         copia.setOrdenCompraDetalle(base.getOrdenCompraDetalle());
         copia.setSolicitudMovimiento(base.getSolicitudMovimiento());
+        copia.setRecepcionOc(base.getRecepcionOc());
+        copia.setCodigoRecepcion(base.getCodigoRecepcion());
         return copia;
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCService.java
@@ -1,0 +1,15 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.model.RecepcionOC;
+
+import java.time.LocalDate;
+
+public interface RecepcionOCService {
+
+    RecepcionOC findOrCreateCabecera(Integer ordenCompraId,
+                                     Integer almacenDestinoId,
+                                     Integer proveedorId,
+                                     Long usuarioId,
+                                     LocalDate fechaNegocio,
+                                     String observaciones);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCServiceImpl.java
@@ -1,0 +1,64 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.repository.RecepcionOCRepository;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+import com.willyes.clemenintegra.shared.model.Usuario;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RecepcionOCServiceImpl implements RecepcionOCService {
+
+    private final RecepcionOCRepository recepcionOCRepository;
+    private final CodigoRecepcionService codigoRecepcionService;
+    private final EntityManager entityManager;
+
+    @Override
+    @Transactional
+    public RecepcionOC findOrCreateCabecera(Integer ordenCompraId,
+                                            Integer almacenDestinoId,
+                                            Integer proveedorId,
+                                            Long usuarioId,
+                                            LocalDate fechaNegocio,
+                                            String observaciones) {
+        Objects.requireNonNull(ordenCompraId, "ordenCompraId es obligatorio");
+        Objects.requireNonNull(almacenDestinoId, "almacenDestinoId es obligatorio");
+        Objects.requireNonNull(usuarioId, "usuarioId es obligatorio");
+        Objects.requireNonNull(fechaNegocio, "fechaNegocio es obligatorio");
+
+        return recepcionOCRepository.findByOrdenCompraIdAndFechaRecepcion(ordenCompraId, fechaNegocio)
+                .orElseGet(() -> crearCabecera(ordenCompraId, almacenDestinoId, proveedorId, usuarioId, fechaNegocio, observaciones));
+    }
+
+    private RecepcionOC crearCabecera(Integer ordenCompraId,
+                                      Integer almacenDestinoId,
+                                      Integer proveedorId,
+                                      Long usuarioId,
+                                      LocalDate fechaNegocio,
+                                      String observaciones) {
+        String codigo = codigoRecepcionService.generarCodigo(fechaNegocio);
+        RecepcionOC nueva = RecepcionOC.builder()
+                .codigo(codigo)
+                .fechaRecepcion(fechaNegocio)
+                .ordenCompra(entityManager.getReference(OrdenCompra.class, ordenCompraId))
+                .almacenDestino(entityManager.getReference(Almacen.class, almacenDestinoId))
+                .usuario(entityManager.getReference(Usuario.class, usuarioId))
+                .observaciones(observaciones)
+                .build();
+        if (proveedorId != null) {
+            nueva.setProveedor(entityManager.getReference(Proveedor.class, proveedorId));
+        }
+        RecepcionOC guardada = recepcionOCRepository.saveAndFlush(nueva);
+        log.info("Creando RecepcionOC codigo={} ocId={} fecha={}", codigo, ordenCompraId, fechaNegocio);
+        return guardada;
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/CodigoRecepcionServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/CodigoRecepcionServiceTest.java
@@ -1,0 +1,81 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(CodigoRecepcionServiceImpl.class)
+@TestPropertySource(properties = "spring.jpa.defer-datasource-initialization=true")
+class CodigoRecepcionServiceTest {
+
+    @Autowired
+    private CodigoRecepcionService codigoRecepcionService;
+
+    @Test
+    void generaCodigosUnicosEnConcurrencia() throws InterruptedException, ExecutionException {
+        LocalDate fecha = LocalDate.of(2025, 5, 20);
+        int solicitudes = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(solicitudes);
+        try {
+            List<Callable<String>> tareas = IntStream.range(0, solicitudes)
+                    .mapToObj(i -> (Callable<String>) () -> codigoRecepcionService.generarCodigo(fecha))
+                    .toList();
+            List<Future<String>> futures = executor.invokeAll(tareas);
+            List<String> codigos = futures.stream().map(f -> {
+                try {
+                    return f.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            }).toList();
+
+            assertThat(codigos).hasSize(solicitudes);
+            assertThat(Set.copyOf(codigos)).hasSize(solicitudes);
+            List<Integer> secuencias = codigos.stream()
+                    .map(c -> c.substring(c.lastIndexOf('-') + 1))
+                    .map(Integer::valueOf)
+                    .sorted()
+                    .collect(Collectors.toList());
+            assertThat(secuencias).containsExactlyElementsOf(IntStream.rangeClosed(1, solicitudes)
+                    .boxed()
+                    .collect(Collectors.toList()));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void reiniciaSecuenciaPorDia() {
+        LocalDate dia1 = LocalDate.of(2025, 5, 21);
+        LocalDate dia2 = dia1.plusDays(1);
+
+        String primeroDia1 = codigoRecepcionService.generarCodigo(dia1);
+        String segundoDia1 = codigoRecepcionService.generarCodigo(dia1);
+        String primeroDia2 = codigoRecepcionService.generarCodigo(dia2);
+
+        assertThat(primeroDia1).isNotEqualTo(segundoDia1);
+        assertThat(primeroDia1).startsWith("RC-" + dia1.format(java.time.format.DateTimeFormatter.BASIC_ISO_DATE));
+        assertThat(primeroDia2).startsWith("RC-" + dia2.format(java.time.format.DateTimeFormatter.BASIC_ISO_DATE));
+
+        int secuenciaDia1 = Integer.parseInt(segundoDia1.substring(segundoDia1.lastIndexOf('-') + 1));
+        int secuenciaDia2 = Integer.parseInt(primeroDia2.substring(primeroDia2.lastIndexOf('-') + 1));
+        assertThat(secuenciaDia1).isGreaterThan(secuenciaDia2);
+        assertThat(secuenciaDia2).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.DirtiesContext;
@@ -22,11 +23,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.jpa.defer-datasource-initialization=true")
 @Transactional
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class MovimientoInventarioServiceIntegrationTest {
@@ -53,9 +57,24 @@ class MovimientoInventarioServiceIntegrationTest {
     private ReservaLoteRepository reservaLoteRepository;
     @Autowired
     private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Autowired
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Autowired
+    private OrdenCompraRepository ordenCompraRepository;
+    @Autowired
+    private OrdenCompraDetalleRepository ordenCompraDetalleRepository;
+    @Autowired
+    private ProveedorRepository proveedorRepository;
+    @Autowired
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Autowired
+    private RecepcionOCRepository recepcionOCRepository;
 
     @MockBean
     private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
 
     @AfterEach
     void limpiarContextoSeguridad() {
@@ -197,6 +216,128 @@ class MovimientoInventarioServiceIntegrationTest {
         assertThat(detalleActualizado.getEstado()).isEqualTo(EstadoSolicitudMovimientoDetalle.ATENDIDO);
         assertThat(reservaActualizada.getEstado()).isEqualTo(EstadoReservaLote.CONSUMIDA);
         assertThat(reservaActualizada.getCantidadConsumida()).isEqualByComparingTo(new BigDecimal("10.000000"));
+    }
+
+    @Test
+    void recepcionCompraGeneraCabeceraYCodigo() {
+        when(inventoryCatalogResolver.decimals(any())).thenReturn(2);
+
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("receptor")
+                .clave("clave")
+                .nombreCompleto("Usuario Recepcion")
+                .correo("receptor@example.com")
+                .rol(RolUsuario.ROL_ALMACENISTA)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+        autenticarUsuario(usuario);
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("u")
+                .build());
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Materia Prima")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-RC")
+                .nombre("Producto Recepcion")
+                .descripcionProducto("Producto para recepcion")
+                .stockMinimo(BigDecimal.ZERO)
+                .stockMinimoProveedor(BigDecimal.ZERO)
+                .rendimientoUnidad(BigDecimal.ONE)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .activo(true)
+                .build());
+
+        Almacen almacenDestino = almacenRepository.save(Almacen.builder()
+                .nombre("Almacen Recepcion")
+                .ubicacion("Zona R")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        Proveedor proveedor = proveedorRepository.save(Proveedor.builder()
+                .nombre("Proveedor Recepcion")
+                .identificacion("999")
+                .telefono("555")
+                .email("prov@recepcion.com")
+                .direccion("Calle 123")
+                .paginaWeb("www.prov.com")
+                .nombreContacto("Contacto Recepcion")
+                .activo(true)
+                .build());
+
+        OrdenCompra ordenCompra = ordenCompraRepository.save(OrdenCompra.builder()
+                .codigoOrden("OC-RC-1")
+                .fechaOrden(LocalDateTime.now())
+                .proveedor(proveedor)
+                .estado(EstadoOrdenCompra.CREADA)
+                .observaciones("Orden de prueba")
+                .build());
+
+        OrdenCompraDetalle detalle = ordenCompraDetalleRepository.save(OrdenCompraDetalle.builder()
+                .ordenCompra(ordenCompra)
+                .producto(producto)
+                .cantidad(new BigDecimal("5.000"))
+                .valorUnitario(new BigDecimal("10.000"))
+                .valorTotal(new BigDecimal("50.000"))
+                .iva(BigDecimal.ZERO.setScale(2))
+                .cantidadRecibida(BigDecimal.ZERO.setScale(3))
+                .build());
+        ordenCompra.setDetalles(new ArrayList<>(List.of(detalle)));
+
+        MotivoMovimiento motivo = motivoMovimientoRepository.save(MotivoMovimiento.builder()
+                .descripcion("Recepción Compra")
+                .motivo(ClasificacionMovimientoInventario.RECEPCION_COMPRA)
+                .build());
+
+        TipoMovimientoDetalle tipoDetalle = tipoMovimientoDetalleRepository.save(TipoMovimientoDetalle.builder()
+                .descripcion("Recepción OC")
+                .build());
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("5.000000"),
+                TipoMovimiento.RECEPCION,
+                ClasificacionMovimientoInventario.RECEPCION_COMPRA,
+                "Factura RC-01",
+                null,
+                producto.getId(),
+                null,
+                null,
+                almacenDestino.getId(),
+                proveedor.getId(),
+                ordenCompra.getId(),
+                motivo.getId(),
+                tipoDetalle.getId(),
+                null,
+                null,
+                null,
+                detalle.getId(),
+                "LOTE-RC-01",
+                LocalDateTime.now().plusWeeks(2),
+                null,
+                Boolean.FALSE,
+                List.of()
+        );
+
+        MovimientoInventarioResponseDTO respuesta = movimientoInventarioService.registrarMovimiento(dto);
+
+        MovimientoInventario guardado = movimientoInventarioRepository.findById(respuesta.getId()).orElseThrow();
+        assertThat(guardado.getRecepcionOc()).isNotNull();
+        RecepcionOC cabecera = recepcionOCRepository.findById(guardado.getRecepcionOc().getId()).orElseThrow();
+
+        assertThat(respuesta.getCodigoRecepcion()).isNotBlank();
+        assertThat(respuesta.getRecepcionOcId()).isEqualTo(cabecera.getId());
+        assertThat(guardado.getCodigoRecepcion()).isEqualTo(cabecera.getCodigo());
+        assertThat(cabecera.getOrdenCompra().getId()).isEqualTo(ordenCompra.getId());
+        assertThat(cabecera.getFechaRecepcion()).isEqualTo(guardado.getFechaIngreso().toLocalDate());
     }
 
     private void autenticarUsuario(Usuario usuario) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/RecepcionOCServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/RecepcionOCServiceTest.java
@@ -1,0 +1,166 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({CodigoRecepcionServiceImpl.class, RecepcionOCServiceImpl.class})
+@TestPropertySource(properties = "spring.jpa.defer-datasource-initialization=true")
+class RecepcionOCServiceTest {
+
+    @Autowired
+    private RecepcionOCService recepcionOCService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private OrdenCompra ordenCompra;
+    private Almacen almacenDestino;
+    private Proveedor proveedor;
+    private Usuario usuario;
+    private Producto producto;
+    private UnidadMedida unidadMedida;
+    private CategoriaProducto categoriaProducto;
+
+    @BeforeEach
+    void setUp() {
+        proveedor = Proveedor.builder()
+                .nombre("Proveedor Test")
+                .identificacion("123")
+                .telefono("123")
+                .email("prov@test.com")
+                .direccion("Dir")
+                .paginaWeb("web")
+                .nombreContacto("Contacto")
+                .activo(true)
+                .build();
+        entityManager.persist(proveedor);
+
+        usuario = Usuario.builder()
+                .nombreUsuario("usuario")
+                .clave("clave")
+                .nombreCompleto("Usuario Test")
+                .correo("user@test.com")
+                .rol(RolUsuario.ROL_ALMACENISTA)
+                .activo(true)
+                .bloqueado(false)
+                .build();
+        entityManager.persist(usuario);
+
+        almacenDestino = Almacen.builder()
+                .nombre("Almacen Central")
+                .ubicacion("Ubicacion")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build();
+        entityManager.persist(almacenDestino);
+
+        unidadMedida = UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("u")
+                .build();
+        entityManager.persist(unidadMedida);
+
+        categoriaProducto = CategoriaProducto.builder()
+                .nombre("Materia Prima")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build();
+        entityManager.persist(categoriaProducto);
+
+        producto = Producto.builder()
+                .codigoSku("SKU-1")
+                .nombre("Producto 1")
+                .descripcionProducto("Desc")
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .activo(true)
+                .stockMinimo(BigDecimal.ZERO)
+                .stockMinimoProveedor(BigDecimal.ZERO)
+                .rendimientoUnidad(BigDecimal.ONE)
+                .unidadMedida(unidadMedida)
+                .categoriaProducto(categoriaProducto)
+                .creadoPor(usuario)
+                .build();
+        entityManager.persist(producto);
+
+        ordenCompra = OrdenCompra.builder()
+                .codigoOrden("OC-1")
+                .fechaOrden(LocalDateTime.now())
+                .proveedor(proveedor)
+                .estado(EstadoOrdenCompra.CREADA)
+                .observaciones("Obs")
+                .build();
+        entityManager.persist(ordenCompra);
+
+        OrdenCompraDetalle detalle = OrdenCompraDetalle.builder()
+                .ordenCompra(ordenCompra)
+                .producto(producto)
+                .cantidad(new BigDecimal("1"))
+                .valorUnitario(new BigDecimal("1"))
+                .valorTotal(new BigDecimal("1"))
+                .iva(new BigDecimal("0.00"))
+                .cantidadRecibida(BigDecimal.ZERO)
+                .build();
+        entityManager.persist(detalle);
+        ordenCompra.setDetalles(new ArrayList<>(List.of(detalle)));
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    void reutilizaCabeceraPorDiaYOrdenCompra() {
+        LocalDate fecha = LocalDate.of(2025, 5, 21);
+        RecepcionOC primera = recepcionOCService.findOrCreateCabecera(
+                ordenCompra.getId(),
+                almacenDestino.getId(),
+                proveedor.getId(),
+                usuario.getId(),
+                fecha,
+                "Obs inicial"
+        );
+        RecepcionOC segunda = recepcionOCService.findOrCreateCabecera(
+                ordenCompra.getId(),
+                almacenDestino.getId(),
+                proveedor.getId(),
+                usuario.getId(),
+                fecha,
+                "Obs distinta"
+        );
+        RecepcionOC otroDia = recepcionOCService.findOrCreateCabecera(
+                ordenCompra.getId(),
+                almacenDestino.getId(),
+                proveedor.getId(),
+                usuario.getId(),
+                fecha.plusDays(1),
+                null
+        );
+
+        assertThat(primera.getId()).isEqualTo(segunda.getId());
+        assertThat(primera.getCodigo()).isEqualTo(segunda.getCodigo());
+        assertThat(otroDia.getId()).isNotEqualTo(primera.getId());
+        assertThat(otroDia.getCodigo()).isNotEqualTo(primera.getCodigo());
+        assertThat(primera.getProveedor().getId()).isEqualTo(proveedor.getId());
+        assertThat(primera.getOrdenCompra().getId()).isEqualTo(ordenCompra.getId());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,6 +6,7 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.sql.init.mode=never
 
 spring.flyway.enabled=false
 
@@ -25,3 +26,7 @@ inventory.produccion.almacen.origen.materiaPrima=1
 inventory.produccion.almacen.origen.materialEmpaque=1
 inventory.produccion.almacen.origen.suministros=1
 inventory.produccion.almacen.origen.preBodegaProduccion=1
+app.inventario.prebodega.id=1
+inventory.solicitud.estados.pendientes=PENDIENTE,AUTORIZADA,RESERVADA
+inventory.solicitud.estados.concluyentes=ATENDIDA,EJECUTADA,CANCELADA,RECHAZADO
+clemen.jwt.secret=0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF


### PR DESCRIPTION
## Summary
- add atomic reception code generator backed by secuencias_recepcion and expose CodigoRecepcionService
- implement RecepcionOCService to reuse or create cabeceras per orden de compra y fecha and link movements to receptions
- update MovimientoInventario flow and DTO/mapper to propagate codigoRecepcion plus add supporting tests and test config

## Testing
- mvn -Dtest=CodigoRecepcionServiceTest test
- mvn -Dtest=RecepcionOCServiceTest test
- mvn -Dtest=MovimientoInventarioServiceIntegrationTest#recepcionCompraGeneraCabeceraYCodigo test


------
https://chatgpt.com/codex/tasks/task_e_68e43078abbc83339b07f57552b3ea09