### PR TITLE
docs: clarify fallback population for solicitud movement header

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/SolicitudMovimientoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/SolicitudMovimientoResponseDTO.java
@@ -8,6 +8,12 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * DTO utilizado para exponer solicitudes de movimiento. Los campos de cabecera relacionados con
+ * producto, lote y almacenes pueden provenir del primer detalle cuando la entidad original tiene
+ * cabecera vacía (caso habitual en solicitudes generadas desde Producción). El frontend puede
+ * apoyarse en estos identificadores para precargar formularios de movimientos asociados a una OP.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -590,6 +590,15 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
         return "MIXTO";
     }
 
+    /**
+     * Convierte una {@link SolicitudMovimiento} en su DTO de respuesta asegurando que el frontend
+     * reciba siempre los identificadores necesarios para precargar el formulario de movimientos.
+     * <p>
+     * Las solicitudes ligadas a producción suelen persistir la información de lote y almacenes en
+     * el primer detalle (multi-lote) y dejar vacía la cabecera. Por ello se toma ese detalle como
+     * fuente de verdad cuando los campos principales vienen nulos.
+     * </p>
+     */
     private SolicitudMovimientoResponseDTO toResponse(SolicitudMovimiento s) {
         SolicitudMovimientoDetalle primerDetalle = Optional.ofNullable(s.getDetalles())
                 .filter(detalles -> !detalles.isEmpty())


### PR DESCRIPTION
## Summary
- add explicit Javadoc in SolicitudMovimientoServiceImpl#toResponse describing how header ids fallback to the first detail
- document in SolicitudMovimientoResponseDTO that product, lot and warehouse identifiers may come from the first detail for production-linked requests

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917bce86f0083339339814ffaaba454)