### PR TITLE
Add quality decision tracking to batch records

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.produccion.controller;
 
 import com.willyes.clemenintegra.produccion.dto.BatchRecordDTO;
+import com.willyes.clemenintegra.produccion.dto.BatchRecordDecisionRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.ControlEmpaqueRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.ControlProcesoRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.ObservacionProcesoRequestDTO;
@@ -24,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
@@ -156,6 +158,17 @@ public class BatchRecordController {
             log.error("Error exportando PDF de batch record para la OP {}", ordenProduccionId, e);
             throw e;
         }
+    }
+
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PostMapping("/{ordenProduccionId}/decision")
+    public ResponseEntity<Void> decidirBatchRecord(
+            @PathVariable Long ordenProduccionId,
+            @Valid @RequestBody BatchRecordDecisionRequestDTO request,
+            Authentication auth) {
+        log.info("Recibida decisión de batch record para OP {}: {}", ordenProduccionId, request.getDecision());
+        batchRecordService.decidirBatchRecord(ordenProduccionId, request, auth);
+        return ResponseEntity.noContent().build();
     }
 
     private OrdenProduccion obtenerOrden(Long ordenProduccionId) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDTO.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.produccion.dto;
 
+import com.willyes.clemenintegra.produccion.model.enums.EstadoBatchRecord;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,6 +17,10 @@ public class BatchRecordDTO {
     public List<ControlProcesoDTO> controlesProceso;
     public List<ControlEmpaqueDTO> controlesEmpaque;
     public List<ObservacionProcesoDTO> observacionesProceso;
+    public EstadoBatchRecord estadoBatchRecord;
+    public String revisadoPorNombre;
+    public LocalDateTime fechaRevision;
+    public String observacionesCalidad;
 
     public static class OpDTO {
         public Long id;

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDecisionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDecisionRequestDTO.java
@@ -1,0 +1,16 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import com.willyes.clemenintegra.produccion.model.enums.EstadoBatchRecord;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class BatchRecordDecisionRequestDTO {
+
+    @NotNull
+    private EstadoBatchRecord decision;
+
+    @Size(max = 2000)
+    private String observacionesCalidad;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
@@ -2,9 +2,10 @@ package com.willyes.clemenintegra.produccion.model;
 
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
-import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoBatchRecord;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.TipoCierre;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -70,6 +71,20 @@ public class OrdenProduccion {
 
     @OneToMany(mappedBy = "ordenProduccion")
     private List<EtapaProduccion> etapas;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "batch_record_estado", nullable = false)
+    private EstadoBatchRecord batchRecordEstado = EstadoBatchRecord.BORRADOR;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_record_revisado_por_id")
+    private Usuario batchRecordRevisadoPor;
+
+    @Column(name = "batch_record_fecha_revision")
+    private LocalDateTime batchRecordFechaRevision;
+
+    @Column(name = "batch_record_observaciones_calidad", columnDefinition = "TEXT")
+    private String batchRecordObservacionesCalidad;
 
     @Version
     private Long version;

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/enums/EstadoBatchRecord.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/enums/EstadoBatchRecord.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.produccion.model.enums;
+
+public enum EstadoBatchRecord {
+    BORRADOR,
+    EN_REVISION_CALIDAD,
+    APROBADO,
+    RECHAZADO
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordService.java
@@ -1,7 +1,13 @@
 package com.willyes.clemenintegra.produccion.service;
 
 import com.willyes.clemenintegra.produccion.dto.BatchRecordDTO;
+import com.willyes.clemenintegra.produccion.dto.BatchRecordDecisionRequestDTO;
+import org.springframework.security.core.Authentication;
 
 public interface BatchRecordService {
     BatchRecordDTO buildByOrdenProduccion(Long ordenProduccionId);
+
+    void decidirBatchRecord(Long ordenProduccionId,
+                            BatchRecordDecisionRequestDTO request,
+                            Authentication auth);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
@@ -15,12 +15,14 @@ import com.willyes.clemenintegra.inventario.model.ReservaLote;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
+import com.willyes.clemenintegra.produccion.dto.BatchRecordDecisionRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.BatchRecordDTO;
 import com.willyes.clemenintegra.produccion.model.CierreProduccion;
 import com.willyes.clemenintegra.produccion.model.ControlEmpaqueLote;
 import com.willyes.clemenintegra.produccion.model.ControlProcesoProduccion;
 import com.willyes.clemenintegra.produccion.model.ObservacionProceso;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoBatchRecord;
 import com.willyes.clemenintegra.produccion.repository.CierreProduccionRepository;
 import com.willyes.clemenintegra.produccion.repository.ControlEmpaqueLoteRepository;
 import com.willyes.clemenintegra.produccion.repository.ControlProcesoProduccionRepository;
@@ -28,12 +30,16 @@ import com.willyes.clemenintegra.produccion.repository.ObservacionProcesoReposit
 import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -57,6 +63,49 @@ public class BatchRecordServiceImpl implements BatchRecordService {
     private final ObservacionProcesoRepository observacionProcesoRepository;
 
     @Override
+    @Transactional
+    public void decidirBatchRecord(Long ordenProduccionId,
+                                   BatchRecordDecisionRequestDTO request,
+                                   Authentication auth) {
+        OrdenProduccion ordenProduccion = ordenProduccionRepository.findById(ordenProduccionId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "ORDEN_NO_ENCONTRADA"));
+
+        if (ordenProduccion.getBatchRecordEstado() == EstadoBatchRecord.APROBADO) {
+            // No se permite modificar un batch record ya aprobado
+            throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA, "BATCH_RECORD_YA_APROBADO");
+        }
+
+        if (request == null || request.getDecision() == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "DECISION_BATCH_RECORD_REQUERIDA");
+        }
+
+        EstadoBatchRecord estadoActual = ordenProduccion.getBatchRecordEstado();
+        if (estadoActual != null
+                && estadoActual != EstadoBatchRecord.BORRADOR
+                && estadoActual != EstadoBatchRecord.EN_REVISION_CALIDAD
+                && estadoActual != EstadoBatchRecord.RECHAZADO) {
+            throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA,
+                    "El estado actual del batch record no permite registrar una decisión");
+        }
+
+        Usuario usuario = obtenerUsuarioDesdeAuth(auth);
+        if (request.getDecision() == EstadoBatchRecord.RECHAZADO
+                && (request.getObservacionesCalidad() == null || request.getObservacionesCalidad().isBlank())) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Las observaciones de calidad son obligatorias al rechazar el batch record");
+        }
+
+        ordenProduccion.setBatchRecordEstado(request.getDecision());
+        ordenProduccion.setBatchRecordRevisadoPor(usuario);
+        ordenProduccion.setBatchRecordFechaRevision(LocalDateTime.now());
+        ordenProduccion.setBatchRecordObservacionesCalidad(request.getObservacionesCalidad());
+
+        ordenProduccionRepository.save(ordenProduccion);
+        log.info("Batch Record de OP {} marcado como {} por {}", ordenProduccionId, request.getDecision(),
+                usuario != null ? usuario.getNombreCompleto() : "usuario-desconocido");
+    }
+
+    @Override
     public BatchRecordDTO buildByOrdenProduccion(Long ordenProduccionId) {
         log.info("Generando Batch Record para orden de producción {}", ordenProduccionId);
         OrdenProduccion ordenProduccion = ordenProduccionRepository.findById(ordenProduccionId)
@@ -74,6 +123,12 @@ public class BatchRecordServiceImpl implements BatchRecordService {
         dto.controlesProceso = mapControlesProceso(ordenProduccionId);
         dto.controlesEmpaque = mapControlesEmpaque(ordenProduccionId);
         dto.observacionesProceso = mapObservaciones(ordenProduccionId);
+        dto.estadoBatchRecord = ordenProduccion.getBatchRecordEstado();
+        dto.revisadoPorNombre = ordenProduccion.getBatchRecordRevisadoPor() != null
+                ? ordenProduccion.getBatchRecordRevisadoPor().getNombreCompleto()
+                : null;
+        dto.fechaRevision = ordenProduccion.getBatchRecordFechaRevision();
+        dto.observacionesCalidad = ordenProduccion.getBatchRecordObservacionesCalidad();
         return dto;
     }
 
@@ -319,5 +374,19 @@ public class BatchRecordServiceImpl implements BatchRecordService {
             resultado.add(dto);
         }
         return resultado;
+    }
+
+    private Usuario obtenerUsuarioDesdeAuth(Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "USUARIO_NO_AUTENTICADO");
+        }
+        Object principal = auth.getPrincipal();
+        if (principal instanceof CustomUserDetails customUserDetails) {
+            return customUserDetails.getUsuario();
+        }
+        if (principal instanceof Usuario usuario) {
+            return usuario;
+        }
+        throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "USUARIO_NO_AUTENTICADO");
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordServiceImpl.java
@@ -89,6 +89,16 @@ public class ReporteBatchRecordServiceImpl implements ReporteBatchRecordService 
 
         template = template.replace("${evaluacionRows}", buildEvaluacionRows(batchRecord.calidad != null ? batchRecord.calidad.evaluaciones : null));
         template = template.replace("${retencionRows}", buildRetencionRows(batchRecord.calidad != null ? batchRecord.calidad.retenciones : null));
