### PR TITLE
Fix FEFO availability consistency for OP

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
@@ -65,27 +65,31 @@ public class DisponibilidadInsumoService {
         List<LoteFefoDisponibleProjection> lotesDisponibles = loteProductoRepository
                 .findFefoDisponibles(productoInsumoId, Integer.MAX_VALUE);
 
+        List<LoteFefoDisponibleProjection> lotesElegibles = lotesDisponibles.stream()
+                .filter(this::esLotePermitido)
+                .toList();
+
         List<Long> preferidos = almacenesPreferidos == null ? List.of() : List.copyOf(almacenesPreferidos);
-        List<LoteFefoDisponibleProjection> lotesSeleccionados = new ArrayList<>(lotesDisponibles);
+        List<LoteFefoDisponibleProjection> lotesSeleccionados = new ArrayList<>(lotesElegibles);
         boolean usoFallback = false;
         String motivoFallback = null;
 
         if (!preferidos.isEmpty()) {
-            lotesSeleccionados = lotesDisponibles.stream()
+            lotesSeleccionados = lotesElegibles.stream()
                     .filter(lote -> lote.getAlmacenId() != null && preferidos.contains(lote.getAlmacenId()))
                     .toList();
 
             BigDecimal cubierto = lotesSeleccionados.stream()
-                    .map(LoteFefoDisponibleProjection::getStockLote)
+                    .map(this::calcularStockLibre)
                     .filter(Objects::nonNull)
                     .reduce(BigDecimal.ZERO, BigDecimal::add);
 
             if (lotesSeleccionados.isEmpty() || cubierto.compareTo(requerida) < 0) {
                 usoFallback = true;
                 motivoFallback = lotesSeleccionados.isEmpty() ? "SIN_ALMACEN_CONFIGURADO" : "STOCK_NO_DISPONIBLE_EN_ORIGEN";
-                lotesSeleccionados = lotesDisponibles;
+                lotesSeleccionados = lotesElegibles;
             }
-        } else if (!lotesDisponibles.isEmpty()) {
+        } else if (!lotesElegibles.isEmpty()) {
             usoFallback = true;
             motivoFallback = "SIN_ALMACEN_CONFIGURADO";
         }
@@ -95,7 +99,7 @@ public class DisponibilidadInsumoService {
                     productoInsumoId, requerida, motivoFallback, preferidos);
         }
 
-        lotesSeleccionados.stream()
+        lotesDisponibles.stream()
                 .map(LoteFefoDisponibleProjection::getEstado)
                 .filter(Objects::nonNull)
                 .map(String::trim)
