### PR TITLE
Allow quality role to review production orders and batch records

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/produccion/batch-record")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 @Slf4j
 public class BatchRecordController {
@@ -49,13 +49,13 @@ public class BatchRecordController {
     private final UsuarioService usuarioService;
     private final ReporteBatchRecordService reporteBatchRecordService;
 
-    @GetMapping("/{ordenProduccionId}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @GetMapping("/produccion/batch-record/{ordenProduccionId}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<BatchRecordDTO> obtener(@PathVariable Long ordenProduccionId) {
         return ResponseEntity.ok(batchRecordService.buildByOrdenProduccion(ordenProduccionId));
     }
 
-    @PostMapping("/{ordenProduccionId}/controles-proceso")
+    @PostMapping("/produccion/batch-record/{ordenProduccionId}/controles-proceso")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_OPERARIO_PRODUCCION','ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<List<BatchRecordDTO.ControlProcesoDTO>> guardarControlesProceso(
@@ -85,7 +85,7 @@ public class BatchRecordController {
         return ResponseEntity.ok(batchRecordDTO != null ? batchRecordDTO.controlesProceso : List.of());
     }
 
-    @PostMapping("/{ordenProduccionId}/controles-empaque")
+    @PostMapping("/produccion/batch-record/{ordenProduccionId}/controles-empaque")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_OPERARIO_PRODUCCION','ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<List<BatchRecordDTO.ControlEmpaqueDTO>> guardarControlesEmpaque(
@@ -114,7 +114,7 @@ public class BatchRecordController {
         return ResponseEntity.ok(batchRecordDTO != null ? batchRecordDTO.controlesEmpaque : List.of());
     }
 
-    @PostMapping("/{ordenProduccionId}/observaciones")
+    @PostMapping("/produccion/batch-record/{ordenProduccionId}/observaciones")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_OPERARIO_PRODUCCION','ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<List<BatchRecordDTO.ObservacionProcesoDTO>> guardarObservaciones(
@@ -140,7 +140,7 @@ public class BatchRecordController {
         return ResponseEntity.ok(batchRecordDTO != null ? batchRecordDTO.observacionesProceso : List.of());
     }
 
-    @GetMapping(value = "/{ordenProduccionId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    @GetMapping(value = "/produccion/batch-record/{ordenProduccionId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportarPdf(@PathVariable Long ordenProduccionId) {
         try {
@@ -161,7 +161,7 @@ public class BatchRecordController {
     }
 
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    @PostMapping("/{ordenProduccionId}/decision")
+    @PostMapping("/produccion/calidad/batch-record/{ordenProduccionId}/decision")
     public ResponseEntity<Void> decidirBatchRecord(
             @PathVariable Long ordenProduccionId,
             @Valid @RequestBody BatchRecordDecisionRequestDTO request,

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -157,14 +157,14 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{id}/cierres")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public Page<CierreProduccionResponseDTO> listarCierres(@PathVariable Long id,
                                                           @PageableDefault(size = 10, sort = "fechaCierre", direction = Sort.Direction.DESC) Pageable pageable) {
         return service.listarCierres(id, pageable);
     }
 
     @GetMapping("/{id}/etapas")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public List<EtapaProduccionResponse> listarEtapas(@PathVariable Long id) {
         return service.listarEtapas(id);
     }
@@ -194,13 +194,13 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{id}/insumos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public List<InsumoOPDTO> listarInsumos(@PathVariable Long id) {
         return service.listarInsumos(id);
     }
 
     @GetMapping("/{id}/movimientos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public Page<MovimientoInventarioResponseDTO> listarMovimientos(@PathVariable Long id,
                                                                    Pageable pageable) {
         return service.listarMovimientos(id, pageable);

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
@@ -161,11 +161,11 @@ class BatchRecordControllerTest {
 
     @Test
     @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
-    @DisplayName("POST /api/produccion/batch-record/{id}/decision devuelve 204")
+    @DisplayName("POST /api/produccion/calidad/batch-record/{id}/decision devuelve 204")
     void decidirBatchRecord() throws Exception {
         String body = "{\"decision\":\"APROBADO\",\"observacionesCalidad\":\"Listo\"}";
 
-        mockMvc.perform(post("/api/produccion/batch-record/{id}/decision", 10L)
+        mockMvc.perform(post("/api/produccion/calidad/batch-record/{id}/decision", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isNoContent());
@@ -175,11 +175,11 @@ class BatchRecordControllerTest {
 
     @Test
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
-    @DisplayName("POST /api/produccion/batch-record/{id}/decision requiere rol de calidad")
+    @DisplayName("POST /api/produccion/calidad/batch-record/{id}/decision requiere rol de calidad")
     void decidirBatchRecordNoAutorizado() throws Exception {
         String body = "{\"decision\":\"APROBADO\"}";
 
-        mockMvc.perform(post("/api/produccion/batch-record/{id}/decision", 10L)
+        mockMvc.perform(post("/api/produccion/calidad/batch-record/{id}/decision", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isForbidden());

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -21,15 +21,19 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -47,6 +51,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 @TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
 class OrdenProduccionControllerTest {
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+    }
 
     @Autowired
     private MockMvc mockMvc;
@@ -88,6 +97,7 @@ class OrdenProduccionControllerTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     @DisplayName("POST /api/produccion/ordenes retorna 201 cuando la validación es correcta")
     void crearOrden_valida() throws Exception {
         OrdenProduccionResponseDTO orden = new OrdenProduccionResponseDTO();
@@ -111,6 +121,7 @@ class OrdenProduccionControllerTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     @DisplayName("POST /api/produccion/ordenes retorna 400 con code STOCK_INSUFICIENTE")
     void crearOrden_insuficiente() throws Exception {
         ResultadoValidacionOrdenDTO respuesta = ResultadoValidacionOrdenDTO.builder()
@@ -136,5 +147,21 @@ class OrdenProduccionControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.esValida").value(false))
                 .andExpect(jsonPath("$.code").value("STOCK_INSUFICIENTE"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    @DisplayName("GET /api/produccion/ordenes/{id} permite consulta a jefe de calidad")
+    void obtenerOrden_jefeCalidadPuedeConsultar() throws Exception {
+        com.willyes.clemenintegra.produccion.model.OrdenProduccion orden = com.willyes.clemenintegra.produccion.model.OrdenProduccion.builder()
+                .id(15L)
+                .codigoOrden("OP-15")
+                .estado(com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion.CREADA)
+                .build();
+
+        when(ordenProduccionService.buscarPorId(15L)).thenReturn(Optional.of(orden));
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/api/produccion/ordenes/{id}", 15L))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## Summary
- Allow Jefe de Calidad to read production order details, inputs, stages, closures, and movements
- Align batch record endpoints and security so quality can view records and submit decisions
- Add controller tests to cover quality-role access and decision permissions

## Testing
- mvn -q -DskipITs -Dtest=BatchRecordControllerTest,OrdenProduccionControllerTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920e488ae4c8333b243465bcf70aaa6)