### PR TITLE
feat(bom): expose active formula for production

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
@@ -181,5 +181,11 @@ public class FormulaProductoController {
         // LÍNEA CODEx: endpoint consultado por Producción para validar disponibilidad de insumos
         return ResponseEntity.ok(formulaService.obtenerFormulaActivaPorProducto(productoId, cantidad));
     }
+
+    @GetMapping("/producto/{productoId}/formula-activa")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<FormulaActivaProduccionDTO> obtenerFormulaActivaProduccion(@PathVariable Long productoId) {
+        return ResponseEntity.ok(formulaService.obtenerFormulaActivaProduccion(productoId));
+    }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaProduccionDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaProduccionDTO.java
@@ -1,0 +1,15 @@
+package com.willyes.clemenintegra.bom.dto;
+
+import java.math.BigDecimal;
+
+public class DetalleFormulaProduccionDTO {
+    public Long detalleId;
+    public Long productoInsumoId;
+    public String codigoInsumo;
+    public String nombreInsumo;
+    public Long unidadMedidaId;
+    public String nombreUnidadMedida;
+    public String simboloUnidadMedida;
+    public BigDecimal cantidadNecesaria;
+    public boolean obligatorio;
+}

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaActivaProduccionDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaActivaProduccionDTO.java
@@ -1,0 +1,19 @@
+package com.willyes.clemenintegra.bom.dto;
+
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class FormulaActivaProduccionDTO {
+    public Long formulaId;
+    public Long productoId;
+    public String codigoProducto;
+    public String nombreProducto;
+    public String version;
+    public EstadoFormula estado;
+    public boolean activo;
+    public LocalDateTime fechaActualizacion;
+    public String usuarioResponsable;
+    public List<DetalleFormulaProduccionDTO> detalles;
+}

