### PR TITLE
Align quality module authorization rules

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/LoteCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/LoteCalidadController.java
@@ -28,7 +28,7 @@ public class LoteCalidadController {
     }
 
     @GetMapping("/{loteId}/estado-calidad")
-    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<EstadoCalidadLoteResponseDTO> obtenerEstadoCalidad(@PathVariable Long loteId) {
         return ResponseEntity.ok(service.obtenerEstadoCalidad(loteId));
     }

--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
@@ -25,6 +25,7 @@ public class NoConformidadController {
     private final UsuarioRepository usuarioRepository;
 
     @GetMapping
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<Page<NoConformidadDTO>> listar(
             @RequestParam(required = false) SeveridadNoConformidad severidad,
             @RequestParam(required = false) OrigenNoConformidad origen,
@@ -33,12 +34,13 @@ public class NoConformidadController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<NoConformidadDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerPorId(id));
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<NoConformidadDTO> crear(
             @RequestBody NoConformidadDTO dto,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -63,7 +65,7 @@ public class NoConformidadController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<NoConformidadDTO> actualizar(
             @PathVariable Long id,
             @RequestBody NoConformidadDTO dto,
@@ -75,7 +77,7 @@ public class NoConformidadController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {
         service.eliminar(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/RetencionLoteController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/RetencionLoteController.java
@@ -21,6 +21,7 @@ public class RetencionLoteController {
     private final RetencionLoteService service;
 
     @GetMapping
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<Page<RetencionLoteDTO>> listar(
             @RequestParam(required = false) EstadoRetencion estado,
             @PageableDefault(size = 10) Pageable pageable) {
@@ -28,12 +29,13 @@ public class RetencionLoteController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<RetencionLoteDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerPorId(id));
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<RetencionLoteDTO> crear(
             @RequestBody RetencionLoteDTO dto,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -44,7 +46,7 @@ public class RetencionLoteController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN') or #dto.estado != T(com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion).LIBERADO")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<RetencionLoteDTO> actualizar(
             @PathVariable Long id,
             @RequestBody RetencionLoteDTO dto,
@@ -56,7 +58,7 @@ public class RetencionLoteController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {
         service.eliminar(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteServiceImpl.java
@@ -13,9 +13,13 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
@@ -61,6 +65,12 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
         existing.setCausa(dto.getCausa());
         existing.setFechaRetencion(dto.getFechaRetencion());
         existing.setFechaLiberacion(dto.getFechaLiberacion());
+        if (existing.getEstado() != EstadoRetencion.LIBERADO
+                && dto.getEstado() == EstadoRetencion.LIBERADO
+                && !esJefeOSuper()) {
+            throw new AccessDeniedException("Solo Jefe de Calidad o Super Admin pueden liberar retenciones");
+        }
+
         existing.setEstado(dto.getEstado());
         existing.setAprobadoPor(user);
         return mapper.toDTO(repository.save(existing));
@@ -145,6 +155,9 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
     @Override
     @Transactional
     public RetencionLote levantar(Long retencionId, Usuario usuario) {
+        if (!esJefeOSuper()) {
+            throw new AccessDeniedException("Solo Jefe de Calidad o Super Admin pueden levantar retenciones");
+        }
         if (retencionId == null) {
             throw new IllegalArgumentException("Retención requerida");
         }
@@ -190,6 +203,24 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
             lote.setEstado(EstadoLote.RETENIDO);
             loteRepository.save(lote);
         }
+    }
+
+    private boolean esJefeOSuper() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return tieneAlgunaAuthority(authentication, "ROL_JEFE_CALIDAD", "ROL_SUPER_ADMIN");
+    }
+
+    private boolean tieneAlgunaAuthority(Authentication authentication, String... authorities) {
+        if (authentication == null || authentication.getAuthorities() == null) {
+            return false;
+        }
+        java.util.Set<String> requeridas = java.util.Set.of(authorities);
+        for (GrantedAuthority authority : authentication.getAuthorities()) {
+            if (requeridas.contains(authority.getAuthority())) {
+                return true;
+            }
+        }
+        return false;
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
@@ -122,25 +122,25 @@ public class LoteProductoController {
     }
 
     @GetMapping("/{id}/evaluaciones")
-    @PreAuthorize("hasAuthority('ROL_JEFE_CALIDAD')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD', 'ROL_SUPER_ADMIN', 'ROL_ANALISTA_CALIDAD', 'ROL_MICROBIOLOGO')")
     public ResponseEntity<java.util.List<EvaluacionCalidadResponseDTO>> obtenerEvaluaciones(@PathVariable Long id) {
         return ResponseEntity.ok(evaluacionService.listarPorLote(id));
     }
 
     @PutMapping("/{id}/liberar")
-    @PreAuthorize("hasAuthority('ROL_JEFE_CALIDAD')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD', 'ROL_SUPER_ADMIN')")
     public ResponseEntity<LoteProductoResponseDTO> liberar(@PathVariable Long id) {
         return ResponseEntity.ok(service.liberarLote(id));
     }
 
     @PutMapping("/{id}/rechazar")
-    @PreAuthorize("hasAuthority('ROL_JEFE_CALIDAD')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD', 'ROL_SUPER_ADMIN')")
     public ResponseEntity<LoteProductoResponseDTO> rechazar(@PathVariable Long id) {
         return ResponseEntity.ok(service.rechazarLote(id));
     }
 
     @PutMapping("/{id}/liberar-retenido")
-    @PreAuthorize("hasAuthority('ROL_JEFE_CALIDAD')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD', 'ROL_SUPER_ADMIN')")
     public ResponseEntity<LoteProductoResponseDTO> liberarRetenido(@PathVariable Long id) {
         return ResponseEntity.ok(service.liberarLoteRetenido(id));
     }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -120,14 +120,17 @@ public class LoteProductoServiceImpl implements LoteProductoService {
 
         List<LoteProducto> lotes;
         if (auth != null) {
-            boolean analista = auth.getAuthorities().stream()
+            java.util.Set<String> authorities = auth.getAuthorities().stream()
                     .map(GrantedAuthority::getAuthority)
-                    .anyMatch("ROL_ANALISTA_CALIDAD"::equals);
-            boolean micro = auth.getAuthorities().stream()
-                    .map(GrantedAuthority::getAuthority)
-                    .anyMatch("ROL_MICROBIOLOGO"::equals);
+                    .collect(Collectors.toSet());
+            boolean jefe = authorities.contains("ROL_JEFE_CALIDAD");
+            boolean superAdmin = authorities.contains("ROL_SUPER_ADMIN");
+            boolean analista = authorities.contains("ROL_ANALISTA_CALIDAD");
+            boolean micro = authorities.contains("ROL_MICROBIOLOGO");
 
-            if (analista) {
+            if (jefe || superAdmin) {
+                lotes = loteRepo.findByEstadoIn(estados);
+            } else if (analista) {
                 lotes = loteRepo.findByEstadoInAndProducto_TipoAnalisisIn(
                         estados,
                         List.of(TipoAnalisisCalidad.FISICO_QUIMICO, TipoAnalisisCalidad.AMBOS)
@@ -419,9 +422,11 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     @Override
     @Transactional(rollbackFor = Exception.class)
     public LoteProductoResponseDTO liberarLotePorCalidad(Long loteId, Usuario usuarioActual) {
-        if (usuarioActual == null || usuarioActual.getRol() != RolUsuario.ROL_JEFE_CALIDAD) {
+        if (usuarioActual == null
+                || (usuarioActual.getRol() != RolUsuario.ROL_JEFE_CALIDAD
+                && usuarioActual.getRol() != RolUsuario.ROL_SUPER_ADMIN)) {
             throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE,
-                    "Solo el Jefe de Calidad puede liberar lotes.");
+                    "Solo el Jefe de Calidad o Super Admin pueden liberar lotes.");
         }
 
         EstadoLote estadoLiberado;

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -118,9 +118,9 @@ public class SecurityConfig {
                     auth.requestMatchers("/api/calidad/**",
                             "/api/calidad/evaluaciones/archivo/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name(),
                             RolUsuario.ROL_ANALISTA_CALIDAD.name(),
-                            RolUsuario.ROL_MICROBIOLOGO.name(),
-                            RolUsuario.ROL_SUPER_ADMIN.name()
+                            RolUsuario.ROL_MICROBIOLOGO.name()
                     );
 
                     auth.requestMatchers("/api/produccion/calidad/**").hasAnyAuthority(


### PR DESCRIPTION
## Summary
- align the calidad HTTP security matcher with the expected authority set
- update lotes, retenciones and no conformidades controllers so micro/analyst have read/write access while liberar/rechazar stays jefe+super
- enforce service-side checks for retención lifting and lot release filtering so super admin is honoured and analysts cannot liberar indirectly

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68ff8936054c83338364a2cc0597b456