### PR TITLE
Fix OP reservation flow for inventory movements

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -607,9 +607,29 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             throw new IllegalStateException("No se generaron lotes para el movimiento");
         }
 
+        boolean solicitudOp = solicitud != null && esContextoOrdenProduccion(dto, solicitud);
         boolean solicitudOpProcesada = solicitudOpProcesadaEnLote.get();
+        boolean respuestaIdempotente = solicitudOp
+                && solicitudOpProcesada
+                && lotesProcesados.size() == 1
+                && (lotesProcesados.get(0).cantidad() == null
+                || lotesProcesados.get(0).cantidad().compareTo(BigDecimal.ZERO) == 0);
+
+        if (respuestaIdempotente) {
+            List<MovimientoInventarioResponseDTO.SolicitudDetalleAtencionDTO> detallesRespuesta =
+                    construirRespuestaSolicitud(solicitud);
+            return MovimientoInventarioResponseDTO.builder()
+                    .solicitudId(solicitud.getId())
+                    .estadoSolicitud(solicitud.getEstado())
+                    .ordenProduccionId(solicitud.getOrdenProduccion() != null
+                            ? solicitud.getOrdenProduccion().getId()
+                            : null)
+                    .detallesSolicitud(detallesRespuesta == null ? List.of() : List.copyOf(detallesRespuesta))
+                    .build();
+        }
+
         if (solicitud != null
-                && esContextoOrdenProduccion(dto, solicitud)
+                && solicitudOp
                 && !detallesProcesadosPorPartidas
                 && !solicitudOpProcesada) {
             detalleRespuesta = aplicarContraSolicitudMovimiento(dto, solicitud);
@@ -1719,15 +1739,6 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         LoteProducto loteProcesadoOp = null;
 
         if (esOpAtencion && detalleOp != null) {
-            if (!EstadoSolicitudMovimientoDetalle.PENDIENTE.equals(detalleOp.getEstado())) {
-                Long solicitudId = detalleOp.getSolicitudMovimiento() != null
-                        ? detalleOp.getSolicitudMovimiento().getId()
-                        : (solicitud != null ? solicitud.getId() : null);
-                log.warn("SOLICITUD_OP_YA_ATENDIDA: solicitudId={}, detalleId={}, estado={}",
-                        solicitudId, detalleOp.getId(), detalleOp.getEstado());
-                throw new ResponseStatusException(HttpStatus.CONFLICT, "SOLICITUD_OP_YA_ATENDIDA");
-            }
-
             BigDecimal solicitadaDetalle = Optional.ofNullable(detalleOp.getCantidad())
                     .orElse(BigDecimal.ZERO)
                     .setScale(6, RoundingMode.HALF_UP);
@@ -1735,37 +1746,70 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                     .orElse(BigDecimal.ZERO)
                     .setScale(6, RoundingMode.HALF_UP);
             BigDecimal pendienteDetalle = solicitadaDetalle.subtract(atendida);
+            if (pendienteDetalle.compareTo(BigDecimal.ZERO) < 0) {
+                pendienteDetalle = BigDecimal.ZERO;
+            }
+
             if (pendienteDetalle.compareTo(BigDecimal.ZERO) <= 0) {
                 Long solicitudId = detalleOp.getSolicitudMovimiento() != null
                         ? detalleOp.getSolicitudMovimiento().getId()
                         : (solicitud != null ? solicitud.getId() : null);
-                log.warn("SOLICITUD_OP_YA_ATENDIDA: solicitudId={}, detalleId={}, estado={}",
-                        solicitudId, detalleOp.getId(), detalleOp.getEstado());
-                throw new ResponseStatusException(HttpStatus.CONFLICT, "SOLICITUD_OP_YA_ATENDIDA");
+                log.info("[OP] Solicitud {} ya atendida para lote {}, reservaPendiente=0. Respuesta idempotente sin modificar stock.",
+                        solicitudId, loteOrigen.getId());
+                if (solicitudOpProcesada != null) {
+                    solicitudOpProcesada.set(true);
+                }
+                return List.of(new MovimientoLoteDetalle(loteOrigen, BigDecimal.ZERO));
             }
 
-            if (cantidad.compareTo(pendienteDetalle) > 0) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                        "SOLICITUD_OP_CANTIDAD_SUPERA_PENDIENTE");
+            BigDecimal reservadoDisponible = reservadoActual.compareTo(BigDecimal.ZERO) > 0
+                    ? reservadoActual
+                    : BigDecimal.ZERO;
+            if (reservadoDisponible.compareTo(pendienteDetalle) < 0) {
+                log.warn("[OP] Reserva insuficiente en lote: loteId={} reservado={} requerido={} productoId={}",
+                        loteOrigen.getId(), reservadoDisponible, pendienteDetalle, producto.getId());
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVA_STOCK_INSUFICIENTE");
             }
 
-            if (cantidad.compareTo(stockActual) > 0) {
+            if (stockActual.compareTo(pendienteDetalle) < 0) {
                 log.warn("Stock físico insuficiente en lote (OP): loteId={} stockLote={} solicitado={} productoId={}",
-                        loteOrigen.getId(), stockActual, cantidad, producto.getId());
+                        loteOrigen.getId(), stockActual, pendienteDetalle, producto.getId());
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE");
             }
 
-            reservaLoteService.consumirReserva(solicitud, detalleOp, loteOrigen, cantidad);
+            reservaLoteService.consumirReserva(solicitud, detalleOp, loteOrigen, pendienteDetalle);
 
             BigDecimal stockAntes = stockActual;
             BigDecimal reservadoAntes = reservadoActual;
             log.debug("VAL-ACTUALIZA (OP) antes actualizarStockLote loteId={} stockAntes={} reservadoAntes={} req={}",
-                    loteOrigen.getId(), stockAntes, reservadoAntes, cantidad);
+                    loteOrigen.getId(), stockAntes, reservadoAntes, pendienteDetalle);
 