--- a/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
@@ -37,6 +37,14 @@ public interface BomMapper {
     @Mapping(target = "usuarioResponsable", expression = "java(mapUsuarioResponsable(formula))")
     FormulaProductoResumenDTO toResumenDTO(FormulaProducto formula);
 
+    @Mapping(target = "formulaId", source = "id")
+    @Mapping(target = "productoId", source = "producto", qualifiedByName = "mapProductoId")
+    @Mapping(target = "codigoProducto", source = "producto", qualifiedByName = "mapProductoCodigo")
+    @Mapping(target = "nombreProducto", source = "producto", qualifiedByName = "mapProductoNombre")
+    @Mapping(target = "fechaActualizacion", expression = "java(mapFechaActualizacion(formula))")
+    @Mapping(target = "usuarioResponsable", expression = "java(mapUsuarioResponsable(formula))")
+    FormulaActivaProduccionDTO toFormulaActivaProduccionDTO(FormulaProducto formula);
+
     @Mapping(target = "id", ignore = true)
     //@Mapping(target = "formula", source = "formula")
     //@Mapping(target = "insumo", source = "insumo")
@@ -48,6 +56,16 @@ public interface BomMapper {
     @Mapping(target = "unidad", source = "unidadMedida", qualifiedByName = "mapUnidadNombre")
     @Mapping(target = "unidadSimbolo", source = "unidadMedida", qualifiedByName = "mapUnidadSimbolo")
     DetalleFormulaResponse toResponseDTO(DetalleFormula detalle);
+
+    @Mapping(target = "detalleId", source = "id")
+    @Mapping(target = "productoInsumoId", source = "insumo", qualifiedByName = "mapProductoId")
+    @Mapping(target = "codigoInsumo", source = "insumo", qualifiedByName = "mapProductoCodigo")
+    @Mapping(target = "nombreInsumo", source = "insumo", qualifiedByName = "mapProductoNombre")
+    @Mapping(target = "unidadMedidaId", source = "unidadMedida", qualifiedByName = "mapUnidadId")
+    @Mapping(target = "nombreUnidadMedida", source = "unidadMedida", qualifiedByName = "mapUnidadNombre")
+    @Mapping(target = "simboloUnidadMedida", source = "unidadMedida", qualifiedByName = "mapUnidadSimbolo")
+    @Mapping(target = "obligatorio", expression = "java(mapObligatorio(detalle.getObligatorio()))")
+    DetalleFormulaProduccionDTO toDetalleFormulaProduccionDTO(DetalleFormula detalle);
 
     //@Mapping(target = "id", ignore = true)
     //@Mapping(target = "formula", source = "formula")
@@ -75,6 +93,11 @@ public interface BomMapper {
     @Named("mapUnidadNombre")
     default String mapUnidadNombre(UnidadMedida unidad) {
         return (unidad != null) ? unidad.getNombre() : null;
+    }
+
+    @Named("mapUnidadId")
+    default Long mapUnidadId(UnidadMedida unidad) {
+        return (unidad != null && unidad.getId() != null) ? unidad.getId().longValue() : null;
     }
 
     @Named("mapUnidadSimbolo")
@@ -110,5 +133,9 @@ public interface BomMapper {
         }
         Usuario responsable = formula.getActualizadoPor() != null ? formula.getActualizadoPor() : formula.getCreadoPor();
         return mapNombreUsuario(responsable);
+    }
+
+    default boolean mapObligatorio(Boolean obligatorio) {
+        return Boolean.TRUE.equals(obligatorio);
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -16,7 +16,14 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
     @EntityGraph(attributePaths = "detalles")
     Optional<FormulaProducto> findByProductoId(Long productoId);
 
-    @EntityGraph(attributePaths = "detalles")
+    @EntityGraph(attributePaths = {
+            "producto",
+            "detalles",
+            "detalles.insumo",
+            "detalles.unidadMedida",
+            "actualizadoPor",
+            "creadoPor"
+    })
     Optional<FormulaProducto> findByProductoIdAndEstadoAndActivoTrue(Long productoId, EstadoFormula estado);
 
     List<FormulaProducto> findAllByProductoId(Long productoId);

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.bom.service;
 
+import com.willyes.clemenintegra.bom.dto.FormulaActivaProduccionDTO;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResponse;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
@@ -17,6 +18,8 @@ public interface FormulaProductoService {
     void eliminar(Long id);
 
     FormulaProductoResponse obtenerFormulaActivaPorProducto(Long productoId, BigDecimal cantidad);
+
+    FormulaActivaProduccionDTO obtenerFormulaActivaProduccion(Long productoId);
 
     FormulaProducto cambiarEstado(Long formulaId, EstadoFormula nuevoEstado, Long usuarioId);
 

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -306,6 +307,23 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
         }
 
         return response;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public FormulaActivaProduccionDTO obtenerFormulaActivaProduccion(Long productoId) {
+        FormulaProducto formula = formulaRepository
+                .findByProductoIdAndEstadoAndActivoTrue(productoId, EstadoFormula.APROBADA)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA,
+                        "El producto seleccionado no tiene una fórmula activa aprobada."));
+
+        if (formula.getDetalles() == null) {
+            formula.setDetalles(Collections.emptyList());
+        } else {
+            formula.getDetalles().size();
+        }
+
+        return bomMapper.toFormulaActivaProduccionDTO(formula);
     }
 }
 

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.bom.service;
 
+import com.willyes.clemenintegra.bom.dto.DetalleFormulaProduccionDTO;
+import com.willyes.clemenintegra.bom.dto.FormulaActivaProduccionDTO;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
 import com.willyes.clemenintegra.bom.mapper.BomMapper;
 import com.willyes.clemenintegra.bom.model.DetalleFormula;
