### PR TITLE
Normaliza reservas FEFO y refuerza smoke tests

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/PasswordEncoderUtil.java
+++ b/src/main/java/com/willyes/clemenintegra/PasswordEncoderUtil.java
@@ -1,8 +1,10 @@
 package com.willyes.clemenintegra;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+@Slf4j
 public class PasswordEncoderUtil {
 
     public static void main(String[] args) {
@@ -12,8 +14,8 @@ public class PasswordEncoderUtil {
         PasswordEncoder encoder = new BCryptPasswordEncoder();
         String encodedPassword = encoder.encode(rawPassword);
 
-        System.out.println("Contraseña original: " + rawPassword);
-        System.out.println("Contraseña codificada: " + encodedPassword);
+        log.info("Contraseña original: {}", rawPassword);
+        log.info("Contraseña codificada: {}", encodedPassword);
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
@@ -44,6 +44,7 @@ public class LoteProductoController {
     }
 
     @GetMapping("/estado/{estado}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_JEFE_CALIDAD', 'ROL_SUPER_ADMIN')")
     public ResponseEntity<List<LoteProductoResponseDTO>> listarPorEstado(@PathVariable String estado) {
         List<LoteProductoResponseDTO> lotes = service.obtenerLotesPorEstado(estado);
         return ResponseEntity.ok(lotes);

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteFefoDisponibleProjection.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteFefoDisponibleProjection.java
@@ -13,4 +13,5 @@ public interface LoteFefoDisponibleProjection {
     LocalDateTime getFechaVencimiento();
     Long getAlmacenId();
     String getNombreAlmacen();
+    String getEstado();
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
@@ -8,15 +8,20 @@ import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import org.mapstruct.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ProductoMapper {
 
+    Logger LOG = LoggerFactory.getLogger(ProductoMapper.class);
+
     default ProductoResponseDTO safeToDto(Producto producto) {
         if (producto == null) {
-            System.out.println("❌ Producto nulo detectado");
+            LOG.warn("Producto nulo detectado al mapear a DTO");
             return null;
         }
         return toDto(producto);

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -120,7 +120,8 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
                (lp.stock_lote - lp.stock_reservado) AS stockLote,
                lp.fecha_vencimiento AS fechaVencimiento,
                lp.almacenes_id AS almacenId,
-               a.nombre AS nombreAlmacen
+               a.nombre AS nombreAlmacen,
+               lp.estado AS estado
         FROM lotes_productos lp
         LEFT JOIN almacenes a ON lp.almacenes_id = a.id
         WHERE lp.productos_id = :productoId

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -102,7 +102,8 @@ public class ProductoServiceImpl implements ProductoService {
     @Transactional(readOnly = true)
     public Page<ProductoResponseDTO> listarTodos(String nombre, String sku, Long categoriaProductoId, Boolean activo, Pageable pageable) {
 
-        System.out.println("🟢 Entró correctamente a ProductoServiceImpl.listarTodos()");
+        log.debug("Listando productos con filtros nombre={}, sku={}, categoriaId={}, activo={}",
+                nombre, sku, categoriaProductoId, activo);
 
         Specification<Producto> spec = Specification
                 .where(nombreContains(nombre))
@@ -111,7 +112,7 @@ public class ProductoServiceImpl implements ProductoService {
                 .and(activoEquals(activo));
 
         Page<Producto> productos = productoRepository.findAll(spec, pageable);
-        System.out.println("▶️ Total productos devueltos: " + productos.getTotalElements());
+        log.debug("Total de productos devueltos: {}", productos.getTotalElements());
 
         List<Long> ids = productos.getContent().stream()
                 .map(p -> p.getId().longValue())
@@ -120,9 +121,9 @@ public class ProductoServiceImpl implements ProductoService {
 
         productos.forEach(p -> {
             if (p == null) {
-                System.out.println("⚠️ Producto nulo detectado");
+                log.warn("Producto nulo detectado durante listado");
             } else {
-                System.out.println("📦 Producto cargado: " + p.getId() + " - " + p.getNombre());
+                log.debug("Producto cargado en listado: id={} nombre={}", p.getId(), p.getNombre());
             }
         });
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,9 +18,11 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class ReservaLoteService {
 
     private final ReservaLoteRepository reservaLoteRepository;
     private final LoteProductoRepository loteProductoRepository;
+    private final SolicitudMovimientoRepository solicitudMovimientoRepository;
 
     @Transactional
     public void sincronizarReservasSolicitud(SolicitudMovimiento solicitud) {
@@ -170,6 +174,62 @@ public class ReservaLoteService {
         ReservaLote guardada = reservaLoteRepository.save(reserva);
         recalcularStockReservado(lote);
         return guardada;
+    }
+
+    @Transactional
+    public void liberarReservasPorOrden(Long ordenProduccionId) {
+        if (ordenProduccionId == null) {
+            return;
+        }
+        List<SolicitudMovimiento> solicitudes = Optional.ofNullable(
+                solicitudMovimientoRepository.findWithDetalles(ordenProduccionId, null, null, null)
+        ).orElse(List.of());
+        if (solicitudes.isEmpty()) {
+            return;
+        }
+
+        Set<Long> lotesARecalcular = new HashSet<>();
+        for (SolicitudMovimiento solicitud : solicitudes) {
+            if (solicitud.getDetalles() == null) {
+                continue;
+            }
+            for (SolicitudMovimientoDetalle detalle : solicitud.getDetalles()) {
+                if (detalle.getId() == null) {
+                    continue;
+                }
+                List<ReservaLote> reservas = reservaLoteRepository.findBySolicitudMovimientoDetalleId(detalle.getId());
+                for (ReservaLote reserva : reservas) {
+                    if (reserva.getEstado() == EstadoReservaLote.CONSUMIDA) {
+                        continue;
+                    }
+                    BigDecimal reservada = Optional.ofNullable(reserva.getCantidadReservada())
+                            .orElse(BigDecimal.ZERO)
+                            .setScale(6, RoundingMode.HALF_UP);
+                    BigDecimal consumida = Optional.ofNullable(reserva.getCantidadConsumida())
+                            .orElse(BigDecimal.ZERO)
+                            .setScale(6, RoundingMode.HALF_UP);
+                    if (consumida.compareTo(reservada) > 0) {
+                        consumida = reservada;
+                    }
+                    reserva.setCantidadReservada(reservada);
+                    reserva.setCantidadConsumida(consumida);
+                    reserva.setEstado(EstadoReservaLote.CANCELADA);
+                    reservaLoteRepository.save(reserva);
+                    if (reserva.getLote() != null && reserva.getLote().getId() != null) {
+                        lotesARecalcular.add(reserva.getLote().getId());
+                    }
+                }
+            }
+        }
+
+        for (Long loteId : lotesARecalcular) {
+            loteProductoRepository.findByIdForUpdate(loteId)
+                    .ifPresent(this::recalcularStockReservado);
+        }
+
+        if (!lotesARecalcular.isEmpty()) {
+            log.info("Reservas liberadas para orden {} en {} lotes", ordenProduccionId, lotesARecalcular.size());
+        }
     }
 
     private BigDecimal calcularPendiente(ReservaLote reserva) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -18,20 +18,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-
-import com.willyes.clemenintegra.shared.model.Usuario;
-import com.willyes.clemenintegra.shared.service.UsuarioService;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-
-
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -63,6 +53,7 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> obtenerPorId(@PathVariable Long id) {
         return service.buscarPorId(id)
                 .map(ProduccionMapper::toResponse)

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -77,6 +77,7 @@ import org.springframework.http.ProblemDetail;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -134,6 +135,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             TipoCategoria.MATERIA_PRIMA, InventoryCatalogResolver::getAlmacenOrigenMateriaPrimaId,
             TipoCategoria.MATERIAL_EMPAQUE, InventoryCatalogResolver::getAlmacenOrigenMaterialEmpaqueId,
             TipoCategoria.SUMINISTROS, InventoryCatalogResolver::getAlmacenOrigenSuministrosId);
+
+    private static final EnumSet<EstadoLote> ESTADOS_FEFO_PERMITIDOS = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
 
     private String generarCodigoOrden() {
         String fecha = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
@@ -553,6 +556,9 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 if (lotesConReserva > 0) {
                     log.warn("OP-cierre stock_reservado sin solicitud pendiente op={}, lotes={}", orden.getId(), lotesConReserva);
                 }
+                if (dto.getTipo() == TipoCierre.TOTAL) {
+                    reservaLoteService.liberarReservasPorOrden(orden.getId());
+                }
             }
 
             Long motivoEntradaId = catalogResolver.getMotivoIdEntradaProductoTerminado();
@@ -803,6 +809,17 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     "STOCK_INSUFICIENTE: faltan " + requerida);
         }
 
+        lotesSeleccionados.stream()
+                .map(LoteFefoDisponibleProjection::getEstado)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(this::parseEstadoLoteSafe)
+                .filter(Objects::nonNull)
+                .filter(estado -> !ESTADOS_FEFO_PERMITIDOS.contains(estado))
+                .findFirst()
+                .ifPresent(estado -> log.warn("OP-reserva detectó lote en estado no permitido: {}", estado));
+
         Long primerLoteId = lotesSeleccionados.get(0).getLoteProductoId();
         if (primerLoteId == null) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
@@ -810,6 +827,15 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         }
 
         return lotesSeleccionados;
+    }
+
+    private EstadoLote parseEstadoLoteSafe(String valor) {
+        try {
+            return EstadoLote.valueOf(valor.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            log.warn("Estado de lote desconocido recibido en FEFO: {}", valor);
+            return null;
+        }
     }
 
     @Transactional(rollbackFor = Exception.class)
@@ -847,7 +873,10 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
         for (DetalleFormula insumo : formula.getDetalles()) {
             Long insumoId = insumo.getInsumo().getId().longValue();
-            BigDecimal requerida = insumo.getCantidadNecesaria().multiply(orden.getCantidadProgramada());
+            BigDecimal requerida = insumo.getCantidadNecesaria()
+                    .multiply(orden.getCantidadProgramada())
+                    .setScale(8, RoundingMode.HALF_UP);
+            BigDecimal requeridaSolicitud = requerida.setScale(2, RoundingMode.HALF_UP);
             List<Long> almacenesValidos = obtenerAlmacenesOrigen(insumo.getInsumo());
 
             List<LoteFefoDisponibleProjection> lotesSeleccionados = seleccionarLotesFefo(
@@ -859,7 +888,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     .tipoMovimiento(TipoMovimiento.SALIDA)
                     .productoId(insumoId)
                     .loteId(primerLoteId)
-                    .cantidad(requerida)
+                    .cantidad(requeridaSolicitud)
                     .ordenProduccionId(orden.getId())
                     .usuarioSolicitanteId(usuario.getId())
                     .motivoMovimientoId(motivo.getId())
@@ -897,22 +926,25 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 if (restante.compareTo(BigDecimal.ZERO) <= 0) {
                     break;
                 }
-                BigDecimal disponible = lote.getStockLote();
+                BigDecimal disponible = Optional.ofNullable(lote.getStockLote()).orElse(BigDecimal.ZERO);
                 BigDecimal usar = disponible.min(restante);
                 if (usar.compareTo(BigDecimal.ZERO) <= 0) {
                     continue;
                 }
 
+                BigDecimal usarCalculo = usar.setScale(8, RoundingMode.HALF_UP);
+                BigDecimal usarDetalle = usarCalculo.setScale(6, RoundingMode.HALF_UP);
+
                 SolicitudMovimientoDetalle detSolicitud = SolicitudMovimientoDetalle.builder()
                         .solicitudMovimiento(solicitud)
                         .lote(new LoteProducto(lote.getLoteProductoId()))
-                        .cantidad(usar)
+                        .cantidad(usarDetalle)
                         .almacenOrigen(lote.getAlmacenId() != null ? new Almacen(Math.toIntExact(lote.getAlmacenId())) : null)
                         .almacenDestino(solicitud.getAlmacenDestino())
                         .build();
                 detallesSolicitud.add(detSolicitud);
 
-                restante = restante.subtract(usar);
+                restante = restante.subtract(usarCalculo).setScale(8, RoundingMode.HALF_UP);
             }
 
             if (restante.compareTo(BigDecimal.ZERO) > 0) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteServiceTest.java
@@ -1,0 +1,107 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.ReservaLote;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReservaLoteServiceTest {
+
+    @Mock
+    private ReservaLoteRepository reservaLoteRepository;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private SolicitudMovimientoRepository solicitudMovimientoRepository;
+
+    @InjectMocks
+    private ReservaLoteService service;
+
+    @Test
+    @DisplayName("crearOActualizarDesdeDetalle normaliza cantidades a escala 6")
+    void crearOActualizarDesdeDetalle_normalizaEscala() {
+        SolicitudMovimientoDetalle detalle = SolicitudMovimientoDetalle.builder()
+                .id(10L)
+                .cantidad(new BigDecimal("3.45678901"))
+                .lote(LoteProducto.builder().id(5L).build())
+                .build();
+
+        LoteProducto lote = LoteProducto.builder()
+                .id(5L)
+                .stockLote(new BigDecimal("10"))
+                .almacen(new Almacen())
+                .build();
+
+        when(loteProductoRepository.findByIdForUpdate(5L)).thenReturn(Optional.of(lote));
+        when(reservaLoteRepository.findByDetalleIdAndLoteIdForUpdate(10L, 5L)).thenReturn(Optional.empty());
+        when(reservaLoteRepository.sumPendienteByLoteId(eq(5L), any())).thenReturn(BigDecimal.ZERO);
+        when(reservaLoteRepository.save(any(ReservaLote.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ReservaLote reserva = service.crearOActualizarDesdeDetalle(detalle);
+
+        assertThat(reserva.getCantidadReservada().scale()).isEqualTo(6);
+        assertThat(reserva.getCantidadReservada()).isEqualByComparingTo(new BigDecimal("3.456789"));
+        assertThat(reserva.getCantidadConsumida()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("liberarReservasPorOrden cancela reservas activas y recalcula stock")
+    void liberarReservasPorOrden_cancelaReservas() {
+        SolicitudMovimientoDetalle detalle = new SolicitudMovimientoDetalle();
+        detalle.setId(20L);
+        LoteProducto lote = LoteProducto.builder().id(8L).stockLote(new BigDecimal("15")).build();
+        SolicitudMovimiento solicitud = new SolicitudMovimiento();
+        solicitud.setId(99L);
+        solicitud.setDetalles(List.of(detalle));
+
+        ReservaLote reserva = ReservaLote.builder()
+                .id(30L)
+                .lote(lote)
+                .cantidadReservada(new BigDecimal("4.000000"))
+                .cantidadConsumida(BigDecimal.ZERO)
+                .estado(EstadoReservaLote.ACTIVA)
+                .solicitudMovimientoDetalle(detalle)
+                .build();
+
+        when(solicitudMovimientoRepository.findWithDetalles(1L, null, null, null))
+                .thenReturn(List.of(solicitud));
+        when(reservaLoteRepository.findBySolicitudMovimientoDetalleId(20L))
+                .thenReturn(List.of(reserva));
+        when(reservaLoteRepository.save(any(ReservaLote.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(loteProductoRepository.findByIdForUpdate(8L)).thenReturn(Optional.of(lote));
+        when(reservaLoteRepository.sumPendienteByLoteId(eq(8L), any())).thenReturn(BigDecimal.ZERO);
+
+        service.liberarReservasPorOrden(1L);
+
+        ArgumentCaptor<ReservaLote> captor = ArgumentCaptor.forClass(ReservaLote.class);
+        verify(reservaLoteRepository).save(captor.capture());
+        ReservaLote actualizado = captor.getValue();
+        assertThat(actualizado.getEstado()).isEqualTo(EstadoReservaLote.CANCELADA);
+        assertThat(actualizado.getCantidadConsumida()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+        verify(loteProductoRepository).findByIdForUpdate(8L);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/LoteProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/LoteProductoControllerSmokeTest.java
@@ -1,0 +1,97 @@
+package com.willyes.clemenintegra.inventario.web;
+
+import com.willyes.clemenintegra.inventario.controller.LoteProductoController;
+import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LoteProductoController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
+class LoteProductoControllerSmokeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LoteProductoService loteProductoService;
+    @MockBean
+    private LoteProductoRepository loteProductoRepository;
+    @MockBean
+    private LoteProductoMapper loteProductoMapper;
+    @MockBean
+    private EvaluacionCalidadService evaluacionCalidadService;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    @DisplayName("GET /api/lotes devuelve 200 con contenido paginado")
+    void listarLotes_devuelvePagina() throws Exception {
+        LoteProductoResponseDTO dto = LoteProductoResponseDTO.builder()
+                .id(1L)
+                .codigoLote("L-001")
+                .estado(EstadoLote.DISPONIBLE)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<LoteProductoResponseDTO> page = new PageImpl<>(List.of(dto), pageable, 1);
+        when(loteProductoService.listarTodos(any(), any(), any(), any(), any(), any(), any(Pageable.class)))
+                .thenReturn(page);
+
+        mockMvc.perform(get("/api/lotes")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].codigoLote").value("L-001"))
+                .andExpect(jsonPath("$.content[0].estado").value("DISPONIBLE"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    @DisplayName("GET /api/lotes/estado/{estado} devuelve lista simple")
+    void listarPorEstado_devuelveLista() throws Exception {
+        LoteProductoResponseDTO dto = LoteProductoResponseDTO.builder()
+                .id(2L)
+                .codigoLote("L-002")
+                .estado(EstadoLote.LIBERADO)
+                .build();
+        when(loteProductoService.obtenerLotesPorEstado("LIBERADO")).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/lotes/estado/LIBERADO"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].estado").value("LIBERADO"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ReporteInventarioControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ReporteInventarioControllerSmokeTest.java
@@ -1,0 +1,79 @@
+package com.willyes.clemenintegra.inventario.web;
+
+import com.willyes.clemenintegra.inventario.controller.ReporteInventarioController;
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import com.willyes.clemenintegra.inventario.service.ProductoService;
+import com.willyes.clemenintegra.inventario.service.ReporteInventarioService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReporteInventarioController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
+class ReporteInventarioControllerSmokeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReporteInventarioService reporteInventarioService;
+    @MockBean
+    private ProductoService productoService;
+    @MockBean
+    private LoteProductoService loteProductoService;
+    @MockBean
+    private MovimientoInventarioService movimientoInventarioService;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    @DisplayName("GET /api/reportes/alta-rotacion responde 200 y cabecera de adjunto")
+    void altaRotacion_devuelveExcel() throws Exception {
+        when(reporteInventarioService.generarReporteAltaRotacion(any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(new XSSFWorkbook());
+
+        mockMvc.perform(get("/api/reportes/alta-rotacion")
+                        .param("fechaInicio", "2024-01-01")
+                        .param("fechaFin", "2024-01-31"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", "attachment; filename=alta_rotacion.xlsx"))
+                .andExpect(header().string("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    @DisplayName("GET /api/reportes/productos-por-vencer responde 200 con adjunto")
+    void productosPorVencer_devuelveExcel() throws Exception {
+        when(loteProductoService.generarReporteLotesPorVencerExcel(any(), any()))
+                .thenReturn(new XSSFWorkbook());
+
+        mockMvc.perform(get("/api/reportes/productos-por-vencer")
+                        .param("fechaInicio", "2024-02-01")
+                        .param("fechaFin", "2024-02-10"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", "attachment; filename=lotes_por_vencer.xlsx"))
+                .andExpect(header().string("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -1,0 +1,328 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
+import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoResponseDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MotivoMovimiento;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.TipoMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MotivoMovimientoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
+import com.willyes.clemenintegra.inventario.repository.TipoMovimientoDetalleRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import com.willyes.clemenintegra.inventario.service.ReservaLoteService;
+import com.willyes.clemenintegra.inventario.service.SolicitudMovimientoService;
+import com.willyes.clemenintegra.inventario.service.StockQueryService;
+import com.willyes.clemenintegra.inventario.service.UmValidator;
+import com.willyes.clemenintegra.inventario.model.VidaUtilProducto;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.produccion.dto.CierreProduccionRequestDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.TipoCierre;
+import com.willyes.clemenintegra.produccion.repository.CierreProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.inventario.repository.VidaUtilProductoRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OrdenProduccionServiceReservaTest {
+
+    @Mock private FormulaProductoRepository formulaProductoRepository;
+    @Mock private ProductoRepository productoRepository;
+    @Mock private StockQueryService stockQueryService;
+    @Mock private UsuarioRepository usuarioRepository;
+    @Mock private SolicitudMovimientoService solicitudMovimientoService;
+    @Mock private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock private CierreProduccionRepository cierreProduccionRepository;
+    @Mock private MovimientoInventarioService movimientoInventarioService;
+    @Mock private LoteProductoRepository loteProductoRepository;
+    @Mock private AlmacenRepository almacenRepository;
+    @Mock private UnidadConversionService unidadConversionService;
+    @Mock private EtapaProduccionRepository etapaProduccionRepository;
+    @Mock private EtapaPlantillaRepository etapaPlantillaRepository;
+    @Mock private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock private com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper movimientoInventarioMapper;
+    @Mock private UsuarioService usuarioService;
+    @Mock private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    @Mock private InventoryCatalogResolver catalogResolver;
+    @Mock private UmValidator umValidator;
+    @Mock private VidaUtilProductoRepository vidaUtilProductoRepository;
+    @Mock private ReservaLoteService reservaLoteService;
+
+    @InjectMocks
+    private OrdenProduccionServiceImpl service;
+
+    private OrdenProduccion orden;
+    private Producto productoInsumo;
+
+    @BeforeEach
+    void setUp() {
+        orden = new OrdenProduccion();
+        orden.setId(1L);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+        Producto producto = new Producto();
+        producto.setId(10);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setSimbolo("kg");
+        producto.setUnidadMedida(unidad);
+        producto.setTipoAnalisis(com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.NINGUNO);
+        com.willyes.clemenintegra.inventario.model.CategoriaProducto categoriaPt = new com.willyes.clemenintegra.inventario.model.CategoriaProducto();
+        categoriaPt.setTipo(TipoCategoria.PRODUCTO_TERMINADO);
+        producto.setCategoriaProducto(categoriaPt);
+        producto.setNombre("Producto Final");
+        orden.setProducto(producto);
+        orden.setCantidadProgramada(new BigDecimal("5.5"));
+
+        productoInsumo = new Producto();
+        productoInsumo.setId(50);
+        productoInsumo.setNombre("INSUMO-X");
+        productoInsumo.setCategoriaProducto(new com.willyes.clemenintegra.inventario.model.CategoriaProducto());
+        productoInsumo.getCategoriaProducto().setTipo(TipoCategoria.MATERIA_PRIMA);
+
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenAnswer(invocation -> Optional.of(crearFormula()));
+        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), any(), eq(null), eq(null)))
+                .thenReturn(List.of());
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(99L);
+        when(catalogResolver.getAlmacenOrigenMateriaPrimaId()).thenReturn(5L);
+        Usuario usuario = new Usuario();
+        usuario.setId(7L);
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        MotivoMovimiento motivo = new MotivoMovimiento();
+        motivo.setId(11L);
+        when(motivoMovimientoRepository.findByMotivo(ClasificacionMovimientoInventario.SALIDA_PRODUCCION))
+                .thenReturn(Optional.of(motivo));
+        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
+        tipoDetalle.setId(33L);
+        when(tipoMovimientoDetalleRepository.findById(anyLong())).thenReturn(Optional.of(tipoDetalle));
+        lenient().when(solicitudMovimientoRepository.findById(100L)).thenReturn(Optional.of(crearSolicitudBase()));
+        lenient().when(solicitudMovimientoRepository.saveAndFlush(any(SolicitudMovimiento.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().doNothing().when(reservaLoteService).sincronizarReservasSolicitud(any(SolicitudMovimiento.class));
+        ReflectionTestUtils.setField(service, "estadosSolicitudPendientesConf", "PENDIENTE");
+        ReflectionTestUtils.setField(service, "estadosSolicitudConcluyentesConf", "EJECUTADA");
+        ReflectionTestUtils.setField(service, "clasificacionEntradaPtConf", "ENTRADA_PRODUCTO_TERMINADO");
+    }
+
+    @Test
+    @DisplayName("reservarInsumosParaOP genera detalles multi-lote con escala ajustada")
+    void reservarInsumosParaOp_creaDetallesMultiLote() {
+        when(solicitudMovimientoService.registrarSolicitud(any(SolicitudMovimientoRequestDTO.class)))
+                .thenReturn(SolicitudMovimientoResponseDTO.builder().id(100L).build());
+        when(loteProductoRepository.findFefoDisponibles(50L, Integer.MAX_VALUE))
+                .thenReturn(List.of(
+                        loteFefo(200L, new BigDecimal("3.123456"), "DISPONIBLE"),
+                        loteFefo(201L, new BigDecimal("10.000000"), "LIBERADO")
+                ));
+
+        service.reservarInsumosParaOP(1L);
+
+        ArgumentCaptor<SolicitudMovimientoRequestDTO> dtoCaptor = ArgumentCaptor.forClass(SolicitudMovimientoRequestDTO.class);
+        verify(solicitudMovimientoService).registrarSolicitud(dtoCaptor.capture());
+        assertThat(dtoCaptor.getValue().getCantidad()).isEqualByComparingTo(new BigDecimal("6.79"));
+
+        ArgumentCaptor<SolicitudMovimiento> solicitudCaptor = ArgumentCaptor.forClass(SolicitudMovimiento.class);
+        verify(solicitudMovimientoRepository).saveAndFlush(solicitudCaptor.capture());
+        List<SolicitudMovimientoDetalle> detalles = solicitudCaptor.getValue().getDetalles();
+        assertThat(detalles).hasSize(2);
+        BigDecimal total = detalles.stream()
+                .map(SolicitudMovimientoDetalle::getCantidad)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(detalles.get(0).getCantidad().scale()).isEqualTo(6);
+        assertThat(detalles.get(1).getCantidad().scale()).isEqualTo(6);
+        assertThat(total).isEqualByComparingTo(new BigDecimal("6.790123"));
+        verify(reservaLoteService).sincronizarReservasSolicitud(solicitudCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("reservarInsumosParaOP falla con 422 cuando no hay lotes elegibles")
+    void reservarInsumosParaOp_sinLotesLanzaError() {
+        when(loteProductoRepository.findFefoDisponibles(50L, Integer.MAX_VALUE)).thenReturn(List.of());
+        assertThatThrownBy(() -> service.reservarInsumosParaOP(1L))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+        verify(reservaLoteService, never()).sincronizarReservasSolicitud(any());
+    }
+
+    @Test
+    @DisplayName("registrarCierre total sin pendientes libera reservas")
+    void registrarCierre_totalSinPendientesLiberaReservas() {
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("1.25"))
+                .tipo(TipoCierre.TOTAL)
+                .build();
+
+        when(umValidator.ajustar(any(BigDecimal.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(umValidator.getRoundingMode()).thenReturn(RoundingMode.HALF_UP);
+        when(catalogResolver.decimals(any(UnidadMedida.class))).thenReturn(6);
+        when(catalogResolver.getMotivoIdDevolucionDesdeProduccion()).thenReturn(70L);
+        MotivoMovimiento motivoDev = new MotivoMovimiento();
+        motivoDev.setId(70L);
+        when(motivoMovimientoRepository.findById(70L)).thenReturn(Optional.of(motivoDev));
+        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), eq(null), eq(null), eq(null)))
+                .thenReturn(List.of());
+        when(catalogResolver.getMotivoIdEntradaProductoTerminado()).thenReturn(80L);
+        MotivoMovimiento motivoEntrada = new MotivoMovimiento();
+        motivoEntrada.setId(80L);
+        when(motivoMovimientoRepository.findById(80L)).thenReturn(Optional.of(motivoEntrada));
+        when(catalogResolver.getTipoDetalleEntradaId()).thenReturn(90L);
+        TipoMovimientoDetalle tipoDetalleEntrada = new TipoMovimientoDetalle();
+        tipoDetalleEntrada.setId(90L);
+        when(tipoMovimientoDetalleRepository.findById(90L)).thenReturn(Optional.of(tipoDetalleEntrada));
+        EtapaProduccion etapa = new EtapaProduccion();
+        etapa.setEstado(EstadoEtapa.FINALIZADA);
+        etapa.setFechaInicio(LocalDateTime.now().minusDays(2));
+        when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(1L))
+                .thenReturn(List.of(etapa));
+        when(vidaUtilProductoRepository.findById(10)).thenReturn(Optional.of(VidaUtilProducto.builder()
+                .productoId(10)
+                .semanasVigencia(4)
+                .build()));
+        when(ordenProduccionRepository.findTopByLoteProduccionStartingWithOrderByLoteProduccionDesc(any(String.class)))
+                .thenReturn(Optional.empty());
+        Almacen almacenPt = new Almacen();
+        almacenPt.setId(1);
+        Almacen almacenCuarentena = new Almacen();
+        almacenCuarentena.setId(2);
+        when(catalogResolver.getAlmacenPtId()).thenReturn(1L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(2L);
+        when(almacenRepository.findById(1L)).thenReturn(Optional.of(almacenPt));
+        when(almacenRepository.findById(2L)).thenReturn(Optional.of(almacenCuarentena));
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(1L, 10L)).thenReturn(Optional.empty());
+        when(loteProductoRepository.findByCodigoLote(any())).thenReturn(Optional.empty());
+        when(loteProductoRepository.save(any(LoteProducto.class))).thenAnswer(invocation -> {
+            LoteProducto lote = invocation.getArgument(0);
+            lote.setId(555L);
+            return lote;
+        });
+        Usuario usuario = new Usuario();
+        usuario.setId(7L);
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), any(), eq(null), eq(null)))
+                .thenReturn(List.of());
+        when(movimientoInventarioService.registrarMovimiento(any())).thenReturn(new MovimientoInventarioResponseDTO());
+        orden.setCodigoOrden("OP-001");
+
+        service.registrarCierre(1L, dto);
+
+        verify(reservaLoteService).liberarReservasPorOrden(1L);
+    }
+
+    private FormulaProducto crearFormula() {
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(productoInsumo);
+        detalle.setCantidadNecesaria(new BigDecimal("1.23456789"));
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(detalle));
+        return formula;
+    }
+
+    private SolicitudMovimiento crearSolicitudBase() {
+        SolicitudMovimiento solicitud = new SolicitudMovimiento();
+        solicitud.setId(100L);
+        solicitud.setDetalles(new ArrayList<>());
+        Almacen destino = new Almacen();
+        destino.setId(9);
+        solicitud.setAlmacenDestino(destino);
+        return solicitud;
+    }
+
+    private LoteFefoDisponibleProjection loteFefo(Long id, BigDecimal stock, String estado) {
+        return new LoteFefoDisponibleProjection() {
+            @Override
+            public Long getLoteProductoId() {
+                return id;
+            }
+
+            @Override
+            public String getCodigoLote() {
+                return "L" + id;
+            }
+
+            @Override
+            public BigDecimal getStockLote() {
+                return stock;
+            }
+
+            @Override
+            public LocalDateTime getFechaVencimiento() {
+                return LocalDateTime.now().plusDays(30);
+            }
+
+            @Override
+            public Long getAlmacenId() {
+                return 5L;
+            }
+
+            @Override
+            public String getNombreAlmacen() {
+                return "MP";
+            }
+
+            @Override
+            public String getEstado() {
+                return estado;
+            }
+        };
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
@@ -1,0 +1,78 @@
+package com.willyes.clemenintegra.produccion.web;
+
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import com.willyes.clemenintegra.produccion.controller.OrdenProduccionController;
+import com.willyes.clemenintegra.produccion.service.OrdenProduccionService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OrdenProduccionController.class)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
+@Import(SecurityConfig.class)
+class OrdenProduccionControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OrdenProduccionService ordenProduccionService;
+    @MockBean
+    private UsuarioService usuarioService;
+    @MockBean
+    private MovimientoInventarioService movimientoInventarioService;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void configureFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    @DisplayName("GET /api/produccion/ordenes/{id} sin rol permitido devuelve 403")
+    void obtenerOrden_sinPermisos_devuelve403() throws Exception {
+        mockMvc.perform(get("/api/produccion/ordenes/{id}", 1L))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+MAIL_HOST=localhost
+MAIL_PORT=1025

--- a/src/test/resources/sql/proveedor-schema.sql
+++ b/src/test/resources/sql/proveedor-schema.sql
@@ -1,0 +1,1 @@
+-- placeholder script for proveedor tests


### PR DESCRIPTION
## Summary
- ajusta las reservas FEFO para trabajar con escala 8/6, valida estados permitidos y libera reservas en cierres totales
- reemplaza System.out por logging estructurado y restringe los endpoints sensibles de lotes y producción con @PreAuthorize
- amplía la cobertura con pruebas unitarias de reservas/cierres y smoke tests de inventario y seguridad

## Testing
- mvn -q -Dtest=OrdenProduccionServiceReservaTest test
- mvn -q -Dtest=ReservaLoteServiceTest test
- mvn -q -Dtest=LoteProductoControllerSmokeTest test
- mvn -q -Dtest=ReporteInventarioControllerSmokeTest test
- mvn -q -Dtest=OrdenProduccionControllerSecurityTest test

------
https://chatgpt.com/codex/tasks/task_e_6904eb944c448333ba9d3f703de55dfe