### PR TITLE
Accept timezone formatted fechas in movimientos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -46,6 +46,26 @@ public class ProductoController {
         return ResponseEntity.ok(page);
     }
 
+    @GetMapping("/buscar-insumos")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Page<ProductoResumenDTO>> buscarInsumos(
+            @RequestParam(name = "term") String term,
+            @PageableDefault(size = 20, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {
+        validarTerminoBusqueda(term);
+        Page<ProductoResumenDTO> page = productoService.buscarInsumos(term, pageable);
+        return ResponseEntity.ok(page);
+    }
+
+    @GetMapping("/buscar-pt")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Page<ProductoResumenDTO>> buscarProductosTerminados(
+            @RequestParam(name = "term") String term,
+            @PageableDefault(size = 20, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {
+        validarTerminoBusqueda(term);
+        Page<ProductoResumenDTO> page = productoService.buscarProductosTerminados(term, pageable);
+        return ResponseEntity.ok(page);
+    }
+
     @GetMapping("/categoria/{nombre}")
     public ResponseEntity<List<ProductoResponseDTO>> buscarPorCategoria(
             @PathVariable String nombre) {
@@ -194,6 +214,12 @@ public class ProductoController {
         String finalSku = sku != null ? sku : codigoSkuLegacy;
         Page<ProductoResponseDTO> productos = productoService.listarTodos(nombre, finalSku, categoriaProductoId, activo, sanitized);
         return ResponseEntity.ok(productos);
+    }
+
+    private void validarTerminoBusqueda(String term) {
+        if (term == null || term.trim().length() < 2) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Debe enviar al menos 2 caracteres para la búsqueda");
+        }
     }
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
@@ -1,9 +1,11 @@
 package com.willyes.clemenintegra.inventario.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.shared.json.LenientLocalDateTimeDeserializer;
 import jakarta.validation.constraints.*;
 
 import java.math.BigDecimal;
@@ -37,6 +39,7 @@ public record MovimientoInventarioDTO(
         Long ordenProduccionId,
         Long ordenCompraDetalleId,
         String codigoLote,
+        @JsonDeserialize(using = LenientLocalDateTimeDeserializer.class)
         LocalDateTime fechaVencimiento,
         /**
          * Estado inicial sugerido por el cliente. Este valor se ignora en el

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResumenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResumenDTO.java
@@ -1,0 +1,22 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO ligero para autocompletados/listados de búsqueda de productos.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductoResumenDTO {
+    private Long id;
+    private String nombre;
+    private String codigoSku;
+    private TipoCategoria tipoCategoria;
+    private String unidadMedida;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/enums/TipoCategoria.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/enums/TipoCategoria.java
@@ -1,9 +1,13 @@
 package com.willyes.clemenintegra.inventario.model.enums;
 
 public enum TipoCategoria {
+    /** INSUMOS: Materia Prima */
     MATERIA_PRIMA,
+    /** PT: Producto terminado */
     PRODUCTO_TERMINADO,
+    /** INSUMOS: Material de empaque */
     MATERIAL_EMPAQUE,
+    /** INSUMOS: Suministros varios utilizados en planta */
     SUMINISTROS,
     REPUESTOS,
     OBSOLETOS

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -45,6 +45,28 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
     """)
     Page<Producto> buscarPorTexto(@Param("q") String q, Pageable pageable);
 
+    /**
+     * Busca insumos (MP, ME y suministros) por nombre.
+     */
+    @Query("""
+            select p
+            from Producto p
+            where lower(p.nombre) like lower(concat('%', :term, '%'))
+              and p.categoriaProducto.tipo in ('MATERIA_PRIMA','MATERIAL_EMPAQUE','SUMINISTROS')
+            """)
+    Page<Producto> searchInsumosByNombre(@Param("term") String term, Pageable pageable);
+
+    /**
+     * Busca productos terminados por nombre.
+     */
+    @Query("""
+            select p
+            from Producto p
+            where lower(p.nombre) like lower(concat('%', :term, '%'))
+              and p.categoriaProducto.tipo = 'PRODUCTO_TERMINADO'
+            """)
+    Page<Producto> searchProductosTerminadosByNombre(@Param("term") String term, Pageable pageable);
+
     @Query(value = """
             SELECT p.id AS productoId,
                    COALESCE(SUM(CASE WHEN lp.estado IN ('DISPONIBLE','LIBERADO')

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -35,4 +35,8 @@ public interface ProductoService {
     Producto findById(Long id);
 
     Page<ProductoOptionDTO> buscarOpciones(String q, Pageable pageable);
+
+    Page<ProductoResumenDTO> buscarInsumos(String term, Pageable pageable);
+
+    Page<ProductoResumenDTO> buscarProductosTerminados(String term, Pageable pageable);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -91,6 +91,25 @@ public class ProductoServiceImpl implements ProductoService {
         return val.setScale(2, RoundingMode.HALF_UP);
     }
 
+    private String sanitizeBusqueda(String term) {
+        return term == null ? "" : term.trim();
+    }
+
+    private ProductoResumenDTO mapToResumenDto(Producto producto) {
+        if (producto == null) {
+            return null;
+        }
+        return ProductoResumenDTO.builder()
+                .id(producto.getId() != null ? producto.getId().longValue() : null)
+                .nombre(producto.getNombre())
+                .codigoSku(producto.getCodigoSku())
+                .tipoCategoria(producto.getCategoriaProducto() != null
+                        ? producto.getCategoriaProducto().getTipo() : null)
+                .unidadMedida(producto.getUnidadMedida() != null
+                        ? producto.getUnidadMedida().getNombre() : null)
+                .build();
+    }
+
     private TipoAnalisisCalidad obtenerTipoAnalisisDesdeDto(String valor) {
         if (valor == null || valor.isBlank()) {
             return TipoAnalisisCalidad.NINGUNO;
@@ -502,6 +521,22 @@ public class ProductoServiceImpl implements ProductoService {
                             loteDTOs
                     );
                 }).toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ProductoResumenDTO> buscarInsumos(String term, Pageable pageable) {
+        String sanitized = sanitizeBusqueda(term);
+        Page<Producto> page = productoRepository.searchInsumosByNombre(sanitized, pageable);
+        return page.map(this::mapToResumenDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ProductoResumenDTO> buscarProductosTerminados(String term, Pageable pageable) {
+        String sanitized = sanitizeBusqueda(term);
+        Page<Producto> page = productoRepository.searchProductosTerminadosByNombre(sanitized, pageable);
+        return page.map(this::mapToResumenDto);
     }
 
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/json/LenientLocalDateTimeDeserializer.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/json/LenientLocalDateTimeDeserializer.java
@@ -1,0 +1,53 @@
+package com.willyes.clemenintegra.shared.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Permite deserializar fechas provenientes del frontend que puedan traer zona horaria o fracciones.
+ * Siempre se normaliza a LocalDateTime ignorando la zona horaria explícita.
+ */
+public class LenientLocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+
+    private static final DateTimeFormatter ISO_LOCAL = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    @Override
+    public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String value = p.getValueAsString();
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        try {
+            return LocalDateTime.parse(trimmed, ISO_LOCAL);
+        } catch (DateTimeParseException ignored) {
+            // probar con formatos que incluyan zona horaria
+        }
+        try {
+            OffsetDateTime offset = OffsetDateTime.parse(trimmed);
+            return offset.toLocalDateTime();
+        } catch (DateTimeParseException ignored) {
+            // intentar como instante absoluto (terminado en Z)
+        }
+        try {
+            Instant instant = Instant.parse(trimmed);
+            return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+        } catch (DateTimeParseException ignored) {
+            // dejar caer en excepción genérica
+        }
+        throw InvalidFormatException.from(p, "Formato de fecha inválido", trimmed, LocalDateTime.class);
+    }
+}


### PR DESCRIPTION
## Summary
- add a lenient LocalDateTime deserializer that accepts ISO timestamps with offsets or milliseconds
- use the new deserializer on `MovimientoInventarioDTO.fechaVencimiento` so `POST /api/movimientos` no longer fails when the frontend sends timestamps that include timezone information

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd52fd06c833397dc7f9adbcbf20e)