### PR TITLE
Implementar PDF de Batch Record

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
@@ -13,10 +13,12 @@ import com.willyes.clemenintegra.produccion.repository.ControlProcesoProduccionR
 import com.willyes.clemenintegra.produccion.repository.ObservacionProcesoRepository;
 import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
 import com.willyes.clemenintegra.produccion.service.BatchRecordService;
+import com.willyes.clemenintegra.produccion.service.ReporteBatchRecordService;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -34,6 +36,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/produccion/batch-record")
 @RequiredArgsConstructor
+@Slf4j
 public class BatchRecordController {
 
     private final BatchRecordService batchRecordService;
@@ -42,6 +45,7 @@ public class BatchRecordController {
     private final ControlEmpaqueLoteRepository controlEmpaqueLoteRepository;
     private final ObservacionProcesoRepository observacionProcesoRepository;
     private final UsuarioService usuarioService;
+    private final ReporteBatchRecordService reporteBatchRecordService;
 
     @GetMapping("/{ordenProduccionId}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
@@ -137,12 +141,21 @@ public class BatchRecordController {
     @GetMapping(value = "/{ordenProduccionId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportarPdf(@PathVariable Long ordenProduccionId) {
-        batchRecordService.buildByOrdenProduccion(ordenProduccionId);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_PDF);
-        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=batch-record.pdf");
-        // TODO: Implementar renderizado PDF reutilizando el motor de exportación existente.
-        return new ResponseEntity<>(new byte[0], headers, HttpStatus.OK);
+        try {
+            BatchRecordDTO batchRecordDTO = batchRecordService.buildByOrdenProduccion(ordenProduccionId);
+            byte[] pdf = reporteBatchRecordService.generarPdfBatchRecord(ordenProduccionId);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_PDF);
+            String filename = batchRecordDTO != null && batchRecordDTO.op != null && batchRecordDTO.op.codigoOrden != null
+                    ? "batch-record-" + batchRecordDTO.op.codigoOrden + ".pdf"
+                    : "batch-record-orden-" + ordenProduccionId + ".pdf";
+            headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + filename);
+            return new ResponseEntity<>(pdf, headers, HttpStatus.OK);
+        } catch (Exception e) {
+            log.error("Error exportando PDF de batch record para la OP {}", ordenProduccionId, e);
+            throw e;
+        }
     }
 
     private OrdenProduccion obtenerOrden(Long ordenProduccionId) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordService.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.produccion.service;
+
+public interface ReporteBatchRecordService {
+
+    byte[] generarPdfBatchRecord(Long ordenProduccionId);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordServiceImpl.java
@@ -1,0 +1,263 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.willyes.clemenintegra.produccion.dto.BatchRecordDTO;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StreamUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ReporteBatchRecordServiceImpl implements ReporteBatchRecordService {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    private final BatchRecordService batchRecordService;
+
+    @Override
+    public byte[] generarPdfBatchRecord(Long ordenProduccionId) {
+        BatchRecordDTO batchRecord = batchRecordService.buildByOrdenProduccion(ordenProduccionId);
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            String html = buildHtml(batchRecord);
+            PdfRendererBuilder builder = new PdfRendererBuilder();
+            builder.useFastMode();
+            builder.withHtmlContent(html, null);
+            builder.toStream(out);
+            builder.run();
+            return out.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando PDF de batch record para la OP {}", ordenProduccionId, e);
+            throw new CustomBusinessException(ApiErrorCode.ERROR_INTERNO, "REPORTE_NO_DISPONIBLE");
+        }
+    }
+
+    private String buildHtml(BatchRecordDTO batchRecord) throws IOException {
+        String template = loadTemplate("templates/produccion/batch-record.ftl");
+
+        BatchRecordDTO.OpDTO op = batchRecord.op;
+        BatchRecordDTO.ProduccionFinalDTO produccionFinal = batchRecord.produccionFinal;
+        BatchRecordDTO.LotePTDTO lotePT = batchRecord.loteProductoTerminado;
+
+        template = template.replace("${op.codigoOrden}", escape(nz(op != null ? op.codigoOrden : "")))
+                .replace("${op.producto}", escape(nz(op != null ? op.productoNombre : "")))
+                .replace("${op.codigoSku}", escape(nz(op != null ? op.codigoSku : "")))
+                .replace("${op.lote}", escape(nz(op != null ? op.loteProduccion : "")))
+                .replace("${op.presentacion}", escape(nz(op != null ? op.presentacion : "")))
+                .replace("${op.cantidadProgramada}", escape(formatInteger(op != null ? op.cantidadProgramada : null)))
+                .replace("${op.cantidadProducida}", escape(formatInteger(op != null ? op.cantidadProducida : null)))
+                .replace("${op.estado}", escape(nz(op != null ? op.estado : "")))
+                .replace("${op.fechaInicio}", escape(formatDate(op != null ? op.fechaInicio : null)))
+                .replace("${op.fechaFin}", escape(formatDate(op != null ? op.fechaFin : null)))
+                .replace("${op.responsable}", escape(nz(op != null ? op.responsableNombre : "")))
+                .replace("${op.porcentajeCumplimiento}", escape(formatDecimal(op != null ? op.porcentajeCumplimiento : null)));
+
+        template = template.replace("${formulaRows}", buildFormulaRows(batchRecord.formula));
+        template = template.replace("${consumoRows}", buildConsumoRows(batchRecord.consumos));
+        template = template.replace("${reservaRows}", buildReservaRows(batchRecord.reservas));
+        template = template.replace("${controlProcesoRows}", buildControlProcesoRows(batchRecord.controlesProceso));
+        template = template.replace("${controlEmpaqueRows}", buildControlEmpaqueRows(batchRecord.controlesEmpaque));
+        template = template.replace("${observacionRows}", buildObservacionRows(batchRecord.observacionesProceso));
+
+        template = template.replace("${produccionFinal.unidadesProducidas}", escape(formatInteger(produccionFinal != null ? produccionFinal.unidadesProducidas : null)))
+                .replace("${produccionFinal.unidadesAprobadas}", escape(formatInteger(produccionFinal != null ? produccionFinal.unidadesAprobadas : null)))
+                .replace("${produccionFinal.unidadesRechazadas}", escape(formatInteger(produccionFinal != null ? produccionFinal.unidadesRechazadas : null)))
+                .replace("${produccionFinal.rendimiento}", escape(formatDecimal(produccionFinal != null ? produccionFinal.rendimientoCalculado : null)));
+
+        template = template.replace("${lotePT.codigoLote}", escape(nz(lotePT != null ? lotePT.codigoLote : "")))
+                .replace("${lotePT.estado}", escape(nz(lotePT != null ? lotePT.estado : "")))
+                .replace("${lotePT.fechaFabricacion}", escape(formatDate(lotePT != null ? lotePT.fechaFabricacion : null)))
+                .replace("${lotePT.fechaVencimiento}", escape(formatDate(lotePT != null ? lotePT.fechaVencimiento : null)))
+                .replace("${lotePT.fechaLiberacion}", escape(formatDate(lotePT != null ? lotePT.fechaLiberacion : null)))
+                .replace("${lotePT.usuarioLiberador}", escape(nz(lotePT != null ? lotePT.usuarioLiberador : "")));
+
+        template = template.replace("${evaluacionRows}", buildEvaluacionRows(batchRecord.calidad != null ? batchRecord.calidad.evaluaciones : null));
+        template = template.replace("${retencionRows}", buildRetencionRows(batchRecord.calidad != null ? batchRecord.calidad.retenciones : null));
+        return template;
+    }
+
+    private String buildFormulaRows(BatchRecordDTO.FormulaDTO formula) {
+        StringBuilder sb = new StringBuilder();
+        List<BatchRecordDTO.DetalleFormulaDTO> detalles = formula != null ? formula.detalles : null;
+        if (detalles != null) {
+            for (BatchRecordDTO.DetalleFormulaDTO detalle : detalles) {
+                sb.append("<tr>")
+                        .append(td(detalle.codigoSku))
+                        .append(td(detalle.nombre))
+                        .append(td(detalle.unidad))
+                        .append(td(formatDecimal(detalle.cantidadNecesaria)))
+                        .append(td(detalle.obligatorio ? "Sí" : "No"))
+                        .append("</tr>");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String buildConsumoRows(List<BatchRecordDTO.ConsumoDTO> consumos) {
+        StringBuilder sb = new StringBuilder();
+        if (consumos != null) {
+            for (BatchRecordDTO.ConsumoDTO consumo : consumos) {
+                sb.append("<tr>")
+                        .append(td(consumo.nombreProducto))
+                        .append(td(consumo.codigoLote))
+                        .append(td(consumo.almacenOrigen))
+                        .append(td(formatDecimal(consumo.cantidad)))
+                        .append(td(consumo.unidad))
+                        .append(td(formatDate(consumo.fechaMovimiento)))
+                        .append("</tr>");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String buildReservaRows(List<BatchRecordDTO.ReservaDTO> reservas) {
+        StringBuilder sb = new StringBuilder();
+        if (reservas != null) {
+            for (BatchRecordDTO.ReservaDTO reserva : reservas) {
+                sb.append("<tr>")
+                        .append(td(reserva.codigoLote))
+                        .append(td(formatDecimal(reserva.cantidadReservada)))
+                        .append(td(formatDecimal(reserva.cantidadConsumida)))
+                        .append(td(reserva.estado))
+                        .append("</tr>");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String buildControlProcesoRows(List<BatchRecordDTO.ControlProcesoDTO> controles) {
+        StringBuilder sb = new StringBuilder();
+        if (controles != null) {
+            for (BatchRecordDTO.ControlProcesoDTO control : controles) {
+                sb.append("<tr>")
+                        .append(td(control.etapa))
+                        .append(td(control.parametro))
+                        .append(td(control.valorMedido))
+                        .append(td(control.unidad))
+                        .append(td(control.cumple != null && control.cumple ? "Sí" : "No"))
+                        .append(td(control.observaciones))
+                        .append(td(control.evaluadoPor))
+                        .append(td(formatDate(control.fechaRegistro)))
+                        .append("</tr>");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String buildControlEmpaqueRows(List<BatchRecordDTO.ControlEmpaqueDTO> controles) {
+        StringBuilder sb = new StringBuilder();
+        if (controles != null) {
+            for (BatchRecordDTO.ControlEmpaqueDTO control : controles) {
+                sb.append("<tr>")
+                        .append(td(control.parametro))
+                        .append(td(control.valorMedido))
+                        .append(td(control.unidad))
+                        .append(td(control.cumple != null && control.cumple ? "Sí" : "No"))
+                        .append(td(control.observaciones))
+                        .append(td(control.evaluadoPor))
+                        .append(td(formatDate(control.fechaRegistro)))
+                        .append("</tr>");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String buildObservacionRows(List<BatchRecordDTO.ObservacionProcesoDTO> observaciones) {
+        StringBuilder sb = new StringBuilder();
+        if (observaciones != null) {
+            for (BatchRecordDTO.ObservacionProcesoDTO obs : observaciones) {
+                sb.append("<tr>")
+                        .append(td(obs.tipo))
+                        .append(td(obs.descripcion))
+                        .append(td(obs.registradoPor))
+                        .append(td(formatDate(obs.fechaRegistro)))
+                        .append("</tr>");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String buildEvaluacionRows(List<BatchRecordDTO.EvaluacionDTO> evaluaciones) {
+        StringBuilder sb = new StringBuilder();
+        if (evaluaciones != null) {
+            for (BatchRecordDTO.EvaluacionDTO eval : evaluaciones) {
+                sb.append("<tr>")
+                        .append(td(eval.tipoEvaluacion))
+                        .append(td(eval.resultado))
+                        .append(td(eval.observaciones))
+                        .append(td(eval.evaluador))
+                        .append(td(formatDate(eval.fechaEvaluacion)))
+                        .append("</tr>");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String buildRetencionRows(List<BatchRecordDTO.RetencionDTO> retenciones) {
+        StringBuilder sb = new StringBuilder();
+        if (retenciones != null) {
+            for (BatchRecordDTO.RetencionDTO ret : retenciones) {
+                sb.append("<tr>")
+                        .append(td(ret.estado))
+                        .append(td(ret.motivo))
+                        .append(td(formatDate(ret.fechaRetencion)))
+                        .append(td(formatDate(ret.fechaLiberacion)))
+                        .append(td(ret.aprobador))
+                        .append("</tr>");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String loadTemplate(String path) throws IOException {
+        ClassPathResource resource = new ClassPathResource(path);
+        try (var inputStream = resource.getInputStream()) {
+            return StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+        }
+    }
+
+    private String td(String value) {
+        return "<td>" + escape(nz(value)) + "</td>";
+    }
+
+    private String nz(String value) {
+        return value == null ? "" : value;
+    }
+
+    private String escape(String value) {
+        String sanitized = nz(value);
+        String normalized = java.text.Normalizer.normalize(sanitized, java.text.Normalizer.Form.NFD)
+                .replaceAll("[^\\p{ASCII}]", "");
+        return normalized
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private String formatDecimal(java.math.BigDecimal value) {
+        if (value == null) return "";
+        return String.format(Locale.US, "%.2f", value);
+    }
+
+    private String formatInteger(Integer value) {
+        return value == null ? "" : value.toString();
+    }
+
+    private String formatDate(LocalDateTime value) {
+        return value == null ? "" : DATE_TIME_FORMATTER.format(value);
+    }
+}

--- a/src/main/resources/templates/produccion/batch-record.ftl
+++ b/src/main/resources/templates/produccion/batch-record.ftl
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: Arial, sans-serif; font-size: 12px; color: #333; }
+        h1 { text-align: center; font-size: 18px; margin-bottom: 8px; }
+        h2 { font-size: 15px; margin-top: 16px; margin-bottom: 8px; }
+        table { width: 100%; border-collapse: collapse; margin-bottom: 12px; }
+        th, td { border: 1px solid #ccc; padding: 6px; text-align: left; }
+        th { background-color: #f2f2f2; }
+        .header-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 6px; margin-bottom: 12px; }
+        .label { font-weight: bold; }
+    </style>
+</head>
+<body>
+<h1>BATCH RECORD – REGISTRO DE LOTE</h1>
+
+<h2>Datos de la orden</h2>
+<div class="header-grid">
+    <div><span class="label">Producto:</span> ${op.producto}</div>
+    <div><span class="label">Código OP:</span> ${op.codigoOrden}</div>
+    <div><span class="label">SKU:</span> ${op.codigoSku}</div>
+    <div><span class="label">Lote:</span> ${op.lote}</div>
+    <div><span class="label">Presentación:</span> ${op.presentacion}</div>
+    <div><span class="label">Responsable:</span> ${op.responsable}</div>
+    <div><span class="label">Cantidad programada:</span> ${op.cantidadProgramada}</div>
+    <div><span class="label">Cantidad producida:</span> ${op.cantidadProducida}</div>
+    <div><span class="label">Estado:</span> ${op.estado}</div>
+    <div><span class="label">% Cumplimiento:</span> ${op.porcentajeCumplimiento}</div>
+    <div><span class="label">Inicio:</span> ${op.fechaInicio}</div>
+    <div><span class="label">Fin:</span> ${op.fechaFin}</div>
+</div>
+
+<h2>1. Fórmula / Componentes requeridos</h2>
+<table>
+    <thead>
+    <tr>
+        <th>Código insumo</th>
+        <th>Nombre</th>
+        <th>Unidad</th>
+        <th>Cantidad necesaria</th>
+        <th>Obligatorio</th>
+    </tr>
+    </thead>
+    <tbody>${formulaRows}</tbody>
+</table>
+
+<h2>2. Consumos reales / reservas</h2>
+<table>
+    <thead>
+    <tr>
+        <th>Producto</th>
+        <th>Lote</th>
+        <th>Almacén origen</th>
+        <th>Cantidad</th>
+        <th>Unidad</th>
+        <th>Fecha movimiento</th>
+    </tr>
+    </thead>
+    <tbody>${consumoRows}</tbody>
+</table>
+
+<table>
+    <thead>
+    <tr>
+        <th>Lote reservado</th>
+        <th>Cantidad reservada</th>
+        <th>Cantidad consumida</th>
+        <th>Estado</th>
+    </tr>
+    </thead>
+    <tbody>${reservaRows}</tbody>
+</table>
+
+<h2>3. Controles en proceso</h2>
+<table>
+    <thead>
+    <tr>
+        <th>Etapa</th>
+        <th>Parámetro</th>
+        <th>Valor medido</th>
+        <th>Unidad</th>
+        <th>Cumple</th>
+        <th>Observaciones</th>
+        <th>Evaluado por</th>
+        <th>Fecha registro</th>
+    </tr>
+    </thead>
+    <tbody>${controlProcesoRows}</tbody>
+</table>
+
+<h2>4. Controles de empaque</h2>
+<table>
+    <thead>
+    <tr>
+        <th>Parámetro</th>
+        <th>Valor medido</th>
+        <th>Unidad</th>
+        <th>Cumple</th>
+        <th>Observaciones</th>
+        <th>Evaluado por</th>
+        <th>Fecha registro</th>
+    </tr>
+    </thead>
+    <tbody>${controlEmpaqueRows}</tbody>
+</table>
+
+<h2>5. Producción final y calidad</h2>
+<table>
+    <thead>
+    <tr>
+        <th>Unidades producidas</th>
+        <th>Unidades aprobadas</th>
+        <th>Unidades rechazadas</th>
+        <th>Rendimiento calculado</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>${produccionFinal.unidadesProducidas}</td>
+        <td>${produccionFinal.unidadesAprobadas}</td>
+        <td>${produccionFinal.unidadesRechazadas}</td>
+        <td>${produccionFinal.rendimiento}</td>
+    </tr>
+    </tbody>
+</table>
+
+<table>
+    <thead>
+    <tr>
+        <th>Lote PT</th>
+        <th>Estado</th>
+        <th>Fabricación</th>
+        <th>Vencimiento</th>
+        <th>Liberación</th>
+        <th>Usuario liberador</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>${lotePT.codigoLote}</td>
+        <td>${lotePT.estado}</td>
+        <td>${lotePT.fechaFabricacion}</td>
+        <td>${lotePT.fechaVencimiento}</td>
+        <td>${lotePT.fechaLiberacion}</td>
+        <td>${lotePT.usuarioLiberador}</td>
+    </tr>
+    </tbody>
+</table>
+
+<table>
+    <thead>
+    <tr>
+        <th>Tipo evaluación</th>
+        <th>Resultado</th>
+        <th>Observaciones</th>
+        <th>Evaluador</th>
+        <th>Fecha</th>
+    </tr>
+    </thead>
+    <tbody>${evaluacionRows}</tbody>
+</table>
+
+<table>
+    <thead>
+    <tr>
+        <th>Estado</th>
+        <th>Motivo</th>
+        <th>Fecha retención</th>
+        <th>Fecha liberación</th>
+        <th>Aprobador</th>
+    </tr>
+    </thead>
+    <tbody>${retencionRows}</tbody>
+</table>
+
+<h2>6. Observaciones</h2>
+<table>
+    <thead>
+    <tr>
+        <th>Tipo</th>
+        <th>Descripción</th>
+        <th>Registrado por</th>
+        <th>Fecha registro</th>
+    </tr>
+    </thead>
+    <tbody>${observacionRows}</tbody>
+</table>
+
+</body>
+</html>

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.produccion.repository.ControlProcesoProduccionR
 import com.willyes.clemenintegra.produccion.repository.ObservacionProcesoRepository;
 import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
 import com.willyes.clemenintegra.produccion.service.BatchRecordService;
+import com.willyes.clemenintegra.produccion.service.ReporteBatchRecordService;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 
 @WebMvcTest(BatchRecordController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -50,6 +52,8 @@ class BatchRecordControllerTest {
     private ObservacionProcesoRepository observacionProcesoRepository;
     @MockBean
     private UsuarioService usuarioService;
+    @MockBean
+    private ReporteBatchRecordService reporteBatchRecordService;
     @MockBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
     @MockBean
@@ -89,5 +93,23 @@ class BatchRecordControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(ApiErrorCode.RECURSO_NO_ENCONTRADO.name()));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/produccion/batch-record/{id}/pdf devuelve PDF con headers")
+    void exportarPdfBatchRecord() throws Exception {
+        BatchRecordDTO dto = new BatchRecordDTO();
+        BatchRecordDTO.OpDTO opDTO = new BatchRecordDTO.OpDTO();
+        opDTO.id = 5L;
+        opDTO.codigoOrden = "OP-123";
+        dto.op = opDTO;
+        when(batchRecordService.buildByOrdenProduccion(5L)).thenReturn(dto);
+        when(reporteBatchRecordService.generarPdfBatchRecord(5L)).thenReturn("pdf".getBytes());
+
+        mockMvc.perform(get("/api/produccion/batch-record/{id}/pdf", 5L))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", MediaType.APPLICATION_PDF_VALUE))
+                .andExpect(header().string("Content-Disposition", "attachment; filename=batch-record-OP-123.pdf"));
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated Batch Record report service to build PDF from BatchRecord data using shared renderer
- include Freemarker-style HTML template for Batch Record content
- wire BatchRecordController PDF endpoint and extend controller tests for PDF download headers

## Testing
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208f822ca08333bb38acc382687d5a)