### PR TITLE
Normalize API IDs and error handling for calidad/inventario

### DIFF
--- a/docs/api/convenciones.md
+++ b/docs/api/convenciones.md
@@ -1,0 +1,135 @@
+# Convenciones API Calidad e Inventarios
+
+## Identificadores canónicos
+- Todos los DTOs de respuesta exponen el campo `id` como identificador principal.
+- Alias históricos como `idLote` se exponen únicamente como propiedades de lectura y están marcados como **DEPRECATED**. Serán removidos el 31/12/2024; actualice los consumidores para usar `id`.
+- Para cargas útiles de entrada se aceptan alias mediante `@JsonAlias`, pero las respuestas siempre incluirán el campo canónico.
+
+## Códigos de error funcionales
+| Código | HTTP | Descripción |
+|--------|------|-------------|
+| `BLOQUEO_RETENCION_NC` | 409 | El lote permanece retenido por una no conformidad activa o sin detalle asociado. |
+| `BLOQUEO_ESTADO_CUARENTENA` | 409 | La operación requiere que el lote continúe en CUARENTENA/RETENIDO. |
+| `NC_ABIERTA` | 409 | Existen no conformidades abiertas asociadas al lote. |
+| `EVALUACIONES_FALTANTES` | 422 | Faltan evaluaciones previas o datos complementarios (condición/severidad). |
+| `ROL_INSUFICIENTE` | 403 | El usuario autenticado no cuenta con el rol requerido para la acción. |
+| `SOLICITUD_INVALIDA` | 400 | Datos faltantes o malformados en la solicitud. |
+| `RECURSO_NO_ENCONTRADO` | 404 | El recurso referenciado no existe o ya fue atendido. |
+| `OPERACION_NO_PERMITIDA` | 409 | Reglas de negocio que impiden completar la operación. |
+| `ERROR_INTERNO` | 500 | Error inesperado no controlado. |
+
+Todas las respuestas de error siguen la estructura:
+
+```json
+{
+  "code": "BLOQUEO_RETENCION_NC",
+  "message": "El lote está retenido por una no conformidad abierta.",
+  "details": {
+    "loteId": 98,
+    "retencionId": 312
+  }
+}
+```
+
+## Ejemplos de contrato
+
+### Registrar evaluación de calidad
+**Request**
+```json
+{
+  "loteProductoId": 15,
+  "tipoEvaluacion": "FISICO_QUIMICO",
+  "resultado": "CONDICIONADO",
+  "observaciones": "Se requiere seguimiento",
+  "condicion": {
+    "tipo": "FECHA_LIMITE",
+    "parametroFecha": "2024-09-30T00:00:00",
+    "descripcion": "Liberar solo después del reproceso"
+  },
+  "archivosAdjuntos": [
+    {"nombreArchivo": "rep-qa.pdf", "nombreVisible": "Reporte QA"}
+  ]
+}
+```
+**Response (201)**
+```json
+{
+  "id": 1204,
+  "resultado": "CONDICIONADO",
+  "tipoEvaluacion": "FISICO_QUIMICO",
+  "fechaEvaluacion": "2024-09-01T09:14:22",
+  "observaciones": "Se requiere seguimiento",
+  "archivosAdjuntos": [
+    {"nombreArchivo": "rep-qa.pdf", "nombreVisible": "Reporte QA"}
+  ],
+  "nombreLote": "L-2408-01",
+  "nombreProducto": "Jarabe expectorante",
+  "nombreEvaluador": "Lucía Torres"
+}
+```
+
+### Liberación de lote retenido
+**Respuesta exitosa (caso requerido)**
+```json
+{
+  "id": 42,
+  "codigoLote": "LT-2024-00042",
+  "estado": "LIBERADO",
+  "almacenNombre": "Producto Terminado",
+  "stockDisponible": 125.0,
+  "fechaLiberacion": "2024-09-02T11:45:00",
+  "nombreUsuarioLiberador": "Jefe Calidad"
+}
+```
+
+**Error `BLOQUEO_RETENCION_NC`**
+```json
+{
+  "code": "BLOQUEO_RETENCION_NC",
+  "message": "El lote está retenido por una no conformidad abierta.",
+  "details": {
+    "loteId": 42,
+    "retencionId": 818
+  }
+}
+```
+
+**Error `NC_ABIERTA`**
+```json
+{
+  "code": "NC_ABIERTA",
+  "message": "Debe cerrar la no conformidad NC-2024-005 antes de liberar el lote.",
+  "details": {
+    "loteId": 42,
+    "ncId": 995
+  }
+}
+```
+
+**Error `ROL_INSUFICIENTE`**
+```json
+{
+  "code": "ROL_INSUFICIENTE",
+  "message": "Solo el Jefe de Calidad puede liberar lotes."
+}
+```
+
+### Estado de calidad de un lote
+**GET `/api/calidad/lotes/{loteId}/estado-calidad`**
+```json
+{
+  "loteId": 42,
+  "estadoLote": "RETENIDO",
+  "retencionActiva": true,
+  "motivoRetencion": "NO_CONFORMIDAD",
+  "nc": {
+    "id": 995,
+    "severidad": "MAYOR",
+    "estado": "ABIERTA"
+  },
+  "condicionUsoActiva": false,
+  "condicionUso": null
+}
+```
+
+> Nota: Los campos `motivoRetencion`, `nc` y `condicionUso` son opcionales y se omiten cuando no aplican.

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/LoteResumenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/LoteResumenDTO.java
@@ -1,15 +1,17 @@
 package com.willyes.clemenintegra.bom.dto;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
 @Data
 @AllArgsConstructor
 public class LoteResumenDTO {
-    private Long idLote;
+    private Long id;
     private String codigoLote;
     private EstadoLote estado;
     private String almacenNombre;
@@ -17,4 +19,22 @@ public class LoteResumenDTO {
     private LocalDateTime fechaVencimiento;
     private LocalDateTime fechaLiberacion;
     private String nombreUsuarioLiberador;
+
+    /**
+     * @deprecated Usar {@link #getId()}. Este alias se retirará el 31/12/2024.
+     */
+    @Deprecated(since = "2024-09-01", forRemoval = true)
+    @JsonProperty("idLote")
+    public Long getIdLote() {
+        return id;
+    }
+
+    /**
+     * @deprecated Usar {@link #setId(Long)}. Este alias se retirará el 31/12/2024.
+     */
+    @Deprecated(since = "2024-09-01", forRemoval = true)
+    @JsonProperty(value = "idLote", access = JsonProperty.Access.WRITE_ONLY)
+    public void setIdLote(Long legacyId) {
+        this.id = legacyId;
+    }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCalidadRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCalidadRequestDTO.java
@@ -25,7 +25,9 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class EvaluacionCalidadRequestDTO {
 
-    @NotNull(message = "El resultado es obligatorio")
+    /**
+     * Resultado de la evaluación. Opcional para permitir evaluaciones en progreso.
+     */
     private ResultadoEvaluacion resultado;
 
     @NotNull(message = "El tipo de evaluación es obligatorio")
@@ -41,8 +43,14 @@ public class EvaluacionCalidadRequestDTO {
 
     private Long usuarioEvaluadorId;
 
+    /**
+     * Datos de la condición de uso en caso el resultado sea CONDICIONADO.
+     */
     private EvaluacionCondicionDTO condicion;
 
+    /**
+     * Severidad para la NC generada cuando el resultado es NO_CONFORME.
+     */
     private SeveridadNoConformidad severidadNc;
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
@@ -1,6 +1,10 @@
 package com.willyes.clemenintegra.calidad.dto;
 
-import lombok.*;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -9,10 +13,28 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class EvaluacionConsolidadaResponseDTO {
-    private Long idLote;
+    private Long id;
     private String nombreLote;
     private String nombreProducto;
     private String estadoLote;
     private String tipoAnalisisCalidad;
     private List<EvaluacionSimpleDTO> evaluaciones;
+
+    /**
+     * @deprecated Usar {@link #getId()}. Este alias se retirará el 31/12/2024.
+     */
+    @Deprecated(since = "2024-09-01", forRemoval = true)
+    @JsonProperty("idLote")
+    public Long getIdLote() {
+        return id;
+    }
+
+    /**
+     * @deprecated Usar {@link #setId(Long)}. Este alias se retirará el 31/12/2024.
+     */
+    @Deprecated(since = "2024-09-01", forRemoval = true)
+    @JsonProperty(value = "idLote", access = JsonProperty.Access.WRITE_ONLY)
+    public void setIdLote(Long legacyId) {
+        this.id = legacyId;
+    }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
@@ -75,7 +75,7 @@ public class EvaluacionCalidadMapper {
         if (lote == null) return null;
 
         return EvaluacionConsolidadaResponseDTO.builder()
-                .idLote(lote.getId())
+                .id(lote.getId())
                 .nombreLote(lote.getCodigoLote())
                 .nombreProducto(lote.getProducto().getNombre())
                 .estadoLote(lote.getEstado().name())

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -21,6 +21,8 @@ import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
@@ -29,10 +31,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -41,6 +41,7 @@ import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
@@ -82,11 +83,16 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
 
         // FAIL-FAST: solo se permite registrar evaluación si el lote sigue en cuarentena/retención
         if (!estaEnCuarentenaOLotenRetenido(lote)) {
-            log.warn("AUDIT_CALIDAD: intento de registrar evaluación con lote fuera de cuarentena/retención. loteId={} estado={} almacenId={}",
-                    lote.getId(), (lote.getEstado() != null ? lote.getEstado().name() : null), obtenerAlmacenId(lote));
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "El lote no está en CUARENTENA o RETENIDO. No es posible registrar evaluación.");
-            }
+            log.info("[CALIDAD] intento de registrar evaluación con lote fuera de cuarentena/retención. loteId={} estado={} almacenId={} usuario={}",
+                    lote.getId(), (lote.getEstado() != null ? lote.getEstado().name() : null), obtenerAlmacenId(lote),
+                    user != null ? user.getId() : null);
+            throw new CustomBusinessException(
+                    ApiErrorCode.BLOQUEO_ESTADO_CUARENTENA,
+                    "El lote debe permanecer en CUARENTENA o RETENIDO para registrar evaluaciones.",
+                    Map.of(
+                            "loteId", lote.getId(),
+                            "estadoActual", lote.getEstado() != null ? lote.getEstado().name() : null));
+        }
 
         Long cuarentenaId = catalogResolver.getAlmacenCuarentenaId();
         String operacion = buildOperacion("registrarEvaluacion", dto.getTipoEvaluacion());
@@ -94,21 +100,22 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
 
         if (dto.getTipoEvaluacion() == TipoEvaluacion.FISICO_QUIMICO
                 && !java.util.Set.of(RolUsuario.ROL_ANALISTA_CALIDAD, RolUsuario.ROL_JEFE_CALIDAD).contains(user.getRol())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-                    "Solo un analista o el jefe de calidad puede registrar evaluaciones físico-químicas");
+            throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE,
+                    "Solo un analista o el jefe de calidad puede registrar evaluaciones físico-químicas.");
         }
         if (dto.getTipoEvaluacion() == TipoEvaluacion.MICROBIOLOGICO
                 && !java.util.Set.of(RolUsuario.ROL_MICROBIOLOGO, RolUsuario.ROL_JEFE_CALIDAD).contains(user.getRol())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-                    "Solo un microbiólogo o el jefe de calidad puede registrar evaluaciones microbiológicas");
+            throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE,
+                    "Solo un microbiólogo o el jefe de calidad puede registrar evaluaciones microbiológicas.");
         }
 
         if (repository.existsByLoteProductoIdAndTipoEvaluacion(lote.getId(), dto.getTipoEvaluacion())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ya existe una evaluación de este tipo para el lote");
+            throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA,
+                    "Ya existe una evaluación de este tipo para el lote.");
         }
 
         if (archivos == null || archivos.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
                     "Debe adjuntar al menos un documento.");
         }
 
