### PR TITLE
Grant quality managers read-only access to production orders

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -44,7 +44,7 @@ public class OrdenProduccionController {
 
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public Page<OrdenProduccionResponseDTO> listar(
             @RequestParam(required = false) String codigo,
             @RequestParam(required = false) EstadoProduccion estado,
@@ -88,7 +88,7 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> obtenerPorId(@PathVariable Long id) {
         return service.buscarPorId(id)
                 .map(ProduccionMapper::toResponse)

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -141,6 +141,20 @@ public class SecurityConfig {
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
+                    // Acceso de solo lectura a órdenes de producción y batch record para rol de calidad
+                    auth.requestMatchers(
+                            HttpMethod.GET,
+                            "/api/produccion/ordenes",
+                            "/api/produccion/ordenes/**",
+                            "/api/produccion/batch-record/**"
+                    ).hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_LIDER_ALIMENTOS.name(),
+                            RolUsuario.ROL_LIDER_HOMEOPATICOS.name(),
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
                     auth.requestMatchers("/api/produccion/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
                             RolUsuario.ROL_LIDER_ALIMENTOS.name(),

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
@@ -97,6 +97,21 @@ class BatchRecordControllerTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    @DisplayName("GET /api/produccion/batch-record/{id} permite consulta a jefe de calidad")
+    void obtenerBatchRecordRolCalidad() throws Exception {
+        BatchRecordDTO dto = new BatchRecordDTO();
+        dto.op = new BatchRecordDTO.OpDTO();
+        dto.op.codigoOrden = "OP-2";
+        when(batchRecordService.buildByOrdenProduccion(2L)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/produccion/batch-record/{id}", 2L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.op.codigoOrden").value("OP-2"));
+    }
+
+    @Test
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     @DisplayName("GET /api/produccion/batch-record/{id} devuelve 404 cuando no existe")
     void obtenerBatchRecordNoExiste() throws Exception {
@@ -129,6 +144,23 @@ class BatchRecordControllerTest {
 
     @Test
     @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    @DisplayName("GET /api/produccion/batch-record/{id}/pdf permite acceso a jefe de calidad")
+    void exportarPdfBatchRecordRolCalidad() throws Exception {
+        BatchRecordDTO dto = new BatchRecordDTO();
+        BatchRecordDTO.OpDTO opDTO = new BatchRecordDTO.OpDTO();
+        opDTO.id = 7L;
+        opDTO.codigoOrden = "OP-777";
+        dto.op = opDTO;
+        when(batchRecordService.buildByOrdenProduccion(7L)).thenReturn(dto);
+        when(reporteBatchRecordService.generarPdfBatchRecord(7L)).thenReturn("pdf".getBytes());
+
+        mockMvc.perform(get("/api/produccion/batch-record/{id}/pdf", 7L))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", "attachment; filename=batch-record-OP-777.pdf"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
     @DisplayName("POST /api/produccion/batch-record/{id}/decision devuelve 204")
     void decidirBatchRecord() throws Exception {
         String body = "{\"decision\":\"APROBADO\",\"observacionesCalidad\":\"Listo\"}";
@@ -153,5 +185,15 @@ class BatchRecordControllerTest {
                 .andExpect(status().isForbidden());
 
         verify(batchRecordService, never()).decidirBatchRecord(anyLong(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    @DisplayName("POST /api/produccion/batch-record/{id}/controles-proceso es rechazado para jefe de calidad")
+    void guardarControlesProceso_conRolCalidad_devuelve403() throws Exception {
+        mockMvc.perform(post("/api/produccion/batch-record/{id}/controles-proceso", 3L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[]"))
+                .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
@@ -20,16 +20,20 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.data.domain.Page;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(OrdenProduccionController.class)
@@ -76,6 +80,46 @@ class OrdenProduccionControllerSecurityTest {
     @DisplayName("GET /api/produccion/ordenes/{id} sin rol permitido devuelve 403")
     void obtenerOrden_sinPermisos_devuelve403() throws Exception {
         mockMvc.perform(get("/api/produccion/ordenes/{id}", 1L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    @DisplayName("GET /api/produccion/ordenes permite consulta a jefe de calidad")
+    void listarOrdenes_conRolJefeCalidad_devuelve200() throws Exception {
+        when(ordenProduccionService.listarPaginado(any(), any(), any(), any(), any(), any())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/produccion/ordenes"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    @DisplayName("GET /api/produccion/ordenes/{id} permite ver detalle con rol de calidad")
+    void obtenerOrden_conRolJefeCalidad_devuelve404SiNoExiste() throws Exception {
+        when(ordenProduccionService.buscarPorId(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}", 1L))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    @DisplayName("POST /api/produccion/ordenes es rechazado para jefe de calidad")
+    void crearOrden_conRolJefeCalidad_devuelve403() throws Exception {
+        mockMvc.perform(post("/api/produccion/ordenes")
+                        .contentType("application/json")
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    @DisplayName("POST /api/produccion/ordenes/{id}/cierres es rechazado para jefe de calidad")
+    void registrarCierre_conRolJefeCalidad_devuelve403() throws Exception {
+        mockMvc.perform(post("/api/produccion/ordenes/{id}/cierres", 5L)
+                        .contentType("application/json")
+                        .content("{}"))
                 .andExpect(status().isForbidden());
     }
 


### PR DESCRIPTION
## Summary
- allow ROL_JEFE_CALIDAD to access production order and batch record GET endpoints without relaxing write permissions
- update production controllers to include quality manager authority on read operations
- extend security tests to cover allowed reads and forbidden writes for the quality manager role

## Testing
- mvn -q test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d4a8d6008333b84f7188ea5eb56c)