-            actualizarStockLote(loteOrigen, cantidad, producto);
+            BigDecimal nuevoStock = stockActual.subtract(pendienteDetalle);
+            if (nuevoStock.compareTo(BigDecimal.ZERO) < 0) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE");
+            }
+
+            BigDecimal nuevoReservado = reservadoActual.subtract(pendienteDetalle);
+            if (nuevoReservado.compareTo(BigDecimal.ZERO) < 0) {
+                nuevoReservado = BigDecimal.ZERO;
+            }
+
+            int escala = resolverEscalaProducto(producto);
+            loteOrigen.setStockLote(nuevoStock.setScale(escala, RoundingMode.HALF_UP));
+            loteOrigen.setStockReservado(nuevoReservado.setScale(escala, RoundingMode.HALF_UP));
+            if (loteOrigen.getStockLote().compareTo(BigDecimal.ZERO) <= 0) {
+                loteOrigen.setAgotado(true);
+                if (loteOrigen.getFechaAgotado() == null) {
+                    loteOrigen.setFechaAgotado(LocalDateTime.now());
+                }
+            } else {
+                loteOrigen.setAgotado(false);
+                loteOrigen.setFechaAgotado(null);
+            }
+
             loteProcesadoOp = loteProductoRepository.save(loteOrigen);
 
-            actualizarDetalleSolicitud(detalleOp, cantidad);
+            actualizarDetalleSolicitud(detalleOp, pendienteDetalle);
             solicitudMovimientoDetalleRepository.save(detalleOp);
 
             actualizarEstadoSolicitud(solicitud);
@@ -1778,6 +1822,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
             stockActual = Optional.ofNullable(loteOrigen.getStockLote()).orElse(BigDecimal.ZERO);
             reservadoActual = Optional.ofNullable(loteOrigen.getStockReservado()).orElse(BigDecimal.ZERO);
+            cantidad = pendienteDetalle;
         }
 
         BigDecimal disponible = stockActual.subtract(reservadoActual);
@@ -1786,7 +1831,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                 && (solicitud.getEstado() == EstadoSolicitudMovimiento.AUTORIZADA
                 || solicitud.getEstado() == EstadoSolicitudMovimiento.PARCIAL);
         BigDecimal reservaPendiente = BigDecimal.ZERO;