@@ -169,10 +176,15 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
 
         // FAIL-FAST: no permitir actualizar evaluaciones si el lote ya no está en estado de cuarentena/retención
         if (!estaEnCuarentenaOLotenRetenido(lote)) {
-            log.warn("AUDIT_CALIDAD: intento de actualizar evaluación con lote fuera de cuarentena/retención. loteId={} estado={} almacenId={}",
-                    lote.getId(), (lote.getEstado() != null ? lote.getEstado().name() : null), obtenerAlmacenId(lote));
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "El lote no está en CUARENTENA o RETENIDO. No es posible actualizar evaluación.");
+            log.info("[CALIDAD] intento de actualizar evaluación con lote fuera de cuarentena/retención. loteId={} estado={} almacenId={} usuario={}",
+                    lote.getId(), (lote.getEstado() != null ? lote.getEstado().name() : null), obtenerAlmacenId(lote),
+                    user != null ? user.getId() : null);
+            throw new CustomBusinessException(
+                    ApiErrorCode.BLOQUEO_ESTADO_CUARENTENA,
+                    "El lote debe permanecer en CUARENTENA o RETENIDO para actualizar evaluaciones.",
+                    Map.of(
+                            "loteId", lote.getId(),
+                            "estadoActual", lote.getEstado() != null ? lote.getEstado().name() : null));
         }
 
         Long cuarentenaId = catalogResolver.getAlmacenCuarentenaId();
