### PR TITLE
Alinear liberación con retenciones de no conformidad

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
@@ -4,6 +4,8 @@ import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import com.willyes.clemenintegra.calidad.service.NoConformidadService;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class NoConformidadController {
 
     private final NoConformidadService service;
+    private final UsuarioRepository usuarioRepository;
 
     @GetMapping
     public ResponseEntity<Page<NoConformidadDTO>> listar(
@@ -39,10 +42,12 @@ public class NoConformidadController {
     public ResponseEntity<NoConformidadDTO> crear(
             @RequestBody NoConformidadDTO dto,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Usuario authUser = null;
         if (userDetails != null) {
             dto.setUsuarioReportaId(userDetails.getId());
+            authUser = usuarioRepository.findById(userDetails.getId()).orElse(null);
         }
-        return ResponseEntity.ok(service.crear(dto));
+        return ResponseEntity.ok(service.crear(dto, authUser));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 public interface NoConformidadRepository extends JpaRepository<NoConformidad, Long> {
     boolean existsByCodigo(String codigo);
 
+    Optional<NoConformidad> findFirstByCodigoStartingWithOrderByCodigoDesc(String codigoPrefix);
+
     Page<NoConformidad> findBySeveridad(SeveridadNoConformidad severidad, Pageable pageable);
 
     Page<NoConformidad> findByOrigen(OrigenNoConformidad origen, Pageable pageable);

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadService.java
@@ -17,7 +17,7 @@ public interface NoConformidadService {
                                   OrigenNoConformidad origen,
                                   Pageable pageable);
 
-    NoConformidadDTO crear(NoConformidadDTO dto);
+    NoConformidadDTO crear(NoConformidadDTO dto, Usuario authUser);
 
     NoConformidadDTO actualizar(Long id, NoConformidadDTO dto);
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImpl.java
@@ -7,8 +7,11 @@ import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.calidad.repository.NoConformidadRepository;
+import com.willyes.clemenintegra.calidad.repository.RetencionLoteRepository;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,15 +20,21 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class NoConformidadServiceImpl implements NoConformidadService {
 
+    private static final DateTimeFormatter CODIGO_PERIODO_FORMAT = DateTimeFormatter.ofPattern("yyyyMM");
+    private static final DateTimeFormatter DESCRIPCION_TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
     private final NoConformidadRepository repository;
+    private final RetencionLoteRepository retencionLoteRepository;
     private final UsuarioRepository usuarioRepository;
     private final NoConformidadMapper mapper;
 
@@ -45,21 +54,53 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         return page.map(mapper::toDTO);
     }
 
+    @Override
     @Transactional
-    public NoConformidadDTO crear(NoConformidadDTO dto) {
-        if (repository.existsByCodigo(dto.getCodigo())) {
-            throw new IllegalArgumentException("Ya existe una no conformidad con código: " + dto.getCodigo());
+    public NoConformidadDTO crear(NoConformidadDTO dto, Usuario authUser) {
+        if (dto == null) {
+            throw new IllegalArgumentException("La no conformidad es obligatoria");
         }
-        Usuario usuario = usuarioRepository.findById(dto.getUsuarioReportaId())
-                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + dto.getUsuarioReportaId()));
-        NoConformidad entity = mapper.toEntity(dto, usuario);
-        if (entity.getEstado() == null) {
-            entity.setEstado(EstadoNoConformidad.ABIERTA);
+
+        Usuario usuarioReporta = usuarioRepository.findById(dto.getUsuarioReportaId())
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Usuario no encontrado con ID: " + dto.getUsuarioReportaId()));
+        Usuario usuarioActual = authUser != null ? authUser : usuarioReporta;
+
+        Optional<NoConformidad> existente = buscarNoConformidadActiva(dto.getLoteId(), dto.getEvaluacionId());
+        NoConformidad resultado;
+        if (existente.isPresent()) {
+            NoConformidad nc = existente.get();
+            EvaluacionCalidad evaluacion = dto.getEvaluacionId() != null
+                    ? EvaluacionCalidad.builder().id(dto.getEvaluacionId()).build()
+                    : null;
+            actualizarNoConformidadExistente(nc, dto.getSeveridad(), dto.getDescripcion(), evaluacion, usuarioActual);
+            resultado = repository.save(nc);
+        } else {
+            NoConformidad entity = mapper.toEntity(dto, usuarioReporta);
+            if (entity.getCodigo() == null || entity.getCodigo().isBlank()) {
+                entity.setCodigo(generarCodigoSecuencial());
+            } else if (repository.existsByCodigo(entity.getCodigo())) {
+                throw new IllegalArgumentException("Ya existe una no conformidad con código: " + entity.getCodigo());
+            }
+            if (entity.getEstado() == null) {
+                entity.setEstado(EstadoNoConformidad.ABIERTA);
+            }
+            if (entity.getFechaRegistro() == null) {
+                entity.setFechaRegistro(LocalDateTime.now());
+            }
+            Long usuarioId = usuarioActual != null ? usuarioActual.getId() : usuarioReporta.getId();
+            if (entity.getCreadoPor() == null && usuarioId != null) {
+                entity.setCreadoPor(usuarioId);
+            }
+            if (usuarioId != null) {
+                entity.setActualizadoPor(usuarioId);
+            }
+            entity.setActualizadoEn(LocalDateTime.now());
+            resultado = repository.save(entity);
         }
-        if (entity.getCreadoPor() == null && usuario.getId() != null) {
-            entity.setCreadoPor(usuario.getId());
-        }
-        return mapper.toDTO(repository.save(entity));
+
+        vincularRetencionConNoConformidad(resultado);
+        return mapper.toDTO(resultado);
     }
 
     @Transactional
@@ -110,32 +151,17 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         Long loteId = lote.getId();
         Long evaluacionId = evaluacion != null ? evaluacion.getId() : null;
 
-        Optional<NoConformidad> existente = Optional.empty();
-        if (evaluacionId != null) {
-            existente = repository.findFirstByLote_IdAndEvaluacion_IdAndEstado(loteId, evaluacionId, EstadoNoConformidad.ABIERTA);
-        }
-        if (existente.isEmpty()) {
-            existente = repository.findFirstByLote_IdAndEstadoOrderByFechaRegistroDesc(loteId, EstadoNoConformidad.ABIERTA);
-        }
-
+        Optional<NoConformidad> existente = buscarNoConformidadActiva(loteId, evaluacionId);
         if (existente.isPresent()) {
             NoConformidad nc = existente.get();
-            if (esSeveridadMasCritica(severidad, nc.getSeveridad())) {
-                nc.setSeveridad(severidad);
-            }
-            if (descripcion != null && !descripcion.isBlank()) {
-                nc.setDescripcion(descripcion);
-            }
-            if (evaluacion != null && nc.getEvaluacion() == null) {
-                nc.setEvaluacion(evaluacion);
-            }
-            nc.setActualizadoPor(usuario.getId());
-            nc.setActualizadoEn(LocalDateTime.now());
-            return repository.save(nc);
+            actualizarNoConformidadExistente(nc, severidad, descripcion, evaluacion, usuario);
+            NoConformidad guardada = repository.save(nc);
+            vincularRetencionConNoConformidad(guardada);
+            return guardada;
         }
 
         NoConformidad nueva = new NoConformidad();
-        nueva.setCodigo(generarCodigo());
+        nueva.setCodigo(generarCodigoSecuencial());
         nueva.setOrigen(OrigenNoConformidad.LOTE);
         nueva.setSeveridad(severidad);
         nueva.setEstado(EstadoNoConformidad.ABIERTA);
@@ -146,8 +172,12 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         nueva.setProducto(lote.getProducto());
         nueva.setEvaluacion(evaluacion);
         nueva.setCreadoPor(usuario.getId());
+        nueva.setActualizadoPor(usuario.getId());
+        nueva.setActualizadoEn(LocalDateTime.now());
 
-        return repository.save(nueva);
+        NoConformidad guardada = repository.save(nueva);
+        vincularRetencionConNoConformidad(guardada);
+        return guardada;
     }
 
     @Override
@@ -168,6 +198,71 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         return repository.findFirstByLote_IdAndEvaluacion_IdAndEstado(loteId, evaluacionId, EstadoNoConformidad.ABIERTA);
     }
 
+    private Optional<NoConformidad> buscarNoConformidadActiva(Long loteId, Long evaluacionId) {
+        if (loteId == null) {
+            return Optional.empty();
+        }
+        if (evaluacionId != null) {
+            Optional<NoConformidad> porEvaluacion = repository.findFirstByLote_IdAndEvaluacion_IdAndEstado(
+                    loteId, evaluacionId, EstadoNoConformidad.ABIERTA);
+            if (porEvaluacion.isPresent()) {
+                return porEvaluacion;
+            }
+        }
+        return repository.findFirstByLote_IdAndEstadoOrderByFechaRegistroDesc(loteId, EstadoNoConformidad.ABIERTA);
+    }
+
+    private void actualizarNoConformidadExistente(NoConformidad existente,
+                                                  SeveridadNoConformidad nuevaSeveridad,
+                                                  String descripcionNueva,
+                                                  EvaluacionCalidad evaluacion,
+                                                  Usuario usuarioActual) {
+        boolean modificado = false;
+        if (esSeveridadMasCritica(nuevaSeveridad, existente.getSeveridad())) {
+            existente.setSeveridad(nuevaSeveridad);
+            modificado = true;
+        }
+        if (descripcionNueva != null && !descripcionNueva.isBlank()) {
+            existente.setDescripcion(agregarDescripcionConMarcaTiempo(existente.getDescripcion(), descripcionNueva));
+            modificado = true;
+        }
+        if (evaluacion != null && existente.getEvaluacion() == null) {
+            existente.setEvaluacion(evaluacion);
+            modificado = true;
+        }
+        if (modificado || usuarioActual != null) {
+            Long usuarioId = usuarioActual != null ? usuarioActual.getId() : existente.getActualizadoPor();
+            existente.setActualizadoPor(usuarioId);
+            existente.setActualizadoEn(LocalDateTime.now());
+        }
+    }
+
+    private String agregarDescripcionConMarcaTiempo(String descripcionActual, String nuevaDescripcion) {
+        if (nuevaDescripcion == null || nuevaDescripcion.isBlank()) {
+            return descripcionActual;
+        }
+        String entrada = "[" + LocalDateTime.now().format(DESCRIPCION_TIMESTAMP_FORMAT) + "] "
+                + nuevaDescripcion.trim();
+        if (descripcionActual == null || descripcionActual.isBlank()) {
+            return entrada;
+        }
+        return descripcionActual + System.lineSeparator() + entrada;
+    }
+
+    private void vincularRetencionConNoConformidad(NoConformidad noConformidad) {
+        if (noConformidad == null || noConformidad.getLote() == null || noConformidad.getLote().getId() == null) {
+            return;
+        }
+        Long loteId = noConformidad.getLote().getId();
+        retencionLoteRepository.findFirstByLote_IdAndEstadoAndMotivo(loteId, EstadoRetencion.RETENIDO,
+                        MotivoRetencion.NO_CONFORMIDAD)
+                .filter(retencion -> retencion.getNoConformidad() == null)
+                .ifPresent(retencion -> {
+                    retencion.setNoConformidad(noConformidad);
+                    retencionLoteRepository.save(retencion);
+                });
+    }
+
     private boolean esSeveridadMasCritica(SeveridadNoConformidad nueva, SeveridadNoConformidad actual) {
         if (nueva == null || actual == null) {
             return false;
@@ -183,12 +278,32 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         };
     }
 
-    private String generarCodigo() {
+    private String generarCodigoSecuencial() {
+        YearMonth periodo = YearMonth.now();
+        String prefijo = "NC-" + periodo.format(CODIGO_PERIODO_FORMAT);
+        int correlativo = repository.findFirstByCodigoStartingWithOrderByCodigoDesc(prefijo)
+                .map(NoConformidad::getCodigo)
+                .map(this::extraerCorrelativo)
+                .orElse(0) + 1;
+
         String codigo;
         do {
-            codigo = "NC-" + System.currentTimeMillis();
+            codigo = String.format("%s-%03d", prefijo, correlativo);
+            correlativo++;
         } while (repository.existsByCodigo(codigo));
         return codigo;
+    }
+
+    private int extraerCorrelativo(String codigo) {
+        if (codigo == null || !codigo.contains("-")) {
+            return 0;
+        }
+        String secuencia = codigo.substring(codigo.lastIndexOf('-') + 1);
+        try {
+            return Integer.parseInt(secuencia);
+        } catch (NumberFormatException ex) {
+            return 0;
+        }
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteService.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.calidad.dto.RetencionLoteDTO;
 import com.willyes.clemenintegra.calidad.model.RetencionLote;
 import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.data.domain.Page;
@@ -23,10 +24,18 @@ public interface RetencionLoteService {
 
     void eliminar(Long id);
 
+    RetencionLote retener(Long loteId,
+                          MotivoRetencion motivo,
+                          String descripcion,
+                          NoConformidad noConformidad,
+                          Usuario usuario);
+
     RetencionLote asegurarRetencionNoConformidad(LoteProducto lote,
                                                   String descripcion,
                                                   NoConformidad noConformidad,
                                                   Usuario usuario);
+
+    RetencionLote levantar(Long retencionId, Usuario usuario);
 
     Optional<RetencionLote> obtenerActivaPorLote(Long loteId);
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteServiceImpl.java
@@ -78,6 +78,60 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
 
     @Override
     @Transactional
+    public RetencionLote retener(Long loteId,
+                                 MotivoRetencion motivo,
+                                 String descripcion,
+                                 NoConformidad noConformidad,
+                                 Usuario usuario) {
+        if (loteId == null) {
+            throw new IllegalArgumentException("Lote requerido");
+        }
+        if (motivo == null) {
+            throw new IllegalArgumentException("Motivo de retención requerido");
+        }
+        if (usuario == null || usuario.getId() == null) {
+            throw new IllegalArgumentException("Usuario requerido");
+        }
+
+        LoteProducto lote = loteRepository.findById(loteId)
+                .orElseThrow(() -> new NoSuchElementException("Lote no encontrado con ID: " + loteId));
+        Usuario aprobadoPor = usuarioRepository.findById(usuario.getId())
+                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + usuario.getId()));
+
+        Optional<RetencionLote> existente = repository.findFirstByLote_IdAndEstadoAndMotivo(
+                loteId, EstadoRetencion.RETENIDO, motivo);
+
+        RetencionLote resultado;
+        if (existente.isPresent()) {
+            RetencionLote retencion = existente.get();
+            if (descripcion != null && !descripcion.isBlank()) {
+                retencion.setCausa(descripcion);
+            }
+            if (noConformidad != null && (retencion.getNoConformidad() == null
+                    || (retencion.getNoConformidad().getId() != null
+                    && !retencion.getNoConformidad().getId().equals(noConformidad.getId())))) {
+                retencion.setNoConformidad(noConformidad);
+            }
+            resultado = repository.save(retencion);
+        } else {
+            RetencionLote nueva = RetencionLote.builder()
+                    .lote(lote)
+                    .causa(descripcion != null && !descripcion.isBlank() ? descripcion : "NC pendiente")
+                    .fechaRetencion(LocalDateTime.now())
+                    .estado(EstadoRetencion.RETENIDO)
+                    .motivo(motivo)
+                    .noConformidad(noConformidad)
+                    .aprobadoPor(aprobadoPor)
+                    .build();
+            resultado = repository.save(nueva);
+        }
+
+        asegurarEstadoRetenido(lote);
+        return resultado;
+    }
+
+    @Override
+    @Transactional
     public RetencionLote asegurarRetencionNoConformidad(LoteProducto lote,
                                                         String descripcion,
                                                         NoConformidad noConformidad,
@@ -85,40 +139,32 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
         if (lote == null || lote.getId() == null) {
             throw new IllegalArgumentException("Lote requerido");
         }
-        if (usuario == null || usuario.getId() == null) {
-            throw new IllegalArgumentException("Usuario requerido");
+        return retener(lote.getId(), MotivoRetencion.NO_CONFORMIDAD, descripcion, noConformidad, usuario);
+    }
+
+    @Override
+    @Transactional
+    public RetencionLote levantar(Long retencionId, Usuario usuario) {
+        if (retencionId == null) {
+            throw new IllegalArgumentException("Retención requerida");
+        }
+        RetencionLote retencion = repository.findById(retencionId)
+                .orElseThrow(() -> new NoSuchElementException("Retención no encontrada con ID: " + retencionId));
+        if (retencion.getEstado() == EstadoRetencion.LIBERADO) {
+            return retencion;
         }
 
-        Optional<RetencionLote> existente = repository.findFirstByLote_IdAndEstadoAndMotivo(
-                lote.getId(), EstadoRetencion.RETENIDO, MotivoRetencion.NO_CONFORMIDAD);
-        if (existente.isPresent()) {
-            RetencionLote retencion = existente.get();
-            retencion.setCausa(descripcion != null ? descripcion : retencion.getCausa());
-            if (noConformidad != null) {
-                retencion.setNoConformidad(noConformidad);
-            }
-            return repository.save(retencion);
+        Usuario aprobador = retencion.getAprobadoPor();
+        if (usuario != null && usuario.getId() != null) {
+            aprobador = usuarioRepository.findById(usuario.getId())
+                    .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + usuario.getId()));
         }
-
-        Usuario aprobadoPor = usuarioRepository.findById(usuario.getId())
-                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + usuario.getId()));
-
-        RetencionLote nueva = RetencionLote.builder()
-                .lote(lote)
-                .causa(descripcion != null ? descripcion : "NC pendiente")
-                .fechaRetencion(LocalDateTime.now())
-                .estado(EstadoRetencion.RETENIDO)
-                .motivo(MotivoRetencion.NO_CONFORMIDAD)
-                .noConformidad(noConformidad)
-                .aprobadoPor(aprobadoPor)
-                .build();
-
-        RetencionLote guardada = repository.save(nueva);
-        if (lote.getEstado() != EstadoLote.RETENIDO) {
-            lote.setEstado(EstadoLote.RETENIDO);
-            loteRepository.save(lote);
+        if (aprobador != null) {
+            retencion.setAprobadoPor(aprobador);
         }
-        return guardada;
+        retencion.setEstado(EstadoRetencion.LIBERADO);
+        retencion.setFechaLiberacion(LocalDateTime.now());
+        return repository.save(retencion);
     }
 
     @Override
@@ -137,6 +183,13 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
             return List.of();
         }
         return repository.findByLote_IdAndEstado(loteId, EstadoRetencion.RETENIDO);
+    }
+
+    private void asegurarEstadoRetenido(LoteProducto lote) {
+        if (lote != null && lote.getEstado() != EstadoLote.RETENIDO) {
+            lote.setEstado(EstadoLote.RETENIDO);
+            loteRepository.save(lote);
+        }
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -19,6 +19,7 @@ import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
 import com.willyes.clemenintegra.calidad.service.NoConformidadService;
 import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
 import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
 
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
@@ -305,6 +306,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         LoteProducto lote = loteRepo.findById(id)
                 .orElseThrow(() -> new java.util.NoSuchElementException("Lote no encontrado"));
         validarEvaluacionesExistentes(id);
+        validarNoConformidadesParaLiberacion(lote.getId());
 
         if (lote.getEstado() == EstadoLote.EN_CUARENTENA) {
             lote.setEstado(EstadoLote.DISPONIBLE);
@@ -400,6 +402,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         LoteProducto lote = loteRepo.findById(id)
                 .orElseThrow(() -> new java.util.NoSuchElementException("Lote no encontrado"));
         validarEvaluacionesExistentes(id);
+        validarNoConformidadesParaLiberacion(lote.getId());
         if (lote.getEstado() != EstadoLote.RETENIDO) {
             throw new IllegalStateException("El lote no está en estado RETENIDO");
         }
@@ -482,14 +485,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
             validarEvaluacion(evaluaciones, TipoEvaluacion.MICROBIOLOGICO);
         }
 
-        boolean retencionNcActiva = retencionLoteService.obtenerRetencionesActivas(loteId).stream()
-                .anyMatch(r -> r.getMotivo() == MotivoRetencion.NO_CONFORMIDAD);
-        noConformidadService.obtenerActivaPorLote(loteId).ifPresent(nc -> {
-            if (retencionNcActiva) {
-                log.warn("LIBERACION_BLOQUEADA_RETENCION_NC loteId={} ncId={}", loteId, nc.getId());
-            }
-            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "NC_ABIERTA");
-        });
+        validarNoConformidadesParaLiberacion(loteId);
 
         Almacen origen = lote.getAlmacen();
         Almacen destino = almacenRepo.findById(destinoPrincipalId)
@@ -542,6 +538,41 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     private void validarEvaluacionesExistentes(Long loteId) {
         if (evaluacionRepository.findByLoteProductoId(loteId).isEmpty()) {
             throw new IllegalStateException("El lote no cuenta con evaluaciones registradas");
+        }
+    }
+
+    private void validarNoConformidadesParaLiberacion(Long loteId) {
+        if (loteId == null) {
+            return;
+        }
+        var retenciones = retencionLoteService.obtenerRetencionesActivas(loteId);
+        boolean retencionNcActiva = false;
+        for (var retencion : retenciones) {
+            if (retencion.getMotivo() != MotivoRetencion.NO_CONFORMIDAD) {
+                continue;
+            }
+            retencionNcActiva = true;
+            var noConformidad = retencion.getNoConformidad();
+            if (noConformidad == null) {
+                log.warn("LIBERACION_BLOQUEADA_RETENCION_SIN_NC loteId={} retencionId={}", loteId, retencion.getId());
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "RETENCION_SIN_NC: Existe una retención activa por no conformidad sin NC asociada.");
+            }
+            if (noConformidad.getEstado() != EstadoNoConformidad.CERRADA) {
+                log.warn("LIBERACION_BLOQUEADA_NC_ABIERTA loteId={} ncId={}", loteId, noConformidad.getId());
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "NC_NO_CERRADA: Debe cerrar la no conformidad " + noConformidad.getCodigo()
+                                + " antes de liberar el lote.");
+            }
+        }
+        noConformidadService.obtenerActivaPorLote(loteId).ifPresent(nc -> {
+            log.warn("LIBERACION_BLOQUEADA_NC_ABIERTA loteId={} ncId={}", loteId, nc.getId());
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "NC_NO_CERRADA: Debe cerrar la no conformidad " + nc.getCodigo()
+                            + " antes de liberar el lote.");
+        });
+        if (retencionNcActiva) {
+            log.debug("Retención por NC activa verificada con NC cerrada para lote {}", loteId);
         }
     }
 


### PR DESCRIPTION
## Summary
- Generar códigos secuenciales de no conformidades, evitar duplicados abiertos y anexar descripciones con sello temporal
- Vincular retenciones activas con las no conformidades creadas, exponer operaciones idempotentes de retener/levantar y asegurar el estado RETENIDO del lote
- Bloquear la liberación de lotes mientras exista una NC abierta asociada a retenciones activas e informar errores consistentes

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e833b17a5c8333939a3bb81a6463d4