### PR TITLE
Add production order export endpoints and refine filters

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -35,6 +37,7 @@ import java.util.Map;
 public class OrdenProduccionController {
 
     private final OrdenProduccionService service;
+    private final ReporteOrdenProduccionService reporteOrdenProduccionService;
     private final UsuarioService usuarioService;
     private final com.willyes.clemenintegra.inventario.service.MovimientoInventarioService movimientoInventarioService;
     //private final UsuarioService usuarioService;
@@ -50,6 +53,38 @@ public class OrdenProduccionController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaFin,
             @PageableDefault(size = 10, sort = "fechaInicio", direction = Sort.Direction.DESC) Pageable pageable) {
         return service.listarPaginado(codigo, estado, responsable, fechaInicio, fechaFin, pageable);
+    }
+
+    @GetMapping(value = "/export/excel", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<byte[]> exportarExcel(
+            @RequestParam(required = false) String codigo,
+            @RequestParam(required = false) EstadoProduccion estado,
+            @RequestParam(required = false) String responsable,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaInicio,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaFin) {
+        List<OrdenProduccion> ordenes = service.listar(codigo, estado, responsable, fechaInicio, fechaFin);
+        byte[] excel = reporteOrdenProduccionService.generarExcelOrdenesProduccion(ordenes);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=ordenes-produccion.xlsx");
+        return new ResponseEntity<>(excel, headers, HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/export/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<byte[]> exportarPdf(
+            @RequestParam(required = false) String codigo,
+            @RequestParam(required = false) EstadoProduccion estado,
+            @RequestParam(required = false) String responsable,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaInicio,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fechaFin) {
+        List<OrdenProduccion> ordenes = service.listar(codigo, estado, responsable, fechaInicio, fechaFin);
+        byte[] pdf = reporteOrdenProduccionService.generarPdfOrdenesProduccion(ordenes);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=ordenes-produccion.pdf");
+        return new ResponseEntity<>(pdf, headers, HttpStatus.OK);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -55,5 +55,11 @@ public interface OrdenProduccionService {
                                                     LocalDateTime fechaFin,
                                                     Pageable pageable);
 
+    List<OrdenProduccion> listar(String codigo,
+                                 EstadoProduccion estado,
+                                 String responsable,
+                                 LocalDateTime fechaInicio,
+                                 LocalDateTime fechaFin);
+
     OrdenProduccion cancelarOrden(Long ordenProduccionId, @Nullable String motivo);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -74,6 +74,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
@@ -413,6 +414,21 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 OrdenProduccionSpecifications.byFechaBetween(fechaInicio, fechaFin)
         );
         return repository.findAll(spec, pageable).map(ProduccionMapper::toResponse);
+    }
+
+    @Override
+    public List<OrdenProduccion> listar(String codigo,
+                                        EstadoProduccion estado,
+                                        String responsable,
+                                        LocalDateTime fechaInicio,
+                                        LocalDateTime fechaFin) {
+        Specification<OrdenProduccion> spec = OrdenProduccionSpecifications.and(
+                OrdenProduccionSpecifications.byCodigo(codigo),
+                OrdenProduccionSpecifications.byEstado(estado),
+                OrdenProduccionSpecifications.byResponsable(responsable),
+                OrdenProduccionSpecifications.byFechaBetween(fechaInicio, fechaFin)
+        );
+        return repository.findAll(spec, Sort.by(Sort.Direction.DESC, "fechaInicio"));
     }
 
     public List<OrdenProduccion> listarTodas() {

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteOrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteOrdenProduccionService.java
@@ -1,0 +1,12 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+
+import java.util.List;
+
+public interface ReporteOrdenProduccionService {
+
+    byte[] generarExcelOrdenesProduccion(List<OrdenProduccion> ordenes);
+
+    byte[] generarPdfOrdenesProduccion(List<OrdenProduccion> ordenes);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteOrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteOrdenProduccionServiceImpl.java
@@ -1,0 +1,200 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.service.ReporteOrdenProduccionService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+@Service
+@Slf4j
+public class ReporteOrdenProduccionServiceImpl implements ReporteOrdenProduccionService {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    @Override
+    public byte[] generarExcelOrdenesProduccion(List<OrdenProduccion> ordenes) {
+        try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("ordenes");
+            CreationHelper creationHelper = workbook.getCreationHelper();
+
+            CellStyle headerStyle = workbook.createCellStyle();
+            Font headerFont = workbook.createFont();
+            headerFont.setBold(true);
+            headerStyle.setFont(headerFont);
+
+            CellStyle dateStyle = workbook.createCellStyle();
+            dateStyle.setDataFormat(creationHelper.createDataFormat().getFormat("yyyy-mm-dd hh:mm"));
+
+            String[] headers = {
+                    "Código", "Producto", "Lote producción", "Responsable", "Estado",
+                    "Cantidad programada", "Cantidad producida", "% Cumplimiento",
+                    "Fecha inicio", "Fecha fin", "Fecha cierre"
+            };
+
+            Row headerRow = sheet.createRow(0);
+            for (int i = 0; i < headers.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers[i]);
+                cell.setCellStyle(headerStyle);
+            }
+
+            int rowIdx = 1;
+            for (OrdenProduccion orden : ordenes) {
+                Row row = sheet.createRow(rowIdx++);
+                int col = 0;
+
+                row.createCell(col++).setCellValue(nullSafe(orden.getCodigoOrden()));
+                row.createCell(col++).setCellValue(orden.getProducto() != null ? nullSafe(orden.getProducto().getNombre()) : "");
+                row.createCell(col++).setCellValue(nullSafe(orden.getLoteProduccion()));
+                row.createCell(col++).setCellValue(obtenerResponsable(orden));
+                row.createCell(col++).setCellValue(orden.getEstado() != null ? orden.getEstado().name() : "");
+                setNumeric(row.createCell(col++), orden.getCantidadProgramada());
+                setNumeric(row.createCell(col++), orden.getCantidadProducidaAcumulada());
+                setNumeric(row.createCell(col++), calcularPorcentaje(orden));
+                setDate(row.createCell(col++), orden.getFechaInicio(), dateStyle);
+                setDate(row.createCell(col++), orden.getFechaFin(), dateStyle);
+                setDate(row.createCell(col), orden.getFechaCierre(), dateStyle);
+            }
+
+            for (int i = 0; i < headers.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(out);
+            return out.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando Excel de órdenes de producción", e);
+            throw new IllegalStateException("No se pudo generar el Excel de órdenes de producción", e);
+        }
+    }
+
+    @Override
+    public byte[] generarPdfOrdenesProduccion(List<OrdenProduccion> ordenes) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            String html = construirHtml(ordenes);
+            PdfRendererBuilder builder = new PdfRendererBuilder();
+            builder.useFastMode();
+            builder.withHtmlContent(html, null);
+            builder.toStream(out);
+            builder.run();
+            return out.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando PDF de órdenes de producción", e);
+            throw new IllegalStateException("No se pudo generar el PDF de órdenes de producción", e);
+        }
+    }
+
+    private void setNumeric(Cell cell, java.math.BigDecimal value) {
+        if (value != null) {
+            cell.setCellValue(value.doubleValue());
+        }
+    }
+
+    private void setDate(Cell cell, LocalDateTime value, CellStyle dateStyle) {
+        if (value != null) {
+            cell.setCellValue(java.sql.Timestamp.valueOf(value));
+            cell.setCellStyle(dateStyle);
+        }
+    }
+
+    private String nullSafe(String value) {
+        return value == null ? "" : value;
+    }
+
+    private String obtenerResponsable(OrdenProduccion orden) {
+        if (orden.getResponsable() == null) {
+            return "";
+        }
+        String nombreCompleto = orden.getResponsable().getNombreCompleto();
+        if (nombreCompleto != null && !nombreCompleto.isBlank()) {
+            return nombreCompleto;
+        }
+        return nullSafe(orden.getResponsable().getNombreUsuario());
+    }
+
+    private java.math.BigDecimal calcularPorcentaje(OrdenProduccion orden) {
+        if (orden.getPorcentajeCumplimiento() != null) {
+            return orden.getPorcentajeCumplimiento();
+        }
+        if (orden.getCantidadProgramada() == null || orden.getCantidadProgramada().compareTo(java.math.BigDecimal.ZERO) == 0) {
+            return null;
+        }
+        java.math.BigDecimal acumulada = Objects.requireNonNullElse(orden.getCantidadProducidaAcumulada(), java.math.BigDecimal.ZERO);
+        return acumulada.multiply(java.math.BigDecimal.valueOf(100))
+                .divide(orden.getCantidadProgramada(), 2, java.math.RoundingMode.HALF_UP);
+    }
+
+    private String construirHtml(List<OrdenProduccion> ordenes) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><head><style>")
+                .append("table { width: 100%; border-collapse: collapse; font-family: Arial, sans-serif; font-size: 12px; }")
+                .append("th, td { border: 1px solid #ccc; padding: 6px; text-align: left; }")
+                .append("th { background-color: #f2f2f2; }")
+                .append("</style></head><body>")
+                .append("<h2>Órdenes de Producción</h2>")
+                .append("<table><thead><tr>")
+                .append("<th>Código</th>")
+                .append("<th>Producto</th>")
+                .append("<th>Lote producción</th>")
+                .append("<th>Responsable</th>")
+                .append("<th>Estado</th>")
+                .append("<th>Cant. programada</th>")
+                .append("<th>Cant. producida</th>")
+                .append("<th>% Cumplimiento</th>")
+                .append("<th>Fecha inicio</th>")
+                .append("<th>Fecha fin</th>")
+                .append("<th>Fecha cierre</th>")
+                .append("</tr></thead><tbody>");
+
+        for (OrdenProduccion orden : ordenes) {
+            sb.append("<tr>")
+                    .append(td(orden.getCodigoOrden()))
+                    .append(td(orden.getProducto() != null ? orden.getProducto().getNombre() : ""))
+                    .append(td(orden.getLoteProduccion()))
+                    .append(td(obtenerResponsable(orden)))
+                    .append(td(orden.getEstado() != null ? orden.getEstado().name() : ""))
+                    .append(td(formatDecimal(orden.getCantidadProgramada())))
+                    .append(td(formatDecimal(orden.getCantidadProducidaAcumulada())))
+                    .append(td(formatDecimal(calcularPorcentaje(orden))))
+                    .append(td(formatDate(orden.getFechaInicio())))
+                    .append(td(formatDate(orden.getFechaFin())))
+                    .append(td(formatDate(orden.getFechaCierre())))
+                    .append("</tr>");
+        }
+
+        sb.append("</tbody></table></body></html>");
+        return sb.toString();
+    }
+
+    private String td(String value) {
+        return "<td>" + escape(value) + "</td>";
+    }
+
+    private String formatDecimal(java.math.BigDecimal value) {
+        if (value == null) return "";
+        return String.format(Locale.US, "%.2f", value);
+    }
+
+    private String formatDate(LocalDateTime value) {
+        return value == null ? "" : DATE_TIME_FORMATTER.format(value);
+    }
+
+    private String escape(String value) {
+        if (value == null) return "";
+        return value.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/spec/OrdenProduccionSpecifications.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/spec/OrdenProduccionSpecifications.java
@@ -33,8 +33,8 @@ public final class OrdenProduccionSpecifications {
             var r = root.join("responsable", JoinType.LEFT);
             String like = "%" + responsable.trim().toUpperCase() + "%";
             return cb.or(
-                    cb.like(cb.upper(r.get("nombreUsuario")), like),
-                    cb.like(cb.upper(r.get("nombreCompleto")), like)
+                    cb.like(cb.upper(cb.coalesce(r.get("nombreUsuario"), cb.literal("")).as(String.class)), like),
+                    cb.like(cb.upper(cb.coalesce(r.get("nombreCompleto"), cb.literal("")).as(String.class)), like)
             );
         };
     }


### PR DESCRIPTION
## Summary
- add Excel and PDF export endpoints for production orders using the existing filter contract
- introduce a report service to generate Excel and PDF files with key order fields
- enhance filtering utilities and expose a non-paginated listing method for reuse in exports

## Testing
- mvn -q -DskipTests package

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f794164448333b8b496a8d7996622)