### PR TITLE
Refactor VidaUtilProducto manual PK handling

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
@@ -63,17 +63,22 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
         }
 
         VidaUtilProducto vidaUtil = vidaUtilProductoRepository.findById(productoId)
-                .orElseGet(VidaUtilProducto::new);
+                .orElseGet(() -> {
+                    VidaUtilProducto nuevo = new VidaUtilProducto();
+                    nuevo.setProductoId(productoId);
+                    return nuevo;
+                });
 
-        vidaUtil.setProducto(producto);
-        if (vidaUtil.getProductoId() == null && producto.getId() != null) {
-            vidaUtil.setProductoId(producto.getId());
-        }
+        vidaUtil.setProductoId(productoId);
         vidaUtil.setSemanasVigencia(semanasVigencia);
 
         Usuario usuarioActual = usuarioService.obtenerUsuarioAutenticado();
         vidaUtil.setActualizadoPor(usuarioActual);
         vidaUtil.setFechaActualizacion(LocalDateTime.now());
+
+        if (vidaUtil.getProductoId() == null) {
+            throw new IllegalStateException("VidaUtilProducto sin productoId antes de guardar");
+        }
 
         return vidaUtilProductoRepository.save(vidaUtil);
     }

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
@@ -21,9 +21,11 @@ public class VidaUtilProducto {
     private Integer productoId;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @MapsId
     @JoinColumn(
             name = "producto_id",
+            referencedColumnName = "id",
+            insertable = false,
+            updatable = false,
             foreignKey = @ForeignKey(name = "fk_vida_util_productos_producto")
     )
     private Producto producto;


### PR DESCRIPTION
## Summary
- remove shared primary key mapping from VidaUtilProducto and make productoId explicit
- ensure VidaUtilProductoService assigns productoId before saving and guards against null identifiers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd1febcfc8333942a8ccc8f1df0ab)