### PR TITLE
Integrate quality evaluations with lot traceability

### DIFF
--- a/docs/manual-tests/calidad_evaluaciones.md
+++ b/docs/manual-tests/calidad_evaluaciones.md
@@ -1,0 +1,31 @@
+# Pruebas manuales - Evaluaciones de Calidad
+
+## 1. Registro CONFORME
+```bash
+curl -X POST "http://localhost:8080/api/calidad/evaluaciones" \
+  -H "Content-Type: multipart/form-data" \
+  -F "dto={\"resultado\":\"CONFORME\",\"tipoEvaluacion\":\"FISICO_QUIMICO\",\"observaciones\":\"Cumple especificaciones\",\"loteProductoId\":1,\"usuarioEvaluadorId\":5};type=application/json" \
+  -F "archivos=@/path/informe.pdf"
+```
+_Verificar que no se crean Condiciones de uso ni Retenciones._
+
+## 2. Registro CONDICIONADO
+```bash
+curl -X POST "http://localhost:8080/api/calidad/evaluaciones" \
+  -H "Content-Type: multipart/form-data" \
+  -F "dto={\"resultado\":\"CONDICIONADO\",\"tipoEvaluacion\":\"FISICO_QUIMICO\",\"observaciones\":\"Liberar bajo restricción\",\"loteProductoId\":1,\"usuarioEvaluadorId\":5,\"condicion\":{\"tipo\":\"LIMITACION_USO\",\"descripcion\":\"Solo muestras internas\"}};type=application/json" \
+  -F "archivos=@/path/informe.pdf"
+```
+_Verificar en `/api/calidad/lotes/1/estado-calidad` que `condicionUsoActiva=true`._
+
+## 3. Registro NO_CONFORME
+```bash
+curl -X POST "http://localhost:8080/api/calidad/evaluaciones" \
+  -H "Content-Type: multipart/form-data" \
+  -F "dto={\"resultado\":\"NO_CONFORME\",\"tipoEvaluacion\":\"FISICO_QUIMICO\",\"observaciones\":\"pH fuera de rango\",\"loteProductoId\":1,\"usuarioEvaluadorId\":5,\"severidadNc\":\"CRITICA\"};type=application/json" \
+  -F "archivos=@/path/informe.pdf"
+```
+_Verificar que el lote pasa a `RETENIDO`, se crea la NC y la retención. Consultar estado agregado con:_
+```bash
+curl http://localhost:8080/api/calidad/lotes/1/estado-calidad
+```

--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/LoteCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/LoteCalidadController.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.controller;
 
 import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
 import com.willyes.clemenintegra.inventario.service.LoteProductoService;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
@@ -24,5 +25,11 @@ public class LoteCalidadController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Usuario usuario = userDetails != null ? userDetails.getUsuario() : null;
         return ResponseEntity.ok(service.liberarLotePorCalidad(loteId, usuario));
