### PR TITLE
Evita doble aprobación de solicitudes OP

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -204,6 +204,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         boolean autoSplitSolicitado = Boolean.TRUE.equals(dto.autoSplit());
 
         List<MovimientoInventarioResponseDTO.SolicitudDetalleAtencionDTO> detalleRespuesta = List.of();
+        boolean detallesProcesadosPorPartidas = false;
 
         // 1. Cargar entidades principales
         Producto producto = productoRepository.findById(dto.productoId().longValue())
@@ -587,6 +588,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                     tipoMovimiento,
                     devolucionInterna
             );
+            detallesProcesadosPorPartidas = true;
 
         } else {
             // Comportamiento anterior (un solo lote desde DTO)
@@ -598,6 +600,12 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
         if (lotesProcesados == null || lotesProcesados.isEmpty()) {
             throw new IllegalStateException("No se generaron lotes para el movimiento");
+        }
+
+        if (solicitud != null
+                && esContextoOrdenProduccion(dto, solicitud)
+                && !detallesProcesadosPorPartidas) {
+            detalleRespuesta = aplicarContraSolicitudMovimiento(dto, solicitud);
         }
 
         MovimientoLoteDetalle principal = lotesProcesados.get(0);
@@ -632,7 +640,8 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         MovimientoInventario guardado = repository.save(movimiento);
 
         if (solicitud != null) {
-            detalleRespuesta = solicitud.getDetalles().stream()
+            if (detalleRespuesta == null || detalleRespuesta.isEmpty()) {
+                detalleRespuesta = solicitud.getDetalles().stream()
                     .map(d -> {
                         BigDecimal atendidaBD = d.getCantidadAtendida() != null
                                 ? d.getCantidadAtendida()
@@ -653,6 +662,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                                 .build();
                     })
                     .collect(java.util.stream.Collectors.toList());
+            }
         }
 
         if (lotesProcesados.size() > 1) {
@@ -675,6 +685,100 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             respuesta.setDetallesSolicitud(detalles);
         }
         return respuesta;
+    }
+
+    private boolean esContextoOrdenProduccion(MovimientoInventarioDTO dto, SolicitudMovimiento solicitud) {
+        if (dto != null && dto.ordenProduccionId() != null) {
+            return true;
+        }
+        return solicitud != null && solicitud.getOrdenProduccion() != null;
+    }
+
+    private List<MovimientoInventarioResponseDTO.SolicitudDetalleAtencionDTO> aplicarContraSolicitudMovimiento(
+            MovimientoInventarioDTO dto,
+            SolicitudMovimiento solicitud
+    ) {
+        entityManager.lock(solicitud, LockModeType.PESSIMISTIC_WRITE);
+
+        EstadoSolicitudMovimiento estadoActual = solicitud.getEstado();
+        if (estadoActual != null && !EnumSet.of(
+                EstadoSolicitudMovimiento.PENDIENTE,
+                EstadoSolicitudMovimiento.AUTORIZADA,
+                EstadoSolicitudMovimiento.PARCIAL,
+                EstadoSolicitudMovimiento.RESERVADA
+        ).contains(estadoActual)) {
+            log.warn("SOLICITUD_YA_ATENDIDA: solId={} estado={}", solicitud.getId(), estadoActual);
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "SOLICITUD_YA_ATENDIDA");
+        }
+
+        List<AtencionDTO> atenciones = obtenerAtencionesParaSolicitud(dto, solicitud);
+        if (atenciones.isEmpty()) {
+            actualizarEstadoSolicitud(solicitud);
+            solicitudMovimientoRepository.saveAndFlush(solicitud);
+            return construirRespuestaSolicitud(solicitud);
+        }
+
+        for (AtencionDTO atencion : atenciones) {
+            BigDecimal cantidad = normalizarCantidad(atencion.getCantidad());
+            if (cantidad == null || cantidad.compareTo(BigDecimal.ZERO) <= 0) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ATENCION_CANTIDAD_INVALIDA");
+            }
+
+            Long loteId = atencion.getLoteId();
+            if (loteId == null) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ATENCION_LOTE_REQUERIDO");
+            }
+
+            SolicitudMovimientoDetalle detalle = obtenerDetalleParaAtencion(solicitud, atencion);
+            if (detalle == null) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "DETALLE_NO_COMPATIBLE");
+            }
+
+            EstadoSolicitudMovimientoDetalle estadoDetalle = detalle.getEstado();
+            if (estadoDetalle != null && !EnumSet.of(
+                    EstadoSolicitudMovimientoDetalle.PENDIENTE,
+                    EstadoSolicitudMovimientoDetalle.PARCIAL
+            ).contains(estadoDetalle)) {
+                log.warn("DETALLE_YA_ATENDIDO: solicitudId={} detalleId={} estado={}",
+                        solicitud.getId(), detalle.getId(), estadoDetalle);
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "DETALLE_YA_ATENDIDO");
+            }
+
+            BigDecimal solicitada = Optional.ofNullable(detalle.getCantidad()).orElse(BigDecimal.ZERO)
+                    .setScale(6, RoundingMode.HALF_UP);
+            BigDecimal atendidaPrev = Optional.ofNullable(detalle.getCantidadAtendida()).orElse(BigDecimal.ZERO)
+                    .setScale(6, RoundingMode.HALF_UP);
+            BigDecimal pendienteDetalle = solicitada.subtract(atendidaPrev);
+            if (pendienteDetalle.compareTo(BigDecimal.ZERO) <= 0) {
+                log.warn("DETALLE_SIN_PENDIENTE solicitudId={} detalleId={}", solicitud.getId(), detalle.getId());
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "DETALLE_YA_ATENDIDO");
+            }
+            if (cantidad.compareTo(pendienteDetalle) > 0) {
+                log.warn("ATENCION_EXCEDE_PENDIENTE solicitudId={} detalleId={} aprobado={} pendiente={}",
+                        solicitud.getId(), detalle.getId(), cantidad, pendienteDetalle);
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "ATENCION_CANTIDAD_EXCEDE_PENDIENTE");
+            }
+
+            LoteProducto lote = loteProductoRepository.findByIdForUpdate(loteId)
+                    .orElseThrow(() -> new NoSuchElementException("Lote no encontrado"));
+
+            reservaLoteService.consumirReserva(solicitud, detalle, lote, cantidad);
+
+            BigDecimal stockAntes = Optional.ofNullable(lote.getStockLote()).orElse(BigDecimal.ZERO);
+            BigDecimal reservadoAntes = Optional.ofNullable(lote.getStockReservado()).orElse(BigDecimal.ZERO);
+            log.debug("VAL-ACTUALIZA (OP) antes actualizarStockLote loteId={} stockAntes={} reservadoAntes={} req={}",
+                    lote.getId(), stockAntes, reservadoAntes, cantidad);
+
+            actualizarStockLote(lote, cantidad, lote.getProducto());
+            loteProductoRepository.save(lote);
+
+            actualizarDetalleSolicitud(detalle, cantidad);
+            solicitudMovimientoDetalleRepository.save(detalle);
+        }
+
+        actualizarEstadoSolicitud(solicitud);
+        solicitudMovimientoRepository.saveAndFlush(solicitud);
+        return construirRespuestaSolicitud(solicitud);
     }
 
     private List<MovimientoInventarioResponseDTO.SolicitudDetalleAtencionDTO> atenderSolicitudMovimiento(

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -1,0 +1,227 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
+import com.willyes.clemenintegra.inventario.dto.AtencionDTO;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.*;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MovimientoInventarioServiceSolicitudOpTest {
+
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private ProveedorRepository proveedorRepository;
+    @Mock
+    private OrdenCompraRepository ordenCompraRepository;
+    @Mock
+    private OrdenCompraService ordenCompraService;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private MovimientoInventarioMapper mapper;
+    @Mock
+    private UsuarioService usuarioService;
+    @Mock
+    private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock
+    private InventoryCatalogResolver catalogResolver;
+    @Mock
+    private ReservaLoteService reservaLoteService;
+    @Mock
+    private ReservaLoteRepository reservaLoteRepository;
+    @Mock
+    private RecepcionOCService recepcionOCService;
+    @Mock
+    private RetencionLoteService retencionLoteService;
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private MovimientoInventarioServiceImpl service;
+
+    @BeforeEach
+    void setupSecurity() {
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("tester", "secret");
+        authentication.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void clearSecurity() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void registrarMovimiento_solicitudOp_aplicaUnaSolaVez() {
+        Producto producto = new Producto();
+        producto.setId(1);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(99L);
+        producto.setUnidadMedida(unidad);
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(100L);
+        lote.setProducto(producto);
+        lote.setAlmacen(new Almacen(10));
+        lote.setStockLote(new BigDecimal("10"));
+        lote.setStockReservado(BigDecimal.ZERO);
+        lote.setEstado(EstadoLote.DISPONIBLE);
+
+        SolicitudMovimientoDetalle detalle = new SolicitudMovimientoDetalle();
+        detalle.setId(300L);
+        detalle.setCantidad(new BigDecimal("5"));
+        detalle.setEstado(EstadoSolicitudMovimientoDetalle.PENDIENTE);
+        detalle.setCantidadAtendida(BigDecimal.ZERO);
+        detalle.setLote(lote);
+
+        SolicitudMovimiento solicitud = new SolicitudMovimiento();
+        solicitud.setId(200L);
+        solicitud.setProducto(producto);
+        solicitud.setLote(lote);
+        solicitud.setTipoMovimiento(TipoMovimiento.TRANSFERENCIA);
+        solicitud.setEstado(EstadoSolicitudMovimiento.PENDIENTE);
+        solicitud.setCantidad(new BigDecimal("5"));
+        solicitud.setDetalles(List.of(detalle));
+        detalle.setSolicitudMovimiento(solicitud);
+
+        OrdenProduccion ordenProduccion = new OrdenProduccion();
+        ordenProduccion.setId(400L);
+        solicitud.setOrdenProduccion(ordenProduccion);
+
+        Usuario usuario = Usuario.builder()
+                .id(50L)
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .nombreUsuario("tester")
+                .clave("secret")
+                .nombreCompleto("Tester")
+                .correo("tester@example.com")
+                .activo(true)
+                .bloqueado(false)
+                .build();
+        solicitud.setUsuarioResponsable(usuario);
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+
+        AtencionDTO atencion = new AtencionDTO();
+        atencion.setDetalleId(detalle.getId());
+        atencion.setLoteId(lote.getId());
+        atencion.setCantidad(new BigDecimal("5"));
+        atencion.setAlmacenOrigenId(10);
+        atencion.setAlmacenDestinoId(20);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("5"),
+                TipoMovimiento.TRANSFERENCIA,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
+                "DOC-1",
+                null,
+                producto.getId(),
+                lote.getId(),
+                10,
+                20,
+                null,
+                null,
+                null,
+                50L,
+                solicitud.getId(),
+                usuario.getId(),
+                ordenProduccion.getId(),
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                List.of(atencion)
+        );
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(productoRepository.findById(1L)).willReturn(Optional.of(producto));
+        given(tipoMovimientoDetalleRepository.findById(50L)).willReturn(Optional.of(new TipoMovimientoDetalle()));
+        given(solicitudMovimientoRepository.findByIdWithLock(200L)).willReturn(Optional.of(solicitud));
+        given(usuarioService.obtenerUsuarioAutenticado()).willReturn(usuario);
+        given(entityManager.getReference(eq(OrdenProduccion.class), eq(ordenProduccion.getId()))).willReturn(ordenProduccion);
+        given(entityManager.getReference(eq(Almacen.class), any())).willAnswer(invocation -> {
+            Object id = invocation.getArgument(1);
+            return new Almacen(id instanceof Integer ? (Integer) id : ((Long) id).intValue());
+        });
+        given(loteProductoRepository.findByIdForUpdate(lote.getId())).willReturn(Optional.of(lote));
+        given(loteProductoRepository.save(any(LoteProducto.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(solicitudMovimientoDetalleRepository.findById(detalle.getId())).willReturn(Optional.of(detalle));
+        given(solicitudMovimientoDetalleRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(solicitudMovimientoRepository.saveAndFlush(solicitud)).willReturn(solicitud);
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(900L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willReturn(MovimientoInventarioResponseDTO.builder().id(900L).build());
+        given(catalogResolver.decimals(any())).willReturn(2);
+        given(reservaLoteRepository.sumPendienteActivaByLoteId(anyLong(), any())).willReturn(BigDecimal.ZERO);
+
+        MovimientoInventarioResponseDTO respuesta = service.registrarMovimiento(dto);
+
+        assertThat(respuesta).isNotNull();
+        assertThat(respuesta.getId()).isEqualTo(900L);
+        assertThat(detalle.getCantidadAtendida()).isEqualByComparingTo(new BigDecimal("5.000000"));
+        assertThat(detalle.getEstado()).isEqualTo(EstadoSolicitudMovimientoDetalle.ATENDIDO);
+        assertThat(solicitud.getEstado()).isEqualTo(EstadoSolicitudMovimiento.ATENDIDA);
+        assertThat(solicitud.getFechaResolucion()).isNotNull();
+        assertThat(lote.getStockLote()).isEqualByComparingTo(new BigDecimal("5.00"));
+
+        BigDecimal stockTrasPrimeraAprobacion = lote.getStockLote();
+
+        assertThatThrownBy(() -> service.registrarMovimiento(dto))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        assertThat(lote.getStockLote()).isEqualByComparingTo(stockTrasPrimeraAprobacion);
+        verify(movimientoInventarioRepository, times(1)).save(any(MovimientoInventario.class));
+    }
+}
+


### PR DESCRIPTION
## Summary
- protege las aprobaciones de movimientos de orden de producción validando el estado de la solicitud y sus detalles antes de registrar el movimiento
- actualiza cantidades atendidas y estado de la solicitud dentro de la misma transacción cuando el movimiento se atiende contra una orden de producción
- agrega una prueba de servicio que cubre la aprobación inicial y el bloqueo de reintentos sobre la misma solicitud

## Testing
- `mvn -q test` *(falla: existen pruebas de integración previas que requieren configuración y devuelven 401/errores de contexto)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185abf5be08333b1d471c968f7dcf7)