### PR TITLE
Fix Excel inventory report generation

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioController.java
@@ -5,9 +5,11 @@ import com.willyes.clemenintegra.inventario.service.ProductoService;
 import com.willyes.clemenintegra.inventario.service.LoteProductoService;
 import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -19,16 +21,22 @@ import org.springframework.web.bind.annotation.RestController;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @RestController
 @RequestMapping("/api/reportes")
 @RequiredArgsConstructor
+@Slf4j
 public class ReporteInventarioController {
 
     private final ReporteInventarioService service;
     private final ProductoService productoService;
     private final LoteProductoService loteProductoService;
     private final MovimientoInventarioService movimientoService;
+
+    private static final MediaType EXCEL =
+            MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
 
     @GetMapping("/alta-rotacion")
     @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
@@ -142,30 +150,50 @@ public class ReporteInventarioController {
                 .body(bos.toByteArray());
     }
 
-    @GetMapping("/stock-disponible")
+    @GetMapping(value = "/stock-disponible", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
-    public ResponseEntity<byte[]> exportarStockDisponible() throws IOException {
-        Workbook workbook = productoService.generarReporteStockDisponibleExcel();
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        workbook.write(bos);
-        workbook.close();
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=stock_disponible.xlsx")
-                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
-                .body(bos.toByteArray());
+    public ResponseEntity<byte[]> exportarStockDisponible() {
+        log.info("Generando reporte de stock disponible");
+        try (Workbook workbook = productoService.generarReporteStockDisponibleExcel();
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            workbook.write(baos);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(EXCEL);
+            headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=stock_disponible.xlsx");
+            return new ResponseEntity<>(baos.toByteArray(), headers, HttpStatus.OK);
+        } catch (IllegalArgumentException ex) {
+            log.warn("Validación fallida al generar reporte de stock disponible", ex);
+            return ResponseEntity.badRequest().build();
+        } catch (Exception ex) {
+            log.error("Error generando reporte de stock disponible", ex);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
-    @GetMapping("/productos-por-vencer")
+    @GetMapping(value = "/productos-por-vencer", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public ResponseEntity<byte[]> exportarLotesPorVencer() throws IOException {
-        Workbook workbook = loteProductoService.generarReporteLotesPorVencerExcel();
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        workbook.write(bos);
-        workbook.close();
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=lotes_por_vencer.xlsx")
-                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
-                .body(bos.toByteArray());
+    public ResponseEntity<byte[]> exportarLotesPorVencer(
+            @RequestParam(name = "fechaInicio", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
+            @RequestParam(name = "fechaFin", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin
+    ) {
+        LocalDateTime inicio = fechaInicio != null ? fechaInicio.atStartOfDay() : null;
+        LocalDateTime fin = fechaFin != null ? fechaFin.atTime(LocalTime.MAX) : null;
+
+        log.info("Generando reporte de productos por vencer: inicio={}, fin={}", inicio, fin);
+        try (Workbook workbook = loteProductoService.generarReporteLotesPorVencerExcel(inicio, fin);
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            workbook.write(baos);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(EXCEL);
+            headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=lotes_por_vencer.xlsx");
+            return new ResponseEntity<>(baos.toByteArray(), headers, HttpStatus.OK);
+        } catch (IllegalArgumentException ex) {
+            log.warn("Validación fallida al generar reporte de productos por vencer", ex);
+            return ResponseEntity.badRequest().build();
+        } catch (Exception ex) {
+            log.error("Error generando reporte de productos por vencer", ex);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @GetMapping("/alertas-inventario")
@@ -178,19 +206,29 @@ public class ReporteInventarioController {
                 .body(stream.toByteArray());
     }
 
-    @GetMapping("/movimientos")
+    @GetMapping(value = "/movimientos", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public ResponseEntity<byte[]> exportarReporteMovimientos() throws IOException {
-        byte[] contenido;
-        try (Workbook workbook = movimientoService.generarReporteMovimientosExcel();
-             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            workbook.write(bos);
-            contenido = bos.toByteArray();
-        }
+    public ResponseEntity<byte[]> exportarReporteMovimientos(
+            @RequestParam(name = "fechaInicio", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
+            @RequestParam(name = "fechaFin", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin
+    ) {
+        LocalDateTime inicio = fechaInicio != null ? fechaInicio.atStartOfDay() : null;
+        LocalDateTime fin = fechaFin != null ? fechaFin.atTime(LocalTime.MAX) : null;
 
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=reporte_movimientos.xlsx")
-                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
-                .body(contenido);
+        log.info("Generando reporte de movimientos: inicio={}, fin={}", inicio, fin);
+        try (Workbook workbook = movimientoService.generarReporteMovimientosExcel(inicio, fin);
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            workbook.write(baos);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(EXCEL);
+            headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=reporte_movimientos.xlsx");
+            return new ResponseEntity<>(baos.toByteArray(), headers, HttpStatus.OK);
+        } catch (IllegalArgumentException ex) {
+            log.warn("Validación fallida al generar reporte de movimientos", ex);
+            return ResponseEntity.badRequest().build();
+        } catch (Exception ex) {
+            log.error("Error generando reporte de movimientos", ex);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -28,9 +28,15 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     boolean existsByCodigoLote(String codigoLote);
     List<LoteProducto> findByEstado(EstadoLote estado);
     Optional<LoteProducto> findByCodigoLote(String codigoLote);
-    @Query("SELECT lp FROM LoteProducto lp JOIN FETCH lp.almacen a WHERE lp.fechaVencimiento BETWEEN :inicio AND :fin")
-    List<LoteProducto> findByFechaVencimientoBetween(@Param("inicio") LocalDateTime inicio,
-                                                     @Param("fin") LocalDateTime fin);
+    @Query("""
+       SELECT lp
+         FROM LoteProducto lp
+         JOIN FETCH lp.producto p
+         JOIN FETCH lp.almacen a
+        WHERE lp.fechaVencimiento BETWEEN :inicio AND :fin
+    """)
+    List<LoteProducto> findByFechaVencimientoBetweenFetchProducto(@Param("inicio") LocalDateTime inicio,
+                                                                  @Param("fin") LocalDateTime fin);
     Optional<LoteProducto> findByCodigoLoteAndProductoIdAndAlmacenId(String codigoLote, Integer productoId, Integer almacenId);
     List<LoteProducto> findByEstadoIn(List<EstadoLote> estados);
     List<LoteProducto> findByEstadoInAndProducto_TipoAnalisisIn(List<EstadoLote> estados, List<TipoAnalisisCalidad> tipos);

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -100,6 +100,19 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
                                              @Param("productoId") Long productoId,
                                              @Param("detalleId") Long detalleId);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "almacenOrigen", "almacenDestino",
+            "proveedor", "ordenCompra", "motivoMovimiento", "tipoMovimientoDetalle", "registradoPor"
+    })
+    @Query("""
+        select m
+          from MovimientoInventario m
+         where (:inicio is null or m.fechaIngreso >= :inicio)
+           and (:fin    is null or m.fechaIngreso <= :fin)
+    """)
+    List<MovimientoInventario> findAllForReporte(@Param("inicio") LocalDateTime inicio,
+                                                 @Param("fin") LocalDateTime fin);
+
     boolean existsByOrdenProduccionIdAndClasificacion(Long ordenProduccionId, ClasificacionMovimientoInventario clasificacion);
 
     java.util.Optional<MovimientoInventario> findByTipoMovimientoAndMotivoMovimientoIdAndOrdenProduccionIdAndProductoIdAndLoteId(

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
@@ -19,7 +19,7 @@ public interface LoteProductoService {
     LoteProductoResponseDTO crearLote(LoteProductoRequestDTO dto);
     List<LoteProductoResponseDTO> obtenerLotesPorEstado(String estado);
     List<LoteProductoResponseDTO> obtenerLotesPorEvaluar();
-    Workbook generarReporteLotesPorVencerExcel();
+    Workbook generarReporteLotesPorVencerExcel(LocalDateTime inicio, LocalDateTime fin);
     ByteArrayOutputStream generarReporteAlertasActivasExcel();
     Page<LoteProductoResponseDTO> listarTodos(String producto, EstadoLote estado, String almacen, Boolean vencidos, LocalDateTime fechaInicio, LocalDateTime fechaFin, Pageable pageable);
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -219,14 +219,13 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         return lotes.map(loteProductoMapper::toResponseDTO);
     }
 
-    public Workbook generarReporteLotesPorVencerExcel() {
+    @Transactional(readOnly = true)
+    public Workbook generarReporteLotesPorVencerExcel(LocalDateTime inicio, LocalDateTime fin) {
         LocalDate hoy = LocalDate.now();
-        LocalDate limite = hoy.plusDays(30); // Puedes parametrizar esto si lo deseas
+        LocalDateTime inicioEf = inicio != null ? inicio : hoy.atStartOfDay();
+        LocalDateTime finEf = fin != null ? fin : hoy.plusDays(30).atTime(java.time.LocalTime.MAX);
 
-        LocalDateTime inicio = hoy.atStartOfDay();
-        LocalDateTime fin = limite.atTime(23, 59, 59);
-
-        List<LoteProducto> lotes = loteRepo.findByFechaVencimientoBetween(inicio, fin);
+        List<LoteProducto> lotes = loteRepo.findByFechaVencimientoBetweenFetchProducto(inicioEf, finEf);
 
         Workbook workbook = new XSSFWorkbook();
         Sheet sheet = workbook.createSheet("Lotes por Vencer");

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
@@ -28,7 +28,7 @@ public interface MovimientoInventarioService {
 
     List<MovimientoInventarioResponseDTO> consultarMovimientos(MovimientoInventarioFiltroDTO filtro);
 
-    Workbook generarReporteMovimientosExcel();
+    Workbook generarReporteMovimientosExcel(LocalDateTime inicio, LocalDateTime fin);
 
     Page<MovimientoInventarioResponseDTO> listarTodos(Pageable pageable);
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -1118,9 +1118,10 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         return lista.stream().map(mapper::safeToResponseDTO).toList();
     }
 
+    @Transactional(readOnly = true)
     @Override
-    public Workbook generarReporteMovimientosExcel() {
-        List<MovimientoInventario> movimientos = repository.findAll();
+    public Workbook generarReporteMovimientosExcel(LocalDateTime inicio, LocalDateTime fin) {
+        List<MovimientoInventario> movimientos = repository.findAllForReporte(inicio, fin);
 
         Workbook workbook = new XSSFWorkbook();
         Sheet sheet = workbook.createSheet("Movimientos Inventario");

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -14,7 +14,10 @@ import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.poi.ss.usermodel.RichTextString;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.DataFormat;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -365,6 +368,10 @@ public class ProductoServiceImpl implements ProductoService {
 
         Workbook workbook = new XSSFWorkbook();
         Sheet sheet = workbook.createSheet("Stock Disponible");
+        CreationHelper creationHelper = workbook.getCreationHelper();
+        DataFormat dataFormat = creationHelper.createDataFormat();
+        CellStyle numericStyle = workbook.createCellStyle();
+        numericStyle.setDataFormat(dataFormat.getFormat("#,##0.00"));
 
         Row header = sheet.createRow(0);
         String[] columnas = {
@@ -382,9 +389,14 @@ public class ProductoServiceImpl implements ProductoService {
             row.createCell(1).setCellValue(producto.getCodigoSku());
             row.createCell(2).setCellValue(producto.getNombre());
             BigDecimal stock = stockMap.getOrDefault(producto.getId().longValue(), BigDecimal.ZERO);
-            row.createCell(3).setCellValue((RichTextString) stock);
+            Cell stockCell = row.createCell(3);
+            stockCell.setCellValue(stock != null ? stock.doubleValue() : 0d);
+            stockCell.setCellStyle(numericStyle);
             row.createCell(4).setCellValue(producto.getUnidadMedida() != null ? producto.getUnidadMedida().getNombre() : "");
-            row.createCell(5).setCellValue((RichTextString) (producto.getStockMinimo() != null ? producto.getStockMinimo() : BigDecimal.ZERO));
+            BigDecimal stockMinimo = producto.getStockMinimo() != null ? producto.getStockMinimo() : BigDecimal.ZERO;
+            Cell minimoCell = row.createCell(5);
+            minimoCell.setCellValue(stockMinimo.doubleValue());
+            minimoCell.setCellStyle(numericStyle);
             row.createCell(6).setCellValue(producto.isActivo());
             row.createCell(7).setCellValue(producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getNombre() : "");
         }


### PR DESCRIPTION
## Summary
- ensure stock and expiring product exports write numeric values with proper formatting inside read-only transactions
- add fetch joins and optional date filters for inventory movement reports to avoid lazy-loading errors
- update Excel report endpoints to stream binary responses with consistent headers and error handling

## Testing
- mvn -q -Dtest='*Reporte*Test' test *(aborted manually after prolonged hang)*

------
https://chatgpt.com/codex/tasks/task_e_690113a92e208333a1ad04d1d6040d0a