### PR TITLE
Fix VidaUtilProducto creation and update flow

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
@@ -51,7 +51,11 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
         }
 
         VidaUtilProducto vidaUtil = vidaUtilProductoRepository.findById(productoId)
-                .orElseGet(VidaUtilProducto::new);
+                .orElseGet(() -> {
+                    VidaUtilProducto nuevo = new VidaUtilProducto();
+                    nuevo.setProductoId(producto.getId());
+                    return nuevo;
+                });
         vidaUtil.setProducto(producto);
         vidaUtil.setProductoId(productoId);
         vidaUtil.setSemanasVigencia(semanasVigencia);

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
@@ -18,8 +18,7 @@ public class VidaUtilProducto {
     private Integer productoId;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @MapsId
-    @JoinColumn(name = "producto_id", foreignKey = @ForeignKey(name = "fk_vida_util_productos_producto"))
+    @JoinColumn(name = "producto_id", insertable = false, updatable = false, foreignKey = @ForeignKey(name = "fk_vida_util_productos_producto"))
     private Producto producto;
 
     @Column(name = "semanas_vigencia", nullable = false)

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -27,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -72,6 +74,11 @@ class VidaUtilProductoServiceImplTest {
         assertThat(resultado.getSemanasVigencia()).isEqualTo(12);
         assertThat(resultado.getProducto()).isEqualTo(productoTerminado);
         assertThat(resultado.getProductoId()).isEqualTo(productoTerminado.getId());
+
+        ArgumentCaptor<VidaUtilProducto> captor = ArgumentCaptor.forClass(VidaUtilProducto.class);
+        verify(vidaUtilProductoRepository).save(captor.capture());
+        VidaUtilProducto enviado = captor.getValue();
+        assertThat(enviado.getProductoId()).isEqualTo(productoTerminado.getId());
     }
 
     @Test
@@ -89,6 +96,12 @@ class VidaUtilProductoServiceImplTest {
         VidaUtilProducto resultado = service.guardar(productoTerminado.getId(), 20);
 
         assertThat(resultado.getSemanasVigencia()).isEqualTo(20);
+
+        ArgumentCaptor<VidaUtilProducto> captor = ArgumentCaptor.forClass(VidaUtilProducto.class);
+        verify(vidaUtilProductoRepository).save(captor.capture());
+        VidaUtilProducto enviado = captor.getValue();
+        assertThat(enviado.getProductoId()).isEqualTo(productoTerminado.getId());
+        assertThat(enviado.getSemanasVigencia()).isEqualTo(20);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- align VidaUtilProducto mapping with manual producto_id primary key handling
- ensure service assigns productoId when creating new life-span entries and updates existing ones
- extend unit tests to verify creation and update flows with proper identifiers

## Testing
- mvn -q -Dtest=VidaUtilProductoServiceImplTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4da6e8f48333894421a2ce476fa3)