+        template = template.replace("${batchRecord.estadoBatchRecord!'-'}",
+                        escape(defaultWithDash(batchRecord != null && batchRecord.estadoBatchRecord != null
+                                ? batchRecord.estadoBatchRecord.name()
+                                : null)))
+                .replace("${batchRecord.revisadoPorNombre!'-'}",
+                        escape(defaultWithDash(batchRecord != null ? batchRecord.revisadoPorNombre : null)))
+                .replace("${batchRecord.fechaRevision!'-'}",
+                        escape(defaultWithDash(formatDate(batchRecord != null ? batchRecord.fechaRevision : null))))
+                .replace("${batchRecord.observacionesCalidad!'-'}",
+                        escape(defaultWithDash(batchRecord != null ? batchRecord.observacionesCalidad : null)));
         return template;
     }
 
@@ -263,5 +273,9 @@ public class ReporteBatchRecordServiceImpl implements ReporteBatchRecordService 
 
     private String formatDate(LocalDateTime value) {
         return value == null ? "" : DATE_TIME_FORMATTER.format(value);
+    }
+
+    private String defaultWithDash(String value) {
+        return (value == null || value.isBlank()) ? "-" : value;
     }
 }

--- a/src/main/resources/db/migration/V20251118__add_batch_record_estado_op.sql
+++ b/src/main/resources/db/migration/V20251118__add_batch_record_estado_op.sql
@@ -1,0 +1,8 @@
+ALTER TABLE orden_produccion
+    ADD COLUMN batch_record_estado VARCHAR(30) NOT NULL DEFAULT 'BORRADOR',
+    ADD COLUMN batch_record_revisado_por_id BIGINT NULL,
+    ADD COLUMN batch_record_fecha_revision DATETIME NULL,
+    ADD COLUMN batch_record_observaciones_calidad TEXT NULL;
+
+ALTER TABLE orden_produccion
+    ADD CONSTRAINT fk_op_batch_record_revisado_por FOREIGN KEY (batch_record_revisado_por_id) REFERENCES usuarios (id);

