### PR TITLE
feat: enable filters on BOM formula listing

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
@@ -44,8 +44,10 @@ public class FormulaProductoController {
 
     @GetMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public List<FormulaProductoResumenDTO> listarTodas() {
-        return formulaService.listarResumen();
+    public List<FormulaProductoResumenDTO> listarTodas(
+            @RequestParam(required = false) EstadoFormula estado,
+            @RequestParam(required = false) String producto) {
+        return formulaService.listarResumen(estado, producto);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -32,8 +32,11 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
             "join fetch f.producto p " +
             "left join fetch f.actualizadoPor ap " +
             "left join fetch f.creadoPor cp " +
+            "where (:estado is null or f.estado = :estado) " +
+            "and (:producto is null or lower(p.codigoSku) like lower(concat('%', :producto, '%')) " +
+            "or lower(p.nombre) like lower(concat('%', :producto, '%'))) " +
             "order by coalesce(f.fechaActualizacion, f.fechaCreacion) desc, f.id desc")
-    List<FormulaProducto> findAllForResumen();
+    List<FormulaProducto> findAllForResumen(@Param("estado") EstadoFormula estado, @Param("producto") String producto);
 
     @Modifying(clearAutomatically = true)
     @Query("update FormulaProducto f set f.activo = false where f.producto = :producto and f.id <> :id")

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface FormulaProductoService {
     List<FormulaProducto> listarTodas();
-    List<FormulaProductoResumenDTO> listarResumen();
+    List<FormulaProductoResumenDTO> listarResumen(EstadoFormula estado, String producto);
     Optional<FormulaProducto> buscarPorId(Long id);
     FormulaProducto guardar(FormulaProducto formula);
     void eliminar(Long id);

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -39,8 +39,13 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<FormulaProductoResumenDTO> listarResumen() {
-        return formulaRepository.findAllForResumen().stream()
+    public List<FormulaProductoResumenDTO> listarResumen(EstadoFormula estado, String producto) {
+        String filtroProducto = producto != null ? producto.trim() : null;
+        if (filtroProducto != null && filtroProducto.isEmpty()) {
+            filtroProducto = null;
+        }
+
+        return formulaRepository.findAllForResumen(estado, filtroProducto).stream()
                 .map(bomMapper::toResumenDTO)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoControllerSecurityTest.java
@@ -134,7 +134,7 @@ class FormulaProductoControllerSecurityTest {
         FormulaProducto formula = new FormulaProducto();
         formula.setId(3L);
 
-        when(formulaProductoService.listarResumen()).thenReturn(List.of(resumenDTO));
+        when(formulaProductoService.listarResumen(any(), any())).thenReturn(List.of(resumenDTO));
         when(formulaProductoService.obtenerFormulaActivaProduccion(anyLong())).thenReturn(formulaActiva);
         when(formulaProductoService.clonarFormula(anyLong(), anyLong())).thenReturn(formula);
         when(formulaProductoService.cambiarEstado(anyLong(), any(EstadoFormula.class), anyLong())).thenReturn(formula);

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -34,6 +35,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -180,9 +182,9 @@ class FormulaProductoServiceImplTest {
         formula.setFechaActualizacion(LocalDateTime.of(2024, 1, 15, 10, 30));
         formula.setActualizadoPor(responsable);
 
-        when(formulaRepository.findAllForResumen()).thenReturn(List.of(formula));
+        when(formulaRepository.findAllForResumen(null, null)).thenReturn(List.of(formula));
 
-        List<FormulaProductoResumenDTO> resultado = service.listarResumen();
+        List<FormulaProductoResumenDTO> resultado = service.listarResumen(null, null);
 
         assertThat(resultado).hasSize(1);
         FormulaProductoResumenDTO dto = resultado.get(0);
@@ -199,6 +201,71 @@ class FormulaProductoServiceImplTest {
         assertThat(Arrays.stream(FormulaProductoResumenDTO.class.getDeclaredFields())
                 .map(java.lang.reflect.Field::getName))
                 .doesNotContain("detalles", "documentos");
+    }
+
+    @Test
+    @DisplayName("listarResumen filtra por estado cuando se proporciona")
+    void listarResumenFiltraPorEstado() {
+        Producto producto = new Producto();
+        producto.setId(2);
+        producto.setCodigoSku("PR-002");
+        producto.setNombre("Producto Borrador");
+
+        Usuario responsable = new Usuario();
+        responsable.setNombreCompleto("Responsable Borrador");
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(20L);
+        formula.setProducto(producto);
+        formula.setVersion("v3");
+        formula.setEstado(EstadoFormula.BORRADOR);
+        formula.setActivo(false);
+        formula.setFechaActualizacion(LocalDateTime.of(2024, 2, 20, 9, 15));
+        formula.setActualizadoPor(responsable);
+
+        when(formulaRepository.findAllForResumen(EstadoFormula.BORRADOR, null)).thenReturn(List.of(formula));
+
+        List<FormulaProductoResumenDTO> resultado = service.listarResumen(EstadoFormula.BORRADOR, null);
+
+        assertThat(resultado).hasSize(1);
+        FormulaProductoResumenDTO dto = resultado.get(0);
+        assertThat(dto.estado).isEqualTo(EstadoFormula.BORRADOR.name());
+        assertThat(dto.codigoProducto).isEqualTo("PR-002");
+        verify(formulaRepository).findAllForResumen(EstadoFormula.BORRADOR, null);
+    }
+
+    @Test
+    @DisplayName("listarResumen normaliza el filtro de producto antes de consultar el repositorio")
+    void listarResumenFiltraPorTextoProducto() {
+        Producto producto = new Producto();
+        producto.setId(3);
+        producto.setCodigoSku("PT-0311");
+        producto.setNombre("CVC-COMPRIMIDO VITAMINA C 500 MG");
+
+        Usuario responsable = new Usuario();
+        responsable.setNombreCompleto("Responsable Texto");
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(30L);
+        formula.setProducto(producto);
+        formula.setVersion("v5");
+        formula.setEstado(EstadoFormula.APROBADA);
+        formula.setActivo(true);
+        formula.setFechaActualizacion(LocalDateTime.of(2024, 3, 10, 8, 45));
+        formula.setActualizadoPor(responsable);
+
+        when(formulaRepository.findAllForResumen(any(), any())).thenReturn(List.of(formula));
+
+        List<FormulaProductoResumenDTO> resultado = service.listarResumen(null, "  vitamina c   ");
+
+        assertThat(resultado).hasSize(1);
+        FormulaProductoResumenDTO dto = resultado.get(0);
+        assertThat(dto.codigoProducto).isEqualTo("PT-0311");
+        assertThat(dto.nombreProducto).contains("VITAMINA C");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(formulaRepository).findAllForResumen(isNull(), captor.capture());
+        assertThat(captor.getValue()).isEqualTo("vitamina c");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- accept optional `estado` and `producto` request parameters for `/api/bom/formulas`
- filter formulas by estado and case-insensitive product code/name in the service and repository layer
- add unit tests covering state and product filters and update controller stubs

## Testing
- mvn -Dtest=FormulaProductoServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177e8071bc833398918aba42849e8e)