### PR TITLE
fix: align solicitud de movimiento precision and strengthen smoke tests

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -876,7 +876,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             BigDecimal requerida = insumo.getCantidadNecesaria()
                     .multiply(orden.getCantidadProgramada())
                     .setScale(8, RoundingMode.HALF_UP);
-            BigDecimal requeridaSolicitud = requerida.setScale(2, RoundingMode.HALF_UP);
+            BigDecimal requeridaSolicitud = requerida.setScale(6, RoundingMode.HALF_UP);
             List<Long> almacenesValidos = obtenerAlmacenesOrigen(insumo.getInsumo());
 
             List<LoteFefoDisponibleProjection> lotesSeleccionados = seleccionarLotesFefo(

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/LoteProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/LoteProductoControllerSmokeTest.java
@@ -72,7 +72,8 @@ class LoteProductoControllerSmokeTest {
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content").exists())
                 .andExpect(jsonPath("$.content[0].codigoLote").value("L-001"))
                 .andExpect(jsonPath("$.content[0].estado").value("DISPONIBLE"))
                 .andExpect(jsonPath("$.totalElements").value(1));
@@ -91,7 +92,8 @@ class LoteProductoControllerSmokeTest {
 
         mockMvc.perform(get("/api/lotes/estado/LIBERADO"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").exists())
                 .andExpect(jsonPath("$[0].estado").value("LIBERADO"));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ReporteInventarioControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ReporteInventarioControllerSmokeTest.java
@@ -8,6 +8,7 @@ import com.willyes.clemenintegra.inventario.service.ReporteInventarioService;
 import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
 import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,8 +24,7 @@ import java.time.LocalDate;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ReporteInventarioController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -58,6 +58,7 @@ class ReporteInventarioControllerSmokeTest {
                         .param("fechaInicio", "2024-01-01")
                         .param("fechaFin", "2024-01-31"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", Matchers.containsString("attachment")))
                 .andExpect(header().string("Content-Disposition", "attachment; filename=alta_rotacion.xlsx"))
                 .andExpect(header().string("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
     }
@@ -73,6 +74,7 @@ class ReporteInventarioControllerSmokeTest {
                         .param("fechaInicio", "2024-02-01")
                         .param("fechaFin", "2024-02-10"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", Matchers.containsString("attachment")))
                 .andExpect(header().string("Content-Disposition", "attachment; filename=lotes_por_vencer.xlsx"))
                 .andExpect(header().string("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
     }

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
@@ -75,4 +75,11 @@ class OrdenProduccionControllerSecurityTest {
         mockMvc.perform(get("/api/produccion/ordenes/{id}", 1L))
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    @DisplayName("GET /api/produccion/ordenes/{id} sin autenticación devuelve 403")
+    void obtenerOrden_sinAutenticacion_devuelve403() throws Exception {
+        mockMvc.perform(get("/api/produccion/ordenes/{id}", 1L))
+                .andExpect(status().isForbidden());
+    }
 }


### PR DESCRIPTION
## Summary
- adjust solicitud de movimiento quantity rounding to 6 decimal places to preserve precision
- expand smoke tests for inventory reports and lot listings with header and payload assertions
- add forbidden expectation for unauthenticated access in the production orders security suite

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905049bee9c8333bb46b0b324e95761