### PR TITLE
Alinear cálculo FEFO en vista previa de fórmulas y reservas de OP

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
@@ -6,6 +6,9 @@ public class DetalleFormulaResponse {
     public java.math.BigDecimal cantidadNecesaria;
     public java.math.BigDecimal cantidadTotalNecesaria;
     public java.math.BigDecimal stockDisponible;
+    public java.math.BigDecimal stockLibreFefo;
+    public java.math.BigDecimal faltanteFefo;
+    public Integer maxProducible;
     public String estadoStock;
     public String unidad;
     public String unidadSimbolo;

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoResponse.java
@@ -18,4 +18,5 @@ public class FormulaProductoResponse {
     public String unidadBaseFormula;
     public List<DetalleFormulaResponse> detalles;
     public List<DocumentoFormulaResponseDTO> documentos;
+    public Boolean disponibilidadSuficiente;
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -234,6 +235,8 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                 ? cantidad
                 : BigDecimal.ONE;
 
+        boolean todosSuficientes = true;
+
         if (response.detalles != null && formula.getDetalles() != null) {
             List<DetalleFormula> detallesEntidad = formula.getDetalles();
             for (int i = 0; i < detallesEntidad.size(); i++) {
@@ -243,7 +246,6 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                 BigDecimal totalNecesaria = entidad.getCantidadNecesaria().multiply(cantidadProduccion);
                 dto.cantidadTotalNecesaria = totalNecesaria;
 
-                // LÍNEA CODEx: antes se tomaba el stock del producto sin discriminar lotes
                 Long insumoId = entidad.getInsumo().getId().longValue();
                 DisponibilidadInsumoDTO disponibilidad = new DisponibilidadInsumoDTO();
 
@@ -294,10 +296,20 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                         true);
 
                 BigDecimal stockLibre = Optional.ofNullable(fefoResult.getStockLibreTotal())
-                        .orElse(disponibilidad.getDisponible());
-                boolean insuficiente = !fefoResult.isSuficiente();
+                        .orElse(BigDecimal.ZERO);
+                BigDecimal faltanteFefo = Optional.ofNullable(fefoResult.getFaltante())
+                        .orElse(BigDecimal.ZERO);
+                boolean suficiente = fefoResult.isSuficiente();
+
+                Integer maxProducible = null;
+                if (entidad.getCantidadNecesaria() != null
+                        && entidad.getCantidadNecesaria().compareTo(BigDecimal.ZERO) > 0) {
+                    maxProducible = stockLibre.divide(entidad.getCantidadNecesaria(), 0, RoundingMode.DOWN).intValue();
+                }
+
                 String motivo = "OK";
-                if (insuficiente) {
+                if (!suficiente) {
+                    motivo = "STOCK_LIBRE_INSUFICIENTE";
                     if (disponibilidad.getEnCuarentena().compareTo(BigDecimal.ZERO) > 0) {
                         motivo = "CUARENTENA";
                     } else if (disponibilidad.getRetenido().compareTo(BigDecimal.ZERO) > 0) {
@@ -306,24 +318,30 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                         motivo = "VENCIDO";
                     } else if (disponibilidad.getRechazado().compareTo(BigDecimal.ZERO) > 0) {
                         motivo = "RECHAZADO";
-                    } else {
-                        motivo = "SIN_STOCK";
                     }
-                    log.info("FORMULA_DISPONIBILIDAD insumoId={} requerido={} disponible={} motivo={}",
+                    log.info("FORMULA_DISPONIBILIDAD insumoId={} requerido={} stockLibreFefo={} faltanteFefo={} motivo={} almacenesPreferidos={}",
                             insumoId,
                             totalNecesaria,
                             stockLibre,
-                            motivo);
+                            faltanteFefo,
+                            motivo,
+                            almacenesPreferidos);
                 }
 
                 dto.stockDisponible = stockLibre;
-                dto.estadoStock = fefoResult.isSuficiente() ? "SUFICIENTE" : "INSUFICIENTE";
+                dto.stockLibreFefo = stockLibre;
+                dto.faltanteFefo = faltanteFefo;
+                dto.maxProducible = maxProducible;
+                dto.estadoStock = suficiente ? "SUFICIENTE" : "INSUFICIENTE";
                 dto.disponibilidad = disponibilidad;
-                dto.bloqueante = new BloqueanteDTO(insuficiente, motivo);
+                dto.bloqueante = new BloqueanteDTO(!suficiente, motivo);
                 dto.lotes = lotes;
+
+                todosSuficientes = todosSuficientes && suficiente;
             }
         }
 
+        response.disponibilidadSuficiente = todosSuficientes;
         return response;
     }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoDetalle;
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
@@ -30,6 +31,7 @@ public class DisponibilidadInsumoService {
 
     private final LoteProductoRepository loteProductoRepository;
     private final InventoryCatalogResolver catalogResolver;
+    private final ProductoRepository productoRepository;
 
     private static final EnumSet<EstadoLote> ESTADOS_FEFO_PERMITIDOS = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
     private static final Map<TipoCategoria, Function<InventoryCatalogResolver, Long>> ALMACENES_ORIGEN_POR_CATEGORIA = Map.of(
@@ -145,6 +147,23 @@ public class DisponibilidadInsumoService {
 
         BigDecimal faltante = restante.setScale(6, RoundingMode.HALF_UP);
         boolean suficiente = faltante.compareTo(BigDecimal.ZERO) <= 0;
+
+        if (productoInsumoId != null
+                && stockFisicoTotal.compareTo(requerida) >= 0
+                && stockLibreTotal.compareTo(requerida) < 0) {
+            String codigo = productoRepository.findById(productoInsumoId)
+                    .map(Producto::getCodigoSku)
+                    .orElse(null);
+            log.warn("Disponibilidad FEFO detectó stock libre insuficiente pese a stock físico: insumoId={} codigo={} requerido={} stockFisicoTotal={} stockReservadoTotal={} stockLibreFefo={} faltante={} almacenes={}",
+                    productoInsumoId,
+                    codigo,
+                    requerida,
+                    stockFisicoTotal,
+                    stockReservadoTotal,
+                    stockLibreTotal,
+                    faltante,
+                    preferidos);
+        }
 
         return DistribucionFefoResult.builder()
                 .productoInsumoId(productoInsumoId)

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -8,7 +8,6 @@ import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.MotivoMovimientoRepository;
 import com.willyes.clemenintegra.inventario.repository.TipoMovimientoDetalleRepository;
-import com.willyes.clemenintegra.inventario.service.StockQueryService;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.produccion.dto.InsumoFaltanteDTO;
 import com.willyes.clemenintegra.produccion.dto.OrdenProduccionRequestDTO;
@@ -100,7 +99,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
     private final FormulaProductoRepository formulaProductoRepository;
     private final ProductoRepository productoRepository;
-    private final StockQueryService stockQueryService;
     private final UsuarioRepository usuarioRepository;
     private final SolicitudMovimientoService solicitudMovimientoService;
     private final OrdenProduccionRepository repository;
@@ -259,41 +257,39 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                         insumoId, tipoCategoria);
             }
 
-            BigDecimal stockDisponible = stockQueryService
-                    .obtenerStockDisponible(List.of(insumoId),
-                            almacenesValidos.isEmpty() ? Collections.emptyList() : almacenesValidos)
-                    .getOrDefault(insumoId, BigDecimal.ZERO);
+            DistribucionFefoResult distribucionPreview = disponibilidadInsumoService.calcularDisponibilidad(
+                    insumoId,
+                    cantidadRequerida,
+                    almacenesValidos,
+                    true);
 
-            if (!almacenesValidos.isEmpty() && stockDisponible.compareTo(BigDecimal.ZERO) == 0) {
-                BigDecimal stockGlobal = stockQueryService
-                        .obtenerStockDisponible(List.of(insumoId))
-                        .getOrDefault(insumoId, BigDecimal.ZERO);
-                stockDisponible = stockGlobal;
-                log.info("OP-validacion fallback stock insumo={} almacenes={} stockGlobal={}",
-                        insumoId, almacenesValidos, stockDisponible);
-            }
+            BigDecimal stockLibreFefo = Optional.ofNullable(distribucionPreview.getStockLibreTotal())
+                    .orElse(BigDecimal.ZERO);
+            BigDecimal faltanteFefo = Optional.ofNullable(distribucionPreview.getFaltante())
+                    .orElse(BigDecimal.ZERO);
 
             int producibleConEste = 0;
             if (insumo.getCantidadNecesaria().compareTo(BigDecimal.ZERO) > 0) {
-                producibleConEste = stockDisponible.divide(insumo.getCantidadNecesaria(), 0, RoundingMode.DOWN).intValue();
+                producibleConEste = stockLibreFefo.divide(insumo.getCantidadNecesaria(), 0, RoundingMode.DOWN).intValue();
             }
             if (maxProducible == null || producibleConEste < maxProducible) {
                 maxProducible = producibleConEste;
             }
 
-            log.debug("OP-VALIDACION insumoId={} requerido={} disponible={} maxProducible={}",
+            log.debug("OP-VALIDACION insumoId={} requerido={} stockLibreFefo={} faltanteFefo={} maxProducible={}",
                     insumoId,
                     cantidadRequerida,
-                    stockDisponible,
+                    stockLibreFefo,
+                    faltanteFefo,
                     maxProducible);
 
-            if (stockDisponible.compareTo(cantidadRequerida) < 0) {
+            if (!distribucionPreview.isSuficiente()) {
                 stockSuficiente = false;
                 faltantes.add(InsumoFaltanteDTO.builder()
                         .productoId(insumoId)
                         .nombre(productoInsumo.getNombre())
                         .requerido(cantidadRequerida)
-                        .disponible(stockDisponible)
+                        .disponible(stockLibreFefo)
                         .unidadSimbolo(productoInsumo.getUnidadMedida() != null
                                 ? productoInsumo.getUnidadMedida().getSimbolo()
                                 : null)

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -1,8 +1,11 @@
 package com.willyes.clemenintegra.bom.service;
 
 import com.willyes.clemenintegra.bom.dto.DetalleFormulaProduccionDTO;
+import com.willyes.clemenintegra.bom.dto.DetalleFormulaResponse;
 import com.willyes.clemenintegra.bom.dto.FormulaActivaProduccionDTO;
+import com.willyes.clemenintegra.bom.dto.FormulaProductoResponse;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
+import com.willyes.clemenintegra.bom.dto.LoteResumenDTO;
 import com.willyes.clemenintegra.bom.mapper.BomMapper;
 import com.willyes.clemenintegra.bom.model.DetalleFormula;
 import com.willyes.clemenintegra.bom.model.DocumentoFormula;
@@ -12,12 +15,14 @@ import com.willyes.clemenintegra.bom.model.enums.TipoDocumento;
 import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.produccion.service.DisponibilidadInsumoService;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -270,6 +276,135 @@ class FormulaProductoServiceImplTest {
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(formulaRepository).findAllForResumen(isNull(), captor.capture());
         assertThat(captor.getValue()).isEqualTo("vitamina c");
+    }
+
+    @Test
+    @DisplayName("obtenerFormulaActivaPorProducto refleja faltante FEFO cuando reservas reducen stock libre")
+    void obtenerFormulaActivaPorProducto_reflejaFaltanteFefo() {
+        Producto producto = new Producto();
+        producto.setId(100);
+        producto.setNombre("JVC-JARABE VITAMINA C 200ML");
+        UnidadMedida umProducto = new UnidadMedida();
+        umProducto.setSimbolo("UND");
+        producto.setUnidadMedida(umProducto);
+
+        Producto insumo = new Producto();
+        insumo.setId(200);
+        insumo.setNombre("COLORANTE NATURAL ROJO");
+        insumo.setCodigoSku("MP-COLRO");
+        UnidadMedida umInsumo = new UnidadMedida();
+        umInsumo.setSimbolo("MILILITRO");
+        insumo.setUnidadMedida(umInsumo);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(insumo);
+        detalle.setCantidadNecesaria(new BigDecimal("0.5"));
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(50L);
+        formula.setProducto(producto);
+        formula.setDetalles(List.of(detalle));
+
+        when(formulaRepository.findByProductoIdAndEstadoAndActivoTrue(100L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+
+        when(loteProductoRepository.sumarPorEstado(200L)).thenReturn(List.of(
+                new Object[]{EstadoLote.DISPONIBLE, new BigDecimal("1012.500000")},
+                new Object[]{EstadoLote.RETENIDO, new BigDecimal("1500.000000")},
+                new Object[]{EstadoLote.VENCIDO, new BigDecimal("1047.500000")}
+        ));
+
+        LocalDateTime futuro = LocalDateTime.now().plusMonths(6);
+        when(loteProductoRepository.listarLotesPorProducto(200L)).thenReturn(List.of(
+                new LoteResumenDTO(1L, "L-170925-3", EstadoLote.DISPONIBLE, "Principal MP", new BigDecimal("125.000000"), futuro, null, null),
+                new LoteResumenDTO(2L, "L-271025-02", EstadoLote.DISPONIBLE, "Principal MP", new BigDecimal("130.000000"), futuro, null, null),
+                new LoteResumenDTO(3L, "L-060825-3", EstadoLote.DISPONIBLE, "Principal MP", new BigDecimal("47.500000"), futuro, null, null)
+        ));
+
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo)).thenReturn(List.of(5L));
+
+        DistribucionFefoResult preview = DistribucionFefoResult.builder()
+                .productoInsumoId(200L)
+                .requerido(new BigDecimal("350.000000"))
+                .stockFisicoTotal(new BigDecimal("775.000000"))
+                .stockReservadoTotal(new BigDecimal("472.500000"))
+                .stockLibreTotal(new BigDecimal("302.500000"))
+                .faltante(new BigDecimal("47.500000"))
+                .suficiente(false)
+                .almacenesPreferidos(List.of(5L))
+                .build();
+
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), eq(List.of(5L)), eq(true)))
+                .thenReturn(preview);
+
+        FormulaProductoResponse respuesta = service.obtenerFormulaActivaPorProducto(100L, new BigDecimal("700"));
+
+        assertThat(respuesta.disponibilidadSuficiente).isFalse();
+        assertThat(respuesta.detalles).hasSize(1);
+
+        DetalleFormulaResponse detalleDto = respuesta.detalles.get(0);
+        assertThat(detalleDto.cantidadTotalNecesaria).isEqualByComparingTo(new BigDecimal("350.0"));
+        assertThat(detalleDto.estadoStock).isEqualTo("INSUFICIENTE");
+        assertThat(detalleDto.stockLibreFefo).isEqualByComparingTo(new BigDecimal("302.500000"));
+        assertThat(detalleDto.stockDisponible).isEqualByComparingTo(detalleDto.stockLibreFefo);
+        assertThat(detalleDto.faltanteFefo).isEqualByComparingTo(new BigDecimal("47.500000"));
+        assertThat(detalleDto.maxProducible).isEqualTo(605);
+        assertThat(detalleDto.bloqueante.isInsuficiente()).isTrue();
+        assertThat(detalleDto.bloqueante.getMotivo()).isEqualTo("RETENIDO");
+    }
+
+    @Test
+    @DisplayName("obtenerFormulaActivaPorProducto marca suficiente cuando stock libre FEFO cubre requerimiento")
+    void obtenerFormulaActivaPorProducto_stockSuficiente() {
+        Producto producto = new Producto();
+        producto.setId(101);
+        UnidadMedida um = new UnidadMedida();
+        um.setSimbolo("UND");
+        producto.setUnidadMedida(um);
+
+        Producto insumo = new Producto();
+        insumo.setId(300);
+        insumo.setNombre("ACIDO ASCORBICO");
+        UnidadMedida umInsumo = new UnidadMedida();
+        umInsumo.setSimbolo("MILILITRO");
+        insumo.setUnidadMedida(umInsumo);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(insumo);
+        detalle.setCantidadNecesaria(new BigDecimal("1.0"));
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(51L);
+        formula.setProducto(producto);
+        formula.setDetalles(List.of(detalle));
+
+        when(formulaRepository.findByProductoIdAndEstadoAndActivoTrue(101L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+        when(loteProductoRepository.sumarPorEstado(300L)).thenReturn(List.of());
+        when(loteProductoRepository.listarLotesPorProducto(300L)).thenReturn(List.of());
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo)).thenReturn(List.of());
+
+        DistribucionFefoResult preview = DistribucionFefoResult.builder()
+                .productoInsumoId(300L)
+                .requerido(new BigDecimal("50.000000"))
+                .stockFisicoTotal(new BigDecimal("120.000000"))
+                .stockReservadoTotal(BigDecimal.ZERO)
+                .stockLibreTotal(new BigDecimal("120.000000"))
+                .faltante(BigDecimal.ZERO)
+                .suficiente(true)
+                .build();
+
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(300L), any(BigDecimal.class), eq(List.of()), eq(true)))
+                .thenReturn(preview);
+
+        FormulaProductoResponse respuesta = service.obtenerFormulaActivaPorProducto(101L, new BigDecimal("50"));
+
+        assertThat(respuesta.disponibilidadSuficiente).isTrue();
+        DetalleFormulaResponse detalleDto = respuesta.detalles.get(0);
+        assertThat(detalleDto.estadoStock).isEqualTo("SUFICIENTE");
+        assertThat(detalleDto.stockLibreFefo).isEqualByComparingTo(new BigDecimal("120.000000"));
+        assertThat(detalleDto.maxProducible).isEqualTo(120);
+        assertThat(detalleDto.bloqueante.isInsuficiente()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -28,6 +30,8 @@ class DisponibilidadInsumoServiceTest {
     private LoteProductoRepository loteProductoRepository;
     @Mock
     private InventoryCatalogResolver catalogResolver;
+    @Mock
+    private ProductoRepository productoRepository;
 
     @InjectMocks
     private DisponibilidadInsumoService service;
@@ -76,6 +80,25 @@ class DisponibilidadInsumoServiceTest {
         DistribucionFefoResult resultado = service.calcularDisponibilidad(20L, new BigDecimal("5"), preferidos, true);
         assertThat(resultado.isSuficiente()).isFalse();
         assertThat(resultado.getFaltante()).isEqualByComparingTo(new BigDecimal("2.500000"));
+    }
+
+    @Test
+    @DisplayName("calcularDisponibilidad detecta faltante por reservas aun con stock físico suficiente")
+    void calcularDisponibilidad_detectaFaltantePorReservas() {
+        when(loteProductoRepository.findFefoDisponibles(30L, Integer.MAX_VALUE))
+                .thenReturn(List.of(
+                        lote(10L, "L-170925-3", new BigDecimal("125.000000"), new BigDecimal("125.000000"), BigDecimal.ZERO, EstadoLote.DISPONIBLE),
+                        lote(11L, "L-271025-02", new BigDecimal("130.000000"), new BigDecimal("500.000000"), new BigDecimal("370.000000"), EstadoLote.DISPONIBLE),
+                        lote(12L, "L-060825-3", new BigDecimal("47.500000"), new BigDecimal("150.000000"), new BigDecimal("102.500000"), EstadoLote.DISPONIBLE)
+                ));
+        when(productoRepository.findById(30L)).thenReturn(Optional.empty());
+
+        DistribucionFefoResult resultado = service.calcularDisponibilidad(30L, new BigDecimal("350"), List.of(5L), true);
+
+        assertThat(resultado.isSuficiente()).isFalse();
+        assertThat(resultado.getStockFisicoTotal()).isEqualByComparingTo(new BigDecimal("775.000000"));
+        assertThat(resultado.getStockLibreTotal()).isEqualByComparingTo(new BigDecimal("302.500000"));
+        assertThat(resultado.getFaltante()).isEqualByComparingTo(new BigDecimal("47.500000"));
     }
 
     private LoteFefoDisponibleProjection lote(Long id, String codigo, BigDecimal stockLibre,

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -16,6 +16,7 @@ import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.repository.*;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +26,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +38,6 @@ class OrdenProduccionServiceImplTest {
 
     @Mock private FormulaProductoRepository formulaProductoRepository;
     @Mock private ProductoRepository productoRepository;
-    @Mock private StockQueryService stockQueryService;
     @Mock private UsuarioRepository usuarioRepository;
     @Mock private SolicitudMovimientoService solicitudMovimientoService;
     @Mock private OrdenProduccionRepository ordenProduccionRepository;
@@ -99,8 +98,20 @@ class OrdenProduccionServiceImplTest {
         when(productoRepository.findAllById(any()))
                 .thenReturn(List.of(insumo));
         when(disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo)).thenReturn(List.of(5L));
-        when(stockQueryService.obtenerStockDisponible(eq(List.of(2L)), eq(List.of(5L))))
-                .thenReturn(Map.of(2L, new BigDecimal("8")));
+
+        DistribucionFefoResult preview = DistribucionFefoResult.builder()
+                .productoInsumoId(2L)
+                .requerido(new BigDecimal("10.000000"))
+                .stockFisicoTotal(new BigDecimal("12.000000"))
+                .stockReservadoTotal(new BigDecimal("4.000000"))
+                .stockLibreTotal(new BigDecimal("8.000000"))
+                .faltante(new BigDecimal("2.000000"))
+                .suficiente(false)
+                .almacenesPreferidos(List.of(5L))
+                .build();
+
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(2L), any(BigDecimal.class), eq(List.of(5L)), eq(true)))
+                .thenReturn(preview);
 
         ResultadoValidacionOrdenDTO resultado = service.guardarConValidacionStock(orden);
 
@@ -109,6 +120,6 @@ class OrdenProduccionServiceImplTest {
         assertThat(resultado.getInsumosFaltantes()).hasSize(1);
         assertThat(resultado.getInsumosFaltantes().get(0).getProductoId()).isEqualTo(2L);
         assertThat(resultado.getInsumosFaltantes().get(0).getRequerido()).isEqualByComparingTo(new BigDecimal("10"));
-        assertThat(resultado.getInsumosFaltantes().get(0).getDisponible()).isEqualByComparingTo(new BigDecimal("8"));
+        assertThat(resultado.getInsumosFaltantes().get(0).getDisponible()).isEqualByComparingTo(new BigDecimal("8.000000"));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -5,6 +5,7 @@ import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoResponseDTO;
+import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
 import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.MotivoMovimiento;
@@ -136,7 +137,7 @@ class OrdenProduccionServiceReservaTest {
         productoInsumo = new Producto();
         productoInsumo.setId(50);
         productoInsumo.setCodigoSku("MP-COLRO");
-        productoInsumo.setNombre("INSUMO-X");
+        productoInsumo.setNombre("COLORANTE NATURAL ROJO");
         productoInsumo.setCategoriaProducto(new com.willyes.clemenintegra.inventario.model.CategoriaProducto());
         productoInsumo.getCategoriaProducto().setTipo(TipoCategoria.MATERIA_PRIMA);
         UnidadMedida unidadInsumo = new UnidadMedida();
@@ -227,6 +228,54 @@ class OrdenProduccionServiceReservaTest {
     }
 
     @Test
+    @DisplayName("flujo FEFO detecta faltante por reservas y al reservar lanza STOCK_INSUFICIENTE")
+    void flujoFefoDetectaFaltantePorReservas() {
+        FormulaProducto formulaEscenario = new FormulaProducto();
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(productoInsumo);
+        detalle.setCantidadNecesaria(new BigDecimal("0.5"));
+        formulaEscenario.setDetalles(List.of(detalle));
+        formulaEscenario.setProducto(orden.getProducto());
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaEscenario));
+        when(productoRepository.findAllById(any()))
+                .thenReturn(List.of(productoInsumo));
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(productoInsumo)).thenReturn(List.of(5L));
+        when(productoRepository.findById(50L)).thenReturn(Optional.of(productoInsumo));
+
+        DistribucionFefoResult preview = DistribucionFefoResult.builder()
+                .productoInsumoId(50L)
+                .requerido(new BigDecimal("350.000000"))
+                .stockFisicoTotal(new BigDecimal("775.000000"))
+                .stockReservadoTotal(new BigDecimal("472.500000"))
+                .stockLibreTotal(new BigDecimal("302.500000"))
+                .faltante(new BigDecimal("47.500000"))
+                .suficiente(false)
+                .almacenesPreferidos(List.of(5L))
+                .build();
+
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(50L), any(BigDecimal.class), eq(List.of(5L)), eq(true)))
+                .thenReturn(preview);
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(50L), any(BigDecimal.class), eq(List.of(5L)), eq(false)))
+                .thenReturn(preview);
+
+        orden.setCantidadProgramada(new BigDecimal("700"));
+
+        ResultadoValidacionOrdenDTO validacion = service.guardarConValidacionStock(orden);
+
+        assertThat(validacion.isEsValida()).isFalse();
+        assertThat(validacion.getUnidadesMaximasProducibles()).isEqualTo(605);
+        assertThat(validacion.getInsumosFaltantes()).hasSize(1);
+        assertThat(validacion.getInsumosFaltantes().get(0).getDisponible())
+                .isEqualByComparingTo(new BigDecimal("302.500000"));
+
+        assertThatThrownBy(() -> service.reservarInsumosParaOP(orden.getId()))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessage("422 UNPROCESSABLE_ENTITY \"STOCK_INSUFICIENTE: insumo MP-COLRO - COLORANTE NATURAL ROJO, faltan 47.500000 MILILITRO\"");
+    }
+
+    @Test
     @DisplayName("reservarInsumosParaOP falla con 422 cuando no hay lotes elegibles")
     void reservarInsumosParaOp_sinLotesLanzaError() {
         DistribucionFefoResult insuficiente = DistribucionFefoResult.builder()
@@ -246,7 +295,7 @@ class OrdenProduccionServiceReservaTest {
         assertThatThrownBy(() -> service.reservarInsumosParaOP(1L))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("MP-COLRO")
-                .hasMessageContaining("INSUMO-X")
+                .hasMessageContaining("COLORANTE NATURAL ROJO")
                 .hasMessageContaining("6.790123")
                 .hasMessageContaining("MILILITRO")
                 .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())


### PR DESCRIPTION
## Summary
- Expone en los DTO de fórmula los campos `stockLibreFefo`, `faltanteFefo`, `maxProducible` y `disponibilidadSuficiente` calculados con DistribucionFefoResult.
- Alinea FormulaProductoServiceImpl y OrdenProduccionServiceImpl para usar la misma simulación FEFO de DisponibilidadInsumoService al validar y mostrar disponibilidad.
- Agrega registros de diagnóstico y pruebas unitarias que cubren el escenario de reservas parciales con faltante de 47.5 MILILITRO.

## Testing
- `mvn -q -DskipITs -Dtest=FormulaProductoServiceImplTest,DisponibilidadInsumoServiceTest,OrdenProduccionServiceImplTest,OrdenProduccionServiceReservaTest test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d4fd4d0c83339ab5aae63c086ad9)