@@ -251,7 +263,7 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
             return;
         }
         if (cuarentenaId == null) {
-            log.error("AUDIT_CALIDAD: id de almacén de cuarentena no configurado. loteId={} operacion={} usuario={} rol={}",
+            log.error("[CALIDAD] id de almacén de cuarentena no configurado. loteId={} operacion={} usuario={} rol={}",
                     lote.getId(), operacion,
                     usuarioActual != null ? usuarioActual.getId() : null,
                     usuarioActual != null ? usuarioActual.getRol() : null);
@@ -260,15 +272,15 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         Long almacenActual = obtenerAlmacenId(lote);
         // Solo restaurar si el lote SIGUE en estado de cuarentena/retención
         if (!Objects.equals(almacenActual, cuarentenaId) && estaEnCuarentenaOLotenRetenido(lote)) {
-            log.warn("AUDIT_CALIDAD: cambiando almacen loteId={} de {} a {} por {}. Usuario={} rol={} estado={} operacion={}",
-                    lote.getId(), almacenActual, cuarentenaId, "pre-evaluacion",
+            log.info("[CALIDAD] restableciendo almacén de cuarentena. loteId={} almacenActual={} almacenDestino={} usuario={} rol={} estado={} operacion={}",
+                    lote.getId(), almacenActual, cuarentenaId,
                     usuarioActual != null ? usuarioActual.getId() : null,
                     usuarioActual != null ? usuarioActual.getRol() : null,
                     lote.getEstado(), operacion);
             restaurarCuarentena(lote, cuarentenaId, operacion, usuarioActual, almacenActual);
         } else if (!estaEnCuarentenaOLotenRetenido(lote)) {
             // Si el estado ya no es de cuarentena/retención, no modificar almacén (posible liberación legítima)
-            log.warn("AUDIT_CALIDAD: lote fuera de estado de cuarentena/retención durante {}. loteId={} estado={} almacenId={}",
+            log.debug("[CALIDAD] lote fuera de estado de cuarentena/retención durante {}. loteId={} estado={} almacenId={}",
                     operacion, lote.getId(), (lote.getEstado() != null ? lote.getEstado().name() : null), almacenActual);
         }
     }
@@ -281,11 +293,11 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         loteRepository.findById(loteId).ifPresent(actual -> {
             Long almacenActual = obtenerAlmacenId(actual);
             if (!Objects.equals(almacenActual, cuarentenaId) && estaEnCuarentenaOLotenRetenido(actual)) {
-                log.warn("AUDIT_CALIDAD: detectado cambio de almacén tras {}. loteId={} almacenId={} estado={}",
+                log.info("[CALIDAD] detectado cambio de almacén tras {}. loteId={} almacenId={} estado={}",
                         operacion, loteId, almacenActual, actual.getEstado());
                 restaurarCuarentena(actual, cuarentenaId, operacion, usuarioActual, almacenActual);
             } else if (!estaEnCuarentenaOLotenRetenido(actual)) {
-                log.warn("AUDIT_CALIDAD: post-{}: lote fuera de estado de cuarentena/retención; no se restaura. loteId={} estado={} almacenId={}",
+                log.debug("[CALIDAD] post-{}: lote fuera de estado de cuarentena/retención; no se restaura. loteId={} estado={} almacenId={}",
                         operacion, loteId, (actual.getEstado() != null ? actual.getEstado().name() : null), almacenActual);
             }
         });
@@ -300,8 +312,8 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
                 .orElseGet(() -> new Almacen(Math.toIntExact(cuarentenaId)));
         lote.setAlmacen(cuarentena);
         loteRepository.saveAndFlush(lote);
-        log.warn("AUDIT_CALIDAD: cambiando almacen loteId={} de {} a {} por {}. Usuario={} rol={} estado={} operacion={}",
-                lote.getId(), almacenPrevio, cuarentenaId, "restaurar-cuarentena",
+        log.info("[CALIDAD] restaurando lote a cuarentena. loteId={} almacenPrevio={} almacenDestino={} usuario={} rol={} estado={} operacion={}",
+                lote.getId(), almacenPrevio, cuarentenaId,
                 usuarioActual != null ? usuarioActual.getId() : null,
                 usuarioActual != null ? usuarioActual.getRol() : null,
                 lote.getEstado(), operacion);
@@ -331,7 +343,8 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         if (resultado == ResultadoEvaluacion.CONDICIONADO) {
             EvaluacionCondicionDTO condicion = dto.getCondicion();
             if (condicion == null || condicion.getTipo() == null) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "CONDICION_USO_REQUERIDA");
+                throw new CustomBusinessException(ApiErrorCode.EVALUACIONES_FALTANTES,
+                        "Debe registrar la condición de uso para completar la evaluación condicionada.");
             }
             CondicionUsoCreateDTO createDTO = CondicionUsoCreateDTO.builder()
                     .loteId(lote.getId())
@@ -343,7 +356,8 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         } else if (resultado == ResultadoEvaluacion.NO_CONFORME) {
             SeveridadNoConformidad severidad = dto.getSeveridadNc();
             if (severidad == null) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "SEVERIDAD_NC_REQUERIDA");
+                throw new CustomBusinessException(ApiErrorCode.EVALUACIONES_FALTANTES,
+                        "Debe indicar la severidad de la no conformidad para continuar.");
             }
             var noConformidad = noConformidadService.registrarDesdeEvaluacion(lote, evaluacion, severidad,
                     dto.getObservaciones(), usuario);

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -59,7 +59,7 @@ public class MovimientoInventarioController {
     @ApiResponse(responseCode = "201", description = "Movimiento registrado correctamente")
     @ApiResponse(responseCode = "400", description = "Solicitud malformada o inválida")
     @ApiResponse(responseCode = "404", description = "Producto o lote no encontrado")
-    @ApiResponse(responseCode = "409", description = "No hay suficiente stock disponible")
+    @ApiResponse(responseCode = "409", description = "Conflictos funcionales (p. ej. BLOQUEO_RETENCION_NC, NC_ABIERTA, stock insuficiente)")
     @ApiResponse(responseCode = "500", description = "Error interno del servidor")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_SUPER_ADMIN')")
     @PostMapping
@@ -67,7 +67,7 @@ public class MovimientoInventarioController {
         dto = normalizarMovimientoDto(dto);
         try {
             int atenciones = dto.atenciones() != null ? dto.atenciones().size() : 0;
-            log.debug("MOV-CONTROLLER registrar solicitudId={} atenciones={} tipo={} clasificacion={} producto={} lote={}",
+            log.debug("[INVENTARIO] registrar movimiento solicitudId={} atenciones={} tipo={} clasificacion={} producto={} lote={}",
                     dto.solicitudMovimientoId(), atenciones, dto.tipoMovimiento(),
                     dto.clasificacionMovimientoInventario(), dto.productoId(), dto.loteProductoId());
 
@@ -90,7 +90,7 @@ public class MovimientoInventarioController {
             SolicitudMovimiento solicitudMovimiento = null;
 
             if (isSalida && permitirLoteNulo) {
-                log.debug("MOV-CONTROLLER skip stock pre-check autoSplit={} atencionesVacias={} esSalidaPt={}",
+                log.debug("[INVENTARIO] omitir pre-validación de stock autoSplit={} atencionesVacias={} esSalidaPt={}",
                         autoSplitSolicitado, atencionesVacias, esSalidaPt);
             } else if (isSalida) {
                 Producto prod = productoRepo.findById(dto.productoId().longValue())
@@ -144,7 +144,7 @@ public class MovimientoInventarioController {
                     almacenesFiltrados = new ArrayList<>(new LinkedHashSet<>(almacenesFiltrados));
                 }
 
-                log.debug("MOV-CONTROLLER stock pre-check: solicitudId={} productoId={} loteId={} cant={} preBodegaId={} almacenesFiltrados={}",
+                log.debug("[INVENTARIO] stock pre-check solicitudId={} productoId={} loteId={} cant={} preBodegaId={} almacenesFiltrados={}",
                         dto.solicitudMovimientoId(), dto.productoId(), dto.loteProductoId(), dto.cantidad(),
                         preBodegaId, almacenesFiltrados);
 
@@ -197,7 +197,7 @@ public class MovimientoInventarioController {
                 BigDecimal stockProductoEvaluado = solicitudConReserva ? stockProductoConReserva : stockProd;
                 BigDecimal stockLoteEvaluado = solicitudConReserva ? disponibleConReserva : stockDisponibleNoNegativo;
 
-                log.debug("MOV-CONTROLLER stock eval: solicitudId={} estadoSol={} reservaPendiente={} stockProd={} stockLote={} stockReservado={} dispLote={} dispConReserva={} prodEval={} loteEval={} cant={}",
+                log.debug("[INVENTARIO] evaluación stock solicitudId={} estadoSol={} reservaPendiente={} stockProd={} stockLote={} stockReservado={} dispLote={} dispConReserva={} prodEval={} loteEval={} cant={}",
                         dto.solicitudMovimientoId(),
                         solicitudMovimiento != null ? solicitudMovimiento.getEstado() : null,
                         reservaPendiente, stockProd, stockActualLote, stockReservado, stockDisponibleNoNegativo,
@@ -224,36 +224,36 @@ public class MovimientoInventarioController {
 
             // 2) Registrar movimiento
             MovimientoInventarioResponseDTO creado = service.registrarMovimiento(dto);
-            log.info("Movimiento registrado correctamente: {}", creado.getId());
+            log.info("[INVENTARIO] movimiento registrado correctamente: {}", creado.getId());
             return ResponseEntity.status(HttpStatus.CREATED).body(creado);
 
         } catch (NoSuchElementException e) {
-            log.warn("Error de entidad no encontrada: {}", e.getMessage());
+            log.warn("[INVENTARIO] entidad no encontrada: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(Map.of("message", e.getMessage()));
 
         } catch (IllegalArgumentException e) {
-            log.warn("Error de validación: {}", e.getMessage());
+            log.warn("[INVENTARIO] error de validación: {}", e.getMessage());
             return ResponseEntity.badRequest()
                     .body(Map.of("message", e.getMessage()));
 
         } catch (IllegalStateException e) {
-            log.warn("Estado inválido: {}", e.getMessage());
+            log.warn("[INVENTARIO] estado inválido: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(Map.of("message", e.getMessage()));
 
         } catch (DataIntegrityViolationException e) {
-            log.error("Violación de integridad en la base de datos", e);
+            log.error("[INVENTARIO] violación de integridad en la base de datos", e);
             return ResponseEntity.badRequest()
                     .body(Map.of("message", "Datos inválidos o faltantes"));
 
         } catch (AuthenticationCredentialsNotFoundException e) {
-            log.warn("Acceso no autorizado: {}", e.getMessage());
+            log.warn("[INVENTARIO] acceso no autorizado: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("message", e.getMessage()));
 
         } catch (Exception e) {
-            log.error("Error inesperado al registrar movimiento", e);
+            log.error("[INVENTARIO] error inesperado al registrar movimiento", e);
             return ResponseEntity.internalServerError()
                     .body(Map.of("message", "No se pudo registrar el movimiento"));
         }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -21,6 +21,8 @@ import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
 import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
 
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
@@ -404,7 +406,9 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         validarEvaluacionesExistentes(id);
         validarNoConformidadesParaLiberacion(lote.getId());
         if (lote.getEstado() != EstadoLote.RETENIDO) {
-            throw new IllegalStateException("El lote no está en estado RETENIDO");
+            throw new CustomBusinessException(ApiErrorCode.BLOQUEO_ESTADO_CUARENTENA,
+                    "El lote debe estar en estado RETENIDO para liberarlo.",
+                    Map.of("loteId", id, "estadoActual", lote.getEstado() != null ? lote.getEstado().name() : null));
         }
         lote.setEstado(EstadoLote.LIBERADO);
         lote.setUsuarioLiberador(usuarioService.obtenerUsuarioAutenticado());
@@ -416,7 +420,8 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     @Transactional(rollbackFor = Exception.class)
     public LoteProductoResponseDTO liberarLotePorCalidad(Long loteId, Usuario usuarioActual) {
         if (usuarioActual == null || usuarioActual.getRol() != RolUsuario.ROL_JEFE_CALIDAD) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Solo el Jefe de Calidad puede liberar lotes.");
+            throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE,
+                    "Solo el Jefe de Calidad puede liberar lotes.");
         }
 
         EstadoLote estadoLiberado;
@@ -460,7 +465,8 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         if (!almacenCuarentenaId.equals(lote.getAlmacen().getId().longValue()) || lote.getEstado() != EstadoLote.EN_CUARENTENA) {
             Long almacenId = Long.valueOf(lote.getAlmacen().getId());
             EstadoLote estadoLote = lote.getEstado();
-            log.warn("Intento de liberar lote {} fuera de cuarentena: almacenId={} estado={}", loteId, almacenId, estadoLote);
+            log.info("[INVENTARIO] intento de liberar lote fuera de cuarentena. loteId={} almacenId={} estado={}",
+                    loteId, almacenId, estadoLote);
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                     "LOTE_NO_EN_CUARENTENA (almacenId=" + almacenId + ", estado=" + estadoLote + ")");
         }
@@ -498,7 +504,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         lote.setAlmacen(destino);
         loteRepo.save(lote);
 
-        log.info("QC_LIBERACION destino={} tipoProducto={} loteId={}",
+        log.info("[INVENTARIO] liberación de lote completada destino={} tipoProducto={} loteId={}",
                 destinoPrincipalId,
                 producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getTipo() : null,
                 loteId);
@@ -526,18 +532,24 @@ public class LoteProductoServiceImpl implements LoteProductoService {
                 .filter(e -> e.getTipoEvaluacion() == tipo)
                 .toList();
         if (filtradas.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Falta evaluación requerida");
+            throw new CustomBusinessException(ApiErrorCode.EVALUACIONES_FALTANTES,
+                    "Falta registrar la evaluación requerida antes de liberar el lote.",
+                    Map.of("tipoEvaluacion", tipo.name()));
         }
         boolean aprobadas = filtradas.stream()
                 .allMatch(e -> e.getResultado() != ResultadoEvaluacion.NO_CONFORME);
         if (!aprobadas) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La evaluación requerida no está aprobada");
+            throw new CustomBusinessException(ApiErrorCode.EVALUACIONES_FALTANTES,
+                    "La evaluación requerida no está aprobada.",
+                    Map.of("tipoEvaluacion", tipo.name()));
         }
     }
 
     private void validarEvaluacionesExistentes(Long loteId) {
         if (evaluacionRepository.findByLoteProductoId(loteId).isEmpty()) {
-            throw new IllegalStateException("El lote no cuenta con evaluaciones registradas");
+            throw new CustomBusinessException(ApiErrorCode.EVALUACIONES_FALTANTES,
+                    "El lote no cuenta con evaluaciones registradas.",
+                    Map.of("loteId", loteId));
         }
     }
 
@@ -554,25 +566,27 @@ public class LoteProductoServiceImpl implements LoteProductoService {
             retencionNcActiva = true;
             var noConformidad = retencion.getNoConformidad();
             if (noConformidad == null) {
-                log.warn("LIBERACION_BLOQUEADA_RETENCION_SIN_NC loteId={} retencionId={}", loteId, retencion.getId());
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                        "RETENCION_SIN_NC: Existe una retención activa por no conformidad sin NC asociada.");
+                log.info("[INVENTARIO] liberación bloqueada por retención sin NC asociada. loteId={} retencionId={}",
+                        loteId, retencion.getId());
+                throw new CustomBusinessException(ApiErrorCode.BLOQUEO_RETENCION_NC,
+                        "Existe una retención activa por no conformidad sin detalle asociado.",
+                        Map.of("loteId", loteId, "retencionId", retencion.getId()));
             }
             if (noConformidad.getEstado() != EstadoNoConformidad.CERRADA) {
-                log.warn("LIBERACION_BLOQUEADA_NC_ABIERTA loteId={} ncId={}", loteId, noConformidad.getId());
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                        "NC_NO_CERRADA: Debe cerrar la no conformidad " + noConformidad.getCodigo()
-                                + " antes de liberar el lote.");
+                log.info("[INVENTARIO] liberación bloqueada por NC abierta. loteId={} ncId={}", loteId, noConformidad.getId());
+                throw new CustomBusinessException(ApiErrorCode.NC_ABIERTA,
+                        "Debe cerrar la no conformidad " + noConformidad.getCodigo() + " antes de liberar el lote.",
+                        Map.of("loteId", loteId, "ncId", noConformidad.getId()));
             }
         }
         noConformidadService.obtenerActivaPorLote(loteId).ifPresent(nc -> {
-            log.warn("LIBERACION_BLOQUEADA_NC_ABIERTA loteId={} ncId={}", loteId, nc.getId());
-            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                    "NC_NO_CERRADA: Debe cerrar la no conformidad " + nc.getCodigo()
-                            + " antes de liberar el lote.");
+            log.info("[INVENTARIO] liberación bloqueada por NC abierta. loteId={} ncId={}", loteId, nc.getId());
+            throw new CustomBusinessException(ApiErrorCode.NC_ABIERTA,
+                    "Debe cerrar la no conformidad " + nc.getCodigo() + " antes de liberar el lote.",
+                    Map.of("loteId", loteId, "ncId", nc.getId()));
         });
         if (retencionNcActiva) {
-            log.debug("Retención por NC activa verificada con NC cerrada para lote {}", loteId);
+            log.debug("[INVENTARIO] retención por NC verificada con NC cerrada para lote {}", loteId);
         }
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -27,6 +27,8 @@ import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
 import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
@@ -1363,19 +1365,22 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                                                                            boolean devolucionInterna,
                                                                            SolicitudMovimiento solicitud) {
         if (dto.loteProductoId() == null) {
-            log.warn(
-                    "procesarMovimientoConLoteExistente: falta loteProductoId tipo={} productoId={} origenId={} destinoId={} cantidad={}",
+            log.info(
+                    "[INVENTARIO] movimiento con lote existente sin id de lote. tipo={} productoId={} origenId={} destinoId={} cantidad={}",
                     tipo, producto.getId(), origen != null ? origen.getId() : null,
                     destino != null ? destino.getId() : null, cantidad);
-            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_ID_REQUERIDO");
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Debe seleccionar el lote a mover.");
         }
 
         LoteProducto loteOrigen = loteProductoRepository.findByIdForUpdate(dto.loteProductoId())
                 .orElseThrow(() -> {
-                    log.warn(
-                            "procesarMovimientoConLoteExistente: lote no encontrado loteId={} productoId={}",
+                    log.info(
+                            "[INVENTARIO] movimiento con lote inexistente. loteId={} productoId={}",
                             dto.loteProductoId(), producto.getId());
-                    return new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_ENCONTRADO");
+                    return new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                            "No se encontró el lote indicado.",
+                            Map.of("loteId", dto.loteProductoId()));
                 });
 
         boolean esPorLote = solicitud != null;
@@ -1389,17 +1394,21 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                 && producto.getCategoriaProducto().getTipo() != TipoCategoria.PRODUCTO_TERMINADO);
 
         if (estadoBloqueado) {
-            log.warn(
-                    "procesarMovimientoConLoteExistente: estado de lote inválido loteId={} estado={} productoId={}",
+            log.info(
+                    "[INVENTARIO] movimiento bloqueado por estado de lote. loteId={} estado={} productoId={}",
                     loteOrigen.getId(), loteOrigen.getEstado(), producto.getId());
             if (loteOrigen.getEstado() == EstadoLote.RETENIDO) {
                 retencionLoteService.obtenerActivaPorLote(loteOrigen.getId()).ifPresent(ret -> {
                     if (ret.getMotivo() == MotivoRetencion.NO_CONFORMIDAD) {
-                        throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "BLOQUEO_RETENCION_NC");
+                        throw new CustomBusinessException(ApiErrorCode.BLOQUEO_RETENCION_NC,
+                                "El lote está retenido por una no conformidad abierta.",
+                                Map.of("loteId", loteOrigen.getId(), "retencionId", ret.getId()));
                     }
                 });
             }
-            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_ESTADO_INVALIDO");
+            throw new CustomBusinessException(ApiErrorCode.BLOQUEO_ESTADO_CUARENTENA,
+                    "El lote no se encuentra en un estado válido para movimientos.",
+                    Map.of("loteId", loteOrigen.getId(), "estado", loteOrigen.getEstado().name()));
         }
 
         Almacen almacenOrigen = origen != null
@@ -1415,7 +1424,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         if (!esDevolucionInternaCalculada
                 && almacenOrigen != null
                 && !loteOrigen.getAlmacen().getId().equals(almacenOrigen.getId())) {
-            log.warn("Almacén origen no coincide: loteId={} almacenLoteId={} almacenOrigenId={}",
+            log.debug("[INVENTARIO] almacén origen no coincide: loteId={} almacenLoteId={} almacenOrigenId={}",
                     loteOrigen.getId(), loteOrigen.getAlmacen().getId(), almacenOrigen.getId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_PERTENECE_ALMACEN_ORIGEN");
         }

--- a/src/main/java/com/willyes/clemenintegra/shared/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/dto/ErrorResponseDTO.java
@@ -1,11 +1,10 @@
 package com.willyes.clemenintegra.shared.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.Instant;
 
 /**
  * DTO estándar para retornar información de errores de la API.
@@ -14,10 +13,9 @@ import java.time.Instant;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponseDTO {
-    private Instant timestamp;
-    private int status;
-    private String error;
+    private String code;
     private String message;
-    private String path;
+    private Object details;
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/ApiErrorCode.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/ApiErrorCode.java
@@ -1,0 +1,34 @@
+package com.willyes.clemenintegra.shared.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Códigos estandarizados para responder errores funcionales de la API.
+ */
+public enum ApiErrorCode {
+
+    BLOQUEO_RETENCION_NC(HttpStatus.CONFLICT),
+    BLOQUEO_ESTADO_CUARENTENA(HttpStatus.CONFLICT),
+    NC_ABIERTA(HttpStatus.CONFLICT),
+    EVALUACIONES_FALTANTES(HttpStatus.UNPROCESSABLE_ENTITY),
+    ROL_INSUFICIENTE(HttpStatus.FORBIDDEN),
+    SOLICITUD_INVALIDA(HttpStatus.BAD_REQUEST),
+    RECURSO_NO_ENCONTRADO(HttpStatus.NOT_FOUND),
+    OPERACION_NO_PERMITIDA(HttpStatus.CONFLICT),
+    ERROR_INTERNO(HttpStatus.INTERNAL_SERVER_ERROR),
+    NEGOCIO_GENERICO(HttpStatus.BAD_REQUEST);
+
+    private final HttpStatus httpStatus;
+
+    ApiErrorCode(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getCode() {
+        return name();
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/CustomBusinessException.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/CustomBusinessException.java
@@ -5,11 +5,39 @@ package com.willyes.clemenintegra.shared.exception;
  * que no cumplen reglas específicas del dominio.
  */
 public class CustomBusinessException extends RuntimeException {
+
+    private final ApiErrorCode code;
+    private final transient Object details;
+
+    public CustomBusinessException(ApiErrorCode code, String message) {
+        super(message);
+        this.code = code;
+        this.details = null;
+    }
+
+    public CustomBusinessException(ApiErrorCode code, String message, Object details) {
+        super(message);
+        this.code = code;
+        this.details = details;
+    }
+
     public CustomBusinessException(String message) {
         super(message);
+        this.code = ApiErrorCode.NEGOCIO_GENERICO;
+        this.details = null;
     }
 
     public CustomBusinessException(String message, Throwable cause) {
         super(message, cause);
+        this.code = ApiErrorCode.NEGOCIO_GENERICO;
+        this.details = null;
+    }
+
+    public ApiErrorCode getCode() {
+        return code;
+    }
+
+    public Object getDetails() {
+        return details;
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -13,9 +13,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.Instant;
 import java.time.format.DateTimeParseException;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -26,27 +25,23 @@ import java.util.stream.Collectors;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, Object>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
-                                                                           HttpServletRequest request) {
-        Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", Instant.now());
-        body.put("status", HttpStatus.BAD_REQUEST.value());
-        body.put("error", ex.getClass().getSimpleName());
-        body.put("message", "Solicitud inválida");
-        body.put("path", request.getRequestURI());
-        body.put("errors", ex.getBindingResult().getFieldErrors().stream()
-                .map(err -> Map.of("field", err.getField(), "message", err.getDefaultMessage()))
-                .toList());
-        return ResponseEntity.badRequest().body(body);
+    public ResponseEntity<ErrorResponseDTO> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                         HttpServletRequest request) {
+        List<Map<String, String>> detalles = ex.getBindingResult().getFieldErrors().stream()
+                .map(err -> Map.of(
+                        "field", err.getField(),
+                        "message", err.getDefaultMessage()))
+                .toList();
+        return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA,
+                "Solicitud inválida",
+                detalles);
     }
 
     @ExceptionHandler({HttpMessageNotReadableException.class, DateTimeParseException.class})
-    public ResponseEntity<Map<String, String>> handleInvalidDateFormat(Exception ex) {
-        Map<String, String> body = Map.of(
-                "error", "Formato de fecha inválido",
-                "detalle", "Use 'YYYY-MM-DDTHH:mm:ss', ej. '2025-09-10T00:00:00'."
-        );
-        return ResponseEntity.badRequest().body(body);
+    public ResponseEntity<ErrorResponseDTO> handleInvalidDateFormat(Exception ex) {
+        return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA,
+                "Formato de fecha inválido",
+                "Use 'YYYY-MM-DDTHH:mm:ss', ej. '2025-09-10T00:00:00'.");
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
@@ -55,61 +50,76 @@ public class GlobalExceptionHandler {
         String message = ex.getConstraintViolations().stream()
                 .map(v -> v.getPropertyPath() + ": " + v.getMessage())
                 .collect(Collectors.joining(", "));
-        return buildResponse(HttpStatus.BAD_REQUEST, ex, message, request.getRequestURI());
+        return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA, message, null);
     }
 
     @ExceptionHandler(CustomBusinessException.class)
     public ResponseEntity<ErrorResponseDTO> handleBusiness(CustomBusinessException ex,
                                                            HttpServletRequest request) {
-        return buildResponse(HttpStatus.BAD_REQUEST, ex, ex.getMessage(), request.getRequestURI());
+        ApiErrorCode code = ex.getCode() != null ? ex.getCode() : ApiErrorCode.NEGOCIO_GENERICO;
+        return buildResponse(code, ex.getMessage(), ex.getDetails());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponseDTO> handleIllegalArgument(IllegalArgumentException ex,
-                                                                 HttpServletRequest request) {
-        return buildResponse(HttpStatus.BAD_REQUEST, ex, ex.getMessage(), request.getRequestURI());
+                                                                  HttpServletRequest request) {
+        return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA, ex.getMessage(), null);
     }
 
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ErrorResponseDTO> handleIllegalState(IllegalStateException ex,
                                                                HttpServletRequest request) {
-        return buildResponse(HttpStatus.BAD_REQUEST, ex, ex.getMessage(), request.getRequestURI());
+        return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA, ex.getMessage(), null);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponseDTO> handleTypeMismatch(MethodArgumentTypeMismatchException ex,
                                                                HttpServletRequest request) {
         String message = "Valor inválido para el parámetro '" + ex.getName() + "'";
-        return buildResponse(HttpStatus.BAD_REQUEST, ex, message, request.getRequestURI());
+        return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA, message, null);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponseDTO> handleAccessDenied(AccessDeniedException ex,
                                                                HttpServletRequest request) {
-        return buildResponse(HttpStatus.FORBIDDEN, ex, "Acceso denegado", request.getRequestURI());
+        return buildResponse(ApiErrorCode.ROL_INSUFICIENTE,
+                "Acceso denegado. Contacte a un administrador para solicitar el rol adecuado.",
+                null);
     }
 
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ErrorResponseDTO> handleResponseStatus(ResponseStatusException ex,
-                                                                HttpServletRequest request) {
+                                                                 HttpServletRequest request) {
         HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
-        return buildResponse(status, ex, ex.getReason(), request.getRequestURI());
+        String code = ex.getReason() != null ? ex.getReason() : status.name();
+        String message = ex.getReason() != null ? ex.getReason() : status.getReasonPhrase();
+        return buildResponse(status, code, message, null);
     }
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponseDTO> handleRuntime(RuntimeException ex,
                                                           HttpServletRequest request) {
-        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex, ex.getMessage(), request.getRequestURI());
+        return buildResponse(ApiErrorCode.ERROR_INTERNO,
+                "Ocurrió un error inesperado. Intente nuevamente o contacte soporte.",
+                null);
     }
 
-    private ResponseEntity<ErrorResponseDTO> buildResponse(HttpStatus status, Exception ex, String message, String path) {
-        ErrorResponseDTO dto = ErrorResponseDTO.builder()
-                .timestamp(Instant.now())
-                .status(status.value())
-                .error(ex.getClass().getSimpleName())
+    private ResponseEntity<ErrorResponseDTO> buildResponse(ApiErrorCode code, String message, Object details) {
+        ApiErrorCode effective = code != null ? code : ApiErrorCode.ERROR_INTERNO;
+        ErrorResponseDTO body = ErrorResponseDTO.builder()
+                .code(effective.getCode())
                 .message(message)
-                .path(path)
+                .details(details)
                 .build();
-        return ResponseEntity.status(status).body(dto);
+        return ResponseEntity.status(effective.getHttpStatus()).body(body);
+    }
+
+    private ResponseEntity<ErrorResponseDTO> buildResponse(HttpStatus status, String code, String message, Object details) {
+        ErrorResponseDTO body = ErrorResponseDTO.builder()
+                .code(code != null ? code : status.name())
+                .message(message)
+                .details(details)
+                .build();
+        return ResponseEntity.status(status).body(body);
     }
 }


### PR DESCRIPTION
## Summary
- normalize API responses to expose canonical `id` fields while keeping deprecated aliases for existing consumers
- introduce ApiErrorCode catalog with enriched CustomBusinessException and unified `{code,message,details}` error envelope
- update calidad/inventario services and controllers to emit the new domain error codes, streamline logging, and document conventions in docs/api/convenciones.md

## Testing
- mvn -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68e8395d79a88333a7ae5a337731631a