### PR TITLE
Fix batch record template XHTML structure

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordServiceImpl.java
@@ -30,6 +30,10 @@ public class ReporteBatchRecordServiceImpl implements ReporteBatchRecordService 
     @Override
     public byte[] generarPdfBatchRecord(Long ordenProduccionId) {
         BatchRecordDTO batchRecord = batchRecordService.buildByOrdenProduccion(ordenProduccionId);
+        if (log.isDebugEnabled()) {
+            log.debug("Generando PDF de batch record para OP {} con plantilla {}", ordenProduccionId,
+                    "templates/produccion/batch-record.ftl");
+        }
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             String html = buildHtml(batchRecord);
             PdfRendererBuilder builder = new PdfRendererBuilder();

--- a/src/main/resources/templates/produccion/batch-record.ftl
+++ b/src/main/resources/templates/produccion/batch-record.ftl
@@ -1,7 +1,10 @@
-<!DOCTYPE html>
-<html lang="es">
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="es" lang="es">
 <head>
-    <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Batch Record - Registro de Lote</title>
     <style>
         body { font-family: Arial, sans-serif; font-size: 12px; color: #333; }
         h1 { text-align: center; font-size: 18px; margin-bottom: 8px; }


### PR DESCRIPTION
## Summary
- align the batch record FreeMarker template with the working XHTML header used by other reports
- ensure empty tags are self-closing to avoid XML parsing errors in OpenHTMLtoPDF
- add debug logging when generating batch record PDFs to trace template usage

## Testing
- mvn -q test *(fails: dependency resolution error 502 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209be1c6e08333873af1646e2d6019)