-        if (solicitudAutorizadaOParcial) {
+        if (!esOpAtencion && solicitudAutorizadaOParcial) {
             reservaPendiente = calcularReservaPendiente(solicitud, loteOrigen);
             BigDecimal reservadoPositivo = reservadoActual.compareTo(BigDecimal.ZERO) > 0
                     ? reservadoActual

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -20,10 +20,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -31,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -70,8 +67,6 @@ class MovimientoInventarioServiceSolicitudOpTest {
     @Mock
     private ReservaLoteService reservaLoteService;
     @Mock
-    private ReservaLoteRepository reservaLoteRepository;
-    @Mock
     private RecepcionOCService recepcionOCService;
     @Mock
     private RetencionLoteService retencionLoteService;
@@ -94,7 +89,7 @@ class MovimientoInventarioServiceSolicitudOpTest {
     }
 
     @Test
-    void registrarMovimiento_solicitudOp_aplicaUnaSolaVez() {
+    void registrarMovimiento_solicitudOp_consumeReservaYEsIdempotente() {
         Producto producto = new Producto();
         producto.setId(1);
         UnidadMedida unidad = new UnidadMedida();
@@ -105,13 +100,13 @@ class MovimientoInventarioServiceSolicitudOpTest {
         lote.setId(100L);
         lote.setProducto(producto);
         lote.setAlmacen(new Almacen(10));
-        lote.setStockLote(new BigDecimal("10"));
-        lote.setStockReservado(new BigDecimal("5"));
+        lote.setStockLote(new BigDecimal("1000"));
+        lote.setStockReservado(new BigDecimal("1000"));
         lote.setEstado(EstadoLote.DISPONIBLE);
 
         SolicitudMovimientoDetalle detalle = new SolicitudMovimientoDetalle();
         detalle.setId(300L);
-        detalle.setCantidad(new BigDecimal("5"));
+        detalle.setCantidad(new BigDecimal("1000"));
         detalle.setEstado(EstadoSolicitudMovimientoDetalle.PENDIENTE);
         detalle.setCantidadAtendida(BigDecimal.ZERO);
         detalle.setLote(lote);
@@ -122,7 +117,7 @@ class MovimientoInventarioServiceSolicitudOpTest {
         solicitud.setLote(lote);
         solicitud.setTipoMovimiento(TipoMovimiento.TRANSFERENCIA);
         solicitud.setEstado(EstadoSolicitudMovimiento.PENDIENTE);
-        solicitud.setCantidad(new BigDecimal("5"));
+        solicitud.setCantidad(new BigDecimal("1000"));
         solicitud.setDetalles(List.of(detalle));
         detalle.setSolicitudMovimiento(solicitud);
 
@@ -148,13 +143,13 @@ class MovimientoInventarioServiceSolicitudOpTest {
         AtencionDTO atencion = new AtencionDTO();
         atencion.setDetalleId(detalle.getId());
         atencion.setLoteId(lote.getId());
-        atencion.setCantidad(new BigDecimal("5"));
+        atencion.setCantidad(new BigDecimal("1000"));
         atencion.setAlmacenOrigenId(10);
         atencion.setAlmacenDestinoId(20);
 
         MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
                 null,
-                new BigDecimal("5"),
+                new BigDecimal("1000"),
                 TipoMovimiento.TRANSFERENCIA,
                 ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
                 "DOC-1",
@@ -201,33 +196,45 @@ class MovimientoInventarioServiceSolicitudOpTest {
         given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
                 .willReturn(MovimientoInventarioResponseDTO.builder().id(900L).build());
         given(catalogResolver.decimals(any())).willReturn(2);
-        given(reservaLoteRepository.sumPendienteActivaByLoteId(anyLong(), any())).willReturn(BigDecimal.ZERO);
 
         MovimientoInventarioResponseDTO respuesta = service.registrarMovimiento(dto);
 
         assertThat(respuesta).isNotNull();
         assertThat(respuesta.getId()).isEqualTo(900L);
-        assertThat(detalle.getCantidadAtendida()).isEqualByComparingTo(new BigDecimal("5.000000"));
+        assertThat(detalle.getCantidadAtendida()).isEqualByComparingTo(new BigDecimal("1000.000000"));
         assertThat(detalle.getEstado()).isEqualTo(EstadoSolicitudMovimientoDetalle.ATENDIDO);
         assertThat(solicitud.getEstado()).isEqualTo(EstadoSolicitudMovimiento.CERRADA);
         assertThat(solicitud.getFechaResolucion()).isNotNull();
-        assertThat(lote.getStockLote()).isEqualByComparingTo(new BigDecimal("5.00"));
+        assertThat(lote.getStockLote()).isEqualByComparingTo(new BigDecimal("0.00"));
         assertThat(lote.getStockReservado()).isEqualByComparingTo(BigDecimal.ZERO);
 
         BigDecimal stockTrasPrimeraAprobacion = lote.getStockLote();
+        BigDecimal reservaTrasPrimeraAprobacion = lote.getStockReservado();
+        BigDecimal cantidadAtendidaTrasPrimeraAprobacion = detalle.getCantidadAtendida();
 
-        assertThatThrownBy(() -> service.registrarMovimiento(dto))
-                .isInstanceOf(ResponseStatusException.class)
-                .satisfies(ex -> {
-                    ResponseStatusException rse = (ResponseStatusException) ex;
-                    assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
-                    assertThat(rse.getReason()).isEqualTo("SOLICITUD_OP_YA_ATENDIDA");
-                });
+        MovimientoInventarioResponseDTO respuestaIdempotente = service.registrarMovimiento(dto);
+
+        assertThat(respuestaIdempotente).isNotNull();
+        assertThat(respuestaIdempotente.getId()).isNull();
+        assertThat(respuestaIdempotente.getSolicitudId()).isEqualTo(solicitud.getId());
+        assertThat(respuestaIdempotente.getEstadoSolicitud()).isEqualTo(EstadoSolicitudMovimiento.CERRADA);
+        assertThat(respuestaIdempotente.getOrdenProduccionId()).isEqualTo(ordenProduccion.getId());
+        assertThat(respuestaIdempotente.getDetallesSolicitud()).hasSize(1);
+        MovimientoInventarioResponseDTO.SolicitudDetalleAtencionDTO detalleRespuesta =
+                respuestaIdempotente.getDetallesSolicitud().get(0);
+        assertThat(detalleRespuesta.getDetalleId()).isEqualTo(detalle.getId());
+        assertThat(detalleRespuesta.getCantidadAtendida()).isEqualByComparingTo(new BigDecimal("1000.000000"));
+        assertThat(detalleRespuesta.getEstadoDetalle()).isEqualTo(EstadoSolicitudMovimientoDetalle.ATENDIDO);
 
         assertThat(lote.getStockLote()).isEqualByComparingTo(stockTrasPrimeraAprobacion);
-        assertThat(lote.getStockReservado()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(lote.getStockReservado()).isEqualByComparingTo(reservaTrasPrimeraAprobacion);
+        assertThat(detalle.getCantidadAtendida()).isEqualByComparingTo(cantidadAtendidaTrasPrimeraAprobacion);
+        assertThat(solicitud.getEstado()).isEqualTo(EstadoSolicitudMovimiento.CERRADA);
+
         verify(movimientoInventarioRepository, times(1)).save(any(MovimientoInventario.class));
         verify(solicitudMovimientoRepository, times(1)).saveAndFlush(solicitud);
+        verify(reservaLoteService, times(1)).consumirReserva(eq(solicitud), eq(detalle), eq(lote), eq(new BigDecimal("1000.000000")));
+        verify(mapper, times(1)).safeToResponseDTO(any(MovimientoInventario.class));
     }
 }
 


### PR DESCRIPTION
## Summary
- consume pending reservations for OP-linked movements directly from the reserved stock and skip generic stock checks
- short-circuit OP approvals that were already served by returning an idempotent response without duplicating movements
- extend the OP request test to cover the 1000-unit reservation scenario and verify the second approval is a no-op

## Testing
- mvn -Dtest=MovimientoInventarioServiceSolicitudOpTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918737a40d08333b436304472f4958c)