### PR TITLE
feat: add FEFO preview endpoint and harden FEFO selection

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/InventarioFefoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/InventarioFefoController.java
@@ -1,0 +1,62 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.FefoPreviewResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.LoteConsumoDTO;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/inventario/fefo")
+@RequiredArgsConstructor
+public class InventarioFefoController {
+
+    private static final Logger log = LoggerFactory.getLogger(InventarioFefoController.class);
+
+    private final MovimientoInventarioService movimientoInventarioService;
+
+    @GetMapping("/preview")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<FefoPreviewResponseDTO> preview(
+            @RequestParam(required = false) Long almacenId,
+            @RequestParam Long productoId,
+            @RequestParam BigDecimal cantidad) {
+
+        if (productoId == null || productoId <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "PRODUCTO_ID_REQUERIDO");
+        }
+        if (cantidad == null || cantidad.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "CANTIDAD_INVALIDA");
+        }
+
+        log.info("FEFO_PREVIEW_REQUEST productoId={} cantidad={} almacenId={}", productoId, cantidad, almacenId);
+
+        List<LoteConsumoDTO> consumos = movimientoInventarioService.simulateFefo(productoId, cantidad, almacenId);
+        BigDecimal total = consumos.stream()
+                .map(LoteConsumoDTO::getTomar)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        log.debug("FEFO_PREVIEW_RESPONSE productoId={} lotes={} total={}",
+                productoId,
+                consumos.stream().map(LoteConsumoDTO::getLoteId).toList(),
+                total);
+
+        FefoPreviewResponseDTO body = FefoPreviewResponseDTO.builder()
+                .consumos(consumos)
+                .totalTomar(total)
+                .build();
+        return ResponseEntity.ok(body);
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/FefoPreviewResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/FefoPreviewResponseDTO.java
@@ -1,0 +1,15 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Value
+@Builder
+public class FefoPreviewResponseDTO {
+
+    List<LoteConsumoDTO> consumos;
+    BigDecimal totalTomar;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteConsumoDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteConsumoDTO.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Value
+@Builder
+public class LoteConsumoDTO {
+
+    Long loteId;
+    String codigoLote;
+    LocalDateTime fechaVencimiento;
+    Long almacenId;
+    BigDecimal disponibleAntes;
+    BigDecimal tomar;
+    BigDecimal disponibleDespues;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
@@ -80,10 +81,24 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
                                                                               @Param("codigoLote") String codigoLote,
                                                                               @Param("almacenId") Integer almacenId);
 
+    @EntityGraph(attributePaths = {"producto", "almacen"})
     List<LoteProducto> findByProductoIdAndAlmacenIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
             Long productoId,
             Integer almacenId,
             Collection<EstadoLote> estados);
