### PR TITLE
Ajustar consolidado de insumos y estado automático de OP

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ReservaLoteRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ReservaLoteRepository.java
@@ -51,5 +51,14 @@ public interface ReservaLoteRepository extends JpaRepository<ReservaLote, Long> 
 
     boolean existsBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionIdAndEstado(Long ordenProduccionId,
                                                                                               EstadoReservaLote estado);
+
+    @Query("select coalesce(sum(r.cantidadConsumida), 0) " +
+            "from ReservaLote r " +
+            "where r.solicitudMovimientoDetalle.solicitudMovimiento.ordenProduccion.id = :ordenId " +
+            "and r.solicitudMovimientoDetalle.solicitudMovimiento.producto.id = :productoId " +
+            "and r.estado = :estado")
+    BigDecimal sumConsumidaByOrdenAndProducto(@Param("ordenId") Long ordenId,
+                                              @Param("productoId") Long productoId,
+                                              @Param("estado") EstadoReservaLote estado);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -41,6 +41,7 @@ import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoDetall
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
 import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
 import com.willyes.clemenintegra.inventario.service.ReservaLoteService;
+import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
 import com.willyes.clemenintegra.produccion.dto.LoteProductoResponse;
 import com.willyes.clemenintegra.inventario.dto.AlmacenResponseDTO;
 import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
@@ -50,6 +51,7 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.willyes.clemenintegra.shared.model.Usuario;
@@ -121,6 +123,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     private final UmValidator umValidator;
     private final VidaUtilProductoRepository vidaUtilProductoRepository;
     private final ReservaLoteService reservaLoteService;
+    private final ReservaLoteRepository reservaLoteRepository;
     private final DisponibilidadInsumoService disponibilidadInsumoService;
 
     @Value("${inventory.solicitud.estados.pendientes}")
@@ -555,17 +558,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             BigDecimal acumulada = Optional.ofNullable(orden.getCantidadProducidaAcumulada()).orElse(BigDecimal.ZERO);
             BigDecimal nuevaAcumulada = acumulada.add(cantidad);
 
-            if (dto.getTipo() == TipoCierre.TOTAL) {
-                boolean etapasFinalizadas = etapaProduccionRepository
-                        .findByOrdenProduccionIdOrderBySecuenciaAsc(orden.getId())
-                        .stream()
-                        .allMatch(e -> e.getEstado() == EstadoEtapa.FINALIZADA);
-                if (etapasFinalizadas) {
-                    orden.setEstado(EstadoProduccion.FINALIZADA);
-                    orden.setFechaFin(LocalDateTime.now());
-                }
-            }
-
             orden.setCantidadProducidaAcumulada(nuevaAcumulada);
             orden.setCantidadProducida(nuevaAcumulada);
             orden.setFechaUltimoCierre(LocalDateTime.now());
@@ -575,6 +567,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             cierre.setUsuarioId(usuario.getId());
             cierre.setUsuarioNombre(usuario.getNombreCompleto());
             cierreProduccionRepository.save(cierre);
+
+            recalcularEstadoOrden(orden);
 
             if (orden.getProducto() == null || orden.getProducto().getTipoAnalisis() == null) {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "PRODUCTO_SIN_TIPO_ANALISIS");
@@ -1011,6 +1005,34 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         return etapaProduccionRepository.save(etapa);
     }
 
