### PR TITLE
Enable multiple quality evaluations per lot

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
@@ -65,7 +65,7 @@ public class EvaluacionCalidadController {
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<EvaluacionCalidadResponseDTO> crear(
             @ModelAttribute @Valid EvaluacionCalidadRequestDTO dto,
             @RequestPart(value = "archivos", required = false) java.util.List<MultipartFile> archivos) {
@@ -73,7 +73,7 @@ public class EvaluacionCalidadController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<EvaluacionCalidadResponseDTO> actualizar(@PathVariable Long id,
                                                                    @RequestBody EvaluacionCalidadRequestDTO dto) {
         return ResponseEntity.ok(service.actualizar(id, dto));

--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/LoteCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/LoteCalidadController.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.controller;
 
 import com.willyes.clemenintegra.calidad.dto.CondicionUsoResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.ReaperturaLoteRequestDTO;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoCondicionUso;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
@@ -12,6 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
 
 import java.util.Collections;
 import java.util.List;
@@ -46,5 +49,15 @@ public class LoteCalidadController {
 
         List<CondicionUsoResponseDTO> items = service.listarCondicionesUso(loteId, estado);
         return ResponseEntity.ok(items == null ? Collections.emptyList() : items);
+    }
+
+    @PatchMapping("/{loteId}/reabrir")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<LoteProductoResponseDTO> reabrirParaReevaluacion(
+            @PathVariable Long loteId,
+            @RequestBody @Valid ReaperturaLoteRequestDTO dto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Usuario usuario = userDetails != null ? userDetails.getUsuario() : null;
+        return ResponseEntity.ok(service.reabrirParaReevaluacion(loteId, dto, usuario));
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/ReaperturaLoteRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/ReaperturaLoteRequestDTO.java
@@ -1,0 +1,19 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReaperturaLoteRequestDTO {
+
+    @NotBlank
+    private String motivo;
+
+    private String comentarios;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/EvaluacionCalidad.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/EvaluacionCalidad.java
@@ -10,10 +10,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "evaluaciones_calidad",
-        uniqueConstraints = @UniqueConstraint(
-                name = "uk_lote_tipo_evaluacion",
-                columnNames = {"lotes_productos_id", "tipo_evaluacion"}))
+@Table(name = "evaluaciones_calidad")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -88,7 +88,7 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
                     user != null ? user.getId() : null);
             throw new CustomBusinessException(
                     ApiErrorCode.BLOQUEO_ESTADO_CUARENTENA,
-                    "El lote debe permanecer en CUARENTENA o RETENIDO para registrar evaluaciones.",
+                    "El lote debe permanecer en CUARENTENA o RETENIDO para registrar evaluaciones. Reabra el lote desde calidad antes de continuar.",
                     Map.of(
                             "loteId", lote.getId(),
                             "estadoActual", lote.getEstado() != null ? lote.getEstado().name() : null));
@@ -99,11 +99,6 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         auditarYRestaurarCuarentena(lote, cuarentenaId, operacion, user);
 
         validarRolEvaluador(user, dto.getTipoEvaluacion());
-
-        if (repository.existsByLoteProductoIdAndTipoEvaluacion(lote.getId(), dto.getTipoEvaluacion())) {
-            throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA,
-                    "Ya existe una evaluación de este tipo para el lote.");
-        }
 
         if (archivos == null || archivos.isEmpty()) {
             throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
@@ -173,7 +168,7 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
                     user != null ? user.getId() : null);
             throw new CustomBusinessException(
                     ApiErrorCode.BLOQUEO_ESTADO_CUARENTENA,
-                    "El lote debe permanecer en CUARENTENA o RETENIDO para actualizar evaluaciones.",
+                    "El lote debe permanecer en CUARENTENA o RETENIDO para actualizar evaluaciones. Reabra el lote desde calidad antes de continuar.",
                     Map.of(
                             "loteId", lote.getId(),
                             "estadoActual", lote.getEstado() != null ? lote.getEstado().name() : null));
@@ -338,15 +333,19 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         }
         switch (tipoEvaluacion) {
             case FISICO -> {
-                if (!java.util.Set.of(RolUsuario.ROL_ANALISTA_CALIDAD, RolUsuario.ROL_SUPER_ADMIN).contains(rol)) {
+                if (!java.util.Set.of(RolUsuario.ROL_ANALISTA_CALIDAD,
+                        RolUsuario.ROL_JEFE_CALIDAD,
+                        RolUsuario.ROL_SUPER_ADMIN).contains(rol)) {
                     throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE,
-                            "Solo un analista de calidad o un super admin puede registrar evaluaciones físicas.");
+                            "Solo un analista, jefe de calidad o super admin puede registrar evaluaciones físicas.");
                 }
             }
             case QUIMICO_MICROBIOLOGICO -> {
-                if (!java.util.Set.of(RolUsuario.ROL_MICROBIOLOGO, RolUsuario.ROL_SUPER_ADMIN).contains(rol)) {
+                if (!java.util.Set.of(RolUsuario.ROL_MICROBIOLOGO,
+                        RolUsuario.ROL_JEFE_CALIDAD,
+                        RolUsuario.ROL_SUPER_ADMIN).contains(rol)) {
                     throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE,
-                            "Solo un microbiólogo o un super admin puede registrar evaluaciones químico-microbiológicas.");
+                            "Solo un microbiólogo, jefe de calidad o super admin puede registrar evaluaciones químico-microbiológicas.");
                 }
             }
             default -> {

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
@@ -5,6 +5,7 @@ import com.willyes.clemenintegra.calidad.model.enums.EstadoCondicionUso;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.ReaperturaLoteRequestDTO;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -39,5 +40,7 @@ public interface LoteProductoService {
     EstadoCalidadLoteResponseDTO obtenerEstadoCalidad(Long loteId);
 
     List<CondicionUsoResponseDTO> listarCondicionesUso(Long loteId, EstadoCondicionUso estado);
+
+    LoteProductoResponseDTO reabrirParaReevaluacion(Long loteId, ReaperturaLoteRequestDTO dto, com.willyes.clemenintegra.shared.model.Usuario usuarioActual);
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -5,9 +5,11 @@ import com.willyes.clemenintegra.calidad.mapper.CondicionUsoMapper;
 import com.willyes.clemenintegra.calidad.model.CondicionUso;
 import com.willyes.clemenintegra.calidad.model.enums.*;
 import com.willyes.clemenintegra.calidad.repository.CondicionUsoRepository;
+import com.willyes.clemenintegra.inventario.dto.BitacoraCambiosInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.ReaperturaLoteRequestDTO;
 import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
@@ -39,6 +41,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import org.springframework.data.domain.Page;
@@ -77,6 +80,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     private final CondicionUsoService condicionUsoService;
     private final CondicionUsoRepository condicionUsoRepository;
     private final CondicionUsoMapper mapper;
+    private final BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
 
     @Value("${inventory.lote.estadoLiberado}")
     private String estadoLiberadoConf;
@@ -181,6 +185,71 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         return entidades.stream()
                 .map(mapper::toResponseDTO)
                 .toList();
+    }
+
+    @Override
+    @Transactional
+    public LoteProductoResponseDTO reabrirParaReevaluacion(Long loteId,
+                                                           ReaperturaLoteRequestDTO dto,
+                                                           Usuario usuarioActual) {
+        if (usuarioActual == null || usuarioActual.getId() == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Se requiere un usuario autenticado para reabrir el lote.");
+        }
+
+        String motivo = dto != null ? dto.getMotivo() : null;
+        if (motivo == null || motivo.isBlank()) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Debe indicar el motivo de la reapertura.");
+        }
+
+        LoteProducto lote = loteProductoRepository.findByIdForUpdate(loteId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "LOTE_NO_ENCONTRADO"));
+
+        EstadoLote estadoActual = lote.getEstado();
+        if (estadoActual == null) {
+            throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA,
+                    "El lote carece de estado asignado.",
+                    Map.of("loteId", loteId));
+        }
+
+        if (EnumSet.of(EstadoLote.EN_CUARENTENA, EstadoLote.RETENIDO).contains(estadoActual)) {
+            throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA,
+                    "El lote ya se encuentra en evaluación de calidad.",
+                    Map.of("loteId", loteId, "estadoActual", estadoActual.name()));
+        }
+
+        if (!EnumSet.of(EstadoLote.LIBERADO, EstadoLote.RECHAZADO, EstadoLote.DISPONIBLE).contains(estadoActual)) {
+            throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA,
+                    "El lote no puede reabrirse desde su estado actual.",
+                    Map.of("loteId", loteId, "estadoActual", estadoActual.name()));
+        }
+
+        Long cuarentenaId = catalogResolver.getAlmacenCuarentenaId();
+        if (cuarentenaId == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_CUARENTENA_NO_CONFIGURADO");
+        }
+
+        Almacen almacenPrevio = lote.getAlmacen();
+        Almacen almacenCuarentena = almacenRepo.findById(cuarentenaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_CUARENTENA_INEXISTENTE"));
+
+        lote.setEstado(EstadoLote.RETENIDO);
+        lote.setAlmacen(almacenCuarentena);
+        lote = loteRepo.save(lote);
+
+        registrarBitacoraReapertura(lote,
+                estadoActual,
+                almacenPrevio,
+                motivo.trim(),
+                dto != null ? dto.getComentarios() : null,
+                usuarioActual);
+
+        log.info("[CALIDAD] lote reabierto para reevaluación. loteId={} estadoAnterior={} almacenPrevio={} usuario={}",
+                lote.getId(), estadoActual, almacenPrevio != null ? almacenPrevio.getId() : null,
+                usuarioActual.getId());
+
+        return loteProductoMapper.toResponseDTO(lote);
     }
 
     private boolean tieneEvaluacionesRequeridas(TipoAnalisisCalidad requerido, List<EvaluacionCalidad> evaluaciones) {
@@ -563,6 +632,53 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         movimientoInventarioRepository.save(mov);
 
         return loteProductoMapper.toResponseDTO(lote);
+    }
+
+    private void registrarBitacoraReapertura(LoteProducto lote,
+                                             EstadoLote estadoAnterior,
+                                             Almacen almacenAnterior,
+                                             String motivo,
+                                             String comentarios,
+                                             Usuario usuarioActual) {
+        if (lote == null || usuarioActual == null || usuarioActual.getId() == null) {
+            return;
+        }
+        LocalDateTime ahora = LocalDateTime.now();
+        bitacoraCambiosInventarioService.crear(BitacoraCambiosInventarioDTO.builder()
+                .tablaAfectada("lotes_productos")
+                .registroId(lote.getId())
+                .campoModificado("estado")
+                .valorAnt(estadoAnterior != null ? estadoAnterior.name() : "N/A")
+                .valorNuevo(EstadoLote.RETENIDO.name())
+                .fechaCambio(ahora)
+                .usuarioId(usuarioActual.getId())
+                .build());
+
+        bitacoraCambiosInventarioService.crear(BitacoraCambiosInventarioDTO.builder()
+                .tablaAfectada("lotes_productos")
+                .registroId(lote.getId())
+                .campoModificado("motivo_reapertura")
+                .valorAnt("N/A")
+                .valorNuevo(construirDetalleReapertura(motivo, comentarios, almacenAnterior))
+                .fechaCambio(ahora)
+                .usuarioId(usuarioActual.getId())
+                .build());
+    }
+
+    private String construirDetalleReapertura(String motivo,
+                                              String comentarios,
+                                              Almacen almacenAnterior) {
+        StringBuilder detalle = new StringBuilder("motivo=").append(motivo);
+        if (comentarios != null && !comentarios.isBlank()) {
+            detalle.append(" | comentarios=").append(comentarios.trim());
+        }
+        if (almacenAnterior != null && almacenAnterior.getNombre() != null) {
+            detalle.append(" | almacenAnterior=").append(almacenAnterior.getNombre());
+        }
+        if (detalle.length() > 255) {
+            return detalle.substring(0, 255);
+        }
+        return detalle.toString();
     }
 
     private void validarEvaluacion(List<EvaluacionCalidad> evaluaciones, TipoEvaluacion tipo) {

--- a/src/main/resources/db/migration/V20251113__calidad_multiples_evaluaciones.sql
+++ b/src/main/resources/db/migration/V20251113__calidad_multiples_evaluaciones.sql
@@ -1,0 +1,5 @@
+-- Permitir múltiples evaluaciones del mismo tipo por lote
+ALTER TABLE evaluaciones_calidad DROP INDEX uk_lote_tipo_evaluacion;
+
+-- Optimizar consultas por lote y orden cronológico
+CREATE INDEX idx_eval_lote_fecha ON evaluaciones_calidad (lotes_productos_id, fecha_evaluacion DESC);


### PR DESCRIPTION
## Summary
- drop the lot/type unique constraint through a new Flyway migration and allow the entity to persist duplicates
- adjust the quality evaluation service and controller to admit multiple evaluations, extend role access, and improve messaging
- add a re-open endpoint and DTO that move lots back to quarantine with audit logging so further evaluations can be registered

## Testing
- mvn -q -DskipTests package

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e1b05f2c83339879fd2987126066)