### PR TITLE
Ensure default batch record state for production orders

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
@@ -72,6 +72,7 @@ public class OrdenProduccion {
     @OneToMany(mappedBy = "ordenProduccion")
     private List<EtapaProduccion> etapas;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "batch_record_estado", nullable = false)
     private EstadoBatchRecord batchRecordEstado = EstadoBatchRecord.BORRADOR;
@@ -88,4 +89,13 @@ public class OrdenProduccion {
 
     @Version
     private Long version;
+
+    // Garantiza que las instancias construidas con builder no persistan un estado nulo
+    // (causante del error de columna NOT NULL en batch_record_estado).
+    @PrePersist
+    public void prePersist() {
+        if (batchRecordEstado == null) {
+            batchRecordEstado = EstadoBatchRecord.BORRADOR;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- set a builder default for batchRecordEstado so new OrdenProduccion instances start as BORRADOR
- add a PrePersist guard to enforce the non-null batch record state before insertion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921a6dce8748333be6fca4558d9b852)