### PR TITLE
feat: expose BOM formula summary listing

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
@@ -43,10 +43,8 @@ public class FormulaProductoController {
 
     @GetMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public List<FormulaProductoResponse> listarTodas() {
-        return formulaService.listarTodas().stream()
-                .map(formula -> bomMapper.toResponseDTO(formula))
-                .collect(Collectors.toList());
+    public List<FormulaProductoResumenDTO> listarTodas() {
+        return formulaService.listarResumen();
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoResumenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoResumenDTO.java
@@ -1,0 +1,19 @@
+package com.willyes.clemenintegra.bom.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * DTO de resumen utilizado para el listado maestro de fórmulas BOM.
+ */
+public class FormulaProductoResumenDTO {
+    public Long id;
+    public Long productoId;
+    public String codigoProducto;
+    public String nombreProducto;
+    public String version;
+    public String estado;
+    public boolean activo;
+    public LocalDateTime fechaActualizacion;
+    public String usuarioResponsable;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
@@ -29,6 +29,14 @@ public interface BomMapper {
     @Mapping(target = "actualizadoPorNombre", source = "actualizadoPor", qualifiedByName = "mapNombreUsuario")
     FormulaProductoResponse toResponseDTO(FormulaProducto formula);
 
+    @Mapping(target = "productoId", source = "producto", qualifiedByName = "mapProductoId")
+    @Mapping(target = "codigoProducto", source = "producto", qualifiedByName = "mapProductoCodigo")
+    @Mapping(target = "nombreProducto", source = "producto", qualifiedByName = "mapProductoNombre")
+    @Mapping(target = "estado", source = "estado", qualifiedByName = "mapEstadoFormula")
+    @Mapping(target = "fechaActualizacion", expression = "java(mapFechaActualizacion(formula))")
+    @Mapping(target = "usuarioResponsable", expression = "java(mapUsuarioResponsable(formula))")
+    FormulaProductoResumenDTO toResumenDTO(FormulaProducto formula);
+
     @Mapping(target = "id", ignore = true)
     //@Mapping(target = "formula", source = "formula")
     //@Mapping(target = "insumo", source = "insumo")
@@ -54,6 +62,16 @@ public interface BomMapper {
         return (producto != null) ? producto.getNombre() : null;
     }
 
+    @Named("mapProductoId")
+    default Long mapProductoId(Producto producto) {
+        return (producto != null && producto.getId() != null) ? producto.getId().longValue() : null;
+    }
+
+    @Named("mapProductoCodigo")
+    default String mapProductoCodigo(Producto producto) {
+        return (producto != null) ? producto.getCodigoSku() : null;
+    }
+
     @Named("mapUnidadNombre")
     default String mapUnidadNombre(UnidadMedida unidad) {
         return (unidad != null) ? unidad.getNombre() : null;
@@ -77,5 +95,20 @@ public interface BomMapper {
     @Named("mapTipoDocumento")
     default String mapTipoDocumento(TipoDocumento tipoDocumento) {
         return (tipoDocumento != null) ? tipoDocumento.name() : null;
+    }
+
+    default java.time.LocalDateTime mapFechaActualizacion(FormulaProducto formula) {
+        if (formula == null) {
+            return null;
+        }
+        return formula.getFechaActualizacion() != null ? formula.getFechaActualizacion() : formula.getFechaCreacion();
+    }
+
+    default String mapUsuarioResponsable(FormulaProducto formula) {
+        if (formula == null) {
+            return null;
+        }
+        Usuario responsable = formula.getActualizadoPor() != null ? formula.getActualizadoPor() : formula.getCreadoPor();
+        return mapNombreUsuario(responsable);
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -4,7 +4,9 @@ import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FormulaProductoRepository extends JpaRepository<FormulaProducto, Long> {
@@ -13,4 +15,11 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
 
     @EntityGraph(attributePaths = "detalles")
     Optional<FormulaProducto> findByProductoIdAndEstadoAndActivoTrue(Long productoId, EstadoFormula estado);
+
+    @Query("select f from FormulaProducto f " +
+            "join fetch f.producto p " +
+            "left join fetch f.actualizadoPor ap " +
+            "left join fetch f.creadoPor cp " +
+            "order by coalesce(f.fechaActualizacion, f.fechaCreacion) desc, f.id desc")
+    List<FormulaProducto> findAllForResumen();
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.bom.service;
 
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResponse;
+import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 
 import java.math.BigDecimal;
@@ -10,6 +11,7 @@ import java.util.Optional;
 
 public interface FormulaProductoService {
     List<FormulaProducto> listarTodas();
+    List<FormulaProductoResumenDTO> listarResumen();
     Optional<FormulaProducto> buscarPorId(Long id);
     FormulaProducto guardar(FormulaProducto formula);
     void eliminar(Long id);

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +21,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +33,14 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
     private final BomMapper bomMapper;
     private final LoteProductoRepository loteProductoRepository;
     private final UsuarioRepository usuarioRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<FormulaProductoResumenDTO> listarResumen() {
+        return formulaRepository.findAllForResumen().stream()
+                .map(bomMapper::toResumenDTO)
+                .collect(Collectors.toList());
+    }
 
     public List<FormulaProducto> listarTodas() {
         return formulaRepository.findAll();

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -1,0 +1,90 @@
+package com.willyes.clemenintegra.bom.service;
+
+import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
+import com.willyes.clemenintegra.bom.mapper.BomMapper;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FormulaProductoServiceImplTest {
+
+    @Mock
+    private FormulaProductoRepository formulaRepository;
+
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    private BomMapper bomMapper;
+
+    private FormulaProductoServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        bomMapper = Mappers.getMapper(BomMapper.class);
+        service = new FormulaProductoServiceImpl(formulaRepository, bomMapper, loteProductoRepository, usuarioRepository);
+    }
+
+    @Test
+    @DisplayName("listarResumen devuelve los campos necesarios sin detalles ni documentos")
+    void listarResumenDevuelveCamposClaves() {
+        Producto producto = new Producto();
+        producto.setId(1);
+        producto.setCodigoSku("PR-001");
+        producto.setNombre("Producto Test");
+
+        Usuario responsable = new Usuario();
+        responsable.setNombreCompleto("Responsable Calidad");
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(10L);
+        formula.setProducto(producto);
+        formula.setVersion("v1");
+        formula.setEstado(EstadoFormula.BORRADOR);
+        formula.setActivo(true);
+        formula.setFechaActualizacion(LocalDateTime.of(2024, 1, 15, 10, 30));
+        formula.setActualizadoPor(responsable);
+
+        when(formulaRepository.findAllForResumen()).thenReturn(List.of(formula));
+
+        List<FormulaProductoResumenDTO> resultado = service.listarResumen();
+
+        assertThat(resultado).hasSize(1);
+        FormulaProductoResumenDTO dto = resultado.get(0);
+        assertThat(dto.id).isEqualTo(10L);
+        assertThat(dto.productoId).isEqualTo(1L);
+        assertThat(dto.codigoProducto).isEqualTo("PR-001");
+        assertThat(dto.nombreProducto).isEqualTo("Producto Test");
+        assertThat(dto.version).isEqualTo("v1");
+        assertThat(dto.estado).isEqualTo("BORRADOR");
+        assertThat(dto.activo).isTrue();
+        assertThat(dto.fechaActualizacion).isEqualTo(LocalDateTime.of(2024, 1, 15, 10, 30));
+        assertThat(dto.usuarioResponsable).isEqualTo("Responsable Calidad");
+
+        assertThat(Arrays.stream(FormulaProductoResumenDTO.class.getDeclaredFields())
+                .map(java.lang.reflect.Field::getName))
+                .doesNotContain("detalles", "documentos");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add FormulaProductoResumenDTO and mapper support for the BOM listing
- fetch formulas with product and responsible info for the summary endpoint
- adjust the controller to return the summary response and cover it with a service test

## Testing
- mvn -Dtest=FormulaProductoServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171418af7c8333bcbfc71256ba8375)