### PR TITLE
Endurecer job de vencidos con movimientos e idempotencia

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/config/InventoryVencidosProperties.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/config/InventoryVencidosProperties.java
@@ -1,0 +1,96 @@
+package com.willyes.clemenintegra.inventario.config;
+
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+
+@Data
+@Component
+@Validated
+@ConfigurationProperties(prefix = "inventory.vencidos")
+public class InventoryVencidosProperties {
+
+    private final Job job = new Job();
+    private EstadoLote estadoObjetivo = EstadoLote.VENCIDO;
+    @Min(1)
+    private int chunkSize = 500;
+    private final Movimiento movimiento = new Movimiento();
+    private Long almacenDestinoId;
+
+    public ZoneId resolveZoneId() {
+        try {
+            return ZoneId.of(job.getTimezone());
+        } catch (DateTimeException ex) {
+            throw new IllegalStateException("Zona horaria inválida para inventory.vencidos.job.timezone", ex);
+        }
+    }
+
+    public void validateForExecution() {
+        if (chunkSize < 1) {
+            throw new IllegalStateException("inventory.vencidos.chunkSize debe ser mayor a cero");
+        }
+        movimiento.validate(almacenDestinoId);
+    }
+
+    public Long requireAlmacenDestinoId() {
+        if (almacenDestinoId == null) {
+            throw new IllegalStateException("inventory.vencidos.almacenDestinoId es obligatorio cuando movimiento.enabled=true");
+        }
+        return almacenDestinoId;
+    }
+
+    @AssertTrue(message = "inventory.vencidos.estadoObjetivo solo admite VENCIDO o RECHAZADO")
+    public boolean isEstadoObjetivoValido() {
+        return estadoObjetivo == null
+                || estadoObjetivo == EstadoLote.VENCIDO
+                || estadoObjetivo == EstadoLote.RECHAZADO;
+    }
+
+    @Data
+    public static class Job {
+        private boolean enabled = true;
+        private String cron = "0 0 0 * * *";
+        private String timezone = "America/Bogota";
+    }
+
+    @Data
+    public static class Movimiento {
+        private boolean enabled = true;
+        private Long motivoId;
+        private String clasificacion;
+
+        public ClasificacionMovimientoInventario resolveClasificacionEnum() {
+            if (clasificacion == null || clasificacion.isBlank()) {
+                throw new IllegalStateException("inventory.vencidos.movimiento.clasificacion es obligatorio cuando movimiento.enabled=true");
+            }
+            try {
+                return ClasificacionMovimientoInventario.valueOf(clasificacion.trim().toUpperCase());
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalStateException("Clasificación inválida para inventory.vencidos.movimiento.clasificacion: " + clasificacion, ex);
+            }
+        }
+
+        private void validate(Long almacenDestinoId) {
+            if (!enabled) {
+                return;
+            }
+            if (motivoId == null || motivoId <= 0) {
+                throw new IllegalStateException("inventory.vencidos.movimiento.motivoId es obligatorio y debe ser positivo");
+            }
+            if (clasificacion == null || clasificacion.isBlank()) {
+                throw new IllegalStateException("inventory.vencidos.movimiento.clasificacion es obligatorio cuando movimiento.enabled=true");
+            }
+            if (almacenDestinoId == null) {
+                throw new IllegalStateException("inventory.vencidos.almacenDestinoId es obligatorio cuando movimiento.enabled=true");
+            }
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/InventarioTaskController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/InventarioTaskController.java
@@ -1,0 +1,43 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.service.LoteVencimientoJobService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/inventario/tasks")
+@RequiredArgsConstructor
+public class InventarioTaskController {
+
+    private final LoteVencimientoJobService jobService;
+
+    @PostMapping("/expirar-lotes")
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_CALIDAD')")
+    public ResponseEntity<?> expirarLotes(@RequestParam(name = "dryRun", defaultValue = "true") boolean dryRun) {
+        try {
+            if (dryRun) {
+                LoteVencimientoJobService.LoteVencimientoPreview preview = jobService.dryRun();
+                return ResponseEntity.ok(Map.of(
+                        "total", preview.total(),
+                        "loteIds", preview.loteIds()
+                ));
+            }
+            LoteVencimientoJobService.LoteVencimientoExecutionResult result = jobService.ejecutar();
+            return ResponseEntity.ok(Map.of(
+                    "totalActualizados", result.totalActualizados(),
+                    "totalMovimientos", result.totalMovimientos()
+            ));
+        } catch (IllegalStateException ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("code", "CONFIG_INCOMPLETA", "message", ex.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -123,5 +123,17 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     List<com.willyes.clemenintegra.bom.dto.LoteResumenDTO> listarLotesPorProducto(@Param("productoId") Long productoId);
 
     List<LoteProducto> findAllByCodigoLoteAndProductoId(String codigoLote, Long productoId);
+
+    @Query("""
+        select l.id
+        from LoteProducto l
+        where l.fechaVencimiento is not null
+          and l.fechaVencimiento < :cutoff
+          and l.estado not in :estadosExcluidos
+        order by l.id asc
+    """)
+    List<Long> findIdsParaExpirar(@Param("cutoff") LocalDateTime cutoff,
+                                  @Param("estadosExcluidos") Collection<EstadoLote> estadosExcluidos,
+                                  org.springframework.data.domain.Pageable pageable);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -11,9 +11,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.math.BigDecimal;
 
 public interface MovimientoInventarioRepository extends JpaRepository<MovimientoInventario, Long> {
 
@@ -155,6 +155,11 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
                                      @Param("tipoMov") TipoMovimiento tipoMov,
                                      @Param("tipoDetalleId") Long tipoDetalleId,
                                      @Param("motivoId") Long motivoId);
+
+    boolean existsByLoteIdAndMotivoMovimientoIdAndFechaIngresoBetween(Long loteId,
+                                                                       Long motivoMovimientoId,
+                                                                       LocalDateTime fechaInicio,
+                                                                       LocalDateTime fechaFin);
 
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteVencimientoChunkProcessor.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteVencimientoChunkProcessor.java
@@ -1,0 +1,94 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.config.InventoryVencidosProperties;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+class LoteVencimientoChunkProcessor {
+
+    private final LoteProductoRepository loteProductoRepository;
+    private final MovimientoInventarioService movimientoInventarioService;
+    private final InventoryVencidosProperties properties;
+    private final EntityManager entityManager;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ChunkResult process(List<Long> loteIds,
+                               LocalDateTime cutoff,
+                               LocalDateTime inicioDia,
+                               LocalDateTime finDia,
+                               LocalDateTime fechaMovimiento) {
+        long actualizados = 0L;
+        long movimientos = 0L;
+
+        Long destinoIdConfig = properties.getMovimiento().isEnabled()
+                ? properties.requireAlmacenDestinoId()
+                : null;
+
+        for (Long loteId : loteIds) {
+            if (loteId == null) {
+                continue;
+            }
+            Optional<LoteProducto> optional = loteProductoRepository.findByIdWithLock(loteId);
+            if (optional.isEmpty()) {
+                continue;
+            }
+            LoteProducto lote = optional.get();
+            LocalDateTime fechaVencimiento = lote.getFechaVencimiento();
+            if (fechaVencimiento == null || !fechaVencimiento.isBefore(cutoff)) {
+                continue;
+            }
+            if (properties.getEstadoObjetivo() == lote.getEstado()) {
+                continue;
+            }
+
+            lote.setEstado(properties.getEstadoObjetivo());
+            actualizados++;
+
+            if (properties.getMovimiento().isEnabled()) {
+                Long motivoId = properties.getMovimiento().getMotivoId();
+                if (motivoId == null) {
+                    throw new IllegalStateException("inventory.vencidos.movimiento.motivoId es obligatorio cuando movimiento.enabled=true");
+                }
+
+                boolean existeMovimiento = movimientoInventarioService
+                        .existeMovimientoVencimientoHoy(lote.getId(), motivoId, inicioDia, finDia);
+
+                Integer destinoId = destinoIdConfig != null ? Math.toIntExact(destinoIdConfig) : null;
+
+                if (!existeMovimiento) {
+                    movimientoInventarioService.registrarRetiroPorVencimiento(lote, properties, fechaMovimiento);
+                    movimientos++;
+                    if (destinoId != null) {
+                        lote.setAlmacen(entityManager.getReference(Almacen.class, destinoId));
+                    }
+                } else if (destinoId != null) {
+                    Almacen actual = lote.getAlmacen();
+                    if (actual == null || !Objects.equals(actual.getId(), destinoId)) {
+                        lote.setAlmacen(entityManager.getReference(Almacen.class, destinoId));
+                    }
+                }
+            }
+
+            loteProductoRepository.save(lote);
+        }
+
+        return new ChunkResult(actualizados, movimientos);
+    }
+
+    record ChunkResult(long actualizados, long movimientos) { }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteVencimientoJobService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteVencimientoJobService.java
@@ -1,0 +1,88 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.config.InventoryVencidosProperties;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LoteVencimientoJobService {
+
+    private static final EnumSet<EstadoLote> ESTADOS_EXCLUIDOS = EnumSet.of(EstadoLote.VENCIDO, EstadoLote.RECHAZADO);
+
+    private final InventoryVencidosProperties properties;
+    private final LoteProductoRepository loteProductoRepository;
+    private final LoteVencimientoChunkProcessor chunkProcessor;
+
+    public LoteVencimientoPreview dryRun() {
+        properties.validateForExecution();
+        ZoneId zoneId = properties.resolveZoneId();
+        LocalDate today = LocalDate.now(zoneId);
+        LocalDateTime cutoff = today.atStartOfDay();
+
+        List<Long> ids = new ArrayList<>();
+        int page = 0;
+        int chunkSize = properties.getChunkSize();
+        Pageable pageableBase = PageRequest.of(0, chunkSize, Sort.by(Sort.Direction.ASC, "id"));
+
+        while (true) {
+            Pageable pageable = PageRequest.of(page, chunkSize, pageableBase.getSort());
+            List<Long> pageIds = loteProductoRepository.findIdsParaExpirar(cutoff, ESTADOS_EXCLUIDOS, pageable);
+            if (pageIds.isEmpty()) {
+                break;
+            }
+            ids.addAll(pageIds);
+            if (pageIds.size() < chunkSize) {
+                break;
+            }
+            page++;
+        }
+
+        return new LoteVencimientoPreview(ids.size(), ids);
+    }
+
+    public LoteVencimientoExecutionResult ejecutar() {
+        properties.validateForExecution();
+        ZoneId zoneId = properties.resolveZoneId();
+        LocalDate today = LocalDate.now(zoneId);
+        LocalDateTime inicioDia = today.atStartOfDay();
+        LocalDateTime finDia = inicioDia.plusDays(1).minusNanos(1);
+
+        long totalActualizados = 0L;
+        long totalMovimientos = 0L;
+        int chunkSize = properties.getChunkSize();
+        Pageable pageable = PageRequest.of(0, chunkSize, Sort.by(Sort.Direction.ASC, "id"));
+
+        while (true) {
+            List<Long> ids = loteProductoRepository.findIdsParaExpirar(inicioDia, ESTADOS_EXCLUIDOS, pageable);
+            if (ids.isEmpty()) {
+                break;
+            }
+            LocalDateTime fechaMovimiento = LocalDateTime.now(zoneId);
+            LoteVencimientoChunkProcessor.ChunkResult result = chunkProcessor
+                    .process(ids, inicioDia, inicioDia, finDia, fechaMovimiento);
+            totalActualizados += result.actualizados();
+            totalMovimientos += result.movimientos();
+        }
+
+        return new LoteVencimientoExecutionResult(totalActualizados, totalMovimientos);
+    }
+
+    public record LoteVencimientoPreview(long total, List<Long> loteIds) { }
+
+    public record LoteVencimientoExecutionResult(long totalActualizados, long totalMovimientos) { }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteVencimientoScheduler.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteVencimientoScheduler.java
@@ -1,31 +1,37 @@
 package com.willyes.clemenintegra.inventario.service;
 
-import com.willyes.clemenintegra.inventario.model.LoteProducto;
-import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
-import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.config.InventoryVencidosProperties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class LoteVencimientoScheduler {
 
-    private final LoteProductoRepository loteProductoRepository;
+    private final InventoryVencidosProperties properties;
+    private final LoteVencimientoJobService jobService;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "${inventory.vencidos.job.cron}", zone = "${inventory.vencidos.job.timezone}")
     public void actualizarLotesVencidos() {
-        LocalDateTime hoy = LocalDate.now().atStartOfDay();
-        List<LoteProducto> lotes = loteProductoRepository
-                .findByFechaVencimientoBeforeAndEstadoNotIn(hoy,
-                        List.of(EstadoLote.VENCIDO, EstadoLote.RECHAZADO));
-        for (LoteProducto lote : lotes) {
-            lote.setEstado(EstadoLote.VENCIDO);
-            loteProductoRepository.save(lote);
+        if (!properties.getJob().isEnabled()) {
+            log.debug("[VENCIDOS] Job deshabilitado. estadoObjetivo={} cron={} tz={}",
+                    properties.getEstadoObjetivo(), properties.getJob().getCron(), properties.getJob().getTimezone());
+            return;
+        }
+        try {
+            LoteVencimientoJobService.LoteVencimientoExecutionResult result = jobService.ejecutar();
+            log.info("[VENCIDOS] afectados={} movimientos={} estadoObjetivo={} cron={} tz={}",
+                    result.totalActualizados(), result.totalMovimientos(),
+                    properties.getEstadoObjetivo(), properties.getJob().getCron(), properties.getJob().getTimezone());
+        } catch (IllegalStateException ex) {
+            log.error("[VENCIDOS] CONFIG_INCOMPLETA estadoObjetivo={} mensaje={}",
+                    properties.getEstadoObjetivo(), ex.getMessage());
+        } catch (Exception ex) {
+            log.error("[VENCIDOS] ERROR estadoObjetivo={} mensaje={}",
+                    properties.getEstadoObjetivo(), ex.getMessage(), ex);
         }
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
@@ -1,10 +1,13 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.config.InventoryVencidosProperties;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioFiltroDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,5 +31,14 @@ public interface MovimientoInventarioService {
     Workbook generarReporteMovimientosExcel();
 
     Page<MovimientoInventarioResponseDTO> listarTodos(Pageable pageable);
+
+    MovimientoInventario registrarRetiroPorVencimiento(LoteProducto lote,
+                                                       InventoryVencidosProperties properties,
+                                                       java.time.LocalDateTime fechaMovimiento);
+
+    boolean existeMovimientoVencimientoHoy(Long loteId,
+                                           Long motivoId,
+                                           java.time.LocalDateTime fechaInicio,
+                                           java.time.LocalDateTime fechaFin);
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.config.InventoryVencidosProperties;
 import com.willyes.clemenintegra.inventario.dto.AtencionDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioFiltroDTO;
@@ -1007,6 +1008,90 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
         Page<MovimientoInventario> movimientos = repository.findAll(sortedPageable);
         return movimientos.map(mapper::safeToResponseDTO);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public MovimientoInventario registrarRetiroPorVencimiento(LoteProducto lote,
+                                                               InventoryVencidosProperties properties,
+                                                               LocalDateTime fechaMovimiento) {
+        if (lote == null) {
+            throw new IllegalArgumentException("El lote es requerido para registrar el retiro por vencimiento");
+        }
+        if (properties == null) {
+            throw new IllegalArgumentException("La configuración de vencidos es requerida");
+        }
+
+        InventoryVencidosProperties.Movimiento movimientoCfg = properties.getMovimiento();
+        if (!movimientoCfg.isEnabled()) {
+            throw new IllegalStateException("El registro de movimientos por vencimiento está deshabilitado");
+        }
+
+        Usuario usuario;
+        try {
+            usuario = usuarioService.obtenerUsuarioAutenticado();
+        } catch (AuthenticationCredentialsNotFoundException ex) {
+            usuario = usuarioService.obtenerUsuarioSistema();
+        }
+
+        if (usuario == null) {
+            throw new IllegalStateException("No se pudo resolver un usuario para registrar el movimiento por vencimiento");
+        }
+
+        Long motivoId = movimientoCfg.getMotivoId();
+        MotivoMovimiento motivoMovimiento = entityManager.getReference(MotivoMovimiento.class, motivoId);
+        ClasificacionMovimientoInventario clasificacion = movimientoCfg.resolveClasificacionEnum();
+
+        Long tipoDetalleTransferenciaId = catalogResolver.getTipoDetalleTransferenciaId();
+        if (tipoDetalleTransferenciaId == null) {
+            throw new IllegalStateException("No se configuró el tipo de detalle de transferencia para movimientos por vencimiento");
+        }
+        TipoMovimientoDetalle tipoDetalle = entityManager.getReference(TipoMovimientoDetalle.class, tipoDetalleTransferenciaId);
+
+        Almacen origen = lote.getAlmacen();
+        if (origen == null || origen.getId() == null) {
+            throw new IllegalStateException("El lote no tiene un almacén de origen asignado");
+        }
+
+        if (lote.getProducto() == null) {
+            throw new IllegalStateException("El lote no tiene un producto asociado");
+        }
+
+        Long destinoId = properties.requireAlmacenDestinoId();
+        Almacen destino = entityManager.getReference(Almacen.class, Math.toIntExact(destinoId));
+
+        LocalDateTime fecha = fechaMovimiento != null
+                ? fechaMovimiento
+                : ZonedDateTime.now(properties.resolveZoneId()).toLocalDateTime();
+
+        MovimientoInventario movimiento = MovimientoInventario.builder()
+                .cantidad(Optional.ofNullable(lote.getStockLote()).orElse(BigDecimal.ZERO))
+                .tipoMovimiento(TipoMovimiento.TRANSFERENCIA)
+                .clasificacion(clasificacion)
+                .fechaIngreso(fecha)
+                .docReferencia("JOB_VENCIDOS")
+                .registradoPor(usuario)
+                .producto(lote.getProducto())
+                .lote(lote)
+                .almacenOrigen(origen)
+                .almacenDestino(destino)
+                .motivoMovimiento(motivoMovimiento)
+                .tipoMovimientoDetalle(tipoDetalle)
+                .build();
+
+        return repository.save(movimiento);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public boolean existeMovimientoVencimientoHoy(Long loteId,
+                                                  Long motivoId,
+                                                  LocalDateTime fechaInicio,
+                                                  LocalDateTime fechaFin) {
+        if (loteId == null || motivoId == null || fechaInicio == null || fechaFin == null) {
+            return false;
+        }
+        return repository.existsByLoteIdAndMotivoMovimientoIdAndFechaIngresoBetween(loteId, motivoId, fechaInicio, fechaFin);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/willyes/clemenintegra/shared/repository/UsuarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/repository/UsuarioRepository.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.shared.repository;
 
 import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +12,8 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
     Optional<Usuario> findByNombreUsuario(String nombreUsuario);
     Optional<Usuario> findByCorreo(String correo);
     boolean existsByCorreo(String correo);
+
+    Optional<Usuario> findFirstByRolAndActivoTrueOrderByIdAsc(RolUsuario rol);
 
 }
 

--- a/src/main/java/com/willyes/clemenintegra/shared/service/UsuarioService.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/service/UsuarioService.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.shared.service;
 
 import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,5 +37,10 @@ public class UsuarioService {
     public Usuario buscarPorNombreUsuario(String nombreUsuario) {
         return usuarioRepository.findByNombreUsuario(nombreUsuario)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuario no encontrado"));
+    }
+
+    public Usuario obtenerUsuarioSistema() {
+        return usuarioRepository.findFirstByRolAndActivoTrueOrderByIdAsc(RolUsuario.ROL_SUPER_ADMIN)
+                .orElseThrow(() -> new IllegalStateException("No se encontró un usuario activo con rol SUPER_ADMIN para tareas automáticas"));
     }
 }

--- a/src/main/resources/application-demo.properties
+++ b/src/main/resources/application-demo.properties
@@ -21,7 +21,19 @@ app.flyway.migrations.locations=classpath:db/migration
 app.flyway.baseline-on-migrate=true
 app.flyway.baseline-version=1
 
-# Aquí la secundaria es la PRINCIPAL
+
+
+# --- JOB LOTES VENCIDOS (DEMO) ---
+inventory.vencidos.job.enabled=true
+inventory.vencidos.job.cron=0 0 0 * * *
+inventory.vencidos.job.timezone=America/Bogota
+inventory.vencidos.estadoObjetivo=VENCIDO
+inventory.vencidos.chunkSize=500
+inventory.vencidos.movimiento.enabled=true
+inventory.vencidos.movimiento.motivoId=15
+inventory.vencidos.movimiento.clasificacion=RECHAZO_CALIDAD
+inventory.vencidos.almacenDestinoId=3
+# AquÃ­ la secundaria es la PRINCIPAL
 app.flyway.secondary.url=jdbc:mysql://localhost:3306/clemen_integra_erp
 app.flyway.secondary.user=${DB_USERNAME}
 app.flyway.secondary.password=${DB_PASS}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -91,6 +91,17 @@ inventory.mov.clasificacion.liberacionCalidad=LIBERACION_CALIDAD
 inventory.mov.clasificacion.rechazoCalidad=RECHAZO_CALIDAD
 inventory.mov.motivo.ajusteRechazo=15
 
+# --- JOB LOTES VENCIDOS ---
+inventory.vencidos.job.enabled=true
+inventory.vencidos.job.cron=0 0 0 * * *
+inventory.vencidos.job.timezone=America/Bogota
+inventory.vencidos.estadoObjetivo=VENCIDO
+inventory.vencidos.chunkSize=500
+inventory.vencidos.movimiento.enabled=true
+inventory.vencidos.movimiento.motivoId=${inventory.mov.motivo.ajusteRechazo}
+inventory.vencidos.movimiento.clasificacion=RECHAZO_CALIDAD
+inventory.vencidos.almacenDestinoId=${inventory.almacen.obsoletos.id}
+
 # --- LOTE ---
 inventory.lote.estadoLiberado=DISPONIBLE
 

--- a/src/main/resources/db/migration/V20251011__inventario_idx_lotes_vencimiento_estado.sql
+++ b/src/main/resources/db/migration/V20251011__inventario_idx_lotes_vencimiento_estado.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_lote_vencimiento_estado
+    ON lotes_productos(fecha_vencimiento, estado);


### PR DESCRIPTION
## Summary
- add configurable inventory.vencidos properties, scheduler refactor, and chunked job processor for expiring lots with logging and manual trigger
- extend inventory repositories/services to fetch expired lot IDs, ensure idempotent movement registration, and resolve fallback job user
- add REST endpoint for /api/inventario/tasks/expirar-lotes, update application properties, and create Flyway index for lot expiration query

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68ee7fa944d483339c38b08cd837e447