### PR TITLE
Add quality transition documentation and align enums

### DIFF
--- a/docs/calidad/contrato-integracion.md
+++ b/docs/calidad/contrato-integracion.md
@@ -1,0 +1,23 @@
+# Contrato de integración de Calidad con Inventario
+
+## Responsables por acción
+
+| Acción | Responsable primario | Participantes secundarios | Notas |
+| --- | --- | --- | --- |
+| Registrar evaluación (cualquier tipo) | Analista de Calidad | Microbiólogo cuando aplica microbiología | Debe adjuntar evidencia y seleccionar resultado. |
+| Revisar y aprobar evaluaciones condicionadas | Jefe de Calidad | Analista de Calidad | Define condicionantes y fecha objetivo. |
+| Autorizar liberación final | Jefe de Calidad | Analista/Microbiólogo (aportan datos) | No se ejecuta si hay NC abiertas o condiciones activas. |
+| Cargar plan de acción CAPA | Jefe de Calidad | Responsables de área | Sólo se habilita tras registrar la NC. |
+
+## Eventos automáticos
+
+- **Resultado NO CONFORME**: genera Retención y No Conformidad vinculadas al lote y a la evaluación que originó el resultado.
+- **Resultado CONDICIONADO**: crea Condición de uso asociada al lote y deja la Retención activa hasta que el Jefe de Calidad la cierre.
+- **Resultado CONFORME**: elimina Retenciones previas asociadas al mismo motivo (si están resueltas) y no crea NC.
+
+## Reglas de liberación
+
+1. Todas las evaluaciones requeridas según el `TipoAnalisisCalidad` del producto deben estar registradas y con resultado **CONFORME** o **CONDICIONADO** con Condición de uso aprobada.
+2. Si existen No Conformidades asociadas al lote, deben estar en estado **CERRADA** para permitir la liberación.
+3. Las Condiciones de uso en estado **ACTIVA** se mantienen visibles en la interfaz de usuario de inventario y despacho hasta su cierre o hasta que el lote se consuma completamente.
+4. Lotes con resultado **NO_CONFORME** sólo pueden liberarse tras re-procesamiento documentado y actualización del resultado a CONFORME o CONDICIONADO.

--- a/docs/calidad/reglas-transicion-lote.md
+++ b/docs/calidad/reglas-transicion-lote.md
@@ -1,0 +1,18 @@
+# Reglas de transición de estado de lote
+
+La siguiente matriz resume los efectos que provoca cada resultado de evaluación de calidad sobre los lotes, diferenciando entre materias primas/ material de empaque (MP/ME) y producto terminado (PT).
+
+| Tipo de producto | Resultado de la evaluación | Estado del lote después de la evaluación | ¿Crea Retención? | ¿Crea No Conformidad? | ¿Crea Condición de uso? | Precondiciones para liberar el lote |
+| --- | --- | --- | --- | --- | --- | --- |
+| MP / ME | CONFORME | Se mueve a `DISPONIBLE`. | No. | No. | No. | Evaluación registrada como CONFORME. |
+| MP / ME | CONDICIONADO | Permanece en `EN_CUARENTENA` hasta que se defina uso condicionado. | Sí, Retención automática para documentar la limitación. | Sí, NC vinculada a la retención. | Sí, Condición de uso obligatoria con alcance y vigencia definidos. | Requiere aprobación del Jefe de Calidad y resolución de la Condición de uso. |
+| MP / ME | NO CONFORME | Cambia a `RECHAZADO`. | Sí, Retención automática. | Sí, NC automática para seguimiento. | No. | Solo liberable tras re-tratamiento y cierre de la NC; de lo contrario se descarta. |
+| PT | CONFORME | Se mueve a `DISPONIBLE` y puede liberarse al almacén de producto terminado. | No. | No. | No. | Evaluación CONFORME registrada y sin NC abiertas. |
+| PT | CONDICIONADO | Permanece en `RETENIDO` hasta decisión de liberación condicionada. | Sí, Retención automática para control de stock. | Sí, NC vinculada (clasificada como menor). | Sí, Condición de uso que debe mostrarse en despacho. | Liberación requiere aprobación del Jefe de Calidad, NC en estado CERRADA y condición marcada como vigente. |
+| PT | NO CONFORME | Cambia a `RECHAZADO` y se bloquean movimientos de salida. | Sí, Retención automática. | Sí, NC de severidad mayor. | No. | Requiere re-procesamiento documentado y cierre de la NC; de lo contrario se dispone como desperdicio. |
+
+## Consideraciones adicionales
+
+- Toda retención creada por resultados CONDICIONADO o NO CONFORME debe referenciar el lote y la evaluación que la originó.
+- Las Condiciones de uso activas deben ser visibles en la UI de despacho hasta que el lote se consuma o la condición se cierre explícitamente.
+- La liberación final siempre la ejecuta el Jefe de Calidad, quien valida que las evaluaciones requeridas estén en estado CONFORME o que las condiciones asociadas hayan sido resueltas.

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/ResultadoEvaluacion.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/ResultadoEvaluacion.java
@@ -2,5 +2,6 @@ package com.willyes.clemenintegra.calidad.model.enums;
 
 public enum ResultadoEvaluacion {
     CONFORME,
+    CONDICIONADO,
     NO_CONFORME
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/TipoAnalisisCalidad.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/TipoAnalisisCalidad.java
@@ -1,6 +1,0 @@
-package com.willyes.clemenintegra.calidad.model.enums;
-
-public enum TipoAnalisisCalidad {
-    NINGUNO,
-    INSPECCION
-}


### PR DESCRIPTION
## Summary
- add documentation covering lot transition rules and quality-inventory integration responsibilities
- extend the quality evaluation result enum to include the conditioned outcome
- remove the duplicate quality `TipoAnalisisCalidad` enum so the inventory definition is the single source

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7bc8122d88333a4016a28904570a6