+    private void recalcularEstadoOrden(OrdenProduccion orden) {
+        if (orden == null || orden.getId() == null || orden.getEstado() == EstadoProduccion.CANCELADA) {
+            return;
+        }
+
+        List<EtapaProduccion> etapas = etapaProduccionRepository
+                .findByOrdenProduccionIdOrderBySecuenciaAsc(orden.getId());
+
+        boolean todasFinalizadas = !etapas.isEmpty()
+                && etapas.stream().allMatch(e -> e.getEstado() == EstadoEtapa.FINALIZADA);
+
+        BigDecimal programada = Optional.ofNullable(orden.getCantidadProgramada()).orElse(BigDecimal.ZERO);
+        BigDecimal producida = Optional.ofNullable(orden.getCantidadProducidaAcumulada()).orElse(BigDecimal.ZERO);
+
+        if (todasFinalizadas) {
+            if (producida.compareTo(programada) >= 0) {
+                orden.setEstado(EstadoProduccion.FINALIZADA);
+            } else {
+                orden.setEstado(EstadoProduccion.CERRADA_INCOMPLETA);
+            }
+            if (orden.getFechaFin() == null) {
+                orden.setFechaFin(LocalDateTime.now());
+            }
+        } else if (orden.getEstado() != EstadoProduccion.CANCELADA) {
+            orden.setEstado(EstadoProduccion.EN_PROCESO);
+        }
+    }
+
     private void validarSolicitudesMovimientosEjecutadas(OrdenProduccion orden) {
         List<SolicitudMovimiento> solicitudes = solicitudMovimientoRepository.findByOrdenProduccionId(orden.getId());
 
@@ -1057,7 +1079,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         etapa.setFechaFin(LocalDateTime.now());
         etapa.setUsuarioId(usuario.getId());
         etapa.setUsuarioNombre(usuario.getNombreCompleto());
-        return etapaProduccionRepository.save(etapa);
+        EtapaProduccion guardada = etapaProduccionRepository.save(etapa);
+
+        recalcularEstadoOrden(orden);
+        repository.save(orden);
+
+        return guardada;
     }
 
     public List<InsumoOPDTO> listarInsumos(Long id) {
@@ -1073,9 +1100,13 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         for (DetalleFormula det : formula.getDetalles()) {
             BigDecimal requerida = det.getCantidadNecesaria().multiply(orden.getCantidadProgramada());
             Long insumoId = det.getInsumo().getId().longValue();
-            BigDecimal consumida = Optional.ofNullable(
+            BigDecimal consumidaMov = Optional.ofNullable(
                     movimientoInventarioRepository.sumaCantidadPorOrdenYProducto(id, insumoId, detalleId)
             ).orElse(BigDecimal.ZERO);
+            BigDecimal consumidaReservas = Optional.ofNullable(
+                    reservaLoteRepository.sumConsumidaByOrdenAndProducto(id, insumoId, EstadoReservaLote.CONSUMIDA)
+            ).orElse(BigDecimal.ZERO);
+            BigDecimal consumida = consumidaMov.max(consumidaReservas);
             BigDecimal faltante = requerida.subtract(consumida);
             if (faltante.compareTo(BigDecimal.ZERO) < 0) {
                 faltante = BigDecimal.ZERO;

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -7,9 +7,11 @@ import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.TipoMovimientoDetalle;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.*;
@@ -35,6 +37,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -78,6 +81,7 @@ class OrdenProduccionServiceImplTest {
     @Mock private UmValidator umValidator;
     @Mock private VidaUtilProductoRepository vidaUtilProductoRepository;
     @Mock private ReservaLoteService reservaLoteService;
+    @Mock private ReservaLoteRepository reservaLoteRepository;
     @Mock private DisponibilidadInsumoService disponibilidadInsumoService;
 
     @Spy
@@ -426,6 +430,169 @@ class OrdenProduccionServiceImplTest {
                 });
 
         verify(etapaProduccionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("recalcularEstadoOrden marca FINALIZADA cuando las etapas están terminadas y la producción está completa")
+    void recalcularEstadoOrden_finalizadaConProduccionCompleta() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(50L);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+        orden.setCantidadProgramada(new BigDecimal("100"));
+        orden.setCantidadProducidaAcumulada(new BigDecimal("100"));
+
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(1L)
+                .estado(EstadoEtapa.FINALIZADA)
+                .build();
+
+        when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(50L))
+                .thenReturn(List.of(etapa));
+
+        ReflectionTestUtils.invokeMethod(service, "recalcularEstadoOrden", orden);
+
+        assertThat(orden.getEstado()).isEqualTo(EstadoProduccion.FINALIZADA);
+        assertThat(orden.getFechaFin()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("recalcularEstadoOrden marca CERRADA_INCOMPLETA cuando falta producción pese a etapas finalizadas")
+    void recalcularEstadoOrden_cerradaIncompletaCuandoFaltaProduccion() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(60L);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+        orden.setCantidadProgramada(new BigDecimal("120"));
+        orden.setCantidadProducidaAcumulada(new BigDecimal("80"));
+
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(2L)
+                .estado(EstadoEtapa.FINALIZADA)
+                .build();
+
+        when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(60L))
+                .thenReturn(List.of(etapa));
+
+        ReflectionTestUtils.invokeMethod(service, "recalcularEstadoOrden", orden);
+
+        assertThat(orden.getEstado()).isEqualTo(EstadoProduccion.CERRADA_INCOMPLETA);
+        assertThat(orden.getFechaFin()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("recalcularEstadoOrden mantiene EN_PROCESO cuando hay etapas pendientes")
+    void recalcularEstadoOrden_conEtapasPendientes() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(70L);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+        orden.setCantidadProgramada(new BigDecimal("150"));
+        orden.setCantidadProducidaAcumulada(new BigDecimal("140"));
+
+        EtapaProduccion finalizada = EtapaProduccion.builder()
+                .id(3L)
+                .estado(EstadoEtapa.FINALIZADA)
+                .build();
+        EtapaProduccion pendiente = EtapaProduccion.builder()
+                .id(4L)
+                .estado(EstadoEtapa.PENDIENTE)
+                .build();
+
+        when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(70L))
+                .thenReturn(List.of(finalizada, pendiente));
+
+        ReflectionTestUtils.invokeMethod(service, "recalcularEstadoOrden", orden);
+
+        assertThat(orden.getEstado()).isEqualTo(EstadoProduccion.EN_PROCESO);
+        assertThat(orden.getFechaFin()).isNull();
+    }
+
+    @Test
+    @DisplayName("listarInsumos refleja consumido en cero con reservas activas")
+    void listarInsumos_conReservasActivas() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(200L);
+        orden.setCantidadProgramada(new BigDecimal("5"));
+        Producto producto = new Producto();
+        producto.setId(10);
+        orden.setProducto(producto);
+
+        Producto insumo = new Producto();
+        insumo.setId(300);
+        insumo.setNombre("Insumo A");
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setNombre("kg");
+        insumo.setUnidadMedida(unidad);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(insumo);
+        detalle.setCantidadNecesaria(new BigDecimal("2"));
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(detalle));
+
+        when(ordenProduccionRepository.findById(200L)).thenReturn(Optional.of(orden));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+        when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(11L);
+        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
+        tipoDetalle.setId(11L);
+        when(tipoMovimientoDetalleRepository.findById(11L)).thenReturn(Optional.of(tipoDetalle));
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenYProducto(200L, 300L, 11L))
+                .thenReturn(BigDecimal.ZERO);
+        when(reservaLoteRepository.sumConsumidaByOrdenAndProducto(200L, 300L, EstadoReservaLote.CONSUMIDA))
+                .thenReturn(BigDecimal.ZERO);
+
+        List<com.willyes.clemenintegra.produccion.dto.InsumoOPDTO> lista = service.listarInsumos(200L);
+
+        assertThat(lista).hasSize(1);
+        com.willyes.clemenintegra.produccion.dto.InsumoOPDTO dto = lista.get(0);
+        assertThat(dto.getCantidadRequerida()).isEqualByComparingTo(new BigDecimal("10"));
+        assertThat(dto.getCantidadConsumida()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(dto.getFaltante()).isEqualByComparingTo(new BigDecimal("10"));
+    }
+
+    @Test
+    @DisplayName("listarInsumos descuenta reservas consumidas")
+    void listarInsumos_conReservasConsumidas() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(201L);
+        orden.setCantidadProgramada(new BigDecimal("5"));
+        Producto producto = new Producto();
+        producto.setId(10);
+        orden.setProducto(producto);
+
+        Producto insumo = new Producto();
+        insumo.setId(301);
+        insumo.setNombre("Insumo B");
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setNombre("kg");
+        insumo.setUnidadMedida(unidad);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(insumo);
+        detalle.setCantidadNecesaria(new BigDecimal("2"));
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(detalle));
+
+        when(ordenProduccionRepository.findById(201L)).thenReturn(Optional.of(orden));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+        when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(12L);
+        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
+        tipoDetalle.setId(12L);
+        when(tipoMovimientoDetalleRepository.findById(12L)).thenReturn(Optional.of(tipoDetalle));
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenYProducto(201L, 301L, 12L))
+                .thenReturn(BigDecimal.ONE);
+        when(reservaLoteRepository.sumConsumidaByOrdenAndProducto(201L, 301L, EstadoReservaLote.CONSUMIDA))
+                .thenReturn(new BigDecimal("3"));
+
+        List<com.willyes.clemenintegra.produccion.dto.InsumoOPDTO> lista = service.listarInsumos(201L);
+
+        assertThat(lista).hasSize(1);
+        com.willyes.clemenintegra.produccion.dto.InsumoOPDTO dto = lista.get(0);
+        assertThat(dto.getCantidadRequerida()).isEqualByComparingTo(new BigDecimal("10"));
+        assertThat(dto.getCantidadConsumida()).isEqualByComparingTo(new BigDecimal("3"));
+        assertThat(dto.getFaltante()).isEqualByComparingTo(new BigDecimal("7"));
     }
 
     private DistribucionFefoResult crearDistribucionJarabe() {


### PR DESCRIPTION
## Summary
- recalcula el estado de la orden de producción según etapas y cantidades producidas tras cierres y finalización de etapas
- integra las reservas consumidas en el consolidado de insumos para reflejar consumos reales
- añade pruebas unitarias para los nuevos escenarios de estado y consumo de insumos

## Testing
- mvn -q -Dtest=OrdenProduccionServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0b370ff88333b4aef801483dc711)