### PR TITLE
Fix auto split transfer to use effective stock for initial quantity

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -1946,7 +1946,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             List<MovimientoLoteDetalle> detalles = new ArrayList<>();
             List<ParLoteCantidad> consumidos = new ArrayList<>();
 
-            BigDecimal cantidadInicial = cantidad.min(disponibleNoNegativo);
+            BigDecimal cantidadInicial = cantidad.min(stockDisponibleEfectivo);
             if (cantidadInicial.compareTo(BigDecimal.ZERO) > 0) {
                 detalles.add(ejecutarTransferenciaDesdeLote(loteOrigen, destino, producto, cantidadInicial, solicitud));
                 consumidos.add(new ParLoteCantidad(loteOrigen.getId(), cantidadInicial));


### PR DESCRIPTION
## Summary
- update the auto-split transfer path to cap the initial quantity using the effective available stock that replaced the removed variable

## Testing
- mvn -q -DskipTests compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a2f5c13883338f8d45416a5437d6)