+    }
+
+    @GetMapping("/{loteId}/estado-calidad")
+    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<EstadoCalidadLoteResponseDTO> obtenerEstadoCalidad(@PathVariable Long loteId) {
+        return ResponseEntity.ok(service.obtenerEstadoCalidad(loteId));
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/CondicionUsoCreateDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/CondicionUsoCreateDTO.java
@@ -1,0 +1,27 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import com.willyes.clemenintegra.calidad.model.enums.TipoCondicionUso;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CondicionUsoCreateDTO {
+
+    @NotNull
+    private Long loteId;
+
+    @NotNull
+    private TipoCondicionUso tipo;
+
+    private LocalDateTime parametroFecha;
+
+    private String descripcion;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/CondicionUsoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/CondicionUsoResponseDTO.java
@@ -1,0 +1,26 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import com.willyes.clemenintegra.calidad.model.enums.EstadoCondicionUso;
+import com.willyes.clemenintegra.calidad.model.enums.TipoCondicionUso;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CondicionUsoResponseDTO {
+
+    private Long id;
+    private Long loteId;
+    private TipoCondicionUso tipo;
+    private LocalDateTime parametroFecha;
+    private String descripcion;
+    private EstadoCondicionUso estado;
+    private LocalDateTime creadoEn;
+    private Long creadoPor;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EstadoCalidadLoteResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EstadoCalidadLoteResponseDTO.java
@@ -1,0 +1,48 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.TipoCondicionUso;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EstadoCalidadLoteResponseDTO {
+
+    private Long loteId;
+    private String estadoLote;
+    private boolean retencionActiva;
+    private MotivoRetencion motivoRetencion;
+    private NcResumen nc;
+    private boolean condicionUsoActiva;
+    private CondicionUsoResumen condicionUso;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NcResumen {
+        private Long id;
+        private SeveridadNoConformidad severidad;
+        private EstadoNoConformidad estado;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CondicionUsoResumen {
+        private Long id;
+        private TipoCondicionUso tipo;
+        private LocalDateTime parametroFecha;
+        private String descripcion;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCalidadRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCalidadRequestDTO.java
@@ -1,9 +1,17 @@
 package com.willyes.clemenintegra.calidad.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCondicionDTO;
+
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 
 /**
@@ -14,6 +22,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class EvaluacionCalidadRequestDTO {
 
     @NotNull(message = "El resultado es obligatorio")
@@ -31,6 +40,10 @@ public class EvaluacionCalidadRequestDTO {
     private Long loteProductoId;
 
     private Long usuarioEvaluadorId;
+
+    private EvaluacionCondicionDTO condicion;
+
+    private SeveridadNoConformidad severidadNc;
 }
 
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCondicionDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCondicionDTO.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import com.willyes.clemenintegra.calidad.model.enums.TipoCondicionUso;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EvaluacionCondicionDTO {
+
+    private TipoCondicionUso tipo;
+    private LocalDateTime parametroFecha;
+    private String descripcion;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/NoConformidadDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/NoConformidadDTO.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.calidad.dto;
 
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import jakarta.validation.constraints.NotNull;
@@ -26,6 +27,8 @@ public class NoConformidadDTO {
     @NotNull(message = "La severidad es obligatoria")
     private SeveridadNoConformidad severidad;
 
+    private EstadoNoConformidad estado;
+
     private String descripcion;
 
     @Size(max = 255, message = "La evidencia no puede exceder 255 caracteres")
@@ -36,5 +39,17 @@ public class NoConformidadDTO {
 
     @NotNull(message = "El usuario que reporta es obligatorio")
     private Long usuarioReportaId;
+
+    private Long loteId;
+
+    private Long productoId;
+
+    private Long evaluacionId;
+
+    private Long creadoPor;
+
+    private Long actualizadoPor;
+
+    private LocalDateTime actualizadoEn;
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/RetencionLoteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/RetencionLoteDTO.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.dto;
 
 import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -30,5 +31,9 @@ public class RetencionLoteDTO {
 
     @NotNull(message = "El aprobador es obligatorio")
     private Long aprobadoPorId;
+
+    private MotivoRetencion motivo;
+
+    private Long noConformidadId;
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/CondicionUsoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/CondicionUsoMapper.java
@@ -1,0 +1,43 @@
+package com.willyes.clemenintegra.calidad.mapper;
+
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoCreateDTO;
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoResponseDTO;
+import com.willyes.clemenintegra.calidad.model.CondicionUso;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoCondicionUso;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class CondicionUsoMapper {
+
+    public CondicionUso toEntity(CondicionUsoCreateDTO dto, LoteProducto lote, Long usuarioId) {
+        LocalDateTime ahora = LocalDateTime.now();
+        return CondicionUso.builder()
+                .lote(lote)
+                .tipo(dto.getTipo())
+                .parametroFecha(dto.getParametroFecha())
+                .descripcion(dto.getDescripcion())
+                .estado(EstadoCondicionUso.ACTIVA)
+                .creadoPor(usuarioId)
+                .creadoEn(ahora)
+                .build();
+    }
+
+    public CondicionUsoResponseDTO toResponseDTO(CondicionUso entity) {
+        if (entity == null) {
+            return null;
+        }
+        return CondicionUsoResponseDTO.builder()
+                .id(entity.getId())
+                .loteId(entity.getLote() != null ? entity.getLote().getId() : null)
+                .tipo(entity.getTipo())
+                .parametroFecha(entity.getParametroFecha())
+                .descripcion(entity.getDescripcion())
+                .estado(entity.getEstado())
+                .creadoEn(entity.getCreadoEn())
+                .creadoPor(entity.getCreadoPor())
+                .build();
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/NoConformidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/NoConformidadMapper.java
@@ -2,6 +2,9 @@ package com.willyes.clemenintegra.calidad.mapper;
 
 import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
 import com.willyes.clemenintegra.calidad.model.NoConformidad;
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.stereotype.Component;
 
@@ -14,23 +17,44 @@ public class NoConformidadMapper {
                 .codigo(entity.getCodigo())
                 .origen(entity.getOrigen())
                 .severidad(entity.getSeveridad())
+                .estado(entity.getEstado())
                 .descripcion(entity.getDescripcion())
                 .evidencia(entity.getEvidencia())
                 .fechaRegistro(entity.getFechaRegistro())
-                .usuarioReportaId(entity.getUsuarioReporta().getId())
+                .usuarioReportaId(entity.getUsuarioReporta() != null ? entity.getUsuarioReporta().getId() : null)
+                .loteId(entity.getLote() != null ? entity.getLote().getId() : null)
+                .productoId(entity.getProducto() != null && entity.getProducto().getId() != null
+                        ? entity.getProducto().getId().longValue() : null)
+                .evaluacionId(entity.getEvaluacion() != null ? entity.getEvaluacion().getId() : null)
+                .creadoPor(entity.getCreadoPor())
+                .actualizadoPor(entity.getActualizadoPor())
+                .actualizadoEn(entity.getActualizadoEn())
                 .build();
     }
 
     public NoConformidad toEntity(NoConformidadDTO dto, Usuario usuarioReporta) {
+        LoteProducto lote = dto.getLoteId() != null ? new LoteProducto(dto.getLoteId()) : null;
+        Producto producto = dto.getProductoId() != null
+                ? Producto.builder().id(dto.getProductoId().intValue()).build()
+                : null;
+        EvaluacionCalidad evaluacion = dto.getEvaluacionId() != null ? EvaluacionCalidad.builder().id(dto.getEvaluacionId()).build() : null;
+
         return NoConformidad.builder()
                 .id(dto.getId())
                 .codigo(dto.getCodigo())
                 .origen(dto.getOrigen())
                 .severidad(dto.getSeveridad())
+                .estado(dto.getEstado())
                 .descripcion(dto.getDescripcion())
                 .evidencia(dto.getEvidencia())
                 .fechaRegistro(dto.getFechaRegistro())
                 .usuarioReporta(usuarioReporta)
+                .lote(lote)
+                .producto(producto)
+                .evaluacion(evaluacion)
+                .creadoPor(dto.getCreadoPor())
+                .actualizadoPor(dto.getActualizadoPor())
+                .actualizadoEn(dto.getActualizadoEn())
                 .build();
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/RetencionLoteMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/RetencionLoteMapper.java
@@ -1,7 +1,9 @@
 package com.willyes.clemenintegra.calidad.mapper;
 
 import com.willyes.clemenintegra.calidad.dto.RetencionLoteDTO;
+import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.RetencionLote;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.stereotype.Component;
@@ -18,6 +20,8 @@ public class RetencionLoteMapper {
                 .fechaLiberacion(entity.getFechaLiberacion())
                 .estado(entity.getEstado())
                 .aprobadoPorId(entity.getAprobadoPor().getId())
+                .motivo(entity.getMotivo())
+                .noConformidadId(entity.getNoConformidad() != null ? entity.getNoConformidad().getId() : null)
                 .build();
     }
 
@@ -31,6 +35,8 @@ public class RetencionLoteMapper {
                 .fechaRetencion(dto.getFechaRetencion())
                 .fechaLiberacion(dto.getFechaLiberacion())
                 .estado(dto.getEstado())
+                .motivo(dto.getMotivo() != null ? dto.getMotivo() : MotivoRetencion.OTRO)
+                .noConformidad(dto.getNoConformidadId() != null ? NoConformidad.builder().id(dto.getNoConformidadId()).build() : null)
                 .aprobadoPor(aprobadoPor)
                 .build();
     }

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/CondicionUso.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/CondicionUso.java
@@ -1,0 +1,60 @@
+package com.willyes.clemenintegra.calidad.model;
+
+import com.willyes.clemenintegra.calidad.model.enums.EstadoCondicionUso;
+import com.willyes.clemenintegra.calidad.model.enums.TipoCondicionUso;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "condiciones_uso", indexes = {
+        @Index(name = "idx_condicion_uso_lote_estado", columnList = "lote_id, estado")
+})
+public class CondicionUso {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lote_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_condicion_uso_lote"))
+    private LoteProducto lote;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false,
+            columnDefinition = "ENUM('REEVALUACION_FECHA','DISTRIBUCION_CONDICIONADA','LIMITACION_USO','OTRO')")
+    private TipoCondicionUso tipo;
+
+    @Column(name = "parametro_fecha")
+    private LocalDateTime parametroFecha;
+
+    @Column(name = "descripcion", columnDefinition = "TEXT")
+    private String descripcion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado", nullable = false,
+            columnDefinition = "ENUM('ACTIVA','LEVANTADA')")
+    private EstadoCondicionUso estado;
+
+    @Column(name = "creado_por", nullable = false)
+    private Long creadoPor;
+
+    @Column(name = "creado_en", nullable = false)
+    private LocalDateTime creadoEn;
+
+    @Column(name = "actualizado_por")
+    private Long actualizadoPor;
+
+    @Column(name = "actualizado_en")
+    private LocalDateTime actualizadoEn;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/EvaluacionCalidad.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/EvaluacionCalidad.java
@@ -26,7 +26,7 @@ public class EvaluacionCalidad {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "resultado", nullable = false,
-            columnDefinition = "ENUM('CONFORME','NO_CONFORME')")
+            columnDefinition = "ENUM('CONFORME','CONDICIONADO','NO_CONFORME')")
     private ResultadoEvaluacion resultado;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/NoConformidad.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/NoConformidad.java
@@ -1,7 +1,11 @@
 package com.willyes.clemenintegra.calidad.model;
 
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,6 +38,10 @@ public class NoConformidad {
     @Column(name = "severidad", nullable = false, columnDefinition = "ENUM('CRITICA','MAYOR','MENOR')")
     private SeveridadNoConformidad severidad;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado", nullable = false, columnDefinition = "ENUM('ABIERTA','CERRADA')")
+    private EstadoNoConformidad estado;
+
     @Column(name = "descripcion", columnDefinition = "TEXT")
     private String descripcion;
 
@@ -47,5 +55,29 @@ public class NoConformidad {
     @JoinColumn(name = "usuario_reporta_id", nullable = false,
             foreignKey = @ForeignKey(name = "fk_no_conf_usuario_reporta"))
     private Usuario usuarioReporta;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lote_id",
+            foreignKey = @ForeignKey(name = "fk_nc_lote"))
+    private LoteProducto lote;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "producto_id",
+            foreignKey = @ForeignKey(name = "fk_nc_producto"))
+    private Producto producto;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "evaluacion_id",
+            foreignKey = @ForeignKey(name = "fk_nc_evaluacion"))
+    private EvaluacionCalidad evaluacion;
+
+    @Column(name = "creado_por")
+    private Long creadoPor;
+
+    @Column(name = "actualizado_por")
+    private Long actualizadoPor;
+
+    @Column(name = "actualizado_en")
+    private LocalDateTime actualizadoEn;
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/RetencionLote.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/RetencionLote.java
@@ -1,6 +1,8 @@
 package com.willyes.clemenintegra.calidad.model;
 
+import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import jakarta.persistence.*;
@@ -27,6 +29,16 @@ public class RetencionLote {
 
     @Column(name = "causa", columnDefinition = "TEXT", nullable = false)
     private String causa;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "motivo", nullable = false,
+            columnDefinition = "ENUM('NO_CONFORMIDAD','OTRO')")
+    private MotivoRetencion motivo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "no_conformidad_id",
+            foreignKey = @ForeignKey(name = "fk_retencion_no_conformidad"))
+    private NoConformidad noConformidad;
 
     @Column(name = "fecha_retencion", nullable = false)
     private LocalDateTime fechaRetencion;

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/EstadoCondicionUso.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/EstadoCondicionUso.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.calidad.model.enums;
+
+public enum EstadoCondicionUso {
+    ACTIVA,
+    LEVANTADA
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/EstadoNoConformidad.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/EstadoNoConformidad.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.calidad.model.enums;
+
+public enum EstadoNoConformidad {
+    ABIERTA,
+    CERRADA
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/MotivoRetencion.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/MotivoRetencion.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.calidad.model.enums;
+
+public enum MotivoRetencion {
+    NO_CONFORMIDAD,
+    OTRO
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/TipoCondicionUso.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/TipoCondicionUso.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.calidad.model.enums;
+
+public enum TipoCondicionUso {
+    REEVALUACION_FECHA,
+    DISTRIBUCION_CONDICIONADA,
+    LIMITACION_USO,
+    OTRO
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/CondicionUsoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/CondicionUsoRepository.java
@@ -1,0 +1,18 @@
+package com.willyes.clemenintegra.calidad.repository;
+
+import com.willyes.clemenintegra.calidad.model.CondicionUso;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoCondicionUso;
+import com.willyes.clemenintegra.calidad.model.enums.TipoCondicionUso;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CondicionUsoRepository extends JpaRepository<CondicionUso, Long> {
+
+    List<CondicionUso> findByLote_IdAndEstado(Long loteId, EstadoCondicionUso estado);
+
+    Optional<CondicionUso> findFirstByLote_IdAndEstadoAndTipo(Long loteId,
+                                                              EstadoCondicionUso estado,
+                                                              TipoCondicionUso tipo);
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
@@ -1,11 +1,14 @@
 package com.willyes.clemenintegra.calidad.repository;
 
 import com.willyes.clemenintegra.calidad.model.NoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface NoConformidadRepository extends JpaRepository<NoConformidad, Long> {
     boolean existsByCodigo(String codigo);
@@ -17,4 +20,10 @@ public interface NoConformidadRepository extends JpaRepository<NoConformidad, Lo
     Page<NoConformidad> findBySeveridadAndOrigen(SeveridadNoConformidad severidad,
                                                  OrigenNoConformidad origen,
                                                  Pageable pageable);
+
+    Optional<NoConformidad> findFirstByLote_IdAndEstadoOrderByFechaRegistroDesc(Long loteId, EstadoNoConformidad estado);
+
+    Optional<NoConformidad> findFirstByLote_IdAndEvaluacion_IdAndEstado(Long loteId,
+                                                                        Long evaluacionId,
+                                                                        EstadoNoConformidad estado);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/RetencionLoteRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/RetencionLoteRepository.java
@@ -2,10 +2,20 @@ package com.willyes.clemenintegra.calidad.repository;
 
 import com.willyes.clemenintegra.calidad.model.RetencionLote;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface RetencionLoteRepository extends JpaRepository<RetencionLote, Long> {
     Page<RetencionLote> findByEstado(EstadoRetencion estado, Pageable pageable);
+
+    List<RetencionLote> findByLote_IdAndEstado(Long loteId, EstadoRetencion estado);
+
+    Optional<RetencionLote> findFirstByLote_IdAndEstadoAndMotivo(Long loteId,
+                                                                 EstadoRetencion estado,
+                                                                 MotivoRetencion motivo);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/CondicionUsoService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/CondicionUsoService.java
@@ -1,0 +1,16 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoCreateDTO;
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoResponseDTO;
+import com.willyes.clemenintegra.calidad.model.CondicionUso;
+
+import java.util.List;
+
+public interface CondicionUsoService {
+
+    CondicionUso create(CondicionUsoCreateDTO dto, com.willyes.clemenintegra.shared.model.Usuario usuarioAutenticado);
+
+    CondicionUso levantar(Long condicionId, com.willyes.clemenintegra.shared.model.Usuario usuarioAutenticado);
+
+    List<CondicionUsoResponseDTO> getActivasByLote(Long loteId);
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/CondicionUsoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/CondicionUsoServiceImpl.java
@@ -1,0 +1,75 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoCreateDTO;
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoResponseDTO;
+import com.willyes.clemenintegra.calidad.mapper.CondicionUsoMapper;
+import com.willyes.clemenintegra.calidad.model.CondicionUso;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoCondicionUso;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.calidad.repository.CondicionUsoRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CondicionUsoServiceImpl implements CondicionUsoService {
+
+    private final CondicionUsoRepository repository;
+    private final LoteProductoRepository loteProductoRepository;
+    private final CondicionUsoMapper mapper;
+
+    @Override
+    @Transactional
+    public CondicionUso create(CondicionUsoCreateDTO dto, Usuario usuarioAutenticado) {
+        if (usuarioAutenticado == null || usuarioAutenticado.getId() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "USUARIO_NO_AUTENTICADO");
+        }
+        Long loteId = dto.getLoteId();
+        CondicionUso existente = repository
+                .findFirstByLote_IdAndEstadoAndTipo(loteId, EstadoCondicionUso.ACTIVA, dto.getTipo())
+                .orElse(null);
+        if (existente != null) {
+            return existente;
+        }
+
+        var lote = loteProductoRepository.findById(loteId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "LOTE_NO_ENCONTRADO"));
+
+        CondicionUso nueva = mapper.toEntity(dto, lote, usuarioAutenticado.getId());
+        nueva.setCreadoEn(LocalDateTime.now());
+        return repository.save(nueva);
+    }
+
+    @Override
+    @Transactional
+    public CondicionUso levantar(Long condicionId, Usuario usuarioAutenticado) {
+        if (usuarioAutenticado == null || usuarioAutenticado.getId() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "USUARIO_NO_AUTENTICADO");
+        }
+        CondicionUso condicion = repository.findById(condicionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CONDICION_USO_NO_ENCONTRADA"));
+        if (condicion.getEstado() == EstadoCondicionUso.LEVANTADA) {
+            return condicion;
+        }
+        condicion.setEstado(EstadoCondicionUso.LEVANTADA);
+        condicion.setActualizadoPor(usuarioAutenticado.getId());
+        condicion.setActualizadoEn(LocalDateTime.now());
+        return repository.save(condicion);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CondicionUsoResponseDTO> getActivasByLote(Long loteId) {
+        return repository.findByLote_IdAndEstado(loteId, EstadoCondicionUso.ACTIVA)
+                .stream()
+                .map(mapper::toResponseDTO)
+                .toList();
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -4,12 +4,18 @@ import com.willyes.clemenintegra.calidad.dto.ArchivoEvaluacionDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoCreateDTO;
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCondicionDTO;
 import com.willyes.clemenintegra.calidad.mapper.EvaluacionCalidadMapper;
 import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
+import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
+import com.willyes.clemenintegra.calidad.service.NoConformidadService;
 import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
@@ -50,6 +56,9 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
     private final UsuarioRepository usuarioRepository;
     private final InventoryCatalogResolver catalogResolver;
     private final AlmacenRepository almacenRepository;
+    private final CondicionUsoService condicionUsoService;
+    private final RetencionLoteService retencionLoteService;
+    private final NoConformidadService noConformidadService;
 
     public Page<EvaluacionCalidadResponseDTO> listar(ResultadoEvaluacion resultado, Pageable pageable) {
         Page<EvaluacionCalidad> page = (resultado != null)
@@ -141,6 +150,8 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
 
         entidad = repository.save(entidad);
 
+        manejarResultadoEvaluacion(entidad, dto, lote, user);
+
         verificarAlmacenPostOperacion(lote.getId(), cuarentenaId, operacion, user);
 
         return mapper.toResponseDTO(entidad);
@@ -186,6 +197,12 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         existing.setFechaEvaluacion(LocalDateTime.now());
 
         existing = repository.save(existing);
+
+        Usuario actor = usuarioService.obtenerUsuarioAutenticado();
+        if (actor == null) {
+            actor = user;
+        }
+        manejarResultadoEvaluacion(existing, dto, lote, actor);
 
         verificarAlmacenPostOperacion(lote.getId(), cuarentenaId, operacion, user);
 
@@ -301,5 +318,36 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         if (lote == null || lote.getEstado() == null) return false;
         String nombre = lote.getEstado().name();
         return "EN_CUARENTENA".equals(nombre) || "RETENIDO".equals(nombre);
+    }
+
+    private void manejarResultadoEvaluacion(EvaluacionCalidad evaluacion,
+                                            EvaluacionCalidadRequestDTO dto,
+                                            LoteProducto lote,
+                                            Usuario usuario) {
+        ResultadoEvaluacion resultado = dto.getResultado();
+        if (resultado == null) {
+            return;
+        }
+        if (resultado == ResultadoEvaluacion.CONDICIONADO) {
+            EvaluacionCondicionDTO condicion = dto.getCondicion();
+            if (condicion == null || condicion.getTipo() == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "CONDICION_USO_REQUERIDA");
+            }
+            CondicionUsoCreateDTO createDTO = CondicionUsoCreateDTO.builder()
+                    .loteId(lote.getId())
+                    .tipo(condicion.getTipo())
+                    .parametroFecha(condicion.getParametroFecha())
+                    .descripcion(condicion.getDescripcion())
+                    .build();
+            condicionUsoService.create(createDTO, usuario);
+        } else if (resultado == ResultadoEvaluacion.NO_CONFORME) {
+            SeveridadNoConformidad severidad = dto.getSeveridadNc();
+            if (severidad == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "SEVERIDAD_NC_REQUERIDA");
+            }
+            var noConformidad = noConformidadService.registrarDesdeEvaluacion(lote, evaluacion, severidad,
+                    dto.getObservaciones(), usuario);
+            retencionLoteService.asegurarRetencionNoConformidad(lote, "NC pendiente", noConformidad, usuario);
+        }
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadService.java
@@ -1,17 +1,37 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
+import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
 
 public interface NoConformidadService {
     Page<NoConformidadDTO> listar(SeveridadNoConformidad severidad,
                                   OrigenNoConformidad origen,
                                   Pageable pageable);
+
     NoConformidadDTO crear(NoConformidadDTO dto);
+
     NoConformidadDTO actualizar(Long id, NoConformidadDTO dto);
+
     void eliminar(Long id);
+
     NoConformidadDTO obtenerPorId(Long id);
+
+    NoConformidad registrarDesdeEvaluacion(LoteProducto lote,
+                                           EvaluacionCalidad evaluacion,
+                                           SeveridadNoConformidad severidad,
+                                           String descripcion,
+                                           Usuario usuario);
+
+    Optional<NoConformidad> obtenerActivaPorLote(Long loteId);
+
+    Optional<NoConformidad> obtenerActivaPorLoteYEvaluacion(Long loteId, Long evaluacionId);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImpl.java
@@ -2,9 +2,12 @@ package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
 import com.willyes.clemenintegra.calidad.mapper.NoConformidadMapper;
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.NoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.calidad.repository.NoConformidadRepository;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
@@ -12,8 +15,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +45,7 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         return page.map(mapper::toDTO);
     }
 
+    @Transactional
     public NoConformidadDTO crear(NoConformidadDTO dto) {
         if (repository.existsByCodigo(dto.getCodigo())) {
             throw new IllegalArgumentException("Ya existe una no conformidad con código: " + dto.getCodigo());
@@ -46,9 +53,16 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         Usuario usuario = usuarioRepository.findById(dto.getUsuarioReportaId())
                 .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + dto.getUsuarioReportaId()));
         NoConformidad entity = mapper.toEntity(dto, usuario);
+        if (entity.getEstado() == null) {
+            entity.setEstado(EstadoNoConformidad.ABIERTA);
+        }
+        if (entity.getCreadoPor() == null && usuario.getId() != null) {
+            entity.setCreadoPor(usuario.getId());
+        }
         return mapper.toDTO(repository.save(entity));
     }
 
+    @Transactional
     public NoConformidadDTO actualizar(Long id, NoConformidadDTO dto) {
         NoConformidad existing = repository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("No conformidad no encontrada con ID: " + id));
@@ -57,10 +71,15 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         existing.setCodigo(dto.getCodigo());
         existing.setOrigen(dto.getOrigen());
         existing.setSeveridad(dto.getSeveridad());
+        if (dto.getEstado() != null) {
+            existing.setEstado(dto.getEstado());
+        }
         existing.setDescripcion(dto.getDescripcion());
         existing.setEvidencia(dto.getEvidencia());
         existing.setFechaRegistro(dto.getFechaRegistro());
         existing.setUsuarioReporta(usuario);
+        existing.setActualizadoPor(usuario.getId());
+        existing.setActualizadoEn(LocalDateTime.now());
         return mapper.toDTO(repository.save(existing));
     }
 
@@ -72,6 +91,104 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         return repository.findById(id)
                 .map(mapper::toDTO)
                 .orElseThrow(() -> new NoSuchElementException("No conformidad no encontrada con ID: " + id));
+    }
+
+    @Override
+    @Transactional
+    public NoConformidad registrarDesdeEvaluacion(LoteProducto lote,
+                                                  EvaluacionCalidad evaluacion,
+                                                  SeveridadNoConformidad severidad,
+                                                  String descripcion,
+                                                  Usuario usuario) {
+        if (lote == null || lote.getId() == null) {
+            throw new IllegalArgumentException("Lote obligatorio para registrar no conformidad");
+        }
+        if (usuario == null || usuario.getId() == null) {
+            throw new IllegalArgumentException("Usuario autenticado requerido");
+        }
+
+        Long loteId = lote.getId();
+        Long evaluacionId = evaluacion != null ? evaluacion.getId() : null;
+
+        Optional<NoConformidad> existente = Optional.empty();
+        if (evaluacionId != null) {
+            existente = repository.findFirstByLote_IdAndEvaluacion_IdAndEstado(loteId, evaluacionId, EstadoNoConformidad.ABIERTA);
+        }
+        if (existente.isEmpty()) {
+            existente = repository.findFirstByLote_IdAndEstadoOrderByFechaRegistroDesc(loteId, EstadoNoConformidad.ABIERTA);
+        }
+
+        if (existente.isPresent()) {
+            NoConformidad nc = existente.get();
+            if (esSeveridadMasCritica(severidad, nc.getSeveridad())) {
+                nc.setSeveridad(severidad);
+            }
+            if (descripcion != null && !descripcion.isBlank()) {
+                nc.setDescripcion(descripcion);
+            }
+            if (evaluacion != null && nc.getEvaluacion() == null) {
+                nc.setEvaluacion(evaluacion);
+            }
+            nc.setActualizadoPor(usuario.getId());
+            nc.setActualizadoEn(LocalDateTime.now());
+            return repository.save(nc);
+        }
+
+        NoConformidad nueva = new NoConformidad();
+        nueva.setCodigo(generarCodigo());
+        nueva.setOrigen(OrigenNoConformidad.LOTE);
+        nueva.setSeveridad(severidad);
+        nueva.setEstado(EstadoNoConformidad.ABIERTA);
+        nueva.setDescripcion(descripcion);
+        nueva.setFechaRegistro(LocalDateTime.now());
+        nueva.setUsuarioReporta(usuario);
+        nueva.setLote(lote);
+        nueva.setProducto(lote.getProducto());
+        nueva.setEvaluacion(evaluacion);
+        nueva.setCreadoPor(usuario.getId());
+
+        return repository.save(nueva);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<NoConformidad> obtenerActivaPorLote(Long loteId) {
+        if (loteId == null) {
+            return Optional.empty();
+        }
+        return repository.findFirstByLote_IdAndEstadoOrderByFechaRegistroDesc(loteId, EstadoNoConformidad.ABIERTA);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<NoConformidad> obtenerActivaPorLoteYEvaluacion(Long loteId, Long evaluacionId) {
+        if (loteId == null || evaluacionId == null) {
+            return Optional.empty();
+        }
+        return repository.findFirstByLote_IdAndEvaluacion_IdAndEstado(loteId, evaluacionId, EstadoNoConformidad.ABIERTA);
+    }
+
+    private boolean esSeveridadMasCritica(SeveridadNoConformidad nueva, SeveridadNoConformidad actual) {
+        if (nueva == null || actual == null) {
+            return false;
+        }
+        return obtenerPesoSeveridad(nueva) < obtenerPesoSeveridad(actual);
+    }
+
+    private int obtenerPesoSeveridad(SeveridadNoConformidad severidad) {
+        return switch (severidad) {
+            case CRITICA -> 0;
+            case MAYOR -> 1;
+            case MENOR -> 2;
+        };
+    }
+
+    private String generarCodigo() {
+        String codigo;
+        do {
+            codigo = "NC-" + System.currentTimeMillis();
+        } while (repository.existsByCodigo(codigo));
+        return codigo;
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteService.java
@@ -1,14 +1,34 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.RetencionLoteDTO;
+import com.willyes.clemenintegra.calidad.model.RetencionLote;
+import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface RetencionLoteService {
     Page<RetencionLoteDTO> listar(EstadoRetencion estado, Pageable pageable);
+
     RetencionLoteDTO crear(RetencionLoteDTO dto);
+
     RetencionLoteDTO actualizar(Long id, RetencionLoteDTO dto);
+
     RetencionLoteDTO obtenerPorId(Long id);
+
     void eliminar(Long id);
+
+    RetencionLote asegurarRetencionNoConformidad(LoteProducto lote,
+                                                  String descripcion,
+                                                  NoConformidad noConformidad,
+                                                  Usuario usuario);
+
+    Optional<RetencionLote> obtenerActivaPorLote(Long loteId);
+
+    List<RetencionLote> obtenerRetencionesActivas(Long loteId);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteServiceImpl.java
@@ -3,18 +3,25 @@ package com.willyes.clemenintegra.calidad.service;
 import com.willyes.clemenintegra.calidad.dto.RetencionLoteDTO;
 import com.willyes.clemenintegra.calidad.mapper.RetencionLoteMapper;
 import com.willyes.clemenintegra.calidad.model.RetencionLote;
+import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import com.willyes.clemenintegra.calidad.repository.RetencionLoteRepository;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
+import java.util.List;
+import java.util.Optional;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +39,7 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
         return page.map(mapper::toDTO);
     }
 
+    @Transactional
     public RetencionLoteDTO crear(RetencionLoteDTO dto) {
         LoteProducto lote = loteRepository.findById(dto.getLoteId())
                 .orElseThrow(() -> new NoSuchElementException("Lote no encontrado con ID: " + dto.getLoteId()));
@@ -41,6 +49,7 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
         return mapper.toDTO(repository.save(entity));
     }
 
+    @Transactional
     public RetencionLoteDTO actualizar(Long id, RetencionLoteDTO dto) {
         RetencionLote existing = repository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("Retención no encontrada con ID: " + id));
@@ -65,6 +74,69 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
 
     public void eliminar(Long id) {
         repository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public RetencionLote asegurarRetencionNoConformidad(LoteProducto lote,
+                                                        String descripcion,
+                                                        NoConformidad noConformidad,
+                                                        Usuario usuario) {
+        if (lote == null || lote.getId() == null) {
+            throw new IllegalArgumentException("Lote requerido");
+        }
+        if (usuario == null || usuario.getId() == null) {
+            throw new IllegalArgumentException("Usuario requerido");
+        }
+
+        Optional<RetencionLote> existente = repository.findFirstByLote_IdAndEstadoAndMotivo(
+                lote.getId(), EstadoRetencion.RETENIDO, MotivoRetencion.NO_CONFORMIDAD);
+        if (existente.isPresent()) {
+            RetencionLote retencion = existente.get();
+            retencion.setCausa(descripcion != null ? descripcion : retencion.getCausa());
+            if (noConformidad != null) {
+                retencion.setNoConformidad(noConformidad);
+            }
+            return repository.save(retencion);
+        }
+
+        Usuario aprobadoPor = usuarioRepository.findById(usuario.getId())
+                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + usuario.getId()));
+
+        RetencionLote nueva = RetencionLote.builder()
+                .lote(lote)
+                .causa(descripcion != null ? descripcion : "NC pendiente")
+                .fechaRetencion(LocalDateTime.now())
+                .estado(EstadoRetencion.RETENIDO)
+                .motivo(MotivoRetencion.NO_CONFORMIDAD)
+                .noConformidad(noConformidad)
+                .aprobadoPor(aprobadoPor)
+                .build();
+
+        RetencionLote guardada = repository.save(nueva);
+        if (lote.getEstado() != EstadoLote.RETENIDO) {
+            lote.setEstado(EstadoLote.RETENIDO);
+            loteRepository.save(lote);
+        }
+        return guardada;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<RetencionLote> obtenerActivaPorLote(Long loteId) {
+        if (loteId == null) {
+            return Optional.empty();
+        }
+        return repository.findFirstByLote_IdAndEstadoAndMotivo(loteId, EstadoRetencion.RETENIDO, MotivoRetencion.NO_CONFORMIDAD);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<RetencionLote> obtenerRetencionesActivas(Long loteId) {
+        if (loteId == null) {
+            return List.of();
+        }
+        return repository.findByLote_IdAndEstado(loteId, EstadoRetencion.RETENIDO);
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.LoteProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,4 +33,6 @@ public interface LoteProductoService {
      * @return información del lote actualizado
      */
     LoteProductoResponseDTO liberarLotePorCalidad(Long loteId, com.willyes.clemenintegra.shared.model.Usuario usuarioActual);
+
+    EstadoCalidadLoteResponseDTO obtenerEstadoCalidad(Long loteId);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.LoteProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
@@ -14,6 +15,10 @@ import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.inventario.service.StockQueryService;
+import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
+import com.willyes.clemenintegra.calidad.service.NoConformidadService;
+import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
@@ -63,6 +68,9 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     private final MotivoMovimientoRepository motivoMovimientoRepository;
     private final TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
     private final InventoryCatalogResolver catalogResolver;
+    private final RetencionLoteService retencionLoteService;
+    private final NoConformidadService noConformidadService;
+    private final CondicionUsoService condicionUsoService;
 
     @Value("${inventory.lote.estadoLiberado}")
     private String estadoLiberadoConf;
@@ -474,6 +482,15 @@ public class LoteProductoServiceImpl implements LoteProductoService {
             validarEvaluacion(evaluaciones, TipoEvaluacion.MICROBIOLOGICO);
         }
 
+        boolean retencionNcActiva = retencionLoteService.obtenerRetencionesActivas(loteId).stream()
+                .anyMatch(r -> r.getMotivo() == MotivoRetencion.NO_CONFORMIDAD);
+        noConformidadService.obtenerActivaPorLote(loteId).ifPresent(nc -> {
+            if (retencionNcActiva) {
+                log.warn("LIBERACION_BLOQUEADA_RETENCION_NC loteId={} ncId={}", loteId, nc.getId());
+            }
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "NC_ABIERTA");
+        });
+
         Almacen origen = lote.getAlmacen();
         Almacen destino = almacenRepo.findById(destinoPrincipalId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_DESTINO_INEXISTENTE"));
@@ -516,7 +533,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Falta evaluación requerida");
         }
         boolean aprobadas = filtradas.stream()
-                .allMatch(e -> e.getResultado() == ResultadoEvaluacion.CONFORME);
+                .allMatch(e -> e.getResultado() != ResultadoEvaluacion.NO_CONFORME);
         if (!aprobadas) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La evaluación requerida no está aprobada");
         }
@@ -526,6 +543,42 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         if (evaluacionRepository.findByLoteProductoId(loteId).isEmpty()) {
             throw new IllegalStateException("El lote no cuenta con evaluaciones registradas");
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public EstadoCalidadLoteResponseDTO obtenerEstadoCalidad(Long loteId) {
+        LoteProducto lote = loteRepo.findById(loteId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "LOTE_NO_ENCONTRADO"));
+
+        var retenciones = retencionLoteService.obtenerRetencionesActivas(loteId);
+        var retencion = retenciones.stream().findFirst().orElse(null);
+        var ncOpt = noConformidadService.obtenerActivaPorLote(loteId);
+        var condiciones = condicionUsoService.getActivasByLote(loteId);
+
+        EstadoCalidadLoteResponseDTO.NcResumen ncResumen = ncOpt.map(nc -> EstadoCalidadLoteResponseDTO.NcResumen.builder()
+                .id(nc.getId())
+                .severidad(nc.getSeveridad())
+                .estado(nc.getEstado())
+                .build()).orElse(null);
+
+        EstadoCalidadLoteResponseDTO.CondicionUsoResumen condicionResumen = condiciones.isEmpty() ? null
+                : EstadoCalidadLoteResponseDTO.CondicionUsoResumen.builder()
+                .id(condiciones.get(0).getId())
+                .tipo(condiciones.get(0).getTipo())
+                .parametroFecha(condiciones.get(0).getParametroFecha())
+                .descripcion(condiciones.get(0).getDescripcion())
+                .build();
+
+        return EstadoCalidadLoteResponseDTO.builder()
+                .loteId(loteId)
+                .estadoLote(lote.getEstado() != null ? lote.getEstado().name() : null)
+                .retencionActiva(retencion != null)
+                .motivoRetencion(retencion != null ? retencion.getMotivo() : null)
+                .nc(ncResumen)
+                .condicionUsoActiva(!condiciones.isEmpty())
+                .condicionUso(condicionResumen)
+                .build();
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -25,6 +25,8 @@ import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoReposi
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
@@ -107,6 +109,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     private final ReservaLoteService reservaLoteService;
     private final ReservaLoteRepository reservaLoteRepository;
     private final RecepcionOCService recepcionOCService;
+    private final RetencionLoteService retencionLoteService;
     //private final Long motivoSalidaProdId = catalogResolver.getMotivoSalidaProduccionId();
     //private final Long tipoDetSalidaProdId = catalogResolver.getTipoDetalleSalidaProduccionId();
 
@@ -1389,6 +1392,13 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             log.warn(
                     "procesarMovimientoConLoteExistente: estado de lote inválido loteId={} estado={} productoId={}",
                     loteOrigen.getId(), loteOrigen.getEstado(), producto.getId());
+            if (loteOrigen.getEstado() == EstadoLote.RETENIDO) {
+                retencionLoteService.obtenerActivaPorLote(loteOrigen.getId()).ifPresent(ret -> {
+                    if (ret.getMotivo() == MotivoRetencion.NO_CONFORMIDAD) {
+                        throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "BLOQUEO_RETENCION_NC");
+                    }
+                });
+            }
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_ESTADO_INVALIDO");
         }
 

--- a/src/main/resources/db/migration/V20251009__calidad_condicion_uso.sql
+++ b/src/main/resources/db/migration/V20251009__calidad_condicion_uso.sql
@@ -1,0 +1,15 @@
+CREATE TABLE condiciones_uso (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    lote_id BIGINT NOT NULL,
+    tipo ENUM('REEVALUACION_FECHA','DISTRIBUCION_CONDICIONADA','LIMITACION_USO','OTRO') NOT NULL,
+    parametro_fecha DATETIME NULL,
+    descripcion TEXT NULL,
+    estado ENUM('ACTIVA','LEVANTADA') NOT NULL DEFAULT 'ACTIVA',
+    creado_por BIGINT NOT NULL,
+    creado_en DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    actualizado_por BIGINT NULL,
+    actualizado_en DATETIME NULL,
+    CONSTRAINT fk_condicion_uso_lote FOREIGN KEY (lote_id) REFERENCES lotes_productos (id)
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_condicion_uso_lote_estado ON condiciones_uso (lote_id, estado);

--- a/src/main/resources/db/migration/V20251010__calidad_retencion_nc_extensiones.sql
+++ b/src/main/resources/db/migration/V20251010__calidad_retencion_nc_extensiones.sql
@@ -1,0 +1,22 @@
+ALTER TABLE retencion_lote
+    ADD COLUMN motivo ENUM('NO_CONFORMIDAD','OTRO') NOT NULL DEFAULT 'OTRO' AFTER causa,
+    ADD COLUMN no_conformidad_id BIGINT NULL AFTER motivo,
+    ADD CONSTRAINT fk_retencion_no_conformidad FOREIGN KEY (no_conformidad_id) REFERENCES no_conformidad (id);
+
+CREATE INDEX idx_retencion_lote_estado_motivo ON retencion_lote (lote_id, estado, motivo);
+
+ALTER TABLE no_conformidad
+    ADD COLUMN estado ENUM('ABIERTA','CERRADA') NOT NULL DEFAULT 'ABIERTA' AFTER severidad,
+    ADD COLUMN lote_id BIGINT NULL AFTER estado,
+    ADD COLUMN producto_id BIGINT NULL AFTER lote_id,
+    ADD COLUMN evaluacion_id BIGINT NULL AFTER producto_id,
+    ADD COLUMN creado_por BIGINT NULL AFTER usuario_reporta_id,
+    ADD COLUMN actualizado_por BIGINT NULL AFTER creado_por,
+    ADD COLUMN actualizado_en DATETIME(6) NULL AFTER actualizado_por;
+
+ALTER TABLE no_conformidad
+    ADD CONSTRAINT fk_nc_lote FOREIGN KEY (lote_id) REFERENCES lotes_productos (id),
+    ADD CONSTRAINT fk_nc_producto FOREIGN KEY (producto_id) REFERENCES productos (id),
+    ADD CONSTRAINT fk_nc_evaluacion FOREIGN KEY (evaluacion_id) REFERENCES evaluaciones_calidad (id);
+
+CREATE INDEX idx_nc_lote_estado ON no_conformidad (lote_id, estado);


### PR DESCRIPTION
## Summary
- add condiciones_uso schema and associated enums, entity, mapper, DTOs, and service for conditional evaluations
- extend evaluation workflow to create conditional use records, retentions, and non-conformities with idempotent behaviors
- enforce lot release checks, movement blocking messages, and expose aggregated quality status endpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7fcd6fa7c8333a6b426ed3cc5ed3d