--- a/src/main/resources/templates/produccion/batch-record.ftl
+++ b/src/main/resources/templates/produccion/batch-record.ftl
@@ -178,7 +178,29 @@
     <tbody>${retencionRows}</tbody>
 </table>
 
-<h2>6. Observaciones</h2>
+<h2>6. Revisión y aprobación de Calidad</h2>
+<table>
+    <tbody>
+    <tr>
+        <th>Estado Batch Record</th>
+        <td>${batchRecord.estadoBatchRecord!'-'}</td>
+    </tr>
+    <tr>
+        <th>Revisado por</th>
+        <td>${batchRecord.revisadoPorNombre!'-'}</td>
+    </tr>
+    <tr>
+        <th>Fecha de revisión</th>
+        <td>${batchRecord.fechaRevision!'-'}</td>
+    </tr>
+    <tr>
+        <th>Observaciones de Calidad</th>
+        <td>${batchRecord.observacionesCalidad!'-'}</td>
+    </tr>
+    </tbody>
+</table>
+
+<h2>7. Observaciones</h2>
 <table>
     <thead>
     <tr>

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
@@ -19,21 +19,30 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 
 @WebMvcTest(BatchRecordController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@SpringJUnitConfig(classes = BatchRecordControllerTest.TestSecurityConfig.class)
 @TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
 class BatchRecordControllerTest {
 
@@ -58,6 +67,11 @@ class BatchRecordControllerTest {
     private JwtAuthenticationFilter jwtAuthenticationFilter;
     @MockBean
     private UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+    }
 
     @Test
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
@@ -111,5 +125,33 @@ class BatchRecordControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(header().string("Content-Type", MediaType.APPLICATION_PDF_VALUE))
                 .andExpect(header().string("Content-Disposition", "attachment; filename=batch-record-OP-123.pdf"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    @DisplayName("POST /api/produccion/batch-record/{id}/decision devuelve 204")
+    void decidirBatchRecord() throws Exception {
+        String body = "{\"decision\":\"APROBADO\",\"observacionesCalidad\":\"Listo\"}";
+
+        mockMvc.perform(post("/api/produccion/batch-record/{id}/decision", 10L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNoContent());
+
+        verify(batchRecordService).decidirBatchRecord(eq(10L), any(), any());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("POST /api/produccion/batch-record/{id}/decision requiere rol de calidad")
+    void decidirBatchRecordNoAutorizado() throws Exception {
+        String body = "{\"decision\":\"APROBADO\"}";
+
+        mockMvc.perform(post("/api/produccion/batch-record/{id}/decision", 10L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden());
+
+        verify(batchRecordService, never()).decidirBatchRecord(anyLong(), any(), any());
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
@@ -20,7 +20,9 @@ import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
 import com.willyes.clemenintegra.produccion.dto.BatchRecordDTO;
+import com.willyes.clemenintegra.produccion.dto.BatchRecordDecisionRequestDTO;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoBatchRecord;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.repository.CierreProduccionRepository;
 import com.willyes.clemenintegra.produccion.repository.ControlEmpaqueLoteRepository;
@@ -30,6 +32,7 @@ import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +41,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -48,6 +53,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -206,6 +213,53 @@ class BatchRecordServiceImplTest {
                 .hasFieldOrPropertyWithValue("code", ApiErrorCode.RECURSO_NO_ENCONTRADO);
     }
 
+    @Test
+    @DisplayName("decidirBatchRecord establece aprobado y auditoría")
+    void decidirBatchRecordAprobado() {
+        OrdenProduccion orden = buildOrdenProduccion();
+        orden.setBatchRecordEstado(EstadoBatchRecord.BORRADOR);
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+        when(ordenProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Usuario usuario = new Usuario();
+        usuario.setId(50L);
+        usuario.setNombreCompleto("Jefe Calidad");
+        Authentication auth = buildAuth(usuario);
+
+        BatchRecordDecisionRequestDTO request = new BatchRecordDecisionRequestDTO();
+        request.setDecision(EstadoBatchRecord.APROBADO);
+        request.setObservacionesCalidad("Revisión conforme");
+
+        service.decidirBatchRecord(1L, request, auth);
+
+        assertThat(orden.getBatchRecordEstado()).isEqualTo(EstadoBatchRecord.APROBADO);
+        assertThat(orden.getBatchRecordRevisadoPor()).isEqualTo(usuario);
+        assertThat(orden.getBatchRecordFechaRevision()).isNotNull();
+        assertThat(orden.getBatchRecordObservacionesCalidad()).isEqualTo("Revisión conforme");
+        verify(ordenProduccionRepository).save(orden);
+    }
+
+    @Test
+    @DisplayName("decidirBatchRecord rechaza sin observaciones")
+    void decidirBatchRecordRechazadoSinObservaciones() {
+        OrdenProduccion orden = buildOrdenProduccion();
+        orden.setBatchRecordEstado(EstadoBatchRecord.EN_REVISION_CALIDAD);
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+
+        Usuario usuario = new Usuario();
+        usuario.setId(51L);
+        usuario.setNombreCompleto("Inspector Calidad");
+        Authentication auth = buildAuth(usuario);
+
+        BatchRecordDecisionRequestDTO request = new BatchRecordDecisionRequestDTO();
+        request.setDecision(EstadoBatchRecord.RECHAZADO);
+
+        assertThatThrownBy(() -> service.decidirBatchRecord(1L, request, auth))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasFieldOrPropertyWithValue("code", ApiErrorCode.SOLICITUD_INVALIDA);
+        verify(ordenProduccionRepository, never()).save(any());
+    }
+
     private OrdenProduccion buildOrdenProduccion() {
         Producto producto = new Producto();
         producto.setId(10);
@@ -224,6 +278,13 @@ class BatchRecordServiceImplTest {
         orden.setFechaInicio(LocalDateTime.now());
         orden.setEstado(EstadoProduccion.EN_PROCESO);
         return orden;
+    }
+
+    private Authentication buildAuth(Usuario usuario) {
+        TestingAuthenticationToken token = new TestingAuthenticationToken(new CustomUserDetails(usuario), null,
+                "ROL_JEFE_CALIDAD");
+        token.setAuthenticated(true);
+        return token;
     }
 
     private FormulaProducto buildFormula(Producto producto) {


### PR DESCRIPTION
## Summary
- add batch record state tracking on production orders and expose it through DTOs and batch record reports
- implement service and API endpoint for quality decisions with validation and auditing
- update batch record PDF to show decision data and extend tests for the new workflow

## Testing
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920be13b27c8333ad2fc442fc6de1c2)