### PR TITLE
Unificar cálculo FEFO de disponibilidad en órdenes de producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -7,6 +7,8 @@ import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 import com.willyes.clemenintegra.bom.repository.*;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.produccion.service.DisponibilidadInsumoService;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
@@ -35,6 +37,7 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
     private final FormulaProductoRepository formulaRepository;
     private final BomMapper bomMapper;
     private final LoteProductoRepository loteProductoRepository;
+    private final DisponibilidadInsumoService disponibilidadInsumoService;
     private final UsuarioRepository usuarioRepository;
 
     @Override
@@ -282,7 +285,17 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                         .add(disponibilidad.getVencido());
                 disponibilidad.setTotalProducto(totalProducto);
 
-                boolean insuficiente = disponibilidad.getDisponible().compareTo(totalNecesaria) < 0;
+                List<Long> almacenesPreferidos = disponibilidadInsumoService
+                        .resolverAlmacenesPreferidos(entidad.getInsumo());
+                DistribucionFefoResult fefoResult = disponibilidadInsumoService.calcularDisponibilidad(
+                        insumoId,
+                        totalNecesaria,
+                        almacenesPreferidos,
+                        true);
+
+                BigDecimal stockLibre = Optional.ofNullable(fefoResult.getStockLibreTotal())
+                        .orElse(disponibilidad.getDisponible());
+                boolean insuficiente = !fefoResult.isSuficiente();
                 String motivo = "OK";
                 if (insuficiente) {
                     if (disponibilidad.getEnCuarentena().compareTo(BigDecimal.ZERO) > 0) {
@@ -299,12 +312,12 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                     log.info("FORMULA_DISPONIBILIDAD insumoId={} requerido={} disponible={} motivo={}",
                             insumoId,
                             totalNecesaria,
-                            disponibilidad.getDisponible(),
+                            stockLibre,
                             motivo);
                 }
 
-                dto.stockDisponible = disponibilidad.getDisponible();
-                dto.estadoStock = disponibilidad.getDisponible().compareTo(totalNecesaria) >= 0 ? "SUFICIENTE" : "INSUFICIENTE";
+                dto.stockDisponible = stockLibre;
+                dto.estadoStock = fefoResult.isSuficiente() ? "SUFICIENTE" : "INSUFICIENTE";
                 dto.disponibilidad = disponibilidad;
                 dto.bloqueante = new BloqueanteDTO(insuficiente, motivo);
                 dto.lotes = lotes;

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteFefoDisponibleProjection.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteFefoDisponibleProjection.java
@@ -10,6 +10,8 @@ public interface LoteFefoDisponibleProjection {
     Long getLoteProductoId();
     String getCodigoLote();
     BigDecimal getStockLote();
+    BigDecimal getStockFisico();
+    BigDecimal getStockReservado();
     LocalDateTime getFechaVencimiento();
     Long getAlmacenId();
     String getNombreAlmacen();

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -118,6 +118,8 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
         SELECT lp.id AS loteProductoId,
                lp.codigo_lote AS codigoLote,
                (lp.stock_lote - lp.stock_reservado) AS stockLote,
+               lp.stock_lote AS stockFisico,
+               lp.stock_reservado AS stockReservado,
                lp.fecha_vencimiento AS fechaVencimiento,
                lp.almacenes_id AS almacenId,
                a.nombre AS nombreAlmacen,

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
@@ -156,8 +156,35 @@ public class ReservaLoteService {
 
         if (pendienteNuevo.compareTo(disponible) > 0) {
             BigDecimal faltante = pendienteNuevo.subtract(disponible).setScale(6, RoundingMode.HALF_UP);
+            String codigo = lote.getProducto() != null && lote.getProducto().getCodigoSku() != null
+                    ? lote.getProducto().getCodigoSku()
+                    : String.valueOf(loteId);
+            String nombre = lote.getProducto() != null && lote.getProducto().getNombre() != null
+                    ? lote.getProducto().getNombre()
+                    : "Insumo";
+            String unidad = lote.getProducto() != null && lote.getProducto().getUnidadMedida() != null
+                    && lote.getProducto().getUnidadMedida().getNombre() != null
+                    ? lote.getProducto().getUnidadMedida().getNombre()
+                    : "";
+
+            log.warn(
+                    "STOCK_INSUFICIENTE en reserva de lote: loteId={} codigoLote={} insumo {} - {}, requerido={}, stockLote={}, stockReservado={}, stockLibre={}, faltante={}",
+                    lote.getId(),
+                    lote.getCodigoLote(),
+                    codigo,
+                    nombre,
+                    pendienteNuevo,
+                    Optional.ofNullable(lote.getStockLote()).orElse(BigDecimal.ZERO),
+                    Optional.ofNullable(lote.getStockReservado()).orElse(BigDecimal.ZERO),
+                    disponible,
+                    faltante);
+
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                    "STOCK_INSUFICIENTE: faltan " + faltante);
+                    String.format("STOCK_INSUFICIENTE: insumo %s - %s, faltan %s %s",
+                            codigo,
+                            nombre,
+                            faltante.toPlainString(),
+                            unidad));
         }
 
         ReservaLote reserva = existenteOpt.orElseGet(() -> ReservaLote.builder()

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
@@ -1,0 +1,179 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoDetalle;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DisponibilidadInsumoService {
+
+    private final LoteProductoRepository loteProductoRepository;
+    private final InventoryCatalogResolver catalogResolver;
+
+    private static final EnumSet<EstadoLote> ESTADOS_FEFO_PERMITIDOS = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
+    private static final Map<TipoCategoria, Function<InventoryCatalogResolver, Long>> ALMACENES_ORIGEN_POR_CATEGORIA = Map.of(
+            TipoCategoria.MATERIA_PRIMA, InventoryCatalogResolver::getAlmacenOrigenMateriaPrimaId,
+            TipoCategoria.MATERIAL_EMPAQUE, InventoryCatalogResolver::getAlmacenOrigenMaterialEmpaqueId,
+            TipoCategoria.SUMINISTROS, InventoryCatalogResolver::getAlmacenOrigenSuministrosId);
+
+    public List<Long> resolverAlmacenesPreferidos(Producto insumo) {
+        Long preBodegaProduccionId = catalogResolver.getAlmacenPreBodegaProduccionId();
+        Long origenId = Optional.ofNullable(insumo)
+                .map(Producto::getCategoriaProducto)
+                .map(CategoriaProducto::getTipo)
+                .map(ALMACENES_ORIGEN_POR_CATEGORIA::get)
+                .map(func -> func.apply(catalogResolver))
+                .orElse(null);
+
+        if (origenId == null || Objects.equals(origenId, preBodegaProduccionId)) {
+            return List.of();
+        }
+        return List.of(origenId);
+    }
+
+    public DistribucionFefoResult calcularDisponibilidad(Long productoInsumoId,
+                                                          BigDecimal cantidadRequerida,
+                                                          List<Long> almacenesPreferidos,
+                                                          boolean modoPreview) {
+        BigDecimal requerida = Optional.ofNullable(cantidadRequerida)
+                .orElse(BigDecimal.ZERO)
+                .setScale(8, RoundingMode.HALF_UP);
+
+        List<LoteFefoDisponibleProjection> lotesDisponibles = loteProductoRepository
+                .findFefoDisponibles(productoInsumoId, Integer.MAX_VALUE);
+
+        List<Long> preferidos = almacenesPreferidos == null ? List.of() : List.copyOf(almacenesPreferidos);
+        List<LoteFefoDisponibleProjection> lotesSeleccionados = new ArrayList<>(lotesDisponibles);
+        boolean usoFallback = false;
+        String motivoFallback = null;
+
+        if (!preferidos.isEmpty()) {
+            lotesSeleccionados = lotesDisponibles.stream()
+                    .filter(lote -> lote.getAlmacenId() != null && preferidos.contains(lote.getAlmacenId()))
+                    .toList();
+
+            BigDecimal cubierto = lotesSeleccionados.stream()
+                    .map(LoteFefoDisponibleProjection::getStockLote)
+                    .filter(Objects::nonNull)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+            if (lotesSeleccionados.isEmpty() || cubierto.compareTo(requerida) < 0) {
+                usoFallback = true;
+                motivoFallback = lotesSeleccionados.isEmpty() ? "SIN_ALMACEN_CONFIGURADO" : "STOCK_NO_DISPONIBLE_EN_ORIGEN";
+                lotesSeleccionados = lotesDisponibles;
+            }
+        } else if (!lotesDisponibles.isEmpty()) {
+            usoFallback = true;
+            motivoFallback = "SIN_ALMACEN_CONFIGURADO";
+        }
+
+        if (usoFallback && !modoPreview) {
+            log.info("Disponibilidad FEFO fallback insumoId={} requerida={} motivo={} almacenesPreferidos={}",
+                    productoInsumoId, requerida, motivoFallback, preferidos);
+        }
+
+        lotesSeleccionados.stream()
+                .map(LoteFefoDisponibleProjection::getEstado)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(this::parseEstadoLoteSafe)
+                .filter(Objects::nonNull)
+                .filter(estado -> !ESTADOS_FEFO_PERMITIDOS.contains(estado))
+                .findFirst()
+                .ifPresent(estado -> log.warn("Disponibilidad FEFO detectó lote en estado no permitido: {}", estado));
+
+        BigDecimal stockFisicoTotal = sumar(lotesDisponibles, LoteFefoDisponibleProjection::getStockFisico);
+        BigDecimal stockReservadoTotal = sumar(lotesDisponibles, LoteFefoDisponibleProjection::getStockReservado);
+        BigDecimal stockLibreTotal = sumar(lotesDisponibles, LoteFefoDisponibleProjection::getStockLote);
+
+        List<DistribucionFefoDetalle> detalles = new ArrayList<>();
+        BigDecimal restante = requerida;
+        for (LoteFefoDisponibleProjection lote : lotesSeleccionados) {
+            if (restante.compareTo(BigDecimal.ZERO) <= 0) {
+                break;
+            }
+            BigDecimal disponible = Optional.ofNullable(lote.getStockLote()).orElse(BigDecimal.ZERO);
+            if (disponible.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+            BigDecimal usar = disponible.min(restante);
+            if (usar.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+
+            BigDecimal usarCalculo = usar.setScale(8, RoundingMode.HALF_UP);
+            BigDecimal usarDetalle = usarCalculo.setScale(6, RoundingMode.HALF_UP);
+
+            detalles.add(DistribucionFefoDetalle.builder()
+                    .loteProductoId(lote.getLoteProductoId())
+                    .codigoLote(lote.getCodigoLote())
+                    .almacenId(lote.getAlmacenId())
+                    .cantidadCalculo(usarCalculo)
+                    .cantidadReserva(usarDetalle)
+                    .disponible(disponible)
+                    .estado(lote.getEstado())
+                    .build());
+
+            restante = restante.subtract(usarCalculo).setScale(8, RoundingMode.HALF_UP);
+        }
+
+        if (restante.compareTo(BigDecimal.ZERO) < 0) {
+            restante = BigDecimal.ZERO;
+        }
+
+        BigDecimal faltante = restante.setScale(6, RoundingMode.HALF_UP);
+        boolean suficiente = faltante.compareTo(BigDecimal.ZERO) <= 0;
+
+        return DistribucionFefoResult.builder()
+                .productoInsumoId(productoInsumoId)
+                .requerido(requerida.setScale(6, RoundingMode.HALF_UP))
+                .stockFisicoTotal(stockFisicoTotal)
+                .stockReservadoTotal(stockReservadoTotal)
+                .stockLibreTotal(stockLibreTotal)
+                .faltante(faltante)
+                .suficiente(suficiente)
+                .usoFallback(usoFallback)
+                .almacenesPreferidos(preferidos)
+                .detalles(detalles)
+                .build();
+    }
+
+    private BigDecimal sumar(List<LoteFefoDisponibleProjection> lotes,
+                              Function<LoteFefoDisponibleProjection, BigDecimal> extractor) {
+        return lotes.stream()
+                .map(extractor)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private EstadoLote parseEstadoLoteSafe(String valor) {
+        try {
+            return EstadoLote.valueOf(valor.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            log.warn("Estado de lote desconocido recibido en FEFO: {}", valor);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -38,6 +38,8 @@ import com.willyes.clemenintegra.inventario.service.SolicitudMovimientoService;
 import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoDetalle;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
 import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
 import com.willyes.clemenintegra.inventario.service.ReservaLoteService;
 import com.willyes.clemenintegra.produccion.dto.LoteProductoResponse;
@@ -77,7 +79,6 @@ import org.springframework.http.ProblemDetail;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +86,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.function.Function;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.LocalDate;
@@ -121,6 +121,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     private final UmValidator umValidator;
     private final VidaUtilProductoRepository vidaUtilProductoRepository;
     private final ReservaLoteService reservaLoteService;
+    private final DisponibilidadInsumoService disponibilidadInsumoService;
 
     @Value("${inventory.solicitud.estados.pendientes}")
     private String estadosSolicitudPendientesConf;
@@ -131,43 +132,11 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     @Value("${inventory.mov.clasificacion.entradaPt}")
     private String clasificacionEntradaPtConf;
 
-    private static final Map<TipoCategoria, Function<InventoryCatalogResolver, Long>> ALMACENES_ORIGEN_POR_CATEGORIA = Map.of(
-            TipoCategoria.MATERIA_PRIMA, InventoryCatalogResolver::getAlmacenOrigenMateriaPrimaId,
-            TipoCategoria.MATERIAL_EMPAQUE, InventoryCatalogResolver::getAlmacenOrigenMaterialEmpaqueId,
-            TipoCategoria.SUMINISTROS, InventoryCatalogResolver::getAlmacenOrigenSuministrosId);
-
-    private static final EnumSet<EstadoLote> ESTADOS_FEFO_PERMITIDOS = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
-
     private String generarCodigoOrden() {
         String fecha = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         String prefijo = "OP-CLEMEN-" + fecha;
         Long contador = repository.countByCodigoOrdenStartingWith(prefijo);
         return prefijo + "-" + String.format("%02d", contador + 1);
-    }
-
-    /**
-     * Obtiene los almacenes habilitados para consumir insumos desde producción.
-     * <p>
-     * Actualmente solo se permite consumir desde el almacén de origen configurado
-     * por categoría para producción. La pre-bodega de producción se excluye de
-     * manera explícita porque su stock está reservado para las transferencias de
-     * salida y no debe afectar la validación ni la reserva FEFO de insumos.
-     * </p>
-     */
-    private List<Long> obtenerAlmacenesOrigen(Producto insumo) {
-        Long preBodegaProduccionId = catalogResolver.getAlmacenPreBodegaProduccionId();
-        Long origenId = Optional.ofNullable(insumo)
-                .map(Producto::getCategoriaProducto)
-                .map(CategoriaProducto::getTipo)
-                .map(ALMACENES_ORIGEN_POR_CATEGORIA::get)
-                .map(func -> func.apply(catalogResolver))
-                .orElse(null);
-
-        if (origenId == null || Objects.equals(origenId, preBodegaProduccionId)) {
-            return List.of();
-        }
-
-        return List.of(origenId);
     }
 
     private String generarCodigoLote(Producto producto) {
@@ -281,7 +250,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
             BigDecimal cantidadRequerida = insumo.getCantidadNecesaria().multiply(cantidadProgramada);
 
-            List<Long> almacenesValidos = obtenerAlmacenesOrigen(insumo.getInsumo());
+            List<Long> almacenesValidos = disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo.getInsumo());
             if (almacenesValidos.isEmpty()) {
                 TipoCategoria tipoCategoria = Optional.ofNullable(productoInsumo.getCategoriaProducto())
                         .map(CategoriaProducto::getTipo)
@@ -764,80 +733,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         }
     }
 
-    private List<LoteFefoDisponibleProjection> seleccionarLotesFefo(Long ordenId, Long insumoId,
-            BigDecimal requerida, List<Long> almacenesValidos) {
-        List<LoteFefoDisponibleProjection> lotesDisponibles = loteProductoRepository
-                .findFefoDisponibles(insumoId, Integer.MAX_VALUE);
-
-        List<Long> almacenesPreferidos = almacenesValidos == null ? List.of() : almacenesValidos;
-        List<LoteFefoDisponibleProjection> lotesSeleccionados;
-        boolean usoFallback;
-        String motivoFallback = null;
-
-        if (almacenesPreferidos.isEmpty()) {
-            usoFallback = true;
-            lotesSeleccionados = lotesDisponibles;
-            motivoFallback = "SIN_ALMACEN_CONFIGURADO";
-        } else {
-            lotesSeleccionados = lotesDisponibles.stream()
-                    .filter(l -> l.getAlmacenId() != null && almacenesPreferidos.contains(l.getAlmacenId().longValue()))
-                    .toList();
-
-            BigDecimal cubierto = lotesSeleccionados.stream()
-                    .map(LoteFefoDisponibleProjection::getStockLote)
-                    .filter(Objects::nonNull)
-                    .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-            usoFallback = lotesSeleccionados.isEmpty() || cubierto.compareTo(requerida) < 0;
-            if (usoFallback) {
-                lotesSeleccionados = lotesDisponibles;
-                motivoFallback = "STOCK_NO_DISPONIBLE_EN_ORIGEN";
-            }
-        }
-
-        if (usoFallback) {
-            log.info("OP-reserva fallback FEFO ordenId={}, insumoId={}, requerida={}, motivo={}, almacenesPreferidos={}",
-                    ordenId, insumoId, requerida, motivoFallback, almacenesPreferidos);
-        }
-
-        if (lotesSeleccionados.isEmpty()) {
-            log.warn("OP-RESERVA sin lotes elegibles ordenId={} insumoId={} requerida={}",
-                    ordenId,
-                    insumoId,
-                    requerida);
-            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                    "STOCK_INSUFICIENTE: faltan " + requerida);
-        }
-
-        lotesSeleccionados.stream()
-                .map(LoteFefoDisponibleProjection::getEstado)
-                .filter(Objects::nonNull)
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .map(this::parseEstadoLoteSafe)
-                .filter(Objects::nonNull)
-                .filter(estado -> !ESTADOS_FEFO_PERMITIDOS.contains(estado))
-                .findFirst()
-                .ifPresent(estado -> log.warn("OP-reserva detectó lote en estado no permitido: {}", estado));
-
-        Long primerLoteId = lotesSeleccionados.get(0).getLoteProductoId();
-        if (primerLoteId == null) {
-            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                    "STOCK_INSUFICIENTE: faltan " + requerida);
-        }
-
-        return lotesSeleccionados;
-    }
-
-    private EstadoLote parseEstadoLoteSafe(String valor) {
-        try {
-            return EstadoLote.valueOf(valor.toUpperCase());
-        } catch (IllegalArgumentException ex) {
-            log.warn("Estado de lote desconocido recibido en FEFO: {}", valor);
-            return null;
-        }
-    }
-
     @Transactional(rollbackFor = Exception.class)
     public void reservarInsumosParaOP(Long ordenId) {
         OrdenProduccion orden = repository.findById(ordenId)
@@ -877,12 +772,20 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     .multiply(orden.getCantidadProgramada())
                     .setScale(8, RoundingMode.HALF_UP);
             BigDecimal requeridaSolicitud = requerida.setScale(6, RoundingMode.HALF_UP);
-            List<Long> almacenesValidos = obtenerAlmacenesOrigen(insumo.getInsumo());
+            List<Long> almacenesValidos = disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo.getInsumo());
 
-            List<LoteFefoDisponibleProjection> lotesSeleccionados = seleccionarLotesFefo(
-                    ordenId, insumoId, requerida, almacenesValidos);
+            DistribucionFefoResult distribucion = disponibilidadInsumoService.calcularDisponibilidad(
+                    insumoId, requerida, almacenesValidos, false);
 
-            Long primerLoteId = lotesSeleccionados.get(0).getLoteProductoId();
+            if (!distribucion.isSuficiente() || distribucion.getDetalles().isEmpty()) {
+                manejarStockInsuficiente(insumo.getInsumo(), distribucion);
+            }
+
+            DistribucionFefoDetalle primerDetalle = distribucion.getDetalles().get(0);
+            Long primerLoteId = primerDetalle.getLoteProductoId();
+            if (primerLoteId == null) {
+                manejarStockInsuficiente(insumo.getInsumo(), distribucion);
+            }
 
             SolicitudMovimientoRequestDTO solicitudReq = SolicitudMovimientoRequestDTO.builder()
                     .tipoMovimiento(TipoMovimiento.SALIDA)
@@ -920,41 +823,69 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 detallesSolicitud.clear();
             }
 
-            BigDecimal restante = requerida;
-
-            for (LoteFefoDisponibleProjection lote : lotesSeleccionados) {
-                if (restante.compareTo(BigDecimal.ZERO) <= 0) {
-                    break;
-                }
-                BigDecimal disponible = Optional.ofNullable(lote.getStockLote()).orElse(BigDecimal.ZERO);
-                BigDecimal usar = disponible.min(restante);
-                if (usar.compareTo(BigDecimal.ZERO) <= 0) {
+            for (DistribucionFefoDetalle detalleDistribucion : distribucion.getDetalles()) {
+                BigDecimal usarDetalle = Optional.ofNullable(detalleDistribucion.getCantidadReserva())
+                        .orElse(BigDecimal.ZERO);
+                if (usarDetalle.compareTo(BigDecimal.ZERO) <= 0) {
                     continue;
                 }
 
-                BigDecimal usarCalculo = usar.setScale(8, RoundingMode.HALF_UP);
-                BigDecimal usarDetalle = usarCalculo.setScale(6, RoundingMode.HALF_UP);
-
                 SolicitudMovimientoDetalle detSolicitud = SolicitudMovimientoDetalle.builder()
                         .solicitudMovimiento(solicitud)
-                        .lote(new LoteProducto(lote.getLoteProductoId()))
+                        .lote(detalleDistribucion.getLoteProductoId() != null
+                                ? new LoteProducto(detalleDistribucion.getLoteProductoId())
+                                : null)
                         .cantidad(usarDetalle)
-                        .almacenOrigen(lote.getAlmacenId() != null ? new Almacen(Math.toIntExact(lote.getAlmacenId())) : null)
+                        .almacenOrigen(detalleDistribucion.getAlmacenId() != null
+                                ? new Almacen(Math.toIntExact(detalleDistribucion.getAlmacenId()))
+                                : null)
                         .almacenDestino(solicitud.getAlmacenDestino())
                         .build();
                 detallesSolicitud.add(detSolicitud);
-
-                restante = restante.subtract(usarCalculo).setScale(8, RoundingMode.HALF_UP);
-            }
-
-            if (restante.compareTo(BigDecimal.ZERO) > 0) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                        "STOCK_INSUFICIENTE: faltan " + restante);
             }
 
             solicitudMovimientoRepository.saveAndFlush(solicitud);
             reservaLoteService.sincronizarReservasSolicitud(solicitud);
         }
+    }
+
+    private void manejarStockInsuficiente(Producto insumo, DistribucionFefoResult resultado) {
+        BigDecimal faltante = Optional.ofNullable(resultado.getFaltante())
+                .orElse(BigDecimal.ZERO)
+                .setScale(6, RoundingMode.HALF_UP);
+
+        Producto producto = Optional.ofNullable(insumo)
+                .orElseGet(() -> resultado.getProductoInsumoId() != null
+                        ? productoRepository.findById(resultado.getProductoInsumoId()).orElse(null)
+                        : null);
+
+        String codigo = producto != null && producto.getCodigoSku() != null
+                ? producto.getCodigoSku()
+                : resultado.getProductoInsumoId() != null ? resultado.getProductoInsumoId().toString() : "";
+        String nombre = producto != null && producto.getNombre() != null
+                ? producto.getNombre()
+                : "Insumo";
+        String unidad = producto != null && producto.getUnidadMedida() != null
+                && producto.getUnidadMedida().getNombre() != null
+                ? producto.getUnidadMedida().getNombre()
+                : "";
+
+        log.warn(
+                "STOCK_INSUFICIENTE en OP: insumo {} - {}, requerido={}, stockFisicoTotal={}, stockReservadoTotal={}, stockLibreTotal={}, faltante={}",
+                codigo,
+                nombre,
+                Optional.ofNullable(resultado.getRequerido()).orElse(BigDecimal.ZERO),
+                Optional.ofNullable(resultado.getStockFisicoTotal()).orElse(BigDecimal.ZERO),
+                Optional.ofNullable(resultado.getStockReservadoTotal()).orElse(BigDecimal.ZERO),
+                Optional.ofNullable(resultado.getStockLibreTotal()).orElse(BigDecimal.ZERO),
+                faltante);
+
+        throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                String.format("STOCK_INSUFICIENTE: insumo %s - %s, faltan %s %s",
+                        codigo,
+                        nombre,
+                        faltante.toPlainString(),
+                        unidad));
     }
 
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/model/DistribucionFefoDetalle.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/model/DistribucionFefoDetalle.java
@@ -1,0 +1,18 @@
+package com.willyes.clemenintegra.produccion.service.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class DistribucionFefoDetalle {
+    private final Long loteProductoId;
+    private final String codigoLote;
+    private final Long almacenId;
+    private final BigDecimal cantidadCalculo;
+    private final BigDecimal cantidadReserva;
+    private final BigDecimal disponible;
+    private final String estado;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/model/DistribucionFefoResult.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/model/DistribucionFefoResult.java
@@ -1,0 +1,27 @@
+package com.willyes.clemenintegra.produccion.service.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Builder
+public class DistribucionFefoResult {
+    private final Long productoInsumoId;
+    private final BigDecimal requerido;
+    private final BigDecimal stockFisicoTotal;
+    private final BigDecimal stockReservadoTotal;
+    private final BigDecimal stockLibreTotal;
+    private final BigDecimal faltante;
+    private final boolean suficiente;
+    private final boolean usoFallback;
+    private final List<Long> almacenesPreferidos;
+    private final List<DistribucionFefoDetalle> detalles;
+
+    public List<DistribucionFefoDetalle> getDetalles() {
+        return detalles == null ? List.of() : Collections.unmodifiableList(detalles);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -17,6 +17,7 @@ import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.produccion.service.DisponibilidadInsumoService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,9 @@ class FormulaProductoServiceImplTest {
     @Mock
     private UsuarioRepository usuarioRepository;
 
+    @Mock
+    private DisponibilidadInsumoService disponibilidadInsumoService;
+
     private BomMapper bomMapper;
 
     private FormulaProductoServiceImpl service;
@@ -57,7 +61,7 @@ class FormulaProductoServiceImplTest {
     @BeforeEach
     void setUp() {
         bomMapper = Mappers.getMapper(BomMapper.class);
-        service = new FormulaProductoServiceImpl(formulaRepository, bomMapper, loteProductoRepository, usuarioRepository);
+        service = new FormulaProductoServiceImpl(formulaRepository, bomMapper, loteProductoRepository, disponibilidadInsumoService, usuarioRepository);
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteServiceTest.java
@@ -9,6 +9,8 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,12 +18,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -103,5 +107,42 @@ class ReservaLoteServiceTest {
         assertThat(actualizado.getEstado()).isEqualTo(EstadoReservaLote.CANCELADA);
         assertThat(actualizado.getCantidadConsumida()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
         verify(loteProductoRepository).findByIdForUpdate(8L);
+    }
+
+    @Test
+    @DisplayName("crearOActualizarDesdeDetalle insuficiente expone mensaje enriquecido")
+    void crearOActualizarDesdeDetalle_insuficienteMensaje() {
+        SolicitudMovimientoDetalle detalle = SolicitudMovimientoDetalle.builder()
+                .id(30L)
+                .cantidad(new BigDecimal("6"))
+                .lote(LoteProducto.builder().id(15L).build())
+                .build();
+
+        Producto producto = new Producto();
+        producto.setCodigoSku("MP-COLRO");
+        producto.setNombre("Colorante Rojo");
+        UnidadMedida unidadMedida = new UnidadMedida();
+        unidadMedida.setNombre("MILILITRO");
+        producto.setUnidadMedida(unidadMedida);
+
+        LoteProducto lote = LoteProducto.builder()
+                .id(15L)
+                .codigoLote("L-15")
+                .producto(producto)
+                .stockLote(new BigDecimal("5"))
+                .stockReservado(new BigDecimal("2"))
+                .almacen(new Almacen())
+                .build();
+
+        when(loteProductoRepository.findByIdForUpdate(15L)).thenReturn(Optional.of(lote));
+        when(reservaLoteRepository.findByDetalleIdAndLoteIdForUpdate(30L, 15L)).thenReturn(Optional.empty());
+        when(reservaLoteRepository.sumPendienteByLoteId(eq(15L), any())).thenReturn(new BigDecimal("2"));
+
+        assertThatThrownBy(() -> service.crearOActualizarDesdeDetalle(detalle))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("MP-COLRO")
+                .hasMessageContaining("Colorante Rojo")
+                .hasMessageContaining("MILILITRO")
+                .hasMessageContaining("3.000000");
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
@@ -1,0 +1,131 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DisponibilidadInsumoServiceTest {
+
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private InventoryCatalogResolver catalogResolver;
+
+    @InjectMocks
+    private DisponibilidadInsumoService service;
+
+    @Test
+    @DisplayName("calcularDisponibilidad mantiene faltante y stock en preview y real")
+    void calcularDisponibilidad_previewYRealIguales() {
+        when(loteProductoRepository.findFefoDisponibles(10L, Integer.MAX_VALUE))
+                .thenReturn(List.of(
+                        lote(1L, "A", new BigDecimal("4.000000"), new BigDecimal("5.000000"), new BigDecimal("1.000000"), EstadoLote.DISPONIBLE),
+                        lote(2L, "B", new BigDecimal("2.000000"), new BigDecimal("2.000000"), BigDecimal.ZERO, EstadoLote.LIBERADO)
+                ));
+
+        DistribucionFefoResult preview = service.calcularDisponibilidad(10L, new BigDecimal("5"), List.of(), true);
+        DistribucionFefoResult real = service.calcularDisponibilidad(10L, new BigDecimal("5"), List.of(), false);
+
+        assertThat(preview.getStockLibreTotal()).isEqualByComparingTo(new BigDecimal("6.000000"));
+        assertThat(real.getStockLibreTotal()).isEqualByComparingTo(preview.getStockLibreTotal());
+        assertThat(preview.getFaltante()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+        assertThat(real.getFaltante()).isEqualByComparingTo(preview.getFaltante());
+        assertThat(preview.isSuficiente()).isTrue();
+        assertThat(real.isSuficiente()).isTrue();
+        assertThat(preview.getDetalles()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("resolverAlmacenesPreferidos respeta catálogo y faltante se calcula")
+    void calcularDisponibilidad_insuficienteCalculaFaltante() {
+        when(loteProductoRepository.findFefoDisponibles(20L, Integer.MAX_VALUE))
+                .thenReturn(List.of(
+                        lote(5L, "C", new BigDecimal("2.500000"), new BigDecimal("3.000000"), new BigDecimal("0.500000"), EstadoLote.DISPONIBLE)
+                ));
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(99L);
+        when(catalogResolver.getAlmacenOrigenMateriaPrimaId()).thenReturn(7L);
+
+        Producto insumo = new Producto();
+        insumo.setCategoriaProducto(new com.willyes.clemenintegra.inventario.model.CategoriaProducto());
+        insumo.getCategoriaProducto().setTipo(TipoCategoria.MATERIA_PRIMA);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setNombre("LITRO");
+        insumo.setUnidadMedida(unidad);
+
+        List<Long> preferidos = service.resolverAlmacenesPreferidos(insumo);
+        assertThat(preferidos).containsExactly(7L);
+
+        DistribucionFefoResult resultado = service.calcularDisponibilidad(20L, new BigDecimal("5"), preferidos, true);
+        assertThat(resultado.isSuficiente()).isFalse();
+        assertThat(resultado.getFaltante()).isEqualByComparingTo(new BigDecimal("2.500000"));
+    }
+
+    private LoteFefoDisponibleProjection lote(Long id, String codigo, BigDecimal stockLibre,
+                                               BigDecimal stockFisico, BigDecimal stockReservado,
+                                               EstadoLote estado) {
+        return new LoteFefoDisponibleProjection() {
+            @Override
+            public Long getLoteProductoId() {
+                return id;
+            }
+
+            @Override
+            public String getCodigoLote() {
+                return codigo;
+            }
+
+            @Override
+            public BigDecimal getStockLote() {
+                return stockLibre;
+            }
+
+            @Override
+            public BigDecimal getStockFisico() {
+                return stockFisico;
+            }
+
+            @Override
+            public BigDecimal getStockReservado() {
+                return stockReservado;
+            }
+
+            @Override
+            public java.time.LocalDateTime getFechaVencimiento() {
+                return java.time.LocalDateTime.now().plusDays(10);
+            }
+
+            @Override
+            public Long getAlmacenId() {
+                return 5L;
+            }
+
+            @Override
+            public String getNombreAlmacen() {
+                return "ALM";
+            }
+
+            @Override
+            public String getEstado() {
+                return estado.name();
+            }
+        };
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -59,6 +59,7 @@ class OrdenProduccionServiceImplTest {
     @Mock private UmValidator umValidator;
     @Mock private VidaUtilProductoRepository vidaUtilProductoRepository;
     @Mock private ReservaLoteService reservaLoteService;
+    @Mock private DisponibilidadInsumoService disponibilidadInsumoService;
 
     @InjectMocks
     private OrdenProduccionServiceImpl service;
@@ -97,8 +98,7 @@ class OrdenProduccionServiceImplTest {
                 .thenReturn(Optional.of(formula));
         when(productoRepository.findAllById(any()))
                 .thenReturn(List.of(insumo));
-        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(99L);
-        when(catalogResolver.getAlmacenOrigenMateriaPrimaId()).thenReturn(5L);
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo)).thenReturn(List.of(5L));
         when(stockQueryService.obtenerStockDisponible(eq(List.of(2L)), eq(List.of(5L))))
                 .thenReturn(Map.of(2L, new BigDecimal("8")));
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -3,7 +3,6 @@ package com.willyes.clemenintegra.produccion.service;
 import com.willyes.clemenintegra.bom.model.DetalleFormula;
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
-import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoResponseDTO;
 import com.willyes.clemenintegra.inventario.model.Almacen;
@@ -46,6 +45,8 @@ import com.willyes.clemenintegra.inventario.repository.VidaUtilProductoRepositor
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoDetalle;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,6 +72,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
@@ -105,6 +107,7 @@ class OrdenProduccionServiceReservaTest {
     @Mock private UmValidator umValidator;
     @Mock private VidaUtilProductoRepository vidaUtilProductoRepository;
     @Mock private ReservaLoteService reservaLoteService;
+    @Mock private DisponibilidadInsumoService disponibilidadInsumoService;
 
     @InjectMocks
     private OrdenProduccionServiceImpl service;
@@ -132,9 +135,13 @@ class OrdenProduccionServiceReservaTest {
 
         productoInsumo = new Producto();
         productoInsumo.setId(50);
+        productoInsumo.setCodigoSku("MP-COLRO");
         productoInsumo.setNombre("INSUMO-X");
         productoInsumo.setCategoriaProducto(new com.willyes.clemenintegra.inventario.model.CategoriaProducto());
         productoInsumo.getCategoriaProducto().setTipo(TipoCategoria.MATERIA_PRIMA);
+        UnidadMedida unidadInsumo = new UnidadMedida();
+        unidadInsumo.setNombre("MILILITRO");
+        productoInsumo.setUnidadMedida(unidadInsumo);
 
         when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
@@ -143,6 +150,8 @@ class OrdenProduccionServiceReservaTest {
                 .thenReturn(List.of());
         when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(99L);
         when(catalogResolver.getAlmacenOrigenMateriaPrimaId()).thenReturn(5L);
+        lenient().when(disponibilidadInsumoService.resolverAlmacenesPreferidos(productoInsumo))
+                .thenReturn(List.of(5L));
         Usuario usuario = new Usuario();
         usuario.setId(7L);
         when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
@@ -167,17 +176,42 @@ class OrdenProduccionServiceReservaTest {
     void reservarInsumosParaOp_creaDetallesMultiLote() {
         when(solicitudMovimientoService.registrarSolicitud(any(SolicitudMovimientoRequestDTO.class)))
                 .thenReturn(SolicitudMovimientoResponseDTO.builder().id(100L).build());
-        when(loteProductoRepository.findFefoDisponibles(50L, Integer.MAX_VALUE))
-                .thenReturn(List.of(
-                        loteFefo(200L, new BigDecimal("3.123456"), "DISPONIBLE"),
-                        loteFefo(201L, new BigDecimal("10.000000"), "LIBERADO")
-                ));
+        DistribucionFefoResult resultado = DistribucionFefoResult.builder()
+                .productoInsumoId(50L)
+                .requerido(new BigDecimal("6.790123"))
+                .stockFisicoTotal(new BigDecimal("13.123456"))
+                .stockReservadoTotal(BigDecimal.ZERO)
+                .stockLibreTotal(new BigDecimal("13.123456"))
+                .faltante(BigDecimal.ZERO)
+                .suficiente(true)
+                .detalles(List.of(
+                        DistribucionFefoDetalle.builder()
+                                .loteProductoId(200L)
+                                .almacenId(5L)
+                                .cantidadCalculo(new BigDecimal("3.12345600"))
+                                .cantidadReserva(new BigDecimal("3.123456"))
+                                .disponible(new BigDecimal("3.123456"))
+                                .estado("DISPONIBLE")
+                                .build(),
+                        DistribucionFefoDetalle.builder()
+                                .loteProductoId(201L)
+                                .almacenId(5L)
+                                .cantidadCalculo(new BigDecimal("3.66666700"))
+                                .cantidadReserva(new BigDecimal("3.666667"))
+                                .disponible(new BigDecimal("10.000000"))
+                                .estado("LIBERADO")
+                                .build()
+                ))
+                .build();
+
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(50L), any(BigDecimal.class), anyList(), eq(false)))
+                .thenReturn(resultado);
 
         service.reservarInsumosParaOP(1L);
 
         ArgumentCaptor<SolicitudMovimientoRequestDTO> dtoCaptor = ArgumentCaptor.forClass(SolicitudMovimientoRequestDTO.class);
         verify(solicitudMovimientoService).registrarSolicitud(dtoCaptor.capture());
-        assertThat(dtoCaptor.getValue().getCantidad()).isEqualByComparingTo(new BigDecimal("6.79"));
+        assertThat(dtoCaptor.getValue().getCantidad()).isEqualByComparingTo(new BigDecimal("6.790123"));
 
         ArgumentCaptor<SolicitudMovimiento> solicitudCaptor = ArgumentCaptor.forClass(SolicitudMovimiento.class);
         verify(solicitudMovimientoRepository).saveAndFlush(solicitudCaptor.capture());
@@ -195,9 +229,26 @@ class OrdenProduccionServiceReservaTest {
     @Test
     @DisplayName("reservarInsumosParaOP falla con 422 cuando no hay lotes elegibles")
     void reservarInsumosParaOp_sinLotesLanzaError() {
-        when(loteProductoRepository.findFefoDisponibles(50L, Integer.MAX_VALUE)).thenReturn(List.of());
+        DistribucionFefoResult insuficiente = DistribucionFefoResult.builder()
+                .productoInsumoId(50L)
+                .requerido(new BigDecimal("6.790123"))
+                .stockFisicoTotal(BigDecimal.ZERO)
+                .stockReservadoTotal(BigDecimal.ZERO)
+                .stockLibreTotal(BigDecimal.ZERO)
+                .faltante(new BigDecimal("6.790123"))
+                .suficiente(false)
+                .detalles(List.of())
+                .build();
+
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(50L), any(BigDecimal.class), anyList(), eq(false)))
+                .thenReturn(insuficiente);
+
         assertThatThrownBy(() -> service.reservarInsumosParaOP(1L))
                 .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("MP-COLRO")
+                .hasMessageContaining("INSUMO-X")
+                .hasMessageContaining("6.790123")
+                .hasMessageContaining("MILILITRO")
                 .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
                 .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
         verify(reservaLoteService, never()).sincronizarReservasSolicitud(any());
@@ -287,42 +338,4 @@ class OrdenProduccionServiceReservaTest {
         return solicitud;
     }
 
-    private LoteFefoDisponibleProjection loteFefo(Long id, BigDecimal stock, String estado) {
-        return new LoteFefoDisponibleProjection() {
-            @Override
-            public Long getLoteProductoId() {
-                return id;
-            }
-
-            @Override
-            public String getCodigoLote() {
-                return "L" + id;
-            }
-
-            @Override
-            public BigDecimal getStockLote() {
-                return stock;
-            }
-
-            @Override
-            public LocalDateTime getFechaVencimiento() {
-                return LocalDateTime.now().plusDays(30);
-            }
-
-            @Override
-            public Long getAlmacenId() {
-                return 5L;
-            }
-
-            @Override
-            public String getNombreAlmacen() {
-                return "MP";
-            }
-
-            @Override
-            public String getEstado() {
-                return estado;
-            }
-        };
-    }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
@@ -77,9 +77,9 @@ class OrdenProduccionControllerSecurityTest {
     }
 
     @Test
-    @DisplayName("GET /api/produccion/ordenes/{id} sin autenticación devuelve 403")
-    void obtenerOrden_sinAutenticacion_devuelve403() throws Exception {
+    @DisplayName("GET /api/produccion/ordenes/{id} sin autenticación devuelve 401")
+    void obtenerOrden_sinAutenticacion_devuelve401() throws Exception {
         mockMvc.perform(get("/api/produccion/ordenes/{id}", 1L))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## Summary
- introduce DisponibilidadInsumoService y modelos auxiliares para concentrar la simulación FEFO
- reutiliza la distribución FEFO en OrdenProduccionServiceImpl y en la vista previa de fórmulas, con mensajes de error enriquecidos
- ajusta consultas/proyecciones de lotes y actualiza las pruebas unitarias relacionadas

## Testing
- `mvn -Dtest=DisponibilidadInsumoServiceTest test`
- `mvn -Dtest=OrdenProduccionServiceReservaTest,FormulaProductoServiceImplTest,OrdenProduccionServiceImplTest,ReservaLoteServiceTest test`
- `mvn -Dtest=OrdenProduccionControllerSecurityTest test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c650cca8833397d1406cd5241718)