### PR TITLE
Fix VidaUtilProducto mapping and save flow

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
@@ -53,11 +53,12 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
         VidaUtilProducto vidaUtil = vidaUtilProductoRepository.findById(productoId)
                 .orElseGet(() -> {
                     VidaUtilProducto nuevo = new VidaUtilProducto();
+                    nuevo.setProducto(producto);
                     nuevo.setProductoId(producto.getId());
                     return nuevo;
                 });
         vidaUtil.setProducto(producto);
-        vidaUtil.setProductoId(productoId);
+        vidaUtil.setProductoId(producto.getId());
         vidaUtil.setSemanasVigencia(semanasVigencia);
 
         return vidaUtilProductoRepository.save(vidaUtil);

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
@@ -18,7 +18,8 @@ public class VidaUtilProducto {
     private Integer productoId;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "producto_id", insertable = false, updatable = false, foreignKey = @ForeignKey(name = "fk_vida_util_productos_producto"))
+    @MapsId
+    @JoinColumn(name = "producto_id", foreignKey = @ForeignKey(name = "fk_vida_util_productos_producto"))
     private Producto producto;
 
     @Column(name = "semanas_vigencia", nullable = false)

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
@@ -79,6 +79,7 @@ class VidaUtilProductoServiceImplTest {
         verify(vidaUtilProductoRepository).save(captor.capture());
         VidaUtilProducto enviado = captor.getValue();
         assertThat(enviado.getProductoId()).isEqualTo(productoTerminado.getId());
+        assertThat(enviado.getProducto()).isEqualTo(productoTerminado);
     }
 
     @Test
@@ -102,6 +103,7 @@ class VidaUtilProductoServiceImplTest {
         VidaUtilProducto enviado = captor.getValue();
         assertThat(enviado.getProductoId()).isEqualTo(productoTerminado.getId());
         assertThat(enviado.getSemanasVigencia()).isEqualTo(20);
+        assertThat(enviado.getProducto()).isEqualTo(productoTerminado);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- map vida_util_productos with a shared primary key to Producto using @MapsId
- ensure the service sets the product association and identifier before persisting
- strengthen service tests to assert the product link is saved on create and update

## Testing
- mvn -q -Dtest=VidaUtilProductoServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba2edb7408333977867f192f43127)