### PR TITLE
Add cancellation workflow for production orders

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ReservaLoteRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ReservaLoteRepository.java
@@ -48,5 +48,8 @@ public interface ReservaLoteRepository extends JpaRepository<ReservaLote, Long> 
     List<ReservaLote> findBySolicitudMovimientoDetalleId(Long detalleId);
 
     List<ReservaLote> findBySolicitudMovimientoDetalle_SolicitudMovimientoId(Long solicitudId);
+
+    boolean existsBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionIdAndEstado(Long ordenProduccionId,
+                                                                                              EstadoReservaLote estado);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
@@ -34,6 +34,16 @@ public class ReservaLoteService {
     private final LoteProductoRepository loteProductoRepository;
     private final SolicitudMovimientoRepository solicitudMovimientoRepository;
 
+    @Transactional(readOnly = true)
+    public boolean existenReservasConsumidasPorOrden(Long ordenProduccionId) {
+        if (ordenProduccionId == null) {
+            return false;
+        }
+        return reservaLoteRepository
+                .existsBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionIdAndEstado(
+                        ordenProduccionId, EstadoReservaLote.CONSUMIDA);
+    }
+
     @Transactional
     public void sincronizarReservasSolicitud(SolicitudMovimiento solicitud) {
         if (solicitud == null || solicitud.getDetalles() == null || solicitud.getDetalles().isEmpty()) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -104,6 +104,14 @@ public class OrdenProduccionController {
         return ResponseEntity.ok(ProduccionMapper.toResponse(orden));
     }
 
+    @PostMapping("/{id}/cancelar")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<OrdenProduccionResponseDTO> cancelar(@PathVariable Long id,
+                                                               @RequestBody(required = false) CancelarOrdenRequestDTO request) {
+        OrdenProduccion orden = service.cancelarOrden(id, request != null ? request.getMotivo() : null);
+        return ResponseEntity.ok(ProduccionMapper.toResponse(orden));
+    }
+
     @PostMapping("/{id}/cierres")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> registrarCierre(@PathVariable Long id,

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/CancelarOrdenRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/CancelarOrdenRequestDTO.java
@@ -1,0 +1,11 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CancelarOrdenRequestDTO {
+    private String motivo;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
@@ -3,6 +3,11 @@ package com.willyes.clemenintegra.produccion.repository;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
 
 import java.util.Optional;
 
@@ -13,5 +18,9 @@ public interface OrdenProduccionRepository extends JpaRepository<OrdenProduccion
     Long countByCodigoOrdenStartingWith(String prefijo);
 
     Optional<OrdenProduccion> findTopByLoteProduccionStartingWithOrderByLoteProduccionDesc(String prefix);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select o from OrdenProduccion o where o.id = :id")
+    Optional<OrdenProduccion> findByIdForUpdate(@Param("id") Long id);
 
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import org.springframework.lang.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -53,4 +54,6 @@ public interface OrdenProduccionService {
                                                     LocalDateTime fechaInicio,
                                                     LocalDateTime fechaFin,
                                                     Pageable pageable);
+
+    OrdenProduccion cancelarOrden(Long ordenProduccionId, @Nullable String motivo);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -63,6 +63,7 @@ import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -72,6 +73,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.lang.Nullable;
 import org.springframework.web.ErrorResponseException;
 import org.springframework.http.ProblemDetail;
 
@@ -1072,6 +1074,70 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     public Page<MovimientoInventarioResponseDTO> listarMovimientos(Long id, Pageable pageable) {
         return movimientoInventarioRepository.findByOrdenProduccionId(id, pageable)
                 .map(movimientoInventarioMapper::safeToResponseDTO);
+    }
+
+    @Override
+    @Transactional
+    public OrdenProduccion cancelarOrden(Long ordenProduccionId, @Nullable String motivo) {
+        OrdenProduccion orden = repository.findByIdForUpdate(ordenProduccionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ORDEN_NO_ENCONTRADA"));
+
+        if (orden.getEstado() == EstadoProduccion.FINALIZADA
+                || orden.getEstado() == EstadoProduccion.CANCELADA
+                || orden.getEstado() == EstadoProduccion.CERRADA_INCOMPLETA) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "ORDEN_NO_CANCELABLE");
+        }
+
+        if (orden.getEstado() != EstadoProduccion.CREADA && orden.getEstado() != EstadoProduccion.EN_PROCESO) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "ORDEN_NO_CANCELABLE");
+        }
+
+        if (reservaLoteService.existenReservasConsumidasPorOrden(orden.getId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "ORDEN_CONSUMOS_REGISTRADOS");
+        }
+
+        List<SolicitudMovimiento> solicitudes = Optional.ofNullable(
+                solicitudMovimientoRepository.findWithDetalles(orden.getId(), null, null, null)
+        ).orElse(List.of());
+
+        for (SolicitudMovimiento solicitud : solicitudes) {
+            boolean tieneDetalles = solicitud.getDetalles() != null && !solicitud.getDetalles().isEmpty();
+            boolean todosCancelados = true;
+            boolean algunAtendido = false;
+
+            if (tieneDetalles) {
+                for (SolicitudMovimientoDetalle detalle : solicitud.getDetalles()) {
+                    if (detalle.getEstado() == EstadoSolicitudMovimientoDetalle.ATENDIDO) {
+                        algunAtendido = true;
+                        todosCancelados = false;
+                        continue;
+                    }
+                    detalle.setEstado(EstadoSolicitudMovimientoDetalle.CANCELADO);
+                }
+            }
+
+            if (!tieneDetalles) {
+                todosCancelados = true;
+            }
+
+            if (!algunAtendido && todosCancelados) {
+                solicitud.setEstado(EstadoSolicitudMovimiento.CANCELADA);
+                solicitud.setFechaResolucion(LocalDateTime.now());
+            }
+        }
+
+        if (!solicitudes.isEmpty()) {
+            solicitudMovimientoRepository.saveAll(solicitudes);
+        }
+
+        reservaLoteService.liberarReservasPorOrden(orden.getId());
+
+        orden.setEstado(EstadoProduccion.CANCELADA);
+        if (orden.getFechaFin() == null) {
+            orden.setFechaFin(LocalDateTime.now());
+        }
+
+        return repository.save(orden);
     }
 
     @Transactional

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCancelarTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCancelarTest.java
@@ -1,0 +1,130 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.inventario.service.*;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.*;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrdenProduccionServiceCancelarTest {
+
+    @Mock private FormulaProductoRepository formulaProductoRepository;
+    @Mock private ProductoRepository productoRepository;
+    @Mock private UsuarioRepository usuarioRepository;
+    @Mock private SolicitudMovimientoService solicitudMovimientoService;
+    @Mock private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock private CierreProduccionRepository cierreProduccionRepository;
+    @Mock private MovimientoInventarioService movimientoInventarioService;
+    @Mock private LoteProductoRepository loteProductoRepository;
+    @Mock private AlmacenRepository almacenRepository;
+    @Mock private UnidadConversionService unidadConversionService;
+    @Mock private EtapaProduccionRepository etapaProduccionRepository;
+    @Mock private EtapaPlantillaRepository etapaPlantillaRepository;
+    @Mock private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock private MovimientoInventarioMapper movimientoInventarioMapper;
+    @Mock private UsuarioService usuarioService;
+    @Mock private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    @Mock private InventoryCatalogResolver catalogResolver;
+    @Mock private UmValidator umValidator;
+    @Mock private VidaUtilProductoRepository vidaUtilProductoRepository;
+    @Mock private ReservaLoteService reservaLoteService;
+    @Mock private DisponibilidadInsumoService disponibilidadInsumoService;
+
+    @InjectMocks
+    private OrdenProduccionServiceImpl service;
+
+    @Test
+    void cancelarOrden_actualizaEstadosYLiberaciones() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(1L);
+        orden.setEstado(EstadoProduccion.CREADA);
+
+        SolicitudMovimientoDetalle detalle = new SolicitudMovimientoDetalle();
+        detalle.setEstado(EstadoSolicitudMovimientoDetalle.PENDIENTE);
+
+        SolicitudMovimiento solicitud = new SolicitudMovimiento();
+        solicitud.setEstado(EstadoSolicitudMovimiento.PENDIENTE);
+        solicitud.setDetalles(new ArrayList<>(List.of(detalle)));
+        detalle.setSolicitudMovimiento(solicitud);
+
+        when(ordenProduccionRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(orden));
+        when(reservaLoteService.existenReservasConsumidasPorOrden(1L)).thenReturn(false);
+        when(solicitudMovimientoRepository.findWithDetalles(1L, null, null, null)).thenReturn(List.of(solicitud));
+        doNothing().when(reservaLoteService).liberarReservasPorOrden(anyLong());
+        when(ordenProduccionRepository.save(any(OrdenProduccion.class))).thenAnswer(invocation -> {
+            OrdenProduccion op = invocation.getArgument(0);
+            if (op.getFechaFin() == null) {
+                op.setFechaFin(LocalDateTime.now());
+            }
+            return op;
+        });
+
+        OrdenProduccion resultado = service.cancelarOrden(1L, "ajuste formula");
+
+        assertThat(resultado.getEstado()).isEqualTo(EstadoProduccion.CANCELADA);
+        assertThat(resultado.getFechaFin()).isNotNull();
+        assertThat(detalle.getEstado()).isEqualTo(EstadoSolicitudMovimientoDetalle.CANCELADO);
+        assertThat(solicitud.getEstado()).isEqualTo(EstadoSolicitudMovimiento.CANCELADA);
+        verify(reservaLoteService, times(1)).liberarReservasPorOrden(1L);
+    }
+
+    @Test
+    void cancelarOrden_rechazaCuandoHayReservasConsumidas() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(5L);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+
+        when(ordenProduccionRepository.findByIdForUpdate(5L)).thenReturn(Optional.of(orden));
+        when(reservaLoteService.existenReservasConsumidasPorOrden(5L)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.cancelarOrden(5L, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void cancelarOrden_rechazaEstadosNoCancelables() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(7L);
+        orden.setEstado(EstadoProduccion.FINALIZADA);
+
+        when(ordenProduccionRepository.findByIdForUpdate(7L)).thenReturn(Optional.of(orden));
+
+        assertThatThrownBy(() -> service.cancelarOrden(7L, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.CONFLICT);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a cancellation workflow for production orders, including locking and validation for consumptions
- cancel related movement requests, release active reservations, and expose a controller endpoint
- add repository helpers plus unit coverage for the cancellation service

## Testing
- `mvn -q -Dtest=OrdenProduccionServiceCancelarTest test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a41ed6f888333b18922d21841a250)