### PR TITLE
Implement formula cloning endpoint for BOM

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
@@ -11,6 +11,7 @@ import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
 import com.willyes.clemenintegra.inventario.service.ProductoService;
 import com.willyes.clemenintegra.shared.model.Usuario;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -129,6 +130,16 @@ public class FormulaProductoController {
 
         FormulaProducto guardado = formulaService.guardar(formula);
         return ResponseEntity.ok(bomMapper.toResponseDTO(guardado));
+    }
+
+    @PostMapping("/{id}/clonar")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<FormulaProductoResumenDTO> clonar(
+            @PathVariable Long id,
+            @AuthenticationPrincipal com.willyes.clemenintegra.shared.security.service.CustomUserDetails usuario) {
+        FormulaProducto nuevaFormula = formulaService.clonarFormula(id, usuario.getId());
+        FormulaProductoResumenDTO dto = bomMapper.toResumenDTO(nuevaFormula);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -16,6 +16,8 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
     @EntityGraph(attributePaths = "detalles")
     Optional<FormulaProducto> findByProductoIdAndEstadoAndActivoTrue(Long productoId, EstadoFormula estado);
 
+    List<FormulaProducto> findAllByProductoId(Long productoId);
+
     @Query("select f from FormulaProducto f " +
             "join fetch f.producto p " +
             "left join fetch f.actualizadoPor ap " +

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
@@ -19,4 +19,6 @@ public interface FormulaProductoService {
     FormulaProductoResponse obtenerFormulaActivaPorProducto(Long productoId, BigDecimal cantidad);
 
     FormulaProductoResponse actualizarEstado(Long id, EstadoFormula nuevoEstado, String observacion, Long usuarioId);
+
+    FormulaProducto clonarFormula(Long formulaId, Long usuarioId);
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -7,6 +7,8 @@ import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 import com.willyes.clemenintegra.bom.repository.*;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import org.slf4j.Logger;
@@ -21,6 +23,8 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -83,6 +87,108 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
 
         FormulaProducto guardado = formulaRepository.save(formula);
         return bomMapper.toResponseDTO(guardado);
+    }
+
+    @Override
+    @Transactional
+    public FormulaProducto clonarFormula(Long formulaId, Long usuarioId) {
+        FormulaProducto origen = formulaRepository.findById(formulaId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "La fórmula solicitada no existe"));
+
+        if (origen.getProducto() == null || origen.getProducto().getId() == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "La fórmula no cuenta con un producto asociado válido para clonar");
+        }
+
+        Usuario usuario = usuarioRepository.findById(usuarioId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Usuario no encontrado para clonar la fórmula"));
+
+        Long productoId = origen.getProducto().getId().longValue();
+        List<FormulaProducto> formulasProducto = formulaRepository.findAllByProductoId(productoId);
+
+        int nuevaVersionNumerica = formulasProducto.stream()
+                .map(FormulaProducto::getVersion)
+                .map(this::parseNumeroVersion)
+                .max(Integer::compareTo)
+                .orElse(0) + 1;
+
+        String nuevaVersion = construirValorVersion(origen.getVersion(), nuevaVersionNumerica);
+        LocalDateTime ahora = LocalDateTime.now();
+
+        FormulaProducto clon = new FormulaProducto();
+        clon.setProducto(origen.getProducto());
+        clon.setVersion(nuevaVersion);
+        clon.setEstado(EstadoFormula.BORRADOR);
+        clon.setActivo(false);
+        clon.setObservacion(origen.getObservacion());
+        clon.setFechaCreacion(ahora);
+        clon.setFechaActualizacion(ahora);
+        clon.setCreadoPor(usuario);
+        clon.setActualizadoPor(usuario);
+
+        if (origen.getDetalles() != null && !origen.getDetalles().isEmpty()) {
+            List<DetalleFormula> detallesClonados = origen.getDetalles().stream()
+                    .map(detalle -> {
+                        DetalleFormula copia = new DetalleFormula();
+                        copia.setFormula(clon);
+                        copia.setInsumo(detalle.getInsumo());
+                        copia.setUnidadMedida(detalle.getUnidadMedida());
+                        copia.setCantidadNecesaria(detalle.getCantidadNecesaria());
+                        copia.setObligatorio(detalle.getObligatorio());
+                        return copia;
+                    })
+                    .collect(Collectors.toList());
+            clon.setDetalles(detallesClonados);
+        }
+
+        if (origen.getDocumentos() != null && !origen.getDocumentos().isEmpty()) {
+            List<DocumentoFormula> documentosClonados = origen.getDocumentos().stream()
+                    .map(documento -> DocumentoFormula.builder()
+                            .tipoDocumento(documento.getTipoDocumento())
+                            .nombreArchivo(documento.getNombreArchivo())
+                            .rutaArchivo(documento.getRutaArchivo())
+                            .fechaSubida(documento.getFechaSubida())
+                            .usuario(documento.getUsuario())
+                            .formula(clon)
+                            .build())
+                    .collect(Collectors.toList());
+            clon.setDocumentos(documentosClonados);
+        }
+
+        return formulaRepository.save(clon);
+    }
+
+    private int parseNumeroVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return 0;
+        }
+        String digitos = version.replaceAll("[^0-9]", "");
+        if (digitos.isEmpty()) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "La versión registrada no contiene componentes numéricos");
+        }
+        try {
+            return Integer.parseInt(digitos);
+        } catch (NumberFormatException ex) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Formato de versión inválido para la fórmula");
+        }
+    }
+
+    private String construirValorVersion(String versionBase, int numeroVersion) {
+        if (versionBase == null || versionBase.isBlank()) {
+            return String.valueOf(numeroVersion);
+        }
+        Pattern patron = Pattern.compile("^(\\D*)(\\d+)(.*)$");
+        Matcher matcher = patron.matcher(versionBase);
+        if (matcher.matches()) {
+            String prefijo = matcher.group(1);
+            String sufijo = matcher.group(3);
+            return prefijo + numeroVersion + (sufijo != null ? sufijo : "");
+        }
+        return String.valueOf(numeroVersion);
     }
 
     @Override

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -2,11 +2,17 @@ package com.willyes.clemenintegra.bom.service;
 
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
 import com.willyes.clemenintegra.bom.mapper.BomMapper;
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.DocumentoFormula;
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.model.enums.TipoDocumento;
 import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
 import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,11 +23,15 @@ import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -85,6 +95,102 @@ class FormulaProductoServiceImplTest {
         assertThat(Arrays.stream(FormulaProductoResumenDTO.class.getDeclaredFields())
                 .map(java.lang.reflect.Field::getName))
                 .doesNotContain("detalles", "documentos");
+    }
+
+    @Test
+    @DisplayName("clonarFormula genera nueva versión en borrador con detalles y documentos")
+    void clonarFormulaGeneraNuevaVersion() {
+        Producto producto = new Producto();
+        producto.setId(5);
+        producto.setCodigoSku("PR-005");
+
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(2L);
+        unidad.setNombre("Kilogramo");
+
+        Producto insumo = new Producto();
+        insumo.setId(9);
+        insumo.setNombre("Insumo A");
+
+        DetalleFormula detalleOriginal = new DetalleFormula();
+        detalleOriginal.setInsumo(insumo);
+        detalleOriginal.setUnidadMedida(unidad);
+        detalleOriginal.setCantidadNecesaria(BigDecimal.valueOf(2));
+        detalleOriginal.setObligatorio(Boolean.TRUE);
+
+        DocumentoFormula documentoOriginal = DocumentoFormula.builder()
+                .tipoDocumento(TipoDocumento.PROCEDIMIENTO)
+                .nombreArchivo("doc.pdf")
+                .rutaArchivo("/files/doc.pdf")
+                .build();
+
+        FormulaProducto origen = new FormulaProducto();
+        origen.setId(7L);
+        origen.setProducto(producto);
+        origen.setVersion("v3");
+        origen.setObservacion("Observación previa");
+        origen.setDetalles(List.of(detalleOriginal));
+        origen.setDocumentos(List.of(documentoOriginal));
+        detalleOriginal.setFormula(origen);
+        documentoOriginal.setFormula(origen);
+
+        FormulaProducto versionAnterior = new FormulaProducto();
+        versionAnterior.setId(4L);
+        versionAnterior.setProducto(producto);
+        versionAnterior.setVersion("v2");
+
+        Usuario usuario = new Usuario();
+        usuario.setId(3L);
+        usuario.setNombreCompleto("Usuario Clonador");
+
+        when(formulaRepository.findById(7L)).thenReturn(Optional.of(origen));
+        when(usuarioRepository.findById(3L)).thenReturn(Optional.of(usuario));
+        when(formulaRepository.findAllByProductoId(5L)).thenReturn(List.of(versionAnterior, origen));
+        when(formulaRepository.save(any(FormulaProducto.class))).thenAnswer(invocation -> {
+            FormulaProducto guardado = invocation.getArgument(0);
+            guardado.setId(11L);
+            return guardado;
+        });
+
+        FormulaProducto clon = service.clonarFormula(7L, 3L);
+
+        assertThat(clon.getId()).isEqualTo(11L);
+        assertThat(clon.getProducto()).isEqualTo(producto);
+        assertThat(clon.getVersion()).isEqualTo("v4");
+        assertThat(clon.getEstado()).isEqualTo(EstadoFormula.BORRADOR);
+        assertThat(clon.isActivo()).isFalse();
+        assertThat(clon.getCreadoPor()).isEqualTo(usuario);
+        assertThat(clon.getActualizadoPor()).isEqualTo(usuario);
+        assertThat(clon.getObservacion()).isEqualTo("Observación previa");
+        assertThat(clon.getFechaCreacion()).isNotNull();
+        assertThat(clon.getFechaActualizacion()).isNotNull();
+
+        assertThat(clon.getDetalles()).hasSize(1);
+        DetalleFormula detalleClonado = clon.getDetalles().get(0);
+        assertThat(detalleClonado.getId()).isNull();
+        assertThat(detalleClonado.getFormula()).isEqualTo(clon);
+        assertThat(detalleClonado.getInsumo()).isEqualTo(insumo);
+        assertThat(detalleClonado.getUnidadMedida()).isEqualTo(unidad);
+        assertThat(detalleClonado.getCantidadNecesaria()).isEqualTo(BigDecimal.valueOf(2));
+        assertThat(detalleClonado.getObligatorio()).isTrue();
+
+        assertThat(clon.getDocumentos()).hasSize(1);
+        DocumentoFormula documentoClonado = clon.getDocumentos().get(0);
+        assertThat(documentoClonado.getId()).isNull();
+        assertThat(documentoClonado.getFormula()).isEqualTo(clon);
+        assertThat(documentoClonado.getTipoDocumento()).isEqualTo(TipoDocumento.PROCEDIMIENTO);
+        assertThat(documentoClonado.getNombreArchivo()).isEqualTo("doc.pdf");
+        assertThat(documentoClonado.getRutaArchivo()).isEqualTo("/files/doc.pdf");
+    }
+
+    @Test
+    @DisplayName("clonarFormula lanza excepción si la fórmula no existe")
+    void clonarFormulaFormulaNoExiste() {
+        when(formulaRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.clonarFormula(999L, 1L))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasFieldOrPropertyWithValue("code", ApiErrorCode.RECURSO_NO_ENCONTRADO);
     }
 }
 


### PR DESCRIPTION
## Summary
- add domain service logic to clone formulas with a new draft version while copying details and documents
- expose POST /api/bom/formulas/{id}/clonar returning the new FormulaProductoResumenDTO
- cover the cloning flow with unit tests alongside the not-found scenario

## Testing
- mvn test *(fails: existing integration tests outside BOM)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171892e5a883339515d4697768e818)