### PR TITLE
feat(producción): trazabilidad y código de error para insuficiencia de stock

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -9,6 +9,8 @@ import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -22,6 +24,8 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class FormulaProductoServiceImpl implements FormulaProductoService {
+
+    private static final Logger log = LoggerFactory.getLogger(FormulaProductoServiceImpl.class);
 
     private final FormulaProductoRepository formulaRepository;
     private final BomMapper bomMapper;
@@ -152,6 +156,11 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                     } else {
                         motivo = "SIN_STOCK";
                     }
+                    log.info("FORMULA_DISPONIBILIDAD insumoId={} requerido={} disponible={} motivo={}",
+                            insumoId,
+                            totalNecesaria,
+                            disponibilidad.getDisponible(),
+                            motivo);
                 }
 
                 dto.stockDisponible = disponibilidad.getDisponible();

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -75,6 +75,9 @@ public class OrdenProduccionController {
     public ResponseEntity<ResultadoValidacionOrdenDTO> crear(@RequestBody OrdenProduccionRequestDTO request) {
         ResultadoValidacionOrdenDTO resultado = service.crearOrden(request);
         HttpStatus status = resultado.isEsValida() ? HttpStatus.CREATED : HttpStatus.BAD_REQUEST;
+        if (!resultado.isEsValida()) {
+            resultado.setCode("STOCK_INSUFICIENTE");
+        }
         return new ResponseEntity<>(resultado, status);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ResultadoValidacionOrdenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ResultadoValidacionOrdenDTO.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.produccion.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,4 +20,7 @@ public class ResultadoValidacionOrdenDTO {
     private List<InsumoFaltanteDTO> insumosFaltantes;
     private OrdenProduccionResponseDTO orden;
     private BigDecimal unidadesProducidas;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String code;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -309,6 +309,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 maxProducible = producibleConEste;
             }
 
+            log.debug("OP-VALIDACION insumoId={} requerido={} disponible={} maxProducible={}",
+                    insumoId,
+                    cantidadRequerida,
+                    stockDisponible,
+                    maxProducible);
+
             if (stockDisponible.compareTo(cantidadRequerida) < 0) {
                 stockSuficiente = false;
                 faltantes.add(InsumoFaltanteDTO.builder()
@@ -789,6 +795,10 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         }
 
         if (lotesSeleccionados.isEmpty()) {
+            log.warn("OP-RESERVA sin lotes elegibles ordenId={} insumoId={} requerida={}",
+                    ordenId,
+                    insumoId,
+                    requerida);
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                     "STOCK_INSUFICIENTE: faltan " + requerida);
         }
@@ -874,6 +884,10 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 detallesSolicitud = new ArrayList<>();
                 solicitud.setDetalles(detallesSolicitud);
             } else {
+                log.debug("OP-RESERVA antes limpiar: detallesPrevios={} ordenId={} insumoId={}",
+                        detallesSolicitud.size(),
+                        ordenId,
+                        insumoId);
                 detallesSolicitud.clear();
             }
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -1,0 +1,136 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.willyes.clemenintegra.produccion.dto.InsumoFaltanteDTO;
+import com.willyes.clemenintegra.produccion.dto.OrdenProduccionRequestDTO;
+import com.willyes.clemenintegra.produccion.dto.OrdenProduccionResponseDTO;
+import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
+import com.willyes.clemenintegra.produccion.service.OrdenProduccionService;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = OrdenProduccionController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+@ImportAutoConfiguration(exclude = {
+        SecurityAutoConfiguration.class,
+        SecurityFilterAutoConfiguration.class,
+        UserDetailsServiceAutoConfiguration.class
+})
+@TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
+class OrdenProduccionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private OrdenProduccionService ordenProduccionService;
+
+    @MockBean
+    private UsuarioService usuarioService;
+
+    @MockBean
+    private MovimientoInventarioService movimientoInventarioService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    private OrdenProduccionRequestDTO buildRequest() {
+        LocalDateTime inicio = LocalDateTime.now().minusHours(1);
+        LocalDateTime fin = LocalDateTime.now().plusHours(1);
+        return OrdenProduccionRequestDTO.builder()
+                .fechaInicio(inicio)
+                .fechaFin(fin)
+                .cantidadProgramada(BigDecimal.TEN)
+                .cantidadProducida(BigDecimal.ZERO)
+                .estado("CREADA")
+                .productoId(1L)
+                .responsableId(2L)
+                .unidadMedidaSimbolo("kg")
+                .build();
+    }
+
+    @Test
+    @DisplayName("POST /api/produccion/ordenes retorna 201 cuando la validación es correcta")
+    void crearOrden_valida() throws Exception {
+        OrdenProduccionResponseDTO orden = new OrdenProduccionResponseDTO();
+        orden.id = 99L;
+        orden.codigoOrden = "OP-123";
+
+        ResultadoValidacionOrdenDTO respuesta = ResultadoValidacionOrdenDTO.builder()
+                .esValida(true)
+                .mensaje("ok")
+                .orden(orden)
+                .build();
+
+        when(ordenProduccionService.crearOrden(any(OrdenProduccionRequestDTO.class))).thenReturn(respuesta);
+
+        mockMvc.perform(post("/api/produccion/ordenes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(buildRequest())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.esValida").value(true))
+                .andExpect(jsonPath("$.code").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("POST /api/produccion/ordenes retorna 400 con code STOCK_INSUFICIENTE")
+    void crearOrden_insuficiente() throws Exception {
+        ResultadoValidacionOrdenDTO respuesta = ResultadoValidacionOrdenDTO.builder()
+                .esValida(false)
+                .mensaje("Stock insuficiente para algunos insumos")
+                .unidadesMaximasProducibles(5)
+                .insumosFaltantes(List.of(
+                        InsumoFaltanteDTO.builder()
+                                .productoId(10L)
+                                .nombre("Extracto X")
+                                .requerido(new BigDecimal("12.5"))
+                                .disponible(new BigDecimal("8.0"))
+                                .unidadSimbolo("kg")
+                                .build()
+                ))
+                .build();
+
+        when(ordenProduccionService.crearOrden(any(OrdenProduccionRequestDTO.class))).thenReturn(respuesta);
+
+        mockMvc.perform(post("/api/produccion/ordenes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(buildRequest())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.esValida").value(false))
+                .andExpect(jsonPath("$.code").value("STOCK_INSUFICIENTE"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -1,0 +1,114 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.inventario.service.*;
+import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.repository.*;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrdenProduccionServiceImplTest {
+
+    @Mock private FormulaProductoRepository formulaProductoRepository;
+    @Mock private ProductoRepository productoRepository;
+    @Mock private StockQueryService stockQueryService;
+    @Mock private UsuarioRepository usuarioRepository;
+    @Mock private SolicitudMovimientoService solicitudMovimientoService;
+    @Mock private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock private CierreProduccionRepository cierreProduccionRepository;
+    @Mock private MovimientoInventarioService movimientoInventarioService;
+    @Mock private LoteProductoRepository loteProductoRepository;
+    @Mock private AlmacenRepository almacenRepository;
+    @Mock private UnidadConversionService unidadConversionService;
+    @Mock private EtapaProduccionRepository etapaProduccionRepository;
+    @Mock private EtapaPlantillaRepository etapaPlantillaRepository;
+    @Mock private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock private MovimientoInventarioMapper movimientoInventarioMapper;
+    @Mock private UsuarioService usuarioService;
+    @Mock private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    @Mock private InventoryCatalogResolver catalogResolver;
+    @Mock private UmValidator umValidator;
+    @Mock private VidaUtilProductoRepository vidaUtilProductoRepository;
+    @Mock private ReservaLoteService reservaLoteService;
+
+    @InjectMocks
+    private OrdenProduccionServiceImpl service;
+
+    @Test
+    @DisplayName("guardarConValidacionStock retorna faltantes y max producible cuando stock es insuficiente")
+    void guardarConValidacionStock_retornaFaltantes() {
+        Producto producto = new Producto();
+        producto.setId(1);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setSimbolo("kg");
+        producto.setUnidadMedida(unidad);
+
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setProducto(producto);
+        orden.setCantidadProgramada(new BigDecimal("10"));
+
+        Producto insumo = new Producto();
+        insumo.setId(2);
+        insumo.setNombre("Extracto X");
+        UnidadMedida unidadInsumo = new UnidadMedida();
+        unidadInsumo.setSimbolo("kg");
+        insumo.setUnidadMedida(unidadInsumo);
+        CategoriaProducto categoriaInsumo = new CategoriaProducto();
+        categoriaInsumo.setTipo(TipoCategoria.MATERIA_PRIMA);
+        insumo.setCategoriaProducto(categoriaInsumo);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(insumo);
+        detalle.setCantidadNecesaria(BigDecimal.ONE);
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(detalle));
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(1L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+        when(productoRepository.findAllById(any()))
+                .thenReturn(List.of(insumo));
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(99L);
+        when(catalogResolver.getAlmacenOrigenMateriaPrimaId()).thenReturn(5L);
+        when(stockQueryService.obtenerStockDisponible(eq(List.of(2L)), eq(List.of(5L))))
+                .thenReturn(Map.of(2L, new BigDecimal("8")));
+
+        ResultadoValidacionOrdenDTO resultado = service.guardarConValidacionStock(orden);
+
+        assertThat(resultado.isEsValida()).isFalse();
+        assertThat(resultado.getUnidadesMaximasProducibles()).isEqualTo(8);
+        assertThat(resultado.getInsumosFaltantes()).hasSize(1);
+        assertThat(resultado.getInsumosFaltantes().get(0).getProductoId()).isEqualTo(2L);
+        assertThat(resultado.getInsumosFaltantes().get(0).getRequerido()).isEqualByComparingTo(new BigDecimal("10"));
+        assertThat(resultado.getInsumosFaltantes().get(0).getDisponible()).isEqualByComparingTo(new BigDecimal("8"));
+    }
+}


### PR DESCRIPTION
## Summary
- add availability telemetry to the fórmula activa response when an insumo is bloqueante
- record validation/reserva metrics during OP stock checks and FEFO selection
- surface an optional `code` field in ResultadoValidacionOrdenDTO and return `STOCK_INSUFICIENTE` on 400 responses
- cover the controller contract and insuficiente stock calculation with focused tests

## Testing
- mvn -q -Dtest='OrdenProduccionControllerTest,OrdenProduccionServiceImplTest' test

------
https://chatgpt.com/codex/tasks/task_e_69028fc084a88333a790edd7e269cfaf