### PR TITLE
feat: permitir liberación condicionada en calidad

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
@@ -18,6 +18,11 @@ public class EvaluacionConsolidadaResponseDTO {
     private String nombreProducto;
     private String estadoLote;
     private String tipoAnalisisCalidad;
+    private String tipoAnalisisRequerido;
+    private boolean fisicoQuimicoCargado;
+    private boolean microbiologicoCargado;
+    private boolean evaluacionesRequeridasCompletas;
+    private String resultadoGlobal;
     private List<EvaluacionSimpleDTO> evaluaciones;
 
     /**

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
@@ -6,7 +6,10 @@ import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionSimpleDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaResponseDTO;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.stereotype.Component;
 
@@ -74,16 +77,93 @@ public class EvaluacionCalidadMapper {
                                                              java.util.List<EvaluacionCalidad> evaluaciones) {
         if (lote == null) return null;
 
+        java.util.List<EvaluacionCalidad> evals = (evaluaciones == null)
+                ? java.util.List.of()
+                : evaluaciones;
+
+        java.util.Map<TipoEvaluacion, java.util.List<EvaluacionCalidad>> agrupado = evals.stream()
+                .collect(java.util.stream.Collectors.groupingBy(EvaluacionCalidad::getTipoEvaluacion));
+
+        java.util.List<EvaluacionCalidad> fisicos = agrupado.getOrDefault(TipoEvaluacion.FISICO, java.util.List.of());
+        java.util.List<EvaluacionCalidad> micros = agrupado.getOrDefault(TipoEvaluacion.QUIMICO_MICROBIOLOGICO, java.util.List.of());
+
+        boolean fisicoCargado = !fisicos.isEmpty();
+        boolean microCargado = !micros.isEmpty();
+
+        boolean fisicoConforme = fisicos.stream().anyMatch(e -> e.getResultado() == ResultadoEvaluacion.CONFORME);
+        boolean microConforme = micros.stream().anyMatch(e -> e.getResultado() == ResultadoEvaluacion.CONFORME);
+
+        boolean fisicoAnyOk = fisicos.stream().anyMatch(e ->
+                e.getResultado() == ResultadoEvaluacion.CONFORME ||
+                        e.getResultado() == ResultadoEvaluacion.CONDICIONADO);
+
+        boolean microAnyOk = micros.stream().anyMatch(e ->
+                e.getResultado() == ResultadoEvaluacion.CONFORME ||
+                        e.getResultado() == ResultadoEvaluacion.CONDICIONADO);
+
+        boolean algunNoConforme = evals.stream().anyMatch(e -> e.getResultado() == ResultadoEvaluacion.NO_CONFORME);
+
+        TipoAnalisisCalidad tipoAnalisis = lote.getProducto().getTipoAnalisisCalidad();
+
+        boolean completas;
+        if (tipoAnalisis == null) {
+            completas = false;
+        } else {
+            completas = switch (tipoAnalisis) {
+                case NINGUNO -> true;
+                case FISICO -> fisicoAnyOk;
+                case QUIMICO_MICROBIOLOGICO -> microAnyOk;
+                case AMBOS -> fisicoAnyOk && microAnyOk;
+            };
+        }
+
+        String resultadoGlobal;
+        if (tipoAnalisis == null) {
+            resultadoGlobal = "DESCONOCIDO";
+        } else if (tipoAnalisis == TipoAnalisisCalidad.NINGUNO) {
+            resultadoGlobal = "NO_REQUERIDO";
+        } else if (algunNoConforme) {
+            resultadoGlobal = ResultadoEvaluacion.NO_CONFORME.name();
+        } else if (switch (tipoAnalisis) {
+            case FISICO -> fisicoConforme;
+            case QUIMICO_MICROBIOLOGICO -> microConforme;
+            case AMBOS -> fisicoConforme && microConforme;
+            default -> false;
+        }) {
+            resultadoGlobal = ResultadoEvaluacion.CONFORME.name();
+        } else if (completas) {
+            resultadoGlobal = ResultadoEvaluacion.CONDICIONADO.name();
+        } else {
+            boolean avances = ((tipoAnalisis == TipoAnalisisCalidad.FISICO || tipoAnalisis == TipoAnalisisCalidad.AMBOS) && fisicoCargado)
+                    || ((tipoAnalisis == TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO || tipoAnalisis == TipoAnalisisCalidad.AMBOS) && microCargado);
+            resultadoGlobal = avances ? "EN_PROCESO" : "PENDIENTE";
+        }
+
         return EvaluacionConsolidadaResponseDTO.builder()
                 .id(lote.getId())
                 .nombreLote(lote.getCodigoLote())
                 .nombreProducto(lote.getProducto().getNombre())
                 .estadoLote(lote.getEstado().name())
-                .tipoAnalisisCalidad(lote.getProducto().getTipoAnalisisCalidad().name())
-                .evaluaciones(evaluaciones == null ? java.util.List.of() :
-                        evaluaciones.stream()
-                                .map(this::toSimpleDTO)
-                                .toList())
+                .tipoAnalisisCalidad(tipoAnalisis != null ? tipoAnalisis.name() : null)
+                .tipoAnalisisRequerido(mapearAnalisisRequerido(tipoAnalisis))
+                .fisicoQuimicoCargado(fisicoCargado)
+                .microbiologicoCargado(microCargado)
+                .evaluacionesRequeridasCompletas(completas)
+                .resultadoGlobal(resultadoGlobal)
+                .evaluaciones(evals.stream()
+                        .map(this::toSimpleDTO)
+                        .toList())
                 .build();
+    }
+
+    private String mapearAnalisisRequerido(TipoAnalisisCalidad tipoAnalisis) {
+        if (tipoAnalisis == null) {
+            return null;
+        }
+        return switch (tipoAnalisis) {
+            case FISICO -> "FISICO_QUIMICO";
+            case QUIMICO_MICROBIOLOGICO -> "MICROBIOLOGICO";
+            default -> tipoAnalisis.name();
+        };
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -152,17 +152,16 @@ public class LoteProductoServiceImpl implements LoteProductoService {
 
         return lotes.stream()
                 .map(lote -> {
-                    List<TipoEvaluacion> evaluaciones = evaluacionRepository.findByLoteProductoId(lote.getId())
-                            .stream()
-                            .map(EvaluacionCalidad::getTipoEvaluacion)
-                            .collect(Collectors.toList());
+                    List<EvaluacionCalidad> evaluaciones = evaluacionRepository.findByLoteProductoId(lote.getId());
 
                     if (tieneEvaluacionesRequeridas(lote.getProducto().getTipoAnalisis(), evaluaciones)) {
                         return null;
                     }
 
                     LoteProductoResponseDTO dto = loteProductoMapper.toDto(lote);
-                    dto.setEvaluaciones(evaluaciones);
+                    dto.setEvaluaciones(evaluaciones.stream()
+                            .map(EvaluacionCalidad::getTipoEvaluacion)
+                            .toList());
                     return dto;
                 })
                 .filter(java.util.Objects::nonNull)
@@ -184,12 +183,29 @@ public class LoteProductoServiceImpl implements LoteProductoService {
                 .toList();
     }
 
-    private boolean tieneEvaluacionesRequeridas(TipoAnalisisCalidad requerido, List<TipoEvaluacion> evaluaciones) {
+    private boolean tieneEvaluacionesRequeridas(TipoAnalisisCalidad requerido, List<EvaluacionCalidad> evaluaciones) {
+        if (requerido == null) {
+            return false;
+        }
+        if (requerido == TipoAnalisisCalidad.NINGUNO) {
+            return true;
+        }
+        List<EvaluacionCalidad> seguras = evaluaciones == null ? List.of() : evaluaciones;
+
+        boolean fisicoOk = seguras.stream().anyMatch(e ->
+                e.getTipoEvaluacion() == TipoEvaluacion.FISICO &&
+                        (e.getResultado() == ResultadoEvaluacion.CONFORME
+                                || e.getResultado() == ResultadoEvaluacion.CONDICIONADO));
+
+        boolean microOk = seguras.stream().anyMatch(e ->
+                e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO &&
+                        (e.getResultado() == ResultadoEvaluacion.CONFORME
+                                || e.getResultado() == ResultadoEvaluacion.CONDICIONADO));
+
         return switch (requerido) {
-            case FISICO -> evaluaciones.contains(TipoEvaluacion.FISICO);
-            case QUIMICO_MICROBIOLOGICO -> evaluaciones.contains(TipoEvaluacion.QUIMICO_MICROBIOLOGICO);
-            case AMBOS -> evaluaciones.contains(TipoEvaluacion.FISICO)
-                    && evaluaciones.contains(TipoEvaluacion.QUIMICO_MICROBIOLOGICO);
+            case FISICO -> fisicoOk;
+            case QUIMICO_MICROBIOLOGICO -> microOk;
+            case AMBOS -> fisicoOk && microOk;
             default -> false;
         };
     }
@@ -558,11 +574,19 @@ public class LoteProductoServiceImpl implements LoteProductoService {
                     "Falta registrar la evaluación requerida antes de liberar el lote.",
                     Map.of("tipoEvaluacion", tipo.name()));
         }
-        boolean aprobadas = filtradas.stream()
-                .allMatch(e -> e.getResultado() != ResultadoEvaluacion.NO_CONFORME);
-        if (!aprobadas) {
+        boolean existeNoConforme = filtradas.stream()
+                .anyMatch(e -> e.getResultado() == ResultadoEvaluacion.NO_CONFORME);
+        if (existeNoConforme) {
             throw new CustomBusinessException(ApiErrorCode.EVALUACIONES_FALTANTES,
-                    "La evaluación requerida no está aprobada.",
+                    "Existe al menos una evaluación NO_CONFORME.",
+                    Map.of("tipoEvaluacion", tipo.name()));
+        }
+        boolean existeOk = filtradas.stream()
+                .anyMatch(e -> e.getResultado() == ResultadoEvaluacion.CONFORME
+                        || e.getResultado() == ResultadoEvaluacion.CONDICIONADO);
+        if (!existeOk) {
+            throw new CustomBusinessException(ApiErrorCode.EVALUACIONES_FALTANTES,
+                    "Se requiere evaluación CONFORME o CONDICIONADO para liberar el lote.",
                     Map.of("tipoEvaluacion", tipo.name()));
         }
     }


### PR DESCRIPTION
## Summary
- expone en el consolidado de evaluaciones las banderas necesarias y calcula resultadoGlobal considerando CONFORME o CONDICIONADO
- permite que los lotes salgan del listado "por evaluar" cuando cumplen los requisitos con CONFORME o CONDICIONADO
- valida la liberación de lotes bloqueando NO_CONFORME y aceptando resultados CONFORME o CONDICIONADO

## Testing
- mvn -DskipTests=true package

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b75e8a788333b6c15832bb4adb3b)