### PR TITLE
Add audit metadata to vida util productos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/VidaUtilProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/VidaUtilProductoController.java
@@ -39,11 +39,11 @@ public class VidaUtilProductoController {
 
     @PostMapping("/producto-terminado/{productoId}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public ResponseEntity<VidaUtilProductoDTO> guardar(
+    public ResponseEntity<Void> guardar(
             @PathVariable Integer productoId,
             @RequestBody VidaUtilProductoRequest request) {
-        VidaUtilProducto vidaUtil = vidaUtilProductoService.guardar(productoId, request.getSemanasVigencia());
-        return ResponseEntity.ok(mapToDto(vidaUtil));
+        vidaUtilProductoService.guardar(productoId, request.getSemanasVigencia());
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/producto-terminado/{productoId}")
@@ -54,11 +54,17 @@ public class VidaUtilProductoController {
     }
 
     private VidaUtilProductoDTO mapToDto(VidaUtilProducto vidaUtil) {
+        String actualizadoPorNombre = vidaUtil.getActualizadoPor() != null
+                ? vidaUtil.getActualizadoPor().getNombreCompleto()
+                : null;
+
         return VidaUtilProductoDTO.builder()
                 .productoId(vidaUtil.getProducto().getId())
                 .codigoSku(vidaUtil.getProducto().getCodigoSku())
                 .nombreProducto(vidaUtil.getProducto().getNombre())
                 .semanasVigencia(vidaUtil.getSemanasVigencia())
+                .actualizadoPorNombre(actualizadoPorNombre)
+                .fechaActualizacion(vidaUtil.getFechaActualizacion())
                 .build();
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/VidaUtilProductoDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/VidaUtilProductoDTO.java
@@ -3,6 +3,8 @@ package com.willyes.clemenintegra.calidad.dto;
 import lombok.Builder;
 import lombok.Value;
 
+import java.time.LocalDateTime;
+
 @Value
 @Builder
 public class VidaUtilProductoDTO {
@@ -10,5 +12,7 @@ public class VidaUtilProductoDTO {
     String codigoSku;
     String nombreProducto;
     Integer semanasVigencia;
+    String actualizadoPorNombre;
+    LocalDateTime fechaActualizacion;
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
@@ -8,6 +8,8 @@ import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.VidaUtilProductoRepository;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +17,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -28,6 +31,7 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
 
     private final VidaUtilProductoRepository vidaUtilProductoRepository;
     private final ProductoRepository productoRepository;
+    private final UsuarioService usuarioService;
 
     @Override
     @Transactional(readOnly = true)
@@ -65,7 +69,13 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
                     return nuevo;
                 });
 
+        Usuario usuarioActual = usuarioService.obtenerUsuarioAutenticado();
+
+        vidaUtil.setProductoId(producto.getId());
+        vidaUtil.setProducto(producto);
         vidaUtil.setSemanasVigencia(semanasVigencia);
+        vidaUtil.setActualizadoPor(usuarioActual);
+        vidaUtil.setFechaActualizacion(LocalDateTime.now());
 
         return vidaUtilProductoRepository.save(vidaUtil);
     }
@@ -103,6 +113,13 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
                 .nombreProducto(p.getNombre())
                 .semanasVigencia(Optional.ofNullable(vidaUtilMap.get(p.getId()))
                         .map(VidaUtilProducto::getSemanasVigencia)
+                        .orElse(null))
+                .actualizadoPorNombre(Optional.ofNullable(vidaUtilMap.get(p.getId()))
+                        .map(VidaUtilProducto::getActualizadoPor)
+                        .map(Usuario::getNombreCompleto)
+                        .orElse(null))
+                .fechaActualizacion(Optional.ofNullable(vidaUtilMap.get(p.getId()))
+                        .map(VidaUtilProducto::getFechaActualizacion)
                         .orElse(null))
                 .build());
     }

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
@@ -1,7 +1,10 @@
 package com.willyes.clemenintegra.inventario.model;
 
+import com.willyes.clemenintegra.shared.model.Usuario;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "vida_util_productos")
@@ -29,6 +32,13 @@ public class VidaUtilProducto {
 
     @Column(name = "semanas_vigencia", nullable = false)
     private Integer semanasVigencia;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actualizado_por_id")
+    private Usuario actualizadoPor;
+
+    @Column(name = "fecha_actualizacion")
+    private LocalDateTime fechaActualizacion;
 }
 
 