@@ -197,6 +199,84 @@ class FormulaProductoServiceImplTest {
         assertThat(Arrays.stream(FormulaProductoResumenDTO.class.getDeclaredFields())
                 .map(java.lang.reflect.Field::getName))
                 .doesNotContain("detalles", "documentos");
+    }
+
+    @Test
+    @DisplayName("obtenerFormulaActivaProduccion devuelve la fórmula aprobada activa con detalles mapeados")
+    void obtenerFormulaActivaProduccionOk() {
+        Producto producto = new Producto();
+        producto.setId(1);
+        producto.setCodigoSku("PR-001");
+        producto.setNombre("Producto Terminado");
+
+        Producto insumo = new Producto();
+        insumo.setId(2);
+        insumo.setCodigoSku("INS-001");
+        insumo.setNombre("Insumo Principal");
+
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(10L);
+        unidad.setNombre("Kilogramo");
+        unidad.setSimbolo("KG");
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setId(5L);
+        detalle.setInsumo(insumo);
+        detalle.setUnidadMedida(unidad);
+        detalle.setCantidadNecesaria(new BigDecimal("2.5000"));
+        detalle.setObligatorio(true);
+
+        Usuario responsable = new Usuario();
+        responsable.setNombreCompleto("Responsable Producción");
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(3L);
+        formula.setProducto(producto);
+        formula.setVersion("v2");
+        formula.setEstado(EstadoFormula.APROBADA);
+        formula.setActivo(true);
+        formula.setFechaActualizacion(LocalDateTime.of(2024, 5, 1, 12, 0));
+        formula.setActualizadoPor(responsable);
+        formula.setDetalles(List.of(detalle));
+
+        when(formulaRepository.findByProductoIdAndEstadoAndActivoTrue(1L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+
+        FormulaActivaProduccionDTO resultado = service.obtenerFormulaActivaProduccion(1L);
+
+        assertThat(resultado.formulaId).isEqualTo(3L);
+        assertThat(resultado.productoId).isEqualTo(1L);
+        assertThat(resultado.codigoProducto).isEqualTo("PR-001");
+        assertThat(resultado.nombreProducto).isEqualTo("Producto Terminado");
+        assertThat(resultado.version).isEqualTo("v2");
+        assertThat(resultado.estado).isEqualTo(EstadoFormula.APROBADA);
+        assertThat(resultado.activo).isTrue();
+        assertThat(resultado.fechaActualizacion).isEqualTo(LocalDateTime.of(2024, 5, 1, 12, 0));
+        assertThat(resultado.usuarioResponsable).isEqualTo("Responsable Producción");
+        assertThat(resultado.detalles).hasSize(1);
+
+        DetalleFormulaProduccionDTO detalleDTO = resultado.detalles.get(0);
+        assertThat(detalleDTO.detalleId).isEqualTo(5L);
+        assertThat(detalleDTO.productoInsumoId).isEqualTo(2L);
+        assertThat(detalleDTO.codigoInsumo).isEqualTo("INS-001");
+        assertThat(detalleDTO.nombreInsumo).isEqualTo("Insumo Principal");
+        assertThat(detalleDTO.unidadMedidaId).isEqualTo(10L);
+        assertThat(detalleDTO.nombreUnidadMedida).isEqualTo("Kilogramo");
+        assertThat(detalleDTO.simboloUnidadMedida).isEqualTo("KG");
+        assertThat(detalleDTO.cantidadNecesaria).isEqualByComparingTo(new BigDecimal("2.5000"));
+        assertThat(detalleDTO.obligatorio).isTrue();
+    }
+
+    @Test
+    @DisplayName("obtenerFormulaActivaProduccion lanza excepción cuando no existe fórmula activa aprobada")
+    void obtenerFormulaActivaProduccionSinFormulaActiva() {
+        when(formulaRepository.findByProductoIdAndEstadoAndActivoTrue(1L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.obtenerFormulaActivaProduccion(1L))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasFieldOrPropertyWithValue("code", ApiErrorCode.OPERACION_NO_PERMITIDA)
+                .hasMessage("El producto seleccionado no tiene una fórmula activa aprobada.");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add production-facing DTOs and mapper coverage for active formulas and their details
- expose a service and REST endpoint that returns the approved active formula for a product, enforcing business rules
- extend unit tests to validate the happy-path and missing-formula scenarios for production retrieval

## Testing
- `mvn -q test` *(fails: OrdenProduccionControllerSecurityTest expects HTTP 403 but receives 401 in current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171f5061708333875f675120256de3)