@@ -106,9 +110,12 @@ public class DisponibilidadInsumoService {
                 .findFirst()
                 .ifPresent(estado -> log.warn("Disponibilidad FEFO detectó lote en estado no permitido: {}", estado));
 
-        BigDecimal stockFisicoTotal = sumar(lotesDisponibles, LoteFefoDisponibleProjection::getStockFisico);
-        BigDecimal stockReservadoTotal = sumar(lotesDisponibles, LoteFefoDisponibleProjection::getStockReservado);
-        BigDecimal stockLibreTotal = sumar(lotesDisponibles, LoteFefoDisponibleProjection::getStockLote);
+        BigDecimal stockFisicoTotal = sumar(lotesElegibles, LoteFefoDisponibleProjection::getStockFisico);
+        BigDecimal stockReservadoTotal = sumar(lotesElegibles, LoteFefoDisponibleProjection::getStockReservado);
+        BigDecimal stockLibreTotal = lotesElegibles.stream()
+                .map(this::calcularStockLibre)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(6, RoundingMode.HALF_UP);
 
         List<DistribucionFefoDetalle> detalles = new ArrayList<>();
         BigDecimal restante = requerida;
@@ -116,7 +123,7 @@ public class DisponibilidadInsumoService {
             if (restante.compareTo(BigDecimal.ZERO) <= 0) {
                 break;
             }
-            BigDecimal disponible = Optional.ofNullable(lote.getStockLote()).orElse(BigDecimal.ZERO);
+            BigDecimal disponible = calcularStockLibre(lote);
             if (disponible.compareTo(BigDecimal.ZERO) <= 0) {
                 continue;
             }
@@ -145,8 +152,8 @@ public class DisponibilidadInsumoService {
             restante = BigDecimal.ZERO;
         }
 
-        BigDecimal faltante = restante.setScale(6, RoundingMode.HALF_UP);
-        boolean suficiente = faltante.compareTo(BigDecimal.ZERO) <= 0;
+        BigDecimal faltante = restante.max(BigDecimal.ZERO).setScale(6, RoundingMode.HALF_UP);
+        boolean suficiente = faltante.compareTo(BigDecimal.ZERO) == 0;
 
         if (productoInsumoId != null
                 && stockFisicoTotal.compareTo(requerida) >= 0
@@ -181,10 +188,25 @@ public class DisponibilidadInsumoService {
 
     private BigDecimal sumar(List<LoteFefoDisponibleProjection> lotes,
                               Function<LoteFefoDisponibleProjection, BigDecimal> extractor) {
-        return lotes.stream()
+        BigDecimal total = lotes.stream()
                 .map(extractor)
                 .filter(Objects::nonNull)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
+        return total.setScale(6, RoundingMode.HALF_UP);
+    }
+
+    private boolean esLotePermitido(LoteFefoDisponibleProjection lote) {
+        EstadoLote estado = parseEstadoLoteSafe(lote.getEstado());
+        return estado != null && ESTADOS_FEFO_PERMITIDOS.contains(estado);
+    }
+
+    private BigDecimal calcularStockLibre(LoteFefoDisponibleProjection lote) {
+        BigDecimal stockBase = Optional.ofNullable(lote.getStockLote())
+                .orElse(Optional.ofNullable(lote.getStockFisico()).orElse(BigDecimal.ZERO));
+        if (stockBase.compareTo(BigDecimal.ZERO) < 0) {
+            stockBase = BigDecimal.ZERO;
+        }
+        return stockBase.setScale(8, RoundingMode.HALF_UP);
     }
 
     private EstadoLote parseEstadoLoteSafe(String valor) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -767,13 +767,23 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             BigDecimal requerida = insumo.getCantidadNecesaria()
                     .multiply(orden.getCantidadProgramada())
                     .setScale(8, RoundingMode.HALF_UP);
+            if (requerida.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
             BigDecimal requeridaSolicitud = requerida.setScale(6, RoundingMode.HALF_UP);
             List<Long> almacenesValidos = disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo.getInsumo());
 
             DistribucionFefoResult distribucion = disponibilidadInsumoService.calcularDisponibilidad(
                     insumoId, requerida, almacenesValidos, false);
 
-            if (!distribucion.isSuficiente() || distribucion.getDetalles().isEmpty()) {
+            BigDecimal faltanteDistribucion = Optional.ofNullable(distribucion.getFaltante())
+                    .orElse(BigDecimal.ZERO)
+                    .setScale(6, RoundingMode.HALF_UP);
+            BigDecimal totalAsignado = calcularTotalDistribuido(distribucion.getDetalles());
+            BigDecimal requeridaComparacion = requeridaSolicitud.setScale(8, RoundingMode.HALF_UP);
+            boolean sinAsignacion = totalAsignado.compareTo(requeridaComparacion) < 0;
+
+            if (faltanteDistribucion.compareTo(BigDecimal.ZERO) > 0 || sinAsignacion) {
                 manejarStockInsuficiente(insumo.getInsumo(), distribucion);
             }
 
@@ -882,6 +892,17 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                         nombre,
                         faltante.toPlainString(),
                         unidad));
+    }
+
+    private BigDecimal calcularTotalDistribuido(List<DistribucionFefoDetalle> detalles) {
+        if (detalles == null || detalles.isEmpty()) {
+            return BigDecimal.ZERO.setScale(8, RoundingMode.HALF_UP);
+        }
+        return detalles.stream()
+                .map(DistribucionFefoDetalle::getCantidadCalculo)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(8, RoundingMode.HALF_UP);
     }
 
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
@@ -101,6 +101,33 @@ class DisponibilidadInsumoServiceTest {
         assertThat(resultado.getFaltante()).isEqualByComparingTo(new BigDecimal("47.500000"));
     }
 
+    @Test
+    @DisplayName("calcularDisponibilidad mantiene stock suficiente para Jarabe Base excluyendo cuarentena")
+    void calcularDisponibilidad_jarabeBaseSinFaltantes() {
+        when(loteProductoRepository.findFefoDisponibles(38L, Integer.MAX_VALUE))
+                .thenReturn(List.of(
+                        lote(117L, "L-120925-3", new BigDecimal("10000"), new BigDecimal("10000"), BigDecimal.ZERO, EstadoLote.DISPONIBLE),
+                        lote(92L, "L-110925-3", new BigDecimal("30000"), new BigDecimal("30000"), BigDecimal.ZERO, EstadoLote.DISPONIBLE),
+                        lote(118L, "L-120925-2", new BigDecimal("10000"), new BigDecimal("10000"), BigDecimal.ZERO, EstadoLote.DISPONIBLE),
+                        lote(85L, "L-160925-2", new BigDecimal("25000"), new BigDecimal("25000"), BigDecimal.ZERO, EstadoLote.DISPONIBLE),
+                        lote(103L, "L-180925-8", new BigDecimal("59500"), new BigDecimal("59500"), BigDecimal.ZERO, EstadoLote.DISPONIBLE),
+                        lote(119L, "L-050825-3", new BigDecimal("5000"), new BigDecimal("5000"), BigDecimal.ZERO, EstadoLote.DISPONIBLE),
+                        lote(156L, "L-151125-2", new BigDecimal("59650"), new BigDecimal("59650"), BigDecimal.ZERO, EstadoLote.DISPONIBLE),
+                        lote(148L, "L-271025-00", new BigDecimal("5000"), new BigDecimal("5000"), BigDecimal.ZERO, EstadoLote.EN_CUARENTENA)
+                ));
+
+        DistribucionFefoResult resultado = service.calcularDisponibilidad(38L, new BigDecimal("139650"), List.of(), true);
+
+        assertThat(resultado.isSuficiente()).isTrue();
+        assertThat(resultado.getStockLibreTotal()).isEqualByComparingTo(new BigDecimal("199150.000000"));
+        assertThat(resultado.getFaltante()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+        assertThat(resultado.getDetalles()).hasSize(7);
+        BigDecimal totalDistribuido = resultado.getDetalles().stream()
+                .map(det -> det.getCantidadReserva() == null ? BigDecimal.ZERO : det.getCantidadReserva())
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(totalDistribuido).isEqualByComparingTo(new BigDecimal("139650.000000"));
+    }
+
     private LoteFefoDisponibleProjection lote(Long id, String codigo, BigDecimal stockLibre,
                                                BigDecimal stockFisico, BigDecimal stockReservado,
                                                EstadoLote estado) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -13,24 +13,33 @@ import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.*;
 import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.repository.*;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoDetalle;
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -60,8 +69,24 @@ class OrdenProduccionServiceImplTest {
     @Mock private ReservaLoteService reservaLoteService;
     @Mock private DisponibilidadInsumoService disponibilidadInsumoService;
 
+    @Spy
     @InjectMocks
     private OrdenProduccionServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        lenient().doNothing().when(service).reservarInsumosParaOP(anyLong());
+        lenient().when(ordenProduccionRepository.save(any(OrdenProduccion.class))).thenAnswer(invocation -> {
+            OrdenProduccion op = invocation.getArgument(0);
+            if (op.getId() == null) {
+                op.setId(100L);
+            }
+            return op;
+        });
+        lenient().when(ordenProduccionRepository.countByCodigoOrdenStartingWith(any())).thenReturn(0L);
+        lenient().when(etapaPlantillaRepository.findByProductoIdAndActivoTrueOrderBySecuenciaAsc(anyInt())).thenReturn(List.of());
+        lenient().when(etapaProduccionRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
 
     @Test
     @DisplayName("guardarConValidacionStock retorna faltantes y max producible cuando stock es insuficiente")
@@ -75,6 +100,7 @@ class OrdenProduccionServiceImplTest {
         OrdenProduccion orden = new OrdenProduccion();
         orden.setProducto(producto);
         orden.setCantidadProgramada(new BigDecimal("10"));
+        orden.setEstado(EstadoProduccion.CREADA);
 
         Producto insumo = new Producto();
         insumo.setId(2);
@@ -121,5 +147,88 @@ class OrdenProduccionServiceImplTest {
         assertThat(resultado.getInsumosFaltantes().get(0).getProductoId()).isEqualTo(2L);
         assertThat(resultado.getInsumosFaltantes().get(0).getRequerido()).isEqualByComparingTo(new BigDecimal("10"));
         assertThat(resultado.getInsumosFaltantes().get(0).getDisponible()).isEqualByComparingTo(new BigDecimal("8.000000"));
+    }
+
+    @Test
+    @DisplayName("guardarConValidacionStock aprueba Jarabe Base cuando la simulación FEFO es suficiente")
+    void guardarConValidacionStock_jarabeBaseSuficiente() {
+        Producto producto = new Producto();
+        producto.setId(10);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setSimbolo("UND");
+        producto.setUnidadMedida(unidad);
+
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setProducto(producto);
+        orden.setCantidadProgramada(new BigDecimal("700"));
+        orden.setEstado(EstadoProduccion.CREADA);
+
+        Producto jarabe = new Producto();
+        jarabe.setId(38);
+        jarabe.setNombre("JARABE BASE");
+        jarabe.setCodigoSku("MP-JARBA");
+        UnidadMedida unidadMl = new UnidadMedida();
+        unidadMl.setSimbolo("ML");
+        jarabe.setUnidadMedida(unidadMl);
+        CategoriaProducto categoria = new CategoriaProducto();
+        categoria.setTipo(TipoCategoria.MATERIA_PRIMA);
+        jarabe.setCategoriaProducto(categoria);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(jarabe);
+        detalle.setCantidadNecesaria(new BigDecimal("199.5"));
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setProducto(producto);
+        formula.setDetalles(List.of(detalle));
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+        when(productoRepository.findAllById(any())).thenReturn(List.of(jarabe));
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(jarabe)).thenReturn(List.of(5L));
+
+        DistribucionFefoResult jarabeDistribucion = crearDistribucionJarabe();
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(38L), any(BigDecimal.class), eq(List.of(5L)), eq(true)))
+                .thenReturn(jarabeDistribucion);
+
+        ResultadoValidacionOrdenDTO resultado = service.guardarConValidacionStock(orden);
+
+        assertThat(resultado.isEsValida()).isTrue();
+        assertThat(resultado.getOrden()).isNotNull();
+        assertThat(resultado.getInsumosFaltantes()).isNull();
+    }
+
+    private DistribucionFefoResult crearDistribucionJarabe() {
+        return DistribucionFefoResult.builder()
+                .productoInsumoId(38L)
+                .requerido(new BigDecimal("139650.000000"))
+                .stockFisicoTotal(new BigDecimal("204150.000000"))
+                .stockReservadoTotal(BigDecimal.ZERO)
+                .stockLibreTotal(new BigDecimal("199150.000000"))
+                .faltante(BigDecimal.ZERO.setScale(6))
+                .suficiente(true)
+                .detalles(List.of(
+                        detalleFefo(117L, "L-120925-3", "10000.000000", "10000"),
+                        detalleFefo(92L, "L-110925-3", "30000.000000", "30000"),
+                        detalleFefo(118L, "L-120925-2", "10000.000000", "10000"),
+                        detalleFefo(85L, "L-160925-2", "25000.000000", "25000"),
+                        detalleFefo(103L, "L-180925-8", "59500.000000", "59500"),
+                        detalleFefo(119L, "L-050825-3", "5000.000000", "5000"),
+                        detalleFefo(156L, "L-151125-2", "150.000000", "59650")
+                ))
+                .build();
+    }
+
+    private DistribucionFefoDetalle detalleFefo(Long loteId, String codigo, String cantidad, String disponible) {
+        BigDecimal reserva = new BigDecimal(cantidad).setScale(6, RoundingMode.HALF_UP);
+        return DistribucionFefoDetalle.builder()
+                .loteProductoId(loteId)
+                .codigoLote(codigo)
+                .almacenId(5L)
+                .cantidadCalculo(reserva.setScale(8, RoundingMode.HALF_UP))
+                .cantidadReserva(reserva)
+                .disponible(new BigDecimal(disponible))
+                .estado("DISPONIBLE")
+                .build();
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -70,6 +70,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -276,6 +277,50 @@ class OrdenProduccionServiceReservaTest {
     }
 
     @Test
+    @DisplayName("reservarInsumosParaOP no lanza error cuando Jarabe Base tiene stock FEFO suficiente")
+    void reservarInsumosParaOp_jarabeBaseSinErrores() {
+        Producto jarabe = new Producto();
+        jarabe.setId(60);
+        jarabe.setCodigoSku("MP-JARBA");
+        jarabe.setNombre("JARABE BASE");
+        jarabe.setCategoriaProducto(new com.willyes.clemenintegra.inventario.model.CategoriaProducto());
+        jarabe.getCategoriaProducto().setTipo(TipoCategoria.MATERIA_PRIMA);
+        UnidadMedida unidadMl = new UnidadMedida();
+        unidadMl.setNombre("MILILITRO");
+        jarabe.setUnidadMedida(unidadMl);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(jarabe);
+        detalle.setCantidadNecesaria(new BigDecimal("199.5"));
+
+        FormulaProducto formulaJarabe = new FormulaProducto();
+        formulaJarabe.setProducto(orden.getProducto());
+        formulaJarabe.setDetalles(List.of(detalle));
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaJarabe));
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(jarabe)).thenReturn(List.of(5L));
+        when(solicitudMovimientoService.registrarSolicitud(any(SolicitudMovimientoRequestDTO.class)))
+                .thenReturn(SolicitudMovimientoResponseDTO.builder().id(100L).build());
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(60L), any(BigDecimal.class), eq(List.of(5L)), eq(false)))
+                .thenReturn(crearDistribucionJarabeResult(60L));
+
+        orden.setCantidadProgramada(new BigDecimal("700"));
+
+        assertThatCode(() -> service.reservarInsumosParaOP(1L)).doesNotThrowAnyException();
+
+        ArgumentCaptor<SolicitudMovimiento> solicitudCaptor = ArgumentCaptor.forClass(SolicitudMovimiento.class);
+        verify(solicitudMovimientoRepository).saveAndFlush(solicitudCaptor.capture());
+        List<SolicitudMovimientoDetalle> detalles = solicitudCaptor.getValue().getDetalles();
+        assertThat(detalles).hasSize(7);
+        BigDecimal total = detalles.stream()
+                .map(SolicitudMovimientoDetalle::getCantidad)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(total).isEqualByComparingTo(new BigDecimal("139650.000000"));
+        verify(reservaLoteService).sincronizarReservasSolicitud(solicitudCaptor.getValue());
+    }
+
+    @Test
     @DisplayName("reservarInsumosParaOP falla con 422 cuando no hay lotes elegibles")
     void reservarInsumosParaOp_sinLotesLanzaError() {
         DistribucionFefoResult insuficiente = DistribucionFefoResult.builder()
@@ -375,6 +420,39 @@ class OrdenProduccionServiceReservaTest {
         FormulaProducto formula = new FormulaProducto();
         formula.setDetalles(List.of(detalle));
         return formula;
+    }
+
+    private DistribucionFefoResult crearDistribucionJarabeResult(Long productoId) {
+        return DistribucionFefoResult.builder()
+                .productoInsumoId(productoId)
+                .requerido(new BigDecimal("139650.000000"))
+                .stockFisicoTotal(new BigDecimal("204150.000000"))
+                .stockReservadoTotal(BigDecimal.ZERO)
+                .stockLibreTotal(new BigDecimal("199150.000000"))
+                .faltante(BigDecimal.ZERO.setScale(6))
+                .suficiente(true)
+                .detalles(List.of(
+                        detalleJarabe(117L, "10000.000000", "10000"),
+                        detalleJarabe(92L, "30000.000000", "30000"),
+                        detalleJarabe(118L, "10000.000000", "10000"),
+                        detalleJarabe(85L, "25000.000000", "25000"),
+                        detalleJarabe(103L, "59500.000000", "59500"),
+                        detalleJarabe(119L, "5000.000000", "5000"),
+                        detalleJarabe(156L, "150.000000", "59650")
+                ))
+                .build();
+    }
+
+    private DistribucionFefoDetalle detalleJarabe(Long loteId, String cantidad, String disponible) {
+        BigDecimal reserva = new BigDecimal(cantidad).setScale(6, RoundingMode.HALF_UP);
+        return DistribucionFefoDetalle.builder()
+                .loteProductoId(loteId)
+                .almacenId(5L)
+                .cantidadCalculo(reserva.setScale(8, RoundingMode.HALF_UP))
+                .cantidadReserva(reserva)
+                .disponible(new BigDecimal(disponible))
+                .estado("DISPONIBLE")
+                .build();
     }
 
     private SolicitudMovimiento crearSolicitudBase() {


### PR DESCRIPTION
## Summary
- filter FEFO simulations to eligible lots, compute stock/libre/faltante consistently and expose new helper methods for reuse
- harden order reservation logic to reuse FEFO distributions for both validation and reservations, preventing false STOCK_INSUFICIENTE errors and improving test coverage
- add scenario tests covering the Jarabe Base case across availability, validation, and reservation flows

## Testing
- `mvn -DskipITs -Dtest=FormulaProductoServiceImplTest,DisponibilidadInsumoServiceTest,OrdenProduccionServiceImplTest,OrdenProduccionServiceReservaTest test`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e3101d2c833396c92a3b9e3d7570)