--- a/src/main/resources/db/migration/V20251116__add_auditoria_vida_util_productos.sql
+++ b/src/main/resources/db/migration/V20251116__add_auditoria_vida_util_productos.sql
@@ -1,0 +1,5 @@
+ALTER TABLE vida_util_productos
+    ADD COLUMN actualizado_por_id BIGINT NULL,
+    ADD COLUMN fecha_actualizacion DATETIME NULL,
+    ADD CONSTRAINT fk_vida_util_productos_usuario FOREIGN KEY (actualizado_por_id)
+        REFERENCES usuarios (id);

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
@@ -9,6 +9,8 @@ import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.VidaUtilProductoRepository;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,10 +42,14 @@ class VidaUtilProductoServiceImplTest {
     @Mock
     private ProductoRepository productoRepository;
 
+    @Mock
+    private UsuarioService usuarioService;
+
     @InjectMocks
     private VidaUtilProductoServiceImpl service;
 
     private Producto productoTerminado;
+    private Usuario usuarioAutenticado;
 
     @BeforeEach
     void setUp() {
@@ -55,6 +61,11 @@ class VidaUtilProductoServiceImplTest {
         productoTerminado.setCodigoSku("PT-001");
         productoTerminado.setNombre("Producto Terminado");
         productoTerminado.setCategoriaProducto(categoria);
+
+        usuarioAutenticado = Usuario.builder()
+                .id(5L)
+                .nombreCompleto("Usuario Prueba")
+                .build();
     }
 
     @Test
@@ -68,6 +79,7 @@ class VidaUtilProductoServiceImplTest {
         when(productoRepository.findById(10L)).thenReturn(Optional.of(productoTerminado));
         when(vidaUtilProductoRepository.findById(productoTerminado.getId())).thenReturn(Optional.empty());
         when(vidaUtilProductoRepository.save(any(VidaUtilProducto.class))).thenReturn(entidadGuardada);
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuarioAutenticado);
 
         VidaUtilProducto resultado = service.guardar(productoTerminado.getId(), 12);
 
@@ -80,6 +92,8 @@ class VidaUtilProductoServiceImplTest {
         VidaUtilProducto enviado = captor.getValue();
         assertThat(enviado.getProductoId()).isEqualTo(productoTerminado.getId());
         assertThat(enviado.getProducto()).isEqualTo(productoTerminado);
+        assertThat(enviado.getActualizadoPor()).isEqualTo(usuarioAutenticado);
+        assertThat(enviado.getFechaActualizacion()).isNotNull();
     }
 
     @Test
@@ -93,6 +107,7 @@ class VidaUtilProductoServiceImplTest {
         when(productoRepository.findById(10L)).thenReturn(Optional.of(productoTerminado));
         when(vidaUtilProductoRepository.findById(productoTerminado.getId())).thenReturn(Optional.of(existente));
         when(vidaUtilProductoRepository.save(any(VidaUtilProducto.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuarioAutenticado);
 
         VidaUtilProducto resultado = service.guardar(productoTerminado.getId(), 20);
 
@@ -104,6 +119,8 @@ class VidaUtilProductoServiceImplTest {
         assertThat(enviado.getProductoId()).isEqualTo(productoTerminado.getId());
         assertThat(enviado.getSemanasVigencia()).isEqualTo(20);
         assertThat(enviado.getProducto()).isEqualTo(productoTerminado);
+        assertThat(enviado.getActualizadoPor()).isEqualTo(usuarioAutenticado);
+        assertThat(enviado.getFechaActualizacion()).isNotNull();
     }
 
     @Test
@@ -148,6 +165,8 @@ class VidaUtilProductoServiceImplTest {
                 .productoId(productoTerminado.getId())
                 .producto(productoTerminado)
                 .semanasVigencia(15)
+                .actualizadoPor(usuarioAutenticado)
+                .fechaActualizacion(java.time.LocalDateTime.now())
                 .build();
 
         when(productoRepository.findAll(any(Specification.class), eq(PageRequest.of(0, 10))))
@@ -161,5 +180,22 @@ class VidaUtilProductoServiceImplTest {
         VidaUtilProductoDTO dto = page.getContent().get(0);
         assertThat(dto.getProductoId()).isEqualTo(productoTerminado.getId());
         assertThat(dto.getSemanasVigencia()).isEqualTo(15);
+        assertThat(dto.getActualizadoPorNombre()).isEqualTo(usuarioAutenticado.getNombreCompleto());
+        assertThat(dto.getFechaActualizacion()).isEqualTo(vidaUtil.getFechaActualizacion());
+    }
+
+    @Test
+    void listarProductosTerminados_deberiaRetornarCamposNulosCuandoNoExisteVidaUtil() {
+        when(productoRepository.findAll(any(Specification.class), eq(PageRequest.of(0, 10))))
+                .thenReturn(new PageImpl<>(List.of(productoTerminado)));
+        when(vidaUtilProductoRepository.findAllById(List.of(productoTerminado.getId())))
+                .thenReturn(List.of());
+
+        Page<VidaUtilProductoDTO> page = service.listarProductosTerminados(null, PageRequest.of(0, 10));
+
+        VidaUtilProductoDTO dto = page.getContent().get(0);
+        assertThat(dto.getSemanasVigencia()).isNull();
+        assertThat(dto.getActualizadoPorNombre()).isNull();
+        assertThat(dto.getFechaActualizacion()).isNull();
     }
 }


### PR DESCRIPTION
## Summary
- Return an empty 200 response from the vida util POST endpoint to avoid lazy serialization errors.
- Add audit fields and mappings to vida util products, capturing the authenticated user and timestamp on save.
- Extend DTOs, listings, and tests to surface audit information and cover null scenarios; add Flyway migration for new columns.

## Testing
- `mvn test -DskipITs` *(fails: integration tests currently error when bootstrapping Flyway/DataSource in RecepcionOC/Proveedor contexts; see logs for circular dependency and data.sql insert issues)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb99463e48333af9333aec63d791f)