### PR TITLE
feat: add recepcion queries and expose reception code

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/RecepcionOCController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/RecepcionOCController.java
@@ -1,0 +1,41 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.RecepcionOCResponseDTO;
+import com.willyes.clemenintegra.inventario.service.RecepcionOCService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+@RestController
+@RequestMapping("/api/recepciones")
+@RequiredArgsConstructor
+public class RecepcionOCController {
+
+    private final RecepcionOCService recepcionOCService;
+
+    @Operation(summary = "Obtener una recepción por código (parámetro de consulta)")
+    @GetMapping
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<RecepcionOCResponseDTO> obtenerPorCodigoQuery(@RequestParam(name = "codigo") String codigo) {
+        if (codigo == null || codigo.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "CODIGO_RECEPCION_REQUERIDO");
+        }
+        return ResponseEntity.ok(recepcionOCService.obtenerRecepcionPorCodigo(codigo));
+    }
+
+    @Operation(summary = "Obtener una recepción por código (segmento en la ruta)")
+    @GetMapping("/{codigo}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<RecepcionOCResponseDTO> obtenerPorCodigo(@PathVariable String codigo) {
+        return ResponseEntity.ok(recepcionOCService.obtenerRecepcionPorCodigo(codigo));
+    }
+}
+

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
@@ -39,7 +39,9 @@ public class MovimientoInventarioResponseDTO {
     private Long solicitudId;
     private EstadoSolicitudMovimiento estadoSolicitud;
     private List<SolicitudDetalleAtencionDTO> detallesSolicitud;
+    @JsonProperty("recepcionOcId")
     private Long recepcionOcId;
+    @JsonProperty("codigoRecepcion")
     private String codigoRecepcion;
 
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/RecepcionOCDetalleResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/RecepcionOCDetalleResponseDTO.java
@@ -1,0 +1,25 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecepcionOCDetalleResponseDTO {
+
+    private Long id;
+    private Long ordenCompraDetalleId;
+    private Integer productoId;
+    private String productoNombre;
+    private String productoSku;
+    private Long loteId;
+    private String codigoLote;
+    private BigDecimal cantidadRecibida;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/RecepcionOCResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/RecepcionOCResponseDTO.java
@@ -1,0 +1,37 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecepcionOCResponseDTO {
+
+    private Long id;
+    private String codigo;
+    private LocalDate fechaRecepcion;
+    private Integer ordenCompraId;
+    private String codigoOrdenCompra;
+    private Integer almacenDestinoId;
+    private String nombreAlmacenDestino;
+    private Integer proveedorId;
+    private String nombreProveedor;
+    private Long usuarioId;
+    private String nombreUsuario;
+    private String observaciones;
+
+    @Builder.Default
+    private List<RecepcionOCDetalleResponseDTO> detalles = Collections.emptyList();
+
+    @Builder.Default
+    private List<MovimientoInventarioResponseDTO> movimientos = Collections.emptyList();
+}
+

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/RecepcionOCMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/RecepcionOCMapper.java
@@ -1,0 +1,41 @@
+package com.willyes.clemenintegra.inventario.mapper;
+
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.RecepcionOCDetalleResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.RecepcionOCResponseDTO;
+import com.willyes.clemenintegra.inventario.model.RecepcionOC;
+import com.willyes.clemenintegra.inventario.model.RecepcionOCDetalle;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface RecepcionOCMapper {
+
+    @Mapping(target = "ordenCompraId", source = "ordenCompra.id")
+    @Mapping(target = "codigoOrdenCompra", source = "ordenCompra.codigoOrden")
+    @Mapping(target = "almacenDestinoId", source = "almacenDestino.id")
+    @Mapping(target = "nombreAlmacenDestino", source = "almacenDestino.nombre")
+    @Mapping(target = "proveedorId", source = "proveedor.id")
+    @Mapping(target = "nombreProveedor", source = "proveedor.nombre")
+    @Mapping(target = "usuarioId", source = "usuario.id")
+    @Mapping(target = "nombreUsuario", source = "usuario.nombreCompleto")
+    @Mapping(target = "detalles", source = "detalles")
+    RecepcionOCResponseDTO toResponse(RecepcionOC recepcion);
+
+    @Mapping(target = "ordenCompraDetalleId", source = "ordenCompraDetalle.id")
+    @Mapping(target = "productoId", source = "producto.id")
+    @Mapping(target = "productoNombre", source = "producto.nombre")
+    @Mapping(target = "productoSku", source = "producto.codigoSku")
+    @Mapping(target = "loteId", source = "lote.id")
+    @Mapping(target = "codigoLote", source = "lote.codigoLote")
+    RecepcionOCDetalleResponseDTO toDetalle(RecepcionOCDetalle detalle);
+
+    default RecepcionOCResponseDTO toResponse(RecepcionOC recepcion, List<MovimientoInventarioResponseDTO> movimientos) {
+        RecepcionOCResponseDTO response = toResponse(recepcion);
+        response.setMovimientos(movimientos);
+        return response;
+    }
+}
+

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -122,6 +122,26 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
             Long almacenDestinoId,
             ClasificacionMovimientoInventario clasificacion);
 
+    @EntityGraph(attributePaths = {
+            "producto",
+            "lote",
+            "almacenOrigen",
+            "almacenDestino",
+            "registradoPor",
+            "solicitudMovimiento"
+    })
+    List<MovimientoInventario> findAllByCodigoRecepcionOrderByFechaIngresoAsc(String codigoRecepcion);
+
+    @EntityGraph(attributePaths = {
+            "producto",
+            "lote",
+            "almacenOrigen",
+            "almacenDestino",
+            "registradoPor",
+            "solicitudMovimiento"
+    })
+    List<MovimientoInventario> findAllByRecepcionOcIdOrderByFechaIngresoAsc(Long recepcionOcId);
+
     @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m " +
             "where m.solicitudMovimiento.id = :solicitudId " +
             "and m.producto.id = :productoId " +

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/RecepcionOCRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/RecepcionOCRepository.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.repository;
 
 import com.willyes.clemenintegra.inventario.model.RecepcionOC;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -11,4 +12,17 @@ public interface RecepcionOCRepository extends JpaRepository<RecepcionOC, Long> 
     Optional<RecepcionOC> findByOrdenCompraIdAndFechaRecepcion(Integer ordenCompraId, LocalDate fechaRecepcion);
 
     Optional<RecepcionOC> findByCodigo(String codigo);
+
+    @EntityGraph(attributePaths = {
+            "ordenCompra",
+            "ordenCompra.proveedor",
+            "almacenDestino",
+            "proveedor",
+            "usuario",
+            "detalles",
+            "detalles.producto",
+            "detalles.lote",
+            "detalles.ordenCompraDetalle"
+    })
+    Optional<RecepcionOC> findWithDetallesByCodigo(String codigo);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCService.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.dto.RecepcionOCResponseDTO;
 import com.willyes.clemenintegra.inventario.model.RecepcionOC;
 
 import java.time.LocalDate;
@@ -12,4 +13,6 @@ public interface RecepcionOCService {
                                      Long usuarioId,
                                      LocalDate fechaNegocio,
                                      String observaciones);
+
+    RecepcionOCResponseDTO obtenerRecepcionPorCodigo(String codigo);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCServiceImpl.java
@@ -1,15 +1,23 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.RecepcionOCResponseDTO;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.mapper.RecepcionOCMapper;
 import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.repository.RecepcionOCRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 import java.util.Objects;
+import java.util.List;
 
 import com.willyes.clemenintegra.shared.model.Usuario;
 
@@ -20,6 +28,9 @@ public class RecepcionOCServiceImpl implements RecepcionOCService {
 
     private final RecepcionOCRepository recepcionOCRepository;
     private final CodigoRecepcionService codigoRecepcionService;
+    private final MovimientoInventarioRepository movimientoInventarioRepository;
+    private final MovimientoInventarioMapper movimientoInventarioMapper;
+    private final RecepcionOCMapper recepcionOCMapper;
     private final EntityManager entityManager;
 
     @Override
@@ -37,6 +48,25 @@ public class RecepcionOCServiceImpl implements RecepcionOCService {
 
         return recepcionOCRepository.findByOrdenCompraIdAndFechaRecepcion(ordenCompraId, fechaNegocio)
                 .orElseGet(() -> crearCabecera(ordenCompraId, almacenDestinoId, proveedorId, usuarioId, fechaNegocio, observaciones));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public RecepcionOCResponseDTO obtenerRecepcionPorCodigo(String codigo) {
+        if (codigo == null || codigo.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "CODIGO_RECEPCION_REQUERIDO");
+        }
+
+        RecepcionOC recepcion = recepcionOCRepository.findWithDetallesByCodigo(codigo)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "RECEPCION_NO_ENCONTRADA"));
+
+        List<MovimientoInventarioResponseDTO> movimientos = movimientoInventarioRepository
+                .findAllByRecepcionOcIdOrderByFechaIngresoAsc(recepcion.getId())
+                .stream()
+                .map(movimientoInventarioMapper::safeToResponseDTO)
+                .toList();
+
+        return recepcionOCMapper.toResponse(recepcion, movimientos);
     }
 
     private RecepcionOC crearCabecera(Integer ordenCompraId,

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -109,6 +109,12 @@ public class SecurityConfig {
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
+                    auth.requestMatchers("/api/recepciones/**").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_ALMACENISTA.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
                     auth.requestMatchers("/api/calidad/**",
                             "/api/calidad/evaluaciones/archivo/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_CALIDAD.name(),

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/RecepcionOCControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/RecepcionOCControllerIntegrationTest.java
@@ -1,0 +1,228 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "spring.jpa.defer-datasource-initialization=true")
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class RecepcionOCControllerIntegrationTest {
+
+    private static final String CODIGO_RECEPCION = "RC-20240101-01";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private AlmacenRepository almacenRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+    @Autowired
+    private ProveedorRepository proveedorRepository;
+    @Autowired
+    private OrdenCompraRepository ordenCompraRepository;
+    @Autowired
+    private OrdenCompraDetalleRepository ordenCompraDetalleRepository;
+    @Autowired
+    private RecepcionOCRepository recepcionOCRepository;
+    @Autowired
+    private RecepcionOCDetalleRepository recepcionOCDetalleRepository;
+    @Autowired
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Autowired
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Autowired
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @MockBean
+    private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    private RecepcionOC recepcionOC;
+    private MovimientoInventario movimientoInventario;
+
+    @BeforeEach
+    void setUp() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("jefe")
+                .clave("secreto")
+                .nombreCompleto("Jefe Almacenes")
+                .correo("jefe@example.com")
+                .rol(RolUsuario.ROL_JEFE_ALMACENES)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Principal")
+                .ubicacion("Zona A")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen.PRINCIPAL)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("u")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("MP")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-123")
+                .nombre("Producto Recepcion")
+                .descripcionProducto("Descripción")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.NINGUNO)
+                .activo(true)
+                .build());
+
+        LoteProducto lote = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LOTE-01")
+                .producto(producto)
+                .almacen(almacen)
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(new BigDecimal("5.00"))
+                .stockReservado(BigDecimal.ZERO.setScale(6))
+                .agotado(false)
+                .build());
+
+        Proveedor proveedor = proveedorRepository.save(Proveedor.builder()
+                .nombre("Proveedor Test")
+                .identificacion("123456789")
+                .telefono("1234567")
+                .email("proveedor@example.com")
+                .direccion("Calle 123")
+                .nombreContacto("Contacto")
+                .activo(true)
+                .build());
+
+        OrdenCompra ordenCompra = ordenCompraRepository.save(OrdenCompra.builder()
+                .codigoOrden("OC-001")
+                .fechaOrden(LocalDateTime.of(2023, 12, 31, 8, 0))
+                .proveedor(proveedor)
+                .estado(com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra.ENVIADA)
+                .observaciones("Orden de prueba")
+                .build());
+
+        OrdenCompraDetalle ordenCompraDetalle = ordenCompraDetalleRepository.save(OrdenCompraDetalle.builder()
+                .ordenCompra(ordenCompra)
+                .producto(producto)
+                .cantidad(new BigDecimal("10.000"))
+                .valorUnitario(new BigDecimal("2.000"))
+                .valorTotal(new BigDecimal("20.000"))
+                .iva(BigDecimal.ZERO.setScale(2))
+                .cantidadRecibida(BigDecimal.ZERO.setScale(3))
+                .build());
+
+        recepcionOC = recepcionOCRepository.save(RecepcionOC.builder()
+                .codigo(CODIGO_RECEPCION)
+                .fechaRecepcion(LocalDate.of(2024, 1, 1))
+                .ordenCompra(ordenCompra)
+                .almacenDestino(almacen)
+                .proveedor(proveedor)
+                .usuario(usuario)
+                .observaciones("Recepción de prueba")
+                .build());
+
+        RecepcionOCDetalle detalle = recepcionOCDetalleRepository.save(RecepcionOCDetalle.builder()
+                .recepcionOc(recepcionOC)
+                .ordenCompraDetalle(ordenCompraDetalle)
+                .producto(producto)
+                .lote(lote)
+                .cantidadRecibida(new BigDecimal("5.000"))
+                .build());
+        recepcionOC.getDetalles().add(detalle);
+
+        MotivoMovimiento motivo = motivoMovimientoRepository.save(MotivoMovimiento.builder()
+                .descripcion("Recepción de compra")
+                .motivo(ClasificacionMovimientoInventario.RECEPCION_COMPRA)
+                .build());
+
+        TipoMovimientoDetalle tipoDetalle = tipoMovimientoDetalleRepository.save(TipoMovimientoDetalle.builder()
+                .descripcion("Ingreso de recepción")
+                .build());
+
+        movimientoInventario = movimientoInventarioRepository.save(MovimientoInventario.builder()
+                .cantidad(new BigDecimal("5.00"))
+                .tipoMovimiento(TipoMovimiento.RECEPCION)
+                .clasificacion(ClasificacionMovimientoInventario.RECEPCION_COMPRA)
+                .registradoPor(usuario)
+                .producto(producto)
+                .lote(lote)
+                .almacenDestino(almacen)
+                .proveedor(proveedor)
+                .ordenCompra(ordenCompra)
+                .motivoMovimiento(motivo)
+                .tipoMovimientoDetalle(tipoDetalle)
+                .ordenCompraDetalle(ordenCompraDetalle)
+                .recepcionOc(recepcionOC)
+                .codigoRecepcion(CODIGO_RECEPCION)
+                .docReferencia("OC-001")
+                .build());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void obtenerPorCodigoEnRutaDevuelveCabeceraYMovimientos() throws Exception {
+        mockMvc.perform(get("/api/recepciones/{codigo}", CODIGO_RECEPCION)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.codigo").value(CODIGO_RECEPCION))
+                .andExpect(jsonPath("$.ordenCompraId").value(recepcionOC.getOrdenCompra().getId()))
+                .andExpect(jsonPath("$.detalles[0].cantidadRecibida").value(5.0))
+                .andExpect(jsonPath("$.movimientos[0].id").value(movimientoInventario.getId()))
+                .andExpect(jsonPath("$.movimientos[0].codigoRecepcion").value(CODIGO_RECEPCION));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void obtenerPorCodigoEnQueryDevuelveCabeceraYMovimientos() throws Exception {
+        mockMvc.perform(get("/api/recepciones")
+                        .param("codigo", CODIGO_RECEPCION)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.codigo").value(CODIGO_RECEPCION))
+                .andExpect(jsonPath("$.movimientos[0].codigoRecepcion").value(CODIGO_RECEPCION))
+                .andExpect(jsonPath("$.movimientos[0].id").value(movimientoInventario.getId()));
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose `codigoRecepcion` metadata in movement responses for front-end consumption
- add read-only recepcion endpoints that return cabecera, detalles y movimientos vinculados usando nuevos DTOs y mapper MapStruct
- secure `/api/recepciones/**` for roles de almacén y cubrir integración con prueba que consulta por código

## Testing
- mvn -Dtest=RecepcionOCControllerIntegrationTest test

------
https://chatgpt.com/codex/tasks/task_e_68e44744645c8333ab980e2e073632b0