### PR TITLE
Handle OP stock context in SALIDA_PRODUCCION

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -602,9 +602,6 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                 && clasificacion == ClasificacionMovimientoInventario.SALIDA_PRODUCCION) {
 
             // Consumir directamente del lote (ya en Pre-Bodega).
-            // OJO: ignoramos la 'solicitud' para el cálculo de stock (pasamos null),
-            // pero el movimiento seguirá quedando LIGADO a la solicitud más abajo
-            // cuando se setea movimiento.setSolicitudMovimiento(solicitud).
             lotesProcesados = procesarMovimientoConLoteExistente(
                     dto,
                     tipoMovimiento,
@@ -613,7 +610,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                     producto,
                     cantidadSolicitada,
                     devolucionInterna,
-                    /* solicitud */ null, // <- clave para evitar el early-return que no descuenta stock
+                    /* solicitud */ solicitud,
                     solicitudOpProcesadaEnLote
             );
 
@@ -1898,9 +1895,29 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         BigDecimal stockDisponibleEfectivo = stockDisponibleBase.add(reservaPendiente)
                 .setScale(6, RoundingMode.HALF_UP);
 
-        log.debug("VAL-LOTE loteId={} estadoSolicitud={} stockLote={} reservadoTotal={} pendienteSolicitud={} disponibleBase={} disponibleEfectivo={} req={}",
+        SolicitudMovimiento solicitudContexto = solicitud != null
+                ? solicitud
+                : (detalleSolicitudRelacionado != null ? detalleSolicitudRelacionado.getSolicitudMovimiento() : null);
+        SolicitudMovimientoDetalle detalleContexto = detalleSolicitudRelacionado;
+
+        BigDecimal stockReservadoTotal = nvl(loteOrigen.getStockReservado()).setScale(6, RoundingMode.HALF_UP);
+        BigDecimal reservadoPropio = obtenerCantidadReservadaPorEsteDetalle(detalleContexto);
+        if (reservadoPropio.compareTo(stockReservadoTotal) > 0) {
+            reservadoPropio = stockReservadoTotal;
+        }
+        BigDecimal reservaAjena = stockReservadoTotal.subtract(reservadoPropio);
+        if (reservaAjena.compareTo(BigDecimal.ZERO) < 0) {
+            reservaAjena = BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP);
+        }
+        BigDecimal stockDisponibleEfectivoContextual = stockActual.subtract(reservaAjena)
+                .setScale(6, RoundingMode.HALF_UP);
+        BigDecimal cantidadSolicitadaContextual = obtenerCantidadSolicitadaDelDetalle(detalleContexto, cantidad);
+
+        log.debug("VAL-LOTE loteId={} estadoSolicitud={} stockLote={} reservadoTotal={} pendienteSolicitud={} disponibleBase={}disponibleEfectivo={} req={}",
                 loteOrigen.getId(), solicitud != null ? solicitud.getEstado() : null, stockActual, reservadoActual,
                 reservaPendiente, stockDisponibleBase, stockDisponibleEfectivo, cantidad);
+
+        boolean hayContextoSolicitud = solicitudContexto != null || detalleContexto != null;
 
         boolean esTransferenciaInternaProduccion = tipo == TipoMovimiento.TRANSFERENCIA
                 && dto.clasificacionMovimientoInventario() == ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION;
@@ -1923,29 +1940,21 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                     throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVA_INSUFICIENTE");
                 }
             } else if (!requiereAutoSplit) {
-                if (solicitud != null) {
-                    BigDecimal stockLoteTotal = nvl(loteOrigen.getStockLote()).setScale(6, RoundingMode.HALF_UP);
-                    BigDecimal stockReservadoTotal = nvl(loteOrigen.getStockReservado()).setScale(6, RoundingMode.HALF_UP);
-                    BigDecimal reservadoPorEsteDetalle = obtenerCantidadReservadaPorEsteDetalle(detalleSolicitudRelacionado);
-                    if (reservadoPorEsteDetalle.compareTo(stockReservadoTotal) > 0) {
-                        reservadoPorEsteDetalle = stockReservadoTotal;
-                    }
-                    BigDecimal reservadoPorOtros = stockReservadoTotal.subtract(reservadoPorEsteDetalle);
-                    if (reservadoPorOtros.compareTo(BigDecimal.ZERO) < 0) {
-                        reservadoPorOtros = BigDecimal.ZERO;
-                    }
-                    BigDecimal disponibleParaSolicitud = stockLoteTotal.subtract(reservadoPorOtros);
-                    if (disponibleParaSolicitud.compareTo(BigDecimal.ZERO) < 0) {
-                        disponibleParaSolicitud = BigDecimal.ZERO;
-                    }
-                    BigDecimal cantidadSolicitadaDetalle = obtenerCantidadSolicitadaDelDetalle(detalleSolicitudRelacionado, cantidad);
-                    if (disponibleParaSolicitud.compareTo(cantidadSolicitadaDetalle) < 0) {
+                log.debug("VAL-LOTE-CONTEXTO solicitudIdDto={} solicitudCtxId={} detalleCtxId={} stockLote={} reservadoTotal={} reservadoPropio={} reservaAjena={} disponibleCtx={} solicitadoCtx={}",
+                        dto.solicitudMovimientoId(),
+                        solicitudContexto != null ? solicitudContexto.getId() : null,
+                        detalleContexto != null ? detalleContexto.getId() : null,
+                        stockActual, stockReservadoTotal, reservadoPropio, reservaAjena, stockDisponibleEfectivoContextual,
+                        cantidadSolicitadaContextual);
+
+                if (hayContextoSolicitud) {
+                    if (stockDisponibleEfectivoContextual.compareTo(cantidadSolicitadaContextual) < 0) {
                         log.warn(
                                 "Stock insuficiente en lote (CON_SOLICITUD): solicitudId={} detalleId={} loteId={} disponible={} reservadoTotal={} reservadoOtros={} reservadoDetalle={} solicitado={} productoId={}",
-                                solicitud.getId(),
-                                detalleSolicitudRelacionado != null ? detalleSolicitudRelacionado.getId() : null,
-                                loteOrigen.getId(), disponibleParaSolicitud, stockReservadoTotal,
-                                reservadoPorOtros, reservadoPorEsteDetalle, cantidadSolicitadaDetalle, producto.getId());
+                                solicitudContexto != null ? solicitudContexto.getId() : null,
+                                detalleContexto != null ? detalleContexto.getId() : null,
+                                loteOrigen.getId(), stockDisponibleEfectivoContextual, stockReservadoTotal,
+                                reservaAjena, reservadoPropio, cantidadSolicitadaContextual, producto.getId());
                         throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE");
                     }
                 } else if (stockDisponibleEfectivo.compareTo(cantidad) < 0) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -358,6 +358,125 @@ class MovimientoInventarioServiceSolicitudOpTest {
         verify(reservaLoteService, times(1)).consumirReserva(eq(solicitud), eq(detalle), eq(lote), eq(new BigDecimal("500.000000")));
     }
 
+    @Test
+    void salidaProduccion_conSolicitudYReservaPropia_consumoPermitido() {
+        Producto producto = new Producto();
+        producto.setId(547);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(1L);
+        producto.setUnidadMedida(unidad);
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(61L);
+        lote.setProducto(producto);
+        lote.setAlmacen(new Almacen(1));
+        lote.setCodigoLote("LOTE-61");
+        lote.setStockLote(new BigDecimal("5000"));
+        lote.setStockReservado(new BigDecimal("3600"));
+        lote.setEstado(EstadoLote.DISPONIBLE);
+
+        SolicitudMovimientoDetalle detalle = new SolicitudMovimientoDetalle();
+        detalle.setId(16L);
+        detalle.setCantidad(new BigDecimal("3600"));
+        detalle.setCantidadAtendida(BigDecimal.ZERO);
+        detalle.setEstado(EstadoSolicitudMovimientoDetalle.PENDIENTE);
+        detalle.setLote(lote);
+        detalle.setAlmacenOrigen(new Almacen(1));
+        detalle.setAlmacenDestino(new Almacen(6));
+
+        SolicitudMovimiento solicitud = new SolicitudMovimiento();
+        solicitud.setId(16L);
+        solicitud.setProducto(producto);
+        solicitud.setLote(lote);
+        solicitud.setTipoMovimiento(TipoMovimiento.SALIDA);
+        solicitud.setEstado(EstadoSolicitudMovimiento.RESERVADA);
+        solicitud.setCantidad(new BigDecimal("3600"));
+        solicitud.setDetalles(List.of(detalle));
+        detalle.setSolicitudMovimiento(solicitud);
+
+        OrdenProduccion ordenProduccion = new OrdenProduccion();
+        ordenProduccion.setId(2L);
+        solicitud.setOrdenProduccion(ordenProduccion);
+
+        Usuario usuario = Usuario.builder()
+                .id(99L)
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .nombreUsuario("tester")
+                .clave("secret")
+                .nombreCompleto("Tester")
+                .correo("tester@example.com")
+                .activo(true)
+                .bloqueado(false)
+                .build();
+        solicitud.setUsuarioResponsable(usuario);
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("3600"),
+                TipoMovimiento.SALIDA,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                "DOC-OP",
+                null,
+                producto.getId(),
+                lote.getId(),
+                1,
+                6,
+                null,
+                null,
+                null,
+                99L,
+                solicitud.getId(),
+                usuario.getId(),
+                ordenProduccion.getId(),
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                List.of()
+        );
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
+        given(tipoMovimientoDetalleRepository.findById(anyLong())).willReturn(Optional.of(new TipoMovimientoDetalle()));
+        given(solicitudMovimientoRepository.findByIdWithLock(solicitud.getId())).willReturn(Optional.of(solicitud));
+        given(usuarioService.obtenerUsuarioAutenticado()).willReturn(usuario);
+        given(entityManager.getReference(eq(OrdenProduccion.class), eq(ordenProduccion.getId()))).willReturn(ordenProduccion);
+        given(entityManager.getReference(eq(Almacen.class), any())).willAnswer(invocation -> {
+            Object id = invocation.getArgument(1);
+            return new Almacen(id instanceof Integer ? (Integer) id : ((Long) id).intValue());
+        });
+        given(loteProductoRepository.findByIdForUpdate(lote.getId())).willReturn(Optional.of(lote));
+        given(loteProductoRepository.save(any(LoteProducto.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(solicitudMovimientoDetalleRepository.findById(detalle.getId())).willReturn(Optional.of(detalle));
+        given(solicitudMovimientoDetalleRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(solicitudMovimientoRepository.saveAndFlush(solicitud)).willReturn(solicitud);
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(901L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willReturn(MovimientoInventarioResponseDTO.builder().id(901L).build());
+        lenient().when(catalogResolver.decimals(any())).thenReturn(2);
+
+        MovimientoInventarioResponseDTO respuesta = service.registrarMovimiento(dto);
+
+        assertThat(respuesta).isNotNull();
+        assertThat(respuesta.getId()).isEqualTo(901L);
+        assertThat(detalle.getCantidadAtendida()).isEqualByComparingTo(new BigDecimal("3600.000000"));
+        assertThat(detalle.getEstado()).isEqualTo(EstadoSolicitudMovimientoDetalle.ATENDIDO);
+        assertThat(solicitud.getEstado()).isEqualTo(EstadoSolicitudMovimiento.CERRADA);
+        assertThat(lote.getStockReservado()).isEqualByComparingTo(BigDecimal.ZERO.setScale(2));
+        assertThat(lote.getStockLote()).isEqualByComparingTo(new BigDecimal("1400.00"));
+
+        verify(reservaLoteService, times(1))
+                .consumirReserva(eq(solicitud), eq(detalle), eq(lote), eq(new BigDecimal("3600.000000")));
+    }
+
     @Disabled("Requiere entorno de integración para validar consumo doble de lote")
     @Test
     void transferenciaInterna_consumoTotalReservaPropia_noGeneraError() {


### PR DESCRIPTION
## Summary
- Pass the loaded solicitud into SALIDA_PRODUCCION processing and calculate effective stock using reservation context when a solicitud or detalle is present
- Add detailed debug and contextual warning logs for stock validation while preserving the legacy branch only when no context exists
- Cover SALIDA_PRODUCCION consumption of reserved stock for an OP in MovimientoInventarioServiceSolicitudOpTest

## Testing
- mvn -pl . -am -Dtest=MovimientoInventarioServiceSolicitudOpTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3bfc7cd08333a53e1cb1852aa007)