### PR TITLE
Restringe modificación de detalles según estado de la fórmula

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/service/DetalleFormulaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/DetalleFormulaServiceImpl.java
@@ -1,9 +1,14 @@
 package com.willyes.clemenintegra.bom.service;
 
 import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 import com.willyes.clemenintegra.bom.repository.DetalleFormulaRepository;
-import org.springframework.stereotype.Service;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,20 +18,54 @@ import java.util.Optional;
 public class DetalleFormulaServiceImpl implements DetalleFormulaService {
 
     private final DetalleFormulaRepository detalleRepository;
+    private final FormulaProductoRepository formulaRepository;
 
+    @Override
     public List<DetalleFormula> listarTodas() {
         return detalleRepository.findAll();
     }
 
+    @Override
     public Optional<DetalleFormula> buscarPorId(Long id) {
         return detalleRepository.findById(id);
     }
 
+    @Override
     public DetalleFormula guardar(DetalleFormula detalle) {
+        FormulaProducto formula = obtenerFormula(detalle);
+        verificarFormulaEditable(formula);
+        detalle.setFormula(formula);
         return detalleRepository.save(detalle);
     }
 
+    @Override
     public void eliminar(Long id) {
-        detalleRepository.deleteById(id);
+        DetalleFormula existente = detalleRepository.findById(id)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Detalle de fórmula no encontrado"));
+        verificarFormulaEditable(existente.getFormula());
+        detalleRepository.delete(existente);
+    }
+
+    private FormulaProducto obtenerFormula(DetalleFormula detalle) {
+        if (detalle.getFormula() == null || detalle.getFormula().getId() == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Debe indicar la fórmula asociada al detalle");
+        }
+
+        return formulaRepository.findById(detalle.getFormula().getId())
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Fórmula no encontrada"));
+    }
+
+    private void verificarFormulaEditable(FormulaProducto formula) {
+        EstadoFormula estado = formula != null ? formula.getEstado() : null;
+        if (EstadoFormula.BORRADOR.equals(estado) || EstadoFormula.EN_REVISION.equals(estado)) {
+            return;
+        }
+
+        String estadoNombre = estado != null ? estado.name() : "DESCONOCIDO";
+        throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA,
+                "La fórmula en estado " + estadoNombre + " no permite modificar sus detalles");
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/bom/service/DetalleFormulaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/DetalleFormulaServiceImplTest.java
@@ -1,0 +1,112 @@
+package com.willyes.clemenintegra.bom.service;
+
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.DetalleFormulaRepository;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DetalleFormulaServiceImplTest {
+
+    @Mock
+    private DetalleFormulaRepository detalleRepository;
+
+    @Mock
+    private FormulaProductoRepository formulaRepository;
+
+    @InjectMocks
+    private DetalleFormulaServiceImpl service;
+
+    @Test
+    @DisplayName("guardar permite crear detalle cuando la fórmula está en BORRADOR")
+    void guardarPermiteBorrador() {
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(1L);
+        formula.setEstado(EstadoFormula.BORRADOR);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setFormula(formula);
+
+        when(formulaRepository.findById(1L)).thenReturn(Optional.of(formula));
+        when(detalleRepository.save(any(DetalleFormula.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThatCode(() -> service.guardar(detalle)).doesNotThrowAnyException();
+        verify(detalleRepository).save(detalle);
+    }
+
+    @Test
+    @DisplayName("guardar permite actualizar detalle cuando la fórmula está en EN_REVISION")
+    void guardarPermiteEnRevision() {
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(5L);
+        formula.setEstado(EstadoFormula.EN_REVISION);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setFormula(formula);
+
+        when(formulaRepository.findById(5L)).thenReturn(Optional.of(formula));
+        when(detalleRepository.save(any(DetalleFormula.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DetalleFormula resultado = service.guardar(detalle);
+
+        assertThat(resultado.getFormula()).isEqualTo(formula);
+        verify(detalleRepository).save(detalle);
+    }
+
+    @Test
+    @DisplayName("guardar rechaza cambios cuando la fórmula está en APROBADA")
+    void guardarRechazaCuandoFormulaAprobada() {
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(8L);
+        formula.setEstado(EstadoFormula.APROBADA);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setFormula(formula);
+
+        when(formulaRepository.findById(8L)).thenReturn(Optional.of(formula));
+
+        assertThatThrownBy(() -> service.guardar(detalle))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("APROBADA");
+
+        verify(detalleRepository, never()).save(any(DetalleFormula.class));
+    }
+
+    @Test
+    @DisplayName("eliminar rechaza cuando la fórmula está en APROBADA")
+    void eliminarRechazaCuandoFormulaAprobada() {
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(10L);
+        formula.setEstado(EstadoFormula.APROBADA);
+
+        DetalleFormula existente = new DetalleFormula();
+        existente.setId(22L);
+        existente.setFormula(formula);
+
+        when(detalleRepository.findById(22L)).thenReturn(Optional.of(existente));
+
+        assertThatThrownBy(() -> service.eliminar(22L))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("APROBADA");
+
+        verify(detalleRepository, never()).delete(any(DetalleFormula.class));
+    }
+}


### PR DESCRIPTION
## Summary
- valida en `DetalleFormulaServiceImpl` que solo se puedan crear, actualizar o eliminar detalles cuando la fórmula está en BORRADOR o EN_REVISION
- lanza `CustomBusinessException` con `OPERACION_NO_PERMITIDA` al intentar modificar detalles de fórmulas en estados no editables y centraliza la obtención de la fórmula
- añade pruebas unitarias para cubrir casos permitidos y bloqueados al operar con detalles de fórmulas

## Testing
- mvn -q -Dtest=DetalleFormulaServiceImplTest test *(falla por pruebas existentes que requieren contexto completo de base de datos y seguridad)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917100aec6083338d445329a7d54253)