### PR TITLE
Agregar autocompletado paginado para proveedores

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProveedorController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProveedorController.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.inventario.dto.ProveedorRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ProveedorResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.ProveedorMapper;
 import com.willyes.clemenintegra.inventario.model.Proveedor;
+import com.willyes.clemenintegra.inventario.proveedor.dto.ProveedorAutocompleteDTO;
 import com.willyes.clemenintegra.inventario.repository.ProveedorRepository;
 import com.willyes.clemenintegra.inventario.service.ProveedorService;
 import com.willyes.clemenintegra.shared.dto.ErrorResponseDTO;
@@ -20,6 +21,9 @@ import io.swagger.v3.oas.annotations.media.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/proveedores")
@@ -55,6 +59,23 @@ public class ProveedorController {
     public ResponseEntity<Page<ProveedorResponseDTO>> listar(
             @PageableDefault(size = 10) Pageable pageable) {
         return ResponseEntity.ok(proveedorService.listar(pageable));
+    }
+
+    @GetMapping("/autocomplete")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Page<ProveedorAutocompleteDTO>> autocomplete(
+            @RequestParam("term") String term,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+
+        String sanitizedTerm = term != null ? term.trim() : "";
+        if (sanitizedTerm.length() < 2) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "El término de búsqueda debe tener al menos 2 caracteres");
+        }
+
+        PageRequest pageable = PageRequest.of(page, size, Sort.by("nombre").ascending());
+        return ResponseEntity.ok(proveedorService.buscarAutocomplete(sanitizedTerm, pageable));
     }
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/proveedor/dto/ProveedorAutocompleteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/proveedor/dto/ProveedorAutocompleteDTO.java
@@ -1,0 +1,19 @@
+package com.willyes.clemenintegra.inventario.proveedor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProveedorAutocompleteDTO {
+
+    private Long id;
+    private String label;
+    private String nit;
+    private String ciudad;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProveedorRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProveedorRepository.java
@@ -1,7 +1,11 @@
 package com.willyes.clemenintegra.inventario.repository;
 
 import com.willyes.clemenintegra.inventario.model.Proveedor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,5 +14,8 @@ public interface ProveedorRepository extends JpaRepository<Proveedor, Long> {
     Optional<Proveedor> findByIdentificacion(String identificacion);
     boolean existsByIdentificacion(String identificacion);
     boolean existsByEmail(String email);
+
+    @Query("SELECT p FROM Proveedor p WHERE LOWER(p.nombre) LIKE LOWER(CONCAT('%', :term, '%'))")
+    Page<Proveedor> findByProveedorContainingIgnoreCase(@Param("term") String term, Pageable pageable);
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProveedorService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProveedorService.java
@@ -1,9 +1,11 @@
 package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.ProveedorResponseDTO;
+import com.willyes.clemenintegra.inventario.proveedor.dto.ProveedorAutocompleteDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProveedorService {
     Page<ProveedorResponseDTO> listar(Pageable pageable);
+    Page<ProveedorAutocompleteDTO> buscarAutocomplete(String term, Pageable pageable);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProveedorServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProveedorServiceImpl.java
@@ -2,6 +2,8 @@ package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.ProveedorResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.ProveedorMapper;
+import com.willyes.clemenintegra.inventario.model.Proveedor;
+import com.willyes.clemenintegra.inventario.proveedor.dto.ProveedorAutocompleteDTO;
 import com.willyes.clemenintegra.inventario.repository.ProveedorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,5 +20,21 @@ public class ProveedorServiceImpl implements ProveedorService {
     @Override
     public Page<ProveedorResponseDTO> listar(Pageable pageable) {
         return repository.findAll(pageable).map(mapper::toDTO);
+    }
+
+    @Override
+    public Page<ProveedorAutocompleteDTO> buscarAutocomplete(String term, Pageable pageable) {
+        return repository.findByProveedorContainingIgnoreCase(term, pageable)
+                .map(this::mapToAutocompleteDto);
+    }
+
+    private ProveedorAutocompleteDTO mapToAutocompleteDto(Proveedor proveedor) {
+        Long id = proveedor.getId() != null ? proveedor.getId().longValue() : null;
+        return ProveedorAutocompleteDTO.builder()
+                .id(id)
+                .label(proveedor.getNombre())
+                .nit(proveedor.getIdentificacion())
+                .ciudad(proveedor.getCiudad())
+                .build();
     }
 }

--- a/src/main/resources/db/migration/V20251115__proveedores_idx_nombre.sql
+++ b/src/main/resources/db/migration/V20251115__proveedores_idx_nombre.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_proveedores_nombre ON proveedores (proveedor);

--- a/src/test/java/com/willyes/clemenintegra/inventario/proveedor/ProveedorControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/proveedor/ProveedorControllerTest.java
@@ -1,0 +1,98 @@
+package com.willyes.clemenintegra.inventario.proveedor;
+
+import com.willyes.clemenintegra.inventario.controller.ProveedorController;
+import com.willyes.clemenintegra.inventario.mapper.ProveedorMapper;
+import com.willyes.clemenintegra.inventario.proveedor.dto.ProveedorAutocompleteDTO;
+import com.willyes.clemenintegra.inventario.repository.ProveedorRepository;
+import com.willyes.clemenintegra.inventario.service.ProveedorService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProveedorController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
+class ProveedorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProveedorService proveedorService;
+
+    @MockBean
+    private ProveedorRepository proveedorRepository;
+
+    @MockBean
+    private ProveedorMapper proveedorMapper;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    @DisplayName("GET /api/proveedores/autocomplete retorna 200 y contenido paginado cuando term es válido")
+    void autocomplete_deberiaRetornarResultados() throws Exception {
+        ProveedorAutocompleteDTO dto = ProveedorAutocompleteDTO.builder()
+                .id(1L)
+                .label("Colombia Insumos")
+                .nit("900123456")
+                .ciudad("Bogotá")
+                .build();
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ProveedorAutocompleteDTO> page = new PageImpl<>(List.of(dto), pageable, 1);
+
+        when(proveedorService.buscarAutocomplete(eq("col"), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/proveedores/autocomplete")
+                        .param("term", "col")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].label").value("Colombia Insumos"))
+                .andExpect(jsonPath("$.content[0].nit").value("900123456"))
+                .andExpect(jsonPath("$.content[0].ciudad").value("Bogotá"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    @DisplayName("GET /api/proveedores/autocomplete retorna 400 cuando term tiene menos de dos caracteres")
+    void autocomplete_deberiaRetornarBadRequestCuandoTermEsCorto() throws Exception {
+        mockMvc.perform(get("/api/proveedores/autocomplete")
+                        .param("term", "c"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/proveedor/ProveedorRepositoryTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/proveedor/ProveedorRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.willyes.clemenintegra.inventario.proveedor;
+
+import com.willyes.clemenintegra.inventario.model.Proveedor;
+import com.willyes.clemenintegra.inventario.repository.ProveedorRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=none",
+        "spring.flyway.enabled=false",
+        "spring.jpa.properties.hibernate.hbm2ddl.auto=none",
+        "spring.jpa.defer-datasource-initialization=true",
+        "DB_SECURPASS=dummy",
+        "DB_SECURNAME=dummy"
+})
+@Sql(scripts = "classpath:sql/proveedor-schema.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class ProveedorRepositoryTest {
+
+    @Autowired
+    private ProveedorRepository proveedorRepository;
+
+    @Test
+    @DisplayName("findByProveedorContainingIgnoreCase aplica paginación y ordena por nombre")
+    void findByProveedorContainingIgnoreCase_deberiaRespetarPaginacionYOrden() {
+        proveedorRepository.save(Proveedor.builder()
+                .nombre("Colombia Insumos")
+                .identificacion("900111111")
+                .telefono("1111111")
+                .ciudad("Bogotá")
+                .email("contacto1@demo.com")
+                .direccion("Calle 1")
+                .paginaWeb(null)
+                .nombreContacto("Ana Perez")
+                .activo(true)
+                .build());
+
+        proveedorRepository.save(Proveedor.builder()
+                .nombre("Andes Componentes")
+                .identificacion("900222222")
+                .telefono("2222222")
+                .ciudad("Medellín")
+                .email("contacto2@demo.com")
+                .direccion("Calle 2")
+                .paginaWeb(null)
+                .nombreContacto("Luis Gomez")
+                .activo(true)
+                .build());
+
+        proveedorRepository.save(Proveedor.builder()
+                .nombre("Colorantes Andinos")
+                .identificacion("900333333")
+                .telefono("3333333")
+                .ciudad("Cali")
+                .email("contacto3@demo.com")
+                .direccion("Calle 3")
+                .paginaWeb(null)
+                .nombreContacto("Maria Ruiz")
+                .activo(true)
+                .build());
+
+        Pageable pageable = PageRequest.of(0, 2, Sort.by("nombre").ascending());
+
+        Page<Proveedor> page = proveedorRepository.findByProveedorContainingIgnoreCase("co", pageable);
+
+        assertThat(page.getContent()).hasSize(2);
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.getContent().get(0).getNombre()).isEqualTo("Andes Componentes");
+        assertThat(page.getContent().get(1).getNombre()).isEqualTo("Colombia Insumos");
+    }
+}

--- a/src/test/resources/sql/proveedor-schema.sql
+++ b/src/test/resources/sql/proveedor-schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS proveedores (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    proveedor VARCHAR(100) NOT NULL,
+    nit_cedula VARCHAR(20) NOT NULL,
+    telefono_contacto VARCHAR(20),
+    ciudad VARCHAR(120),
+    email VARCHAR(100),
+    direccion VARCHAR(150),
+    pagina_web VARCHAR(150),
+    nombre_contacto VARCHAR(100) NOT NULL,
+    activo BIT NOT NULL,
+    CONSTRAINT uk_proveedores_nombre UNIQUE (proveedor),
+    CONSTRAINT uk_proveedores_nit UNIQUE (nit_cedula),
+    CONSTRAINT uk_proveedores_email UNIQUE (email)
+);


### PR DESCRIPTION
## Summary
- agregar DTO liviano y servicio para búsquedas paginadas de proveedores
- exponer el nuevo endpoint protegido /api/proveedores/autocomplete y consultar el repositorio por coincidencia parcial
- crear migración opcional para el índice y pruebas unitarias/integración para el controlador y repositorio

## Testing
- mvn -Dtest='*Proveedor*Test' test

------
https://chatgpt.com/codex/tasks/task_e_6902a9b7735c8333a5894457ec3580f8