### PR TITLE
Filter authorized solicitudes by open production orders

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.repository;
 
 import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -38,11 +39,14 @@ public interface SolicitudMovimientoRepository extends JpaRepository<SolicitudMo
             "and (:estados is null or s.estado in :estados) " +
             "and (:desde is null or s.fechaSolicitud >= :desde) " +
             "and (:hasta is null or s.fechaSolicitud <= :hasta) " +
+            "and (:filtrarOpAbierta = false or op is null or op.estado not in :estadosOpCerrados) " +
             "order by s.fechaSolicitud desc")
     List<SolicitudMovimiento> findWithDetalles(@Param("ordenId") Long ordenId,
                                                @Param("estados") List<EstadoSolicitudMovimiento> estados,
                                                @Param("desde") LocalDateTime desde,
-                                               @Param("hasta") LocalDateTime hasta);
+                                               @Param("hasta") LocalDateTime hasta,
+                                               @Param("filtrarOpAbierta") boolean filtrarOpAbierta,
+                                               @Param("estadosOpCerrados") List<EstadoProduccion> estadosOpCerrados);
 
     @Query("select s from SolicitudMovimiento s " +
             "left join fetch s.producto p " +

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
@@ -219,7 +219,14 @@ public class ReservaLoteService {
             return;
         }
         List<SolicitudMovimiento> solicitudes = Optional.ofNullable(
-                solicitudMovimientoRepository.findWithDetalles(ordenProduccionId, null, null, null)
+                solicitudMovimientoRepository.findWithDetalles(
+                        ordenProduccionId,
+                        null,
+                        null,
+                        null,
+                        false,
+                        List.of()
+                )
         ).orElse(List.of());
         if (solicitudes.isEmpty()) {
             return;

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimient
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoDetalleRepository.OpDetalleCount;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
@@ -50,6 +51,12 @@ import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 @Service
 @RequiredArgsConstructor
 public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoService {
+
+    private static final List<EstadoProduccion> ESTADOS_OP_CERRADOS = List.of(
+            EstadoProduccion.FINALIZADA,
+            EstadoProduccion.CANCELADA,
+            EstadoProduccion.CERRADA_INCOMPLETA
+    );
 
     private final SolicitudMovimientoRepository repository;
     private final SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
@@ -375,7 +382,22 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                 : List.of(EstadoSolicitudMovimiento.PENDIENTE);
         LocalDateTime inicio = desde;
         LocalDateTime fin = hasta;
-        List<SolicitudMovimiento> solicitudes = repository.findWithDetalles(null, filtros, inicio, fin);
+        boolean filtrarOpAbierta = filtros.contains(EstadoSolicitudMovimiento.AUTORIZADA);
+        List<SolicitudMovimiento> solicitudes = repository.findWithDetalles(
+                null,
+                filtros,
+                inicio,
+                fin,
+                filtrarOpAbierta,
+                ESTADOS_OP_CERRADOS
+        );
+        if (filtrarOpAbierta) {
+            solicitudes = solicitudes.stream()
+                    .filter(s -> s.getOrdenProduccion() == null
+                            || s.getOrdenProduccion().getEstado() == null
+                            || !ESTADOS_OP_CERRADOS.contains(s.getOrdenProduccion().getEstado()))
+                    .toList();
+        }
         Map<Long, List<SolicitudMovimiento>> agrupadas = new LinkedHashMap<>();
         for (SolicitudMovimiento s : solicitudes) {
             if (s.getOrdenProduccion() == null) continue;
@@ -426,7 +448,14 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
     @Override
     @Transactional(readOnly = true)
     public SolicitudesPorOrdenDTO obtenerPorOrden(Long ordenId) {
-        List<SolicitudMovimiento> solicitudes = repository.findWithDetalles(ordenId, null, null, null);
+        List<SolicitudMovimiento> solicitudes = repository.findWithDetalles(
+                ordenId,
+                null,
+                null,
+                null,
+                false,
+                ESTADOS_OP_CERRADOS
+        );
         if (solicitudes.isEmpty()) {
             throw new NoSuchElementException("No se encontraron solicitudes para la orden");
         }
@@ -450,7 +479,14 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
     @Transactional(readOnly = true)
     public PicklistDTO generarPicklist(Long ordenId, boolean incluirAprobadas) {
         List<EstadoSolicitudMovimiento> estados = incluirAprobadas ? null : List.of(EstadoSolicitudMovimiento.PENDIENTE);
-        List<SolicitudMovimiento> solicitudes = repository.findWithDetalles(ordenId, estados, null, null);
+        List<SolicitudMovimiento> solicitudes = repository.findWithDetalles(
+                ordenId,
+                estados,
+                null,
+                null,
+                false,
+                ESTADOS_OP_CERRADOS
+        );
         if (solicitudes.isEmpty()) {
             throw new NoSuchElementException("No se encontraron solicitudes para la orden");
         }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -486,7 +486,14 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MOTIVO_DEVOLUCION_DESDE_PRODUCCION_INEXISTENTE"));
 
             List<SolicitudMovimiento> solicitudesPend = Optional.ofNullable(
-                    solicitudMovimientoRepository.findWithDetalles(orden.getId(), estadosPendientes, null, null)
+                    solicitudMovimientoRepository.findWithDetalles(
+                            orden.getId(),
+                            estadosPendientes,
+                            null,
+                            null,
+                            false,
+                            List.of()
+                    )
             ).orElse(List.of());
 
             List<Map<String, Object>> pendientes = new ArrayList<>();
@@ -536,7 +543,14 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
             if (solicitudesPend.isEmpty()) {
                 List<SolicitudMovimiento> todas = Optional.ofNullable(
-                        solicitudMovimientoRepository.findWithDetalles(orden.getId(), null, null, null)
+                        solicitudMovimientoRepository.findWithDetalles(
+                                orden.getId(),
+                                null,
+                                null,
+                                null,
+                                false,
+                                List.of()
+                        )
                 ).orElse(List.of());
                 long lotesConReserva = todas.stream()
                         .flatMap(s -> s.getDetalles().stream())
@@ -757,7 +771,14 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         // Idempotencia: si ya existen solicitudes SALIDA pendientes para esta OP, no recrear
         List<EstadoSolicitudMovimiento> estadosPendientes = parseEstados(estadosSolicitudPendientesConf);
         List<SolicitudMovimiento> yaPendientes = Optional.ofNullable(
-                solicitudMovimientoRepository.findWithDetalles(ordenId, estadosPendientes, null, null)
+                solicitudMovimientoRepository.findWithDetalles(
+                        ordenId,
+                        estadosPendientes,
+                        null,
+                        null,
+                        false,
+                        List.of()
+                )
         ).orElse(List.of());
 
         boolean haySalidasPendientes = yaPendientes.stream()
@@ -1175,7 +1196,14 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         }
 
         List<SolicitudMovimiento> solicitudes = Optional.ofNullable(
-                solicitudMovimientoRepository.findWithDetalles(orden.getId(), null, null, null)
+                solicitudMovimientoRepository.findWithDetalles(
+                        orden.getId(),
+                        null,
+                        null,
+                        null,
+                        false,
+                        List.of()
+                )
         ).orElse(List.of());
 
         for (SolicitudMovimiento solicitud : solicitudes) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteServiceTest.java
@@ -90,7 +90,7 @@ class ReservaLoteServiceTest {
                 .solicitudMovimientoDetalle(detalle)
                 .build();
 
-        when(solicitudMovimientoRepository.findWithDetalles(1L, null, null, null))
+        when(solicitudMovimientoRepository.findWithDetalles(1L, null, null, null, false, List.of()))
                 .thenReturn(List.of(solicitud));
         when(reservaLoteRepository.findBySolicitudMovimientoDetalleId(20L))
                 .thenReturn(List.of(reserva));

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceFiltroOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceFiltroOpTest.java
@@ -1,0 +1,174 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.SolicitudesPorOrdenDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SolicitudMovimientoServiceFiltroOpTest {
+
+    @Mock
+    private SolicitudMovimientoRepository repository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private LoteProductoRepository loteRepository;
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private ReservaLoteService reservaLoteService;
+
+    @InjectMocks
+    private SolicitudMovimientoServiceImpl service;
+
+    @Test
+    @DisplayName("listarPorOrden excluye autorizadas con OP cerrada")
+    void listarPorOrden_excluyeAutorizadasConOpCerrada() {
+        SolicitudMovimiento autorizadaAbierta = crearSolicitud(1L, "OP-OPEN", EstadoProduccion.EN_PROCESO,
+                EstadoSolicitudMovimiento.AUTORIZADA);
+        SolicitudMovimiento autorizadaCerrada = crearSolicitud(2L, "OP-CLOSED", EstadoProduccion.FINALIZADA,
+                EstadoSolicitudMovimiento.AUTORIZADA);
+
+        when(repository.findWithDetalles(eq(null), eq(List.of(EstadoSolicitudMovimiento.AUTORIZADA)), any(), any(), eq(true), anyList()))
+                .thenReturn(List.of(autorizadaAbierta, autorizadaCerrada));
+
+        Page<SolicitudesPorOrdenDTO> pagina = service.listGroupByOrden(
+                List.of(EstadoSolicitudMovimiento.AUTORIZADA),
+                null,
+                null,
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(pagina.getContent())
+                .extracting(SolicitudesPorOrdenDTO::getCodigoOrden)
+                .containsExactly("OP-OPEN");
+    }
+
+    @Test
+    @DisplayName("listarPorOrden mantiene pendientes aunque la OP esté cerrada")
+    void listarPorOrden_pendientesSinFiltrarPorEstadoOp() {
+        SolicitudMovimiento pendienteCerrada = crearSolicitud(3L, "OP-PEND", EstadoProduccion.CERRADA_INCOMPLETA,
+                EstadoSolicitudMovimiento.PENDIENTE);
+
+        when(repository.findWithDetalles(eq(null), eq(List.of(EstadoSolicitudMovimiento.PENDIENTE)), any(), any(), eq(false), anyList()))
+                .thenReturn(List.of(pendienteCerrada));
+
+        Page<SolicitudesPorOrdenDTO> pagina = service.listGroupByOrden(
+                List.of(EstadoSolicitudMovimiento.PENDIENTE),
+                null,
+                null,
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(pagina.getTotalElements()).isEqualTo(1);
+        assertThat(pagina.getContent().get(0).getCodigoOrden()).isEqualTo("OP-PEND");
+    }
+
+    @Test
+    @DisplayName("listarPorOrden permite pendientes y autorizadas abiertas en la misma respuesta")
+    void listarPorOrden_mixtoRespetaFiltroDeAutorizadas() {
+        SolicitudMovimiento pendienteCerrada = crearSolicitud(4L, "OP-MIX-CLOSED", EstadoProduccion.CERRADA_INCOMPLETA,
+                EstadoSolicitudMovimiento.PENDIENTE);
+        SolicitudMovimiento autorizadaAbierta = crearSolicitud(5L, "OP-MIX-OPEN", EstadoProduccion.EN_PROCESO,
+                EstadoSolicitudMovimiento.AUTORIZADA);
+        SolicitudMovimiento autorizadaCerrada = crearSolicitud(6L, "OP-MIX-CLOSED", EstadoProduccion.FINALIZADA,
+                EstadoSolicitudMovimiento.AUTORIZADA);
+
+        when(repository.findWithDetalles(eq(null), eq(List.of(EstadoSolicitudMovimiento.PENDIENTE, EstadoSolicitudMovimiento.AUTORIZADA)), any(), any(), eq(true), anyList()))
+                .thenReturn(List.of(pendienteCerrada, autorizadaAbierta, autorizadaCerrada));
+
+        Page<SolicitudesPorOrdenDTO> pagina = service.listGroupByOrden(
+                List.of(EstadoSolicitudMovimiento.PENDIENTE, EstadoSolicitudMovimiento.AUTORIZADA),
+                null,
+                null,
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(pagina.getContent())
+                .extracting(SolicitudesPorOrdenDTO::getCodigoOrden)
+                .containsExactly("OP-MIX-OPEN");
+    }
+
+    private SolicitudMovimiento crearSolicitud(Long ordenId, String codigo, EstadoProduccion estadoOp,
+                                               EstadoSolicitudMovimiento estadoSolicitud) {
+        OrdenProduccion op = OrdenProduccion.builder()
+                .id(ordenId)
+                .codigoOrden(codigo)
+                .estado(estadoOp)
+                .fechaInicio(LocalDateTime.now())
+                .build();
+
+        Producto producto = new Producto();
+        producto.setId(10);
+        producto.setNombre("Producto prueba");
+
+        Almacen almacen = new Almacen();
+        almacen.setId(1);
+        almacen.setNombre("ALM-1");
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(100L);
+        lote.setCodigoLote("L-100");
+        lote.setProducto(producto);
+
+        SolicitudMovimientoDetalle detalle = SolicitudMovimientoDetalle.builder()
+                .id(200L)
+                .lote(lote)
+                .cantidad(BigDecimal.ONE)
+                .almacenOrigen(almacen)
+                .build();
+
+        SolicitudMovimiento solicitud = SolicitudMovimiento.builder()
+                .id(ordenId)
+                .tipoMovimiento(TipoMovimiento.SALIDA)
+                .producto(producto)
+                .almacenOrigen(almacen)
+                .ordenProduccion(op)
+                .usuarioSolicitante(new Usuario())
+                .estado(estadoSolicitud)
+                .fechaSolicitud(LocalDateTime.now())
+                .detalles(List.of(detalle))
+                .build();
+        detalle.setSolicitudMovimiento(solicitud);
+        return solicitud;
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCancelarTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCancelarTest.java
@@ -81,7 +81,8 @@ class OrdenProduccionServiceCancelarTest {
 
         when(ordenProduccionRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(orden));
         when(reservaLoteService.existenReservasConsumidasPorOrden(1L)).thenReturn(false);
-        when(solicitudMovimientoRepository.findWithDetalles(1L, null, null, null)).thenReturn(List.of(solicitud));
+        when(solicitudMovimientoRepository.findWithDetalles(1L, null, null, null, false, List.of()))
+                .thenReturn(List.of(solicitud));
         doNothing().when(reservaLoteService).liberarReservasPorOrden(anyLong());
         when(ordenProduccionRepository.save(any(OrdenProduccion.class))).thenAnswer(invocation -> {
             OrdenProduccion op = invocation.getArgument(0);

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -148,7 +148,7 @@ class OrdenProduccionServiceReservaTest {
         when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
                 .thenAnswer(invocation -> Optional.of(crearFormula()));
-        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), any(), eq(null), eq(null)))
+        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), any(), eq(null), eq(null), eq(false), anyList()))
                 .thenReturn(List.of());
         when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(99L);
         when(catalogResolver.getAlmacenOrigenMateriaPrimaId()).thenReturn(5L);
@@ -363,7 +363,7 @@ class OrdenProduccionServiceReservaTest {
         MotivoMovimiento motivoDev = new MotivoMovimiento();
         motivoDev.setId(70L);
         when(motivoMovimientoRepository.findById(70L)).thenReturn(Optional.of(motivoDev));
-        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), eq(null), eq(null), eq(null)))
+        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), eq(null), eq(null), eq(null), eq(false), anyList()))
                 .thenReturn(List.of());
         when(catalogResolver.getMotivoIdEntradaProductoTerminado()).thenReturn(80L);
         MotivoMovimiento motivoEntrada = new MotivoMovimiento();
@@ -403,7 +403,7 @@ class OrdenProduccionServiceReservaTest {
         usuario.setId(7L);
         when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
         when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), any(), eq(null), eq(null)))
+        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), any(), eq(null), eq(null), eq(false), anyList()))
                 .thenReturn(List.of());
         when(movimientoInventarioService.registrarMovimiento(any())).thenReturn(new MovimientoInventarioResponseDTO());
         orden.setCodigoOrden("OP-001");


### PR DESCRIPTION
## Summary
- add optional production-order state filter to the solicitudes grouped listing when authorized statuses are requested
- propagate the new repository signature to services and tests
- add unit coverage for listGroupByOrden filtering of authorized requests

## Testing
- mvn -Dtest=SolicitudMovimientoServiceFiltroOpTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e296258d083338918b5eafac3a45c)