### PR TITLE
Allow solicitudes to consume their reserved lot stock

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -1738,6 +1738,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         SolicitudMovimientoDetalle detalleOp = esOpAtencion
                 ? resolverDetalleSolicitudOp(dto, solicitud, loteOrigen)
                 : null;
+        SolicitudMovimientoDetalle detalleSolicitudRelacionado = validarDetalleCompatibleConLote(detalleOp, loteOrigen);
         boolean detalleOpGestionado = false;
         LoteProducto loteProcesadoOp = null;
 
@@ -1833,9 +1834,14 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             cantidad = pendienteDetalle;
         }
 
+        if (detalleSolicitudRelacionado == null && solicitud != null) {
+            SolicitudMovimientoDetalle posibleDetalle = resolverDetalleSolicitudOp(dto, solicitud, loteOrigen);
+            detalleSolicitudRelacionado = validarDetalleCompatibleConLote(posibleDetalle, loteOrigen);
+        }
+
         BigDecimal reservaPendiente = BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP);
         if (solicitud != null && loteOrigen != null && loteOrigen.getId() != null) {
-            BigDecimal reservaDetalle = calcularReservaPendienteParaDetalle(solicitud, detalleOp, loteOrigen)
+            BigDecimal reservaDetalle = calcularReservaPendienteParaDetalle(solicitud, detalleSolicitudRelacionado, loteOrigen)
                     .setScale(6, RoundingMode.HALF_UP);
             if (reservaDetalle.compareTo(BigDecimal.ZERO) > 0) {
                 reservaPendiente = reservaDetalle;
@@ -1884,7 +1890,30 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                     throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVA_INSUFICIENTE");
                 }
             } else if (!requiereAutoSplit) {
-                if (stockDisponibleEfectivo.compareTo(cantidad) < 0) {
+                if (solicitud != null) {
+                    BigDecimal stockLoteTotal = nvl(loteOrigen.getStockLote()).setScale(6, RoundingMode.HALF_UP);
+                    BigDecimal stockReservadoTotal = nvl(loteOrigen.getStockReservado()).setScale(6, RoundingMode.HALF_UP);
+                    BigDecimal reservadoPorEsteDetalle = obtenerCantidadReservadaPorEsteDetalle(detalleSolicitudRelacionado);
+                    if (reservadoPorEsteDetalle.compareTo(stockReservadoTotal) > 0) {
+                        reservadoPorEsteDetalle = stockReservadoTotal;
+                    }
+                    BigDecimal reservadoPorOtros = stockReservadoTotal.subtract(reservadoPorEsteDetalle);
+                    if (reservadoPorOtros.compareTo(BigDecimal.ZERO) < 0) {
+                        reservadoPorOtros = BigDecimal.ZERO;
+                    }
+                    BigDecimal disponibleParaSolicitud = stockLoteTotal.subtract(reservadoPorOtros);
+                    if (disponibleParaSolicitud.compareTo(BigDecimal.ZERO) < 0) {
+                        disponibleParaSolicitud = BigDecimal.ZERO;
+                    }
+                    BigDecimal cantidadSolicitadaDetalle = obtenerCantidadSolicitadaDelDetalle(detalleSolicitudRelacionado, cantidad);
+                    if (disponibleParaSolicitud.compareTo(cantidadSolicitadaDetalle) < 0) {
+                        log.warn(
+                                "Stock insuficiente en lote: loteId={} disponible={} reservadoTotal={} reservadoOtros={} reservadoDetalle={} solicitado={} productoId={}",
+                                loteOrigen.getId(), disponibleParaSolicitud, stockReservadoTotal,
+                                reservadoPorOtros, reservadoPorEsteDetalle, cantidadSolicitadaDetalle, producto.getId());
+                        throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE");
+                    }
+                } else if (stockDisponibleEfectivo.compareTo(cantidad) < 0) {
                     log.warn("Stock insuficiente en lote: loteId={} disponible={} reservaPendiente={} solicitado={} productoId={}",
                             loteOrigen.getId(), stockDisponibleEfectivo, reservaPendiente, cantidad, producto.getId());
                     throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE");
@@ -2106,7 +2135,16 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
         if (esAtencionReserva(solicitud)) {
             BigDecimal reservadoActual = Optional.ofNullable(loteOrigen.getStockReservado()).orElse(BigDecimal.ZERO);
+            SolicitudMovimientoDetalle detalleReserva = resolverDetalleSolicitudOp(null, solicitud, loteOrigen);
+            detalleReserva = validarDetalleCompatibleConLote(detalleReserva, loteOrigen);
+            BigDecimal reservadoPorDetalle = obtenerCantidadReservadaPorEsteDetalle(detalleReserva);
+            if (reservadoPorDetalle.compareTo(reservadoActual) > 0) {
+                reservadoPorDetalle = reservadoActual;
+            }
             BigDecimal decremento = reservadoActual.min(cantidadNormalizada);
+            if (reservadoPorDetalle.compareTo(BigDecimal.ZERO) > 0) {
+                decremento = reservadoPorDetalle.min(decremento);
+            }
             BigDecimal nuevoReservado = reservadoActual.subtract(decremento);
             if (nuevoReservado.compareTo(BigDecimal.ZERO) < 0) {
                 nuevoReservado = BigDecimal.ZERO;
@@ -2737,6 +2775,54 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             return BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP);
         }
         return disponible.setScale(6, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal nvl(BigDecimal valor) {
+        return valor != null ? valor : BigDecimal.ZERO;
+    }
+
+    private BigDecimal obtenerCantidadReservadaPorEsteDetalle(SolicitudMovimientoDetalle detalle) {
+        if (detalle == null) {
+            return BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP);
+        }
+        BigDecimal solicitada = nvl(detalle.getCantidad()).setScale(6, RoundingMode.HALF_UP);
+        BigDecimal atendida = nvl(detalle.getCantidadAtendida()).setScale(6, RoundingMode.HALF_UP);
+        BigDecimal pendiente = solicitada.subtract(atendida);
+        BigDecimal referencia = pendiente.compareTo(BigDecimal.ZERO) > 0 ? pendiente : solicitada;
+        if (referencia.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP);
+        }
+        return referencia.setScale(6, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal obtenerCantidadSolicitadaDelDetalle(SolicitudMovimientoDetalle detalle, BigDecimal respaldoDto) {
+        if (detalle == null) {
+            return nvl(respaldoDto).setScale(6, RoundingMode.HALF_UP);
+        }
+        BigDecimal solicitada = nvl(detalle.getCantidad()).setScale(6, RoundingMode.HALF_UP);
+        BigDecimal atendida = nvl(detalle.getCantidadAtendida()).setScale(6, RoundingMode.HALF_UP);
+        BigDecimal pendiente = solicitada.subtract(atendida);
+        if (pendiente.compareTo(BigDecimal.ZERO) > 0) {
+            return pendiente.setScale(6, RoundingMode.HALF_UP);
+        }
+        if (solicitada.compareTo(BigDecimal.ZERO) > 0) {
+            return solicitada.setScale(6, RoundingMode.HALF_UP);
+        }
+        return nvl(respaldoDto).setScale(6, RoundingMode.HALF_UP);
+    }
+
+    private SolicitudMovimientoDetalle validarDetalleCompatibleConLote(SolicitudMovimientoDetalle detalle,
+                                                                      LoteProducto loteOrigen) {
+        if (detalle == null || loteOrigen == null || loteOrigen.getId() == null) {
+            return null;
+        }
+        if (detalle.getLote() == null || detalle.getLote().getId() == null) {
+            return null;
+        }
+        if (!Objects.equals(detalle.getLote().getId(), loteOrigen.getId())) {
+            return null;
+        }
+        return detalle;
     }
 
     // =====================================

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -235,6 +237,239 @@ class MovimientoInventarioServiceSolicitudOpTest {
         verify(solicitudMovimientoRepository, times(1)).saveAndFlush(solicitud);
         verify(reservaLoteService, times(1)).consumirReserva(eq(solicitud), eq(detalle), eq(lote), eq(new BigDecimal("1000.000000")));
         verify(mapper, times(1)).safeToResponseDTO(any(MovimientoInventario.class));
+    }
+
+    @Test
+    void transferenciaInterna_consumoTotalReservaPropia_noGeneraError() {
+        Producto producto = new Producto();
+        producto.setId(34);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(12L);
+        producto.setUnidadMedida(unidad);
+
+        LoteProducto loteOrigen = new LoteProducto();
+        loteOrigen.setId(55L);
+        loteOrigen.setProducto(producto);
+        loteOrigen.setCodigoLote("LOT-55");
+        loteOrigen.setAlmacen(new Almacen(10));
+        loteOrigen.setStockLote(new BigDecimal("250"));
+        loteOrigen.setStockReservado(new BigDecimal("250"));
+        loteOrigen.setEstado(EstadoLote.DISPONIBLE);
+
+        LoteProducto loteDestino = new LoteProducto();
+        loteDestino.setId(75L);
+        loteDestino.setProducto(producto);
+        loteDestino.setCodigoLote("LOT-55");
+        loteDestino.setAlmacen(new Almacen(20));
+        loteDestino.setEstado(EstadoLote.DISPONIBLE);
+        loteDestino.setStockLote(BigDecimal.ZERO);
+        loteDestino.setStockReservado(BigDecimal.ZERO);
+
+        SolicitudMovimientoDetalle detalle = new SolicitudMovimientoDetalle();
+        detalle.setId(701L);
+        detalle.setCantidad(new BigDecimal("250"));
+        detalle.setCantidadAtendida(BigDecimal.ZERO);
+        detalle.setEstado(EstadoSolicitudMovimientoDetalle.PENDIENTE);
+        detalle.setLote(loteOrigen);
+
+        SolicitudMovimiento solicitud = new SolicitudMovimiento();
+        solicitud.setId(501L);
+        solicitud.setEstado(EstadoSolicitudMovimiento.AUTORIZADA);
+        solicitud.setTipoMovimiento(TipoMovimiento.TRANSFERENCIA);
+        solicitud.setDetalles(List.of(detalle));
+        detalle.setSolicitudMovimiento(solicitud);
+
+        Usuario usuario = Usuario.builder()
+                .id(80L)
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .nombreUsuario("tester")
+                .clave("secret")
+                .nombreCompleto("Tester")
+                .correo("tester@example.com")
+                .activo(true)
+                .bloqueado(false)
+                .build();
+
+        AtencionDTO atencion = new AtencionDTO();
+        atencion.setDetalleId(detalle.getId());
+        atencion.setLoteId(loteOrigen.getId());
+        atencion.setCantidad(new BigDecimal("250"));
+        atencion.setAlmacenOrigenId(10);
+        atencion.setAlmacenDestinoId(20);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("250"),
+                TipoMovimiento.TRANSFERENCIA,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
+                "DOC-55",
+                null,
+                producto.getId(),
+                loteOrigen.getId(),
+                10,
+                20,
+                null,
+                null,
+                null,
+                70L,
+                solicitud.getId(),
+                usuario.getId(),
+                999L,
+                null,
+                loteOrigen.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                List.of(atencion)
+        );
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+
+        prepararEscenarioComun(dto, producto, solicitud, detalle, loteOrigen, loteDestino, movimientoEntidad, usuario);
+
+        MovimientoInventarioResponseDTO respuesta = service.registrarMovimiento(dto);
+
+        assertThat(respuesta).isNotNull();
+        assertThat(respuesta.getId()).isEqualTo(900L);
+        assertThat(loteOrigen.getStockLote()).isEqualByComparingTo(new BigDecimal("0.00"));
+        assertThat(loteOrigen.getStockReservado()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+    }
+
+    @Test
+    void transferenciaInterna_bloqueadaCuandoReservaEsDeOtros() {
+        Producto producto = new Producto();
+        producto.setId(34);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(12L);
+        producto.setUnidadMedida(unidad);
+
+        LoteProducto loteOrigen = new LoteProducto();
+        loteOrigen.setId(55L);
+        loteOrigen.setProducto(producto);
+        loteOrigen.setCodigoLote("LOT-55");
+        loteOrigen.setAlmacen(new Almacen(10));
+        loteOrigen.setStockLote(new BigDecimal("250"));
+        loteOrigen.setStockReservado(new BigDecimal("250"));
+        loteOrigen.setEstado(EstadoLote.DISPONIBLE);
+
+        LoteProducto loteDestino = new LoteProducto();
+        loteDestino.setId(80L);
+        loteDestino.setProducto(producto);
+        loteDestino.setCodigoLote("LOT-55");
+        loteDestino.setAlmacen(new Almacen(20));
+        loteDestino.setEstado(EstadoLote.DISPONIBLE);
+
+        LoteProducto loteReservaAjena = new LoteProducto();
+        loteReservaAjena.setId(500L);
+        loteReservaAjena.setProducto(producto);
+
+        SolicitudMovimientoDetalle detalle = new SolicitudMovimientoDetalle();
+        detalle.setId(702L);
+        detalle.setCantidad(new BigDecimal("100"));
+        detalle.setCantidadAtendida(BigDecimal.ZERO);
+        detalle.setEstado(EstadoSolicitudMovimientoDetalle.PENDIENTE);
+        detalle.setLote(loteReservaAjena);
+
+        SolicitudMovimiento solicitud = new SolicitudMovimiento();
+        solicitud.setId(777L);
+        solicitud.setEstado(EstadoSolicitudMovimiento.AUTORIZADA);
+        solicitud.setTipoMovimiento(TipoMovimiento.TRANSFERENCIA);
+        solicitud.setDetalles(List.of(detalle));
+        detalle.setSolicitudMovimiento(solicitud);
+
+        Usuario usuario = Usuario.builder()
+                .id(81L)
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .nombreUsuario("tester")
+                .clave("secret")
+                .nombreCompleto("Tester")
+                .correo("tester@example.com")
+                .activo(true)
+                .bloqueado(false)
+                .build();
+
+        AtencionDTO atencion = new AtencionDTO();
+        atencion.setDetalleId(detalle.getId());
+        atencion.setLoteId(loteOrigen.getId());
+        atencion.setCantidad(new BigDecimal("10"));
+        atencion.setAlmacenOrigenId(10);
+        atencion.setAlmacenDestinoId(20);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("10"),
+                TipoMovimiento.TRANSFERENCIA,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
+                "DOC-56",
+                null,
+                producto.getId(),
+                loteOrigen.getId(),
+                10,
+                20,
+                null,
+                null,
+                null,
+                71L,
+                solicitud.getId(),
+                usuario.getId(),
+                999L,
+                null,
+                loteOrigen.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                List.of(atencion)
+        );
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+
+        prepararEscenarioComun(dto, producto, solicitud, detalle, loteOrigen, loteDestino, movimientoEntidad, usuario);
+
+        assertThatThrownBy(() -> service.registrarMovimiento(dto))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("LOTE_STOCK_INSUFICIENTE");
+    }
+
+    private void prepararEscenarioComun(MovimientoInventarioDTO dto,
+                                        Producto producto,
+                                        SolicitudMovimiento solicitud,
+                                        SolicitudMovimientoDetalle detalle,
+                                        LoteProducto loteOrigen,
+                                        LoteProducto loteDestino,
+                                        MovimientoInventario movimientoEntidad,
+                                        Usuario usuario) {
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
+        given(tipoMovimientoDetalleRepository.findById(dto.tipoMovimientoDetalleId())).willReturn(Optional.of(new TipoMovimientoDetalle()));
+        given(solicitudMovimientoRepository.findByIdWithLock(solicitud.getId())).willReturn(Optional.of(solicitud));
+        given(usuarioService.obtenerUsuarioAutenticado()).willReturn(usuario);
+        OrdenProduccion opReferencia = new OrdenProduccion();
+        opReferencia.setId(dto.ordenProduccionId());
+        given(entityManager.getReference(eq(OrdenProduccion.class), eq(dto.ordenProduccionId()))).willReturn(opReferencia);
+        given(entityManager.getReference(eq(Almacen.class), any())).willAnswer(invocation -> {
+            Number id = invocation.getArgument(1);
+            return new Almacen(id.intValue());
+        });
+        given(loteProductoRepository.findByIdForUpdate(loteOrigen.getId())).willReturn(Optional.of(loteOrigen));
+        given(loteProductoRepository.findByCodigoLoteAndProductoIdAndAlmacenId(
+                eq(loteOrigen.getCodigoLote()), eq(producto.getId()), eq(dto.almacenDestinoId()))).willReturn(Optional.of(loteDestino));
+        given(loteProductoRepository.save(any(LoteProducto.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(solicitudMovimientoDetalleRepository.findById(detalle.getId())).willReturn(Optional.of(detalle));
+        given(solicitudMovimientoDetalleRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(solicitudMovimientoDetalleRepository.countBySolicitudMovimientoIdAndEstadoNot(anyLong(), any())).willReturn(0L);
+        given(solicitudMovimientoDetalleRepository.calcularReservaPendientePorSolicitudYLote(anyLong(), anyLong()))
+                .willReturn(BigDecimal.ZERO);
+        given(solicitudMovimientoRepository.saveAndFlush(solicitud)).willReturn(solicitud);
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(900L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willReturn(MovimientoInventarioResponseDTO.builder().id(900L).build());
+        given(catalogResolver.decimals(any())).willReturn(2);
     }
 }
 


### PR DESCRIPTION
## Summary
- allow movimientos ligados a solicitudes de OP to differentiate entre reservas propias y de terceros para validar el stock disponible y registrar el consumo
- ajustar la reducción de reservas durante transferencias y añadir utilitarios para obtener cantidades pendientes por detalle
- añadir pruebas unitarias que cubren el consumo total de la reserva propia y el bloqueo cuando el stock está comprometido por otros detalles

## Testing
- `mvn -q -Dtest=MovimientoInventarioServiceSolicitudOpTest test` *(falla: dependencia jakartaee-api-parent no se pudo descargar desde Maven Central por respuesta 502)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1869b2008333ad68de9874bb7954)