### PR TITLE
Allow production leaders to create stages

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaPlantillaController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaPlantillaController.java
@@ -15,13 +15,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/produccion/plantillas")
 @RequiredArgsConstructor
-@PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
 public class EtapaPlantillaController {
 
     private final EtapaPlantillaService service;
     private final EtapaPlantillaMapper mapper;
 
     @GetMapping("/{productoId}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public List<EtapaPlantillaResponse> listar(@PathVariable Integer productoId) {
         return service.listarPorProducto(productoId).stream()
                 .map(mapper::toResponse)
@@ -29,6 +29,7 @@ public class EtapaPlantillaController {
     }
 
     @PostMapping("/{productoId}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaPlantillaResponse> crear(@PathVariable Integer productoId,
                                                          @RequestBody EtapaPlantillaRequest request) {
         Producto producto = new Producto();
@@ -39,6 +40,7 @@ public class EtapaPlantillaController {
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaPlantillaResponse> actualizar(@PathVariable Long id,
                                                              @RequestBody EtapaPlantillaRequest request) {
         EtapaPlantilla entidad = mapper.toEntity(request);
@@ -46,12 +48,14 @@ public class EtapaPlantillaController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {
         service.eliminar(id);
         return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/{productoId}/reordenar")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> reordenar(@PathVariable Integer productoId,
                                           @RequestBody List<EtapaPlantillaReordenRequest> cambios) {
         service.reordenar(productoId, cambios);
@@ -59,6 +63,7 @@ public class EtapaPlantillaController {
     }
 
     @GetMapping("/{productoId}/preview")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public List<EtapaPlantillaResponse> preview(@PathVariable Integer productoId) {
         return service.preview(productoId).stream()
                 .map(mapper::toResponse)

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaProduccionController.java
@@ -36,7 +36,7 @@ public class EtapaProduccionController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaProduccionResponse> crear(@RequestBody EtapaProduccionRequest request) {
         OrdenProduccion orden = new OrdenProduccion(); orden.setId(request.ordenProduccionId);
         EtapaProduccion entidad = ProduccionMapper.toEntity(request, orden);


### PR DESCRIPTION
## Summary
- extend production stage creation endpoints to authorize production lead roles alongside existing access
- adjust template stage controller to keep previous restrictions on non-creation actions while allowing leaders to create templates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691afbd01bec833390e63c6ee65c0d68)