+
+    @EntityGraph(attributePaths = {"producto", "almacen"})
+    List<LoteProducto> findByProductoIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
+            Long productoId,
+            Collection<EstadoLote> estados);
+
+    @EntityGraph(attributePaths = {"producto", "almacen"})
+    List<LoteProducto> findByProductoIdAndEstadoIn(Long productoId, Collection<EstadoLote> estados);
+
+    @EntityGraph(attributePaths = {"producto", "almacen"})
+    List<LoteProducto> findByProductoIdAndAlmacenIdAndEstadoIn(Long productoId,
+                                                                Integer almacenId,
+                                                                Collection<EstadoLote> estados);
 
     @Query("""
       select l

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.config.InventoryVencidosProperties;
+import com.willyes.clemenintegra.inventario.dto.LoteConsumoDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioFiltroDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
@@ -12,6 +13,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -19,6 +21,8 @@ public interface MovimientoInventarioService {
 
     MovimientoInventarioResponseDTO registrarMovimiento(MovimientoInventarioDTO dto);
     void consumirInsumosPorOrden(Long ordenProduccionId, Long usuarioId);
+
+    List<LoteConsumoDTO> simulateFefo(Long productoId, BigDecimal cantidad, Long almacenId);
 
     Page<MovimientoInventarioResponseDTO> filtrar(
             LocalDateTime fechaInicio, LocalDateTime fechaFin,

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.config.InventoryVencidosProperties;
 import com.willyes.clemenintegra.inventario.dto.AtencionDTO;
+import com.willyes.clemenintegra.inventario.dto.LoteConsumoDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioFiltroDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
@@ -67,7 +68,9 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -95,6 +98,31 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     static final record MovimientoLoteDetalle(LoteProducto lote, BigDecimal cantidad) { }
 
     static final record ParLoteCantidad(Long loteId, BigDecimal cantidad) { }
+
+    private static final record FefoSelection(LoteProducto lote,
+                                             BigDecimal disponibleAntes,
+                                             BigDecimal tomar,
+                                             BigDecimal disponibleDespues) {
+
+        LoteConsumoDTO toDto() {
+            return LoteConsumoDTO.builder()
+                    .loteId(lote != null ? lote.getId() : null)
+                    .codigoLote(lote != null ? lote.getCodigoLote() : null)
+                    .fechaVencimiento(lote != null ? lote.getFechaVencimiento() : null)
+                    .almacenId(lote != null && lote.getAlmacen() != null
+                            ? lote.getAlmacen().getId().longValue()
+                            : null)
+                    .disponibleAntes(disponibleAntes)
+                    .tomar(tomar)
+                    .disponibleDespues(disponibleDespues)
+                    .build();
+        }
+    }
+
+    private static final EnumSet<EstadoLote> ESTADOS_FEFO_ELEGIBLES =
+            EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
+    private static final EnumSet<EstadoLote> ESTADOS_FEFO_NO_ELEGIBLES =
+            EnumSet.of(EstadoLote.VENCIDO, EstadoLote.RETENIDO, EstadoLote.EN_CUARENTENA);
     private final AlmacenRepository almacenRepository;
     private final ProductoRepository productoRepository;
     private final ProveedorRepository proveedorRepository;
@@ -1669,6 +1697,19 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                         throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_PERTENECE_ALMACEN_ORIGEN");
                     }
 
+                    BigDecimal disponibleActual = calcularDisponibleLote(loteAdicional);
+                    if (disponibleActual.compareTo(par.cantidad()) < 0) {
+                        log.warn("AUTO_SPLIT_DISPONIBLE_INSUFICIENTE loteId={} disponible={} requerido={}",
+                                loteAdicional.getId(), disponibleActual, par.cantidad());
+                        throw new CustomBusinessException(ApiErrorCode.STOCK_INSUFICIENTE,
+                                "Stock insuficiente en lote FEFO seleccionado",
+                                Map.of(
+                                        "loteId", loteAdicional.getId(),
+                                        "disponible", disponibleActual,
+                                        "requerido", par.cantidad()
+                                ));
+                    }
+
                     MovimientoLoteDetalle parcial = ejecutarTransferenciaDesdeLote(loteAdicional, destino, producto, par.cantidad(), solicitud);
                     detalles.add(parcial);
                     consumidos.add(new ParLoteCantidad(loteAdicional.getId(), par.cantidad()));
@@ -1900,46 +1941,20 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             return List.of();
         }
 
-        List<LoteProducto> candidatos = loteProductoRepository
-                .findByProductoIdAndAlmacenIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
-                        productoId,
-                        almacenOrigenId,
-                        List.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO));
+        Long almacenIdLong = almacenOrigenId != null ? almacenOrigenId.longValue() : null;
+        Collection<Long> excluidos = loteInicialId != null
+                ? Set.of(loteInicialId)
+                : Collections.emptySet();
 
-        List<ParLoteCantidad> resultado = new ArrayList<>();
-        BigDecimal restante = objetivo;
+        List<FefoSelection> selecciones = calcularSeleccionesFefo(
+                productoId,
+                objetivo,
+                almacenIdLong,
+                excluidos);
 
-        for (LoteProducto lote : candidatos) {
-            if (Objects.equals(lote.getId(), loteInicialId)) {
-                continue;
-            }
-            if (lote.isAgotado()) {
-                continue;
-            }
-            BigDecimal stock = Optional.ofNullable(lote.getStockLote()).orElse(BigDecimal.ZERO);
-            BigDecimal reservado = Optional.ofNullable(lote.getStockReservado()).orElse(BigDecimal.ZERO);
-            BigDecimal disponible = stock.subtract(reservado);
-            if (disponible.compareTo(BigDecimal.ZERO) <= 0) {
-                continue;
-            }
-            BigDecimal tomar = disponible.min(restante);
-            if (tomar.compareTo(BigDecimal.ZERO) > 0) {
-                resultado.add(new ParLoteCantidad(lote.getId(), tomar));
-                restante = restante.subtract(tomar);
-                if (restante.compareTo(BigDecimal.ZERO) <= 0) {
-                    break;
-                }
-            }
-        }
-
-        if (restante.compareTo(BigDecimal.ZERO) > 0) {
-            BigDecimal disponibleTotal = objetivo.subtract(restante);
-            log.warn("AUTO_SPLIT_STOCK_INSUFICIENTE productoId={} almacenOrigenId={} requerido={} disponible={}",
-                    productoId, almacenOrigenId, objetivo, disponibleTotal);
-            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "STOCK_INSUFICIENTE_EN_ALMACEN");
-        }
-
-        return resultado;
+        return selecciones.stream()
+                .map(sel -> new ParLoteCantidad(sel.lote().getId(), sel.tomar()))
+                .toList();
     }
 
     private Long resolveTipoMovimientoDetalleId(MovimientoInventarioDTO dto, Producto producto) {
@@ -2213,6 +2228,175 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
         solicitudMovimientoRepository.saveAndFlush(solicitud);
         return result;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LoteConsumoDTO> simulateFefo(Long productoId, BigDecimal cantidad, Long almacenId) {
+        if (productoId == null || productoId <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "PRODUCTO_ID_REQUERIDO");
+        }
+        if (cantidad == null || cantidad.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "CANTIDAD_INVALIDA");
+        }
+
+        Producto producto = productoRepository.findById(productoId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "PRODUCTO_NO_ENCONTRADO"));
+
+        int escalaPermitida = catalogResolver.decimals(producto.getUnidadMedida());
+        int escalaCantidad = Math.max(0, cantidad.stripTrailingZeros().scale());
+        if (escalaCantidad > escalaPermitida) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CANTIDAD_NO_COMPATIBLE_UDM");
+        }
+        BigDecimal normalizada = cantidad.setScale(Math.max(cantidad.scale(), escalaPermitida), RoundingMode.HALF_UP);
+
+        log.info("FEFO_PREVIEW productoId={} cantidad={} almacenId={}", productoId, normalizada, almacenId);
+
+        List<FefoSelection> selecciones = calcularSeleccionesFefo(
+                producto.getId().longValue(),
+                normalizada,
+                almacenId,
+                Collections.emptySet());
+
+        List<LoteConsumoDTO> consumos = selecciones.stream()
+                .map(FefoSelection::toDto)
+                .toList();
+
+        if (!consumos.isEmpty()) {
+            BigDecimal total = consumos.stream()
+                    .map(LoteConsumoDTO::getTomar)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            log.debug("FEFO_PREVIEW_LOTES productoId={} lotes={} total={}",
+                    productoId,
+                    consumos.stream().map(LoteConsumoDTO::getLoteId).toList(),
+                    total);
+        } else {
+            log.debug("FEFO_PREVIEW_LOTES productoId={} sin lotes elegibles", productoId);
+        }
+
+        return consumos;
+    }
+
+    private List<FefoSelection> calcularSeleccionesFefo(Long productoId,
+                                                         BigDecimal cantidad,
+                                                         Long almacenId,
+                                                         Collection<Long> lotesExcluidos) {
+        if (cantidad == null || cantidad.compareTo(BigDecimal.ZERO) <= 0) {
+            return List.of();
+        }
+
+        BigDecimal restante = cantidad;
+        List<LoteProducto> candidatos = cargarLotesFefo(productoId, almacenId);
+        if (candidatos.isEmpty()) {
+            if (hayLotesNoElegiblesConStock(productoId, almacenId)) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "LOTES_NO_ELEGIBLES");
+            }
+            return List.of();
+        }
+
+        List<FefoSelection> resultado = new ArrayList<>();
+        Collection<Long> excluidos = lotesExcluidos != null ? lotesExcluidos : Collections.emptySet();
+
+        for (LoteProducto lote : candidatos) {
+            if (excluidos.contains(lote.getId())) {
+                continue;
+            }
+            BigDecimal disponible = calcularDisponibleLote(lote);
+            if (disponible.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+            BigDecimal tomar = disponible.min(restante);
+            if (tomar.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+            BigDecimal despues = disponible.subtract(tomar);
+            if (despues.compareTo(BigDecimal.ZERO) < 0) {
+                despues = BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP);
+            }
+            resultado.add(new FefoSelection(lote, disponible, tomar, despues));
+            restante = restante.subtract(tomar);
+            if (restante.compareTo(BigDecimal.ZERO) <= 0) {
+                break;
+            }
+        }
+
+        if (resultado.isEmpty() && hayLotesNoElegiblesConStock(productoId, almacenId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "LOTES_NO_ELEGIBLES");
+        }
+
+        if (restante.compareTo(BigDecimal.ZERO) > 0) {
+            BigDecimal disponibleTotal = cantidad.subtract(restante);
+            log.warn("FEFO_STOCK_INSUFICIENTE productoId={} almacenId={} requerido={} disponible={}",
+                    productoId, almacenId, cantidad, disponibleTotal);
+            List<LoteConsumoDTO> detalle = resultado.stream()
+                    .map(FefoSelection::toDto)
+                    .toList();
+            Map<String, Object> details = new HashMap<>();
+            details.put("faltante", restante);
+            details.put("lotes", detalle);
+            throw new CustomBusinessException(ApiErrorCode.STOCK_INSUFICIENTE,
+                    "Stock insuficiente para consumo FEFO",
+                    details);
+        }
+
+        return resultado;
+    }
+
+    private List<LoteProducto> cargarLotesFefo(Long productoId, Long almacenId) {
+        List<LoteProducto> lotes;
+        if (almacenId != null) {
+            lotes = loteProductoRepository
+                    .findByProductoIdAndAlmacenIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
+                            productoId,
+                            Math.toIntExact(almacenId),
+                            ESTADOS_FEFO_ELEGIBLES);
+        } else {
+            lotes = loteProductoRepository
+                    .findByProductoIdAndEstadoInOrderByFechaVencimientoAscIdAsc(
+                            productoId,
+                            ESTADOS_FEFO_ELEGIBLES);
+        }
+        if (lotes == null || lotes.isEmpty()) {
+            return List.of();
+        }
+        Comparator<LoteProducto> comparator = Comparator
+                .comparing((LoteProducto l) -> Optional.ofNullable(l.getFechaVencimiento())
+                        .orElse(LocalDateTime.MAX))
+                .thenComparing(l -> Optional.ofNullable(l.getFechaLiberacion())
+                        .orElse(LocalDateTime.MIN))
+                .thenComparing(LoteProducto::getId);
+        lotes.sort(comparator);
+        return lotes;
+    }
+
+    private boolean hayLotesNoElegiblesConStock(Long productoId, Long almacenId) {
+        List<LoteProducto> noElegibles;
+        if (almacenId != null) {
+            noElegibles = loteProductoRepository.findByProductoIdAndAlmacenIdAndEstadoIn(
+                    productoId,
+                    Math.toIntExact(almacenId),
+                    ESTADOS_FEFO_NO_ELEGIBLES);
+        } else {
+            noElegibles = loteProductoRepository.findByProductoIdAndEstadoIn(
+                    productoId,
+                    ESTADOS_FEFO_NO_ELEGIBLES);
+        }
+        if (noElegibles == null || noElegibles.isEmpty()) {
+            return false;
+        }
+        return noElegibles.stream()
+                .map(this::calcularDisponibleLote)
+                .anyMatch(disponible -> disponible.compareTo(BigDecimal.ZERO) > 0);
+    }
+
+    private BigDecimal calcularDisponibleLote(LoteProducto lote) {
+        BigDecimal stock = Optional.ofNullable(lote.getStockLote()).orElse(BigDecimal.ZERO);
+        BigDecimal reservado = Optional.ofNullable(lote.getStockReservado()).orElse(BigDecimal.ZERO);
+        BigDecimal disponible = stock.subtract(reservado);
+        if (disponible.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP);
+        }
+        return disponible.setScale(6, RoundingMode.HALF_UP);
     }
 
     // =====================================

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/ApiErrorCode.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/ApiErrorCode.java
@@ -18,7 +18,8 @@ public enum ApiErrorCode {
     RECURSO_NO_ENCONTRADO(HttpStatus.NOT_FOUND),
     OPERACION_NO_PERMITIDA(HttpStatus.CONFLICT),
     ERROR_INTERNO(HttpStatus.INTERNAL_SERVER_ERROR),
-    NEGOCIO_GENERICO(HttpStatus.BAD_REQUEST);
+    NEGOCIO_GENERICO(HttpStatus.BAD_REQUEST),
+    STOCK_INSUFICIENTE(HttpStatus.BAD_REQUEST);
 
     private final HttpStatus httpStatus;
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceFefoTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceFefoTest.java
@@ -1,0 +1,133 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
+import com.willyes.clemenintegra.inventario.dto.LoteConsumoDTO;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MovimientoInventarioServiceFefoTest {
+
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private ProveedorRepository proveedorRepository;
+    @Mock
+    private OrdenCompraRepository ordenCompraRepository;
+    @Mock
+    private OrdenCompraService ordenCompraService;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private MovimientoInventarioMapper mapper;
+    @Mock
+    private UsuarioService usuarioService;
+    @Mock
+    private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock
+    private InventoryCatalogResolver catalogResolver;
+    @Mock
+    private ReservaLoteService reservaLoteService;
+    @Mock
+    private ReservaLoteRepository reservaLoteRepository;
+    @Mock
+    private RecepcionOCService recepcionOCService;
+    @Mock
+    private RetencionLoteService retencionLoteService;
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private MovimientoInventarioServiceImpl service;
+
+    @Test
+    void simulateFefo_ordenaPorVencimientoYDescartaEstadosNoElegibles() {
+        Producto producto = new Producto();
+        producto.setId(1);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(10L);
+        producto.setUnidadMedida(unidad);
+
+        when(productoRepository.findById(1L)).thenReturn(Optional.of(producto));
+        when(catalogResolver.decimals(unidad)).thenReturn(2);
+
+        LoteProducto primero = crearLote(1001L, "L1", EstadoLote.DISPONIBLE,
+                LocalDateTime.now().plusDays(5), new BigDecimal("100"), BigDecimal.ZERO, 1);
+        LoteProducto segundo = crearLote(1002L, "L2", EstadoLote.LIBERADO,
+                LocalDateTime.now().plusDays(10), new BigDecimal("80"), new BigDecimal("10"), 1);
+
+        List<LoteProducto> elegibles = new ArrayList<>(List.of(primero, segundo));
+        when(loteProductoRepository.findByProductoIdAndEstadoInOrderByFechaVencimientoAscIdAsc(eq(1L), any()))
+                .thenReturn(elegibles);
+        lenient().when(loteProductoRepository.findByProductoIdAndEstadoIn(eq(1L), any()))
+                .thenReturn(List.of());
+
+        List<LoteConsumoDTO> resultado = service.simulateFefo(1L, new BigDecimal("150"), null);
+
+        assertThat(resultado).hasSize(2);
+        LoteConsumoDTO primeroDto = resultado.get(0);
+        LoteConsumoDTO segundoDto = resultado.get(1);
+
+        assertThat(primeroDto.getLoteId()).isEqualTo(1001L);
+        assertThat(primeroDto.getTomar()).isEqualByComparingTo(new BigDecimal("100.000000"));
+        assertThat(primeroDto.getDisponibleDespues()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+
+        assertThat(segundoDto.getLoteId()).isEqualTo(1002L);
+        assertThat(segundoDto.getTomar()).isEqualByComparingTo(new BigDecimal("50.000000"));
+        assertThat(segundoDto.getDisponibleAntes()).isEqualByComparingTo(new BigDecimal("70.000000"));
+        assertThat(segundoDto.getDisponibleDespues()).isEqualByComparingTo(new BigDecimal("20.000000"));
+    }
+
+    private LoteProducto crearLote(Long id,
+                                   String codigo,
+                                   EstadoLote estado,
+                                   LocalDateTime vencimiento,
+                                   BigDecimal stock,
+                                   BigDecimal reservado,
+                                   Integer almacenId) {
+        LoteProducto lote = new LoteProducto();
+        lote.setId(id);
+        lote.setCodigoLote(codigo);
+        lote.setEstado(estado);
+        lote.setFechaVencimiento(vencimiento);
+        lote.setStockLote(stock);
+        lote.setStockReservado(reservado);
+        lote.setAlmacen(new Almacen(almacenId));
+        lote.setAgotado(false);
+        return lote;
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/InventarioFefoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/InventarioFefoControllerTest.java
@@ -1,0 +1,108 @@
+package com.willyes.clemenintegra.inventario.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.willyes.clemenintegra.inventario.controller.InventarioFefoController;
+import com.willyes.clemenintegra.inventario.dto.LoteConsumoDTO;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InventarioFefoController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
+class InventarioFefoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MovimientoInventarioService movimientoInventarioService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @Test
+    @DisplayName("GET /api/inventario/fefo/preview devuelve lotes ordenados y total")
+    void previewFefo_ok() throws Exception {
+        LoteConsumoDTO primero = LoteConsumoDTO.builder()
+                .loteId(10L)
+                .codigoLote("L1")
+                .fechaVencimiento(LocalDateTime.now().plusDays(5))
+                .almacenId(2L)
+                .disponibleAntes(new BigDecimal("500.000000"))
+                .tomar(new BigDecimal("500.000000"))
+                .disponibleDespues(BigDecimal.ZERO.setScale(6))
+                .build();
+        LoteConsumoDTO segundo = LoteConsumoDTO.builder()
+                .loteId(11L)
+                .codigoLote("L2")
+                .fechaVencimiento(LocalDateTime.now().plusDays(15))
+                .almacenId(2L)
+                .disponibleAntes(new BigDecimal("600.000000"))
+                .tomar(new BigDecimal("400.000000"))
+                .disponibleDespues(new BigDecimal("200.000000"))
+                .build();
+
+        when(movimientoInventarioService.simulateFefo(eq(1L), any(BigDecimal.class), eq(2L)))
+                .thenReturn(List.of(primero, segundo));
+
+        mockMvc.perform(get("/api/inventario/fefo/preview")
+                        .param("productoId", "1")
+                        .param("cantidad", "900")
+                        .param("almacenId", "2")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.consumos[0].loteId").value(10))
+                .andExpect(jsonPath("$.consumos[1].tomar").value(400.000000))
+                .andExpect(jsonPath("$.totalTomar").value(900.000000));
+    }
+
+    @Test
+    @DisplayName("GET /api/inventario/fefo/preview retorna 400 cuando hay stock insuficiente")
+    void previewFefo_stockInsuficiente() throws Exception {
+        CustomBusinessException exception = new CustomBusinessException(
+                ApiErrorCode.STOCK_INSUFICIENTE,
+                "Stock insuficiente",
+                Map.of("faltante", new BigDecimal("100"))
+        );
+        when(movimientoInventarioService.simulateFefo(eq(1L), any(BigDecimal.class), org.mockito.ArgumentMatchers.isNull()))
+                .thenThrow(exception);
+
+        mockMvc.perform(get("/api/inventario/fefo/preview")
+                        .param("productoId", "1")
+                        .param("cantidad", "1200")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("STOCK_INSUFICIENTE"))
+                .andExpect(jsonPath("$.message").value("Stock insuficiente"));
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs and controller for the `/api/inventario/fefo/preview` dry-run endpoint with validation and logging
- centralize FEFO selection in `MovimientoInventarioService` to reuse the same algorithm for previews and real movements
- extend repository lookups, expose `STOCK_INSUFICIENTE`, and add focused smoke tests for the new flow

## Testing
- mvn -Dtest=MovimientoInventarioServiceFefoTest,InventarioFefoControllerTest test

------
https://chatgpt.com/codex/tasks/task_e_69012d74af588333a2e6d14330e31f9a