### PR TITLE
Fix VidaUtilProducto mapping and creation flow

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
@@ -62,22 +62,16 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
             );
         }
 
-        VidaUtilProducto vidaUtil = vidaUtilProductoRepository.findById(productoId).orElse(null);
-        if (vidaUtil == null) {
-            // Crear una instancia nueva asegurando que el identificador se asigne
-            // antes de que Hibernate intente persistirla (evita el null identifier).
-            vidaUtil = new VidaUtilProducto();
-            vidaUtil.setProductoId(productoId);
-        } else if (vidaUtil.getProductoId() == null) {
-            // Refuerzo defensivo ante datos inconsistentes para evitar fallas de inserción.
-            vidaUtil.setProductoId(productoId);
+        VidaUtilProducto vidaUtil = vidaUtilProductoRepository.findById(productoId)
+                .orElseGet(VidaUtilProducto::new);
+
+        vidaUtil.setProducto(producto);
+        if (vidaUtil.getProductoId() == null && producto.getId() != null) {
+            vidaUtil.setProductoId(producto.getId());
         }
+        vidaUtil.setSemanasVigencia(semanasVigencia);
 
         Usuario usuarioActual = usuarioService.obtenerUsuarioAutenticado();
-
-        vidaUtil.setProductoId(producto.getId());
-        vidaUtil.setProducto(producto);
-        vidaUtil.setSemanasVigencia(semanasVigencia);
         vidaUtil.setActualizadoPor(usuarioActual);
         vidaUtil.setFechaActualizacion(LocalDateTime.now());
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
@@ -16,16 +16,14 @@ import java.time.LocalDateTime;
 public class VidaUtilProducto {
 
     @Id
-    @Column(name = "producto_id")
+    @Column(name = "producto_id", nullable = false)
     @EqualsAndHashCode.Include
     private Integer productoId;
 
-    // 🔹 Relación solo para lectura, NO controla la columna
     @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
     @JoinColumn(
             name = "producto_id",
-            insertable = false,
-            updatable = false,
             foreignKey = @ForeignKey(name = "fk_vida_util_productos_producto")
     )
     private Producto producto;

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
@@ -70,15 +70,10 @@ class VidaUtilProductoServiceImplTest {
 
     @Test
     void guardar_deberiaCrearNuevoCuandoProductoTerminadoValido() {
-        VidaUtilProducto entidadGuardada = VidaUtilProducto.builder()
-                .productoId(productoTerminado.getId())
-                .producto(productoTerminado)
-                .semanasVigencia(12)
-                .build();
-
         when(productoRepository.findById(10L)).thenReturn(Optional.of(productoTerminado));
         when(vidaUtilProductoRepository.findById(productoTerminado.getId())).thenReturn(Optional.empty());
-        when(vidaUtilProductoRepository.save(any(VidaUtilProducto.class))).thenReturn(entidadGuardada);
+        when(vidaUtilProductoRepository.save(any(VidaUtilProducto.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
         when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuarioAutenticado);
 
         VidaUtilProducto resultado = service.guardar(productoTerminado.getId(), 12);
@@ -136,11 +131,15 @@ class VidaUtilProductoServiceImplTest {
         VidaUtilProducto resultado = service.guardar(productoTerminado.getId(), 16);
 
         assertThat(resultado.getProductoId()).isEqualTo(productoTerminado.getId());
+        assertThat(resultado.getProducto()).isEqualTo(productoTerminado);
+        assertThat(resultado.getSemanasVigencia()).isEqualTo(16);
 
         ArgumentCaptor<VidaUtilProducto> captor = ArgumentCaptor.forClass(VidaUtilProducto.class);
         verify(vidaUtilProductoRepository).save(captor.capture());
         VidaUtilProducto enviado = captor.getValue();
         assertThat(enviado.getProductoId()).isEqualTo(productoTerminado.getId());
+        assertThat(enviado.getProducto()).isEqualTo(productoTerminado);
+        assertThat(enviado.getSemanasVigencia()).isEqualTo(16);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- align the VidaUtilProducto entity with a shared primary key using `@MapsId` so Hibernate sets the identifier from the linked producto
- simplify the VidaUtilProducto save flow to rely on the mapped association, setting audit data without manual id juggling
- adjust service tests to assert the new creation/update behavior and audit assignments

## Testing
- mvn -q test *(fails: existing integration tests cannot initialize ApplicationContext because of Flyway/data.sql setup in test profile)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bc5f5f4ec833393a2099b27677b6a)