### PR TITLE
Allow configuring products without stock control

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/model/Producto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/Producto.java
@@ -1,7 +1,8 @@
 package com.willyes.clemenintegra.inventario.model;
 
-import com.willyes.clemenintegra.shared.model.*;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.shared.model.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -77,6 +78,11 @@ public class Producto {
             foreignKey = @ForeignKey(name = "fk_productos_usuarios1"))
     private Usuario creadoPor;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "modo_control_inventario", nullable = false, length = 30)
+    private ModoControlInventario modoControlInventario = ModoControlInventario.CONTROL_STOCK;
+
     public Producto(Integer id) {
         this.id = id;
     }
@@ -85,6 +91,9 @@ public class Producto {
     public void prePersist() {
         if (this.fechaCreacion == null) {
             this.fechaCreacion = LocalDateTime.now();
+        }
+        if (this.modoControlInventario == null) {
+            this.modoControlInventario = ModoControlInventario.CONTROL_STOCK;
         }
     }
 
@@ -119,6 +128,8 @@ public class Producto {
     public void setCreadoPor(Usuario creadoPor) {this.creadoPor = creadoPor;}
     public BigDecimal getRendimientoUnidad() {return rendimientoUnidad;}
     public void setRendimientoUnidad(BigDecimal rendimientoUnidad) {this.rendimientoUnidad = rendimientoUnidad;}
+    public ModoControlInventario getModoControlInventario() {return modoControlInventario;}
+    public void setModoControlInventario(ModoControlInventario modoControlInventario) {this.modoControlInventario = modoControlInventario;}
 
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/enums/ModoControlInventario.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/enums/ModoControlInventario.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.inventario.model.enums;
+
+public enum ModoControlInventario {
+    CONTROL_STOCK,
+    SIN_CONTROL_STOCK
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
@@ -173,6 +173,7 @@ public class BatchRecordServiceImpl implements BatchRecordService {
         if (formula.getDetalles() != null) {
             for (DetalleFormula detalle : formula.getDetalles()) {
                 BatchRecordDTO.DetalleFormulaDTO detalleDTO = new BatchRecordDTO.DetalleFormulaDTO();
+                // Mostrar todos los insumos declarados en el BOM, incluso los que no generan reservas (p.ej. SIN_CONTROL_STOCK)
                 detalleDTO.insumoId = detalle.getInsumo() != null ? detalle.getInsumo().getId().longValue() : null;
                 detalleDTO.codigoSku = detalle.getInsumo() != null ? detalle.getInsumo().getCodigoSku() : null;
                 detalleDTO.nombre = detalle.getInsumo() != null ? detalle.getInsumo().getNombre() : null;

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
@@ -62,6 +63,32 @@ public class DisponibilidadInsumoService {
                 .orElse(BigDecimal.ZERO)
                 .setScale(8, RoundingMode.HALF_UP);
 
+        List<Long> preferidos = almacenesPreferidos == null ? List.of() : List.copyOf(almacenesPreferidos);
+        Producto producto = productoInsumoId != null
+                ? productoRepository.findById(productoInsumoId).orElse(null)
+                : null;
+        ModoControlInventario modoControl = Optional.ofNullable(producto)
+                .map(Producto::getModoControlInventario)
+                .orElse(ModoControlInventario.CONTROL_STOCK);
+
+        if (modoControl == ModoControlInventario.SIN_CONTROL_STOCK) {
+            BigDecimal requeridaEscala = requerida.setScale(6, RoundingMode.HALF_UP);
+            BigDecimal stockLibreSimulado = requeridaEscala;
+            // Insumos sin control de inventario (ej. agua por tubería) no bloquean la OP ni consultan lotes
+            return DistribucionFefoResult.builder()
+                    .productoInsumoId(productoInsumoId)
+                    .requerido(requeridaEscala)
+                    .stockFisicoTotal(requeridaEscala)
+                    .stockReservadoTotal(BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP))
+                    .stockLibreTotal(stockLibreSimulado)
+                    .faltante(BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP))
+                    .suficiente(true)
+                    .usoFallback(false)
+                    .almacenesPreferidos(preferidos)
+                    .detalles(List.of())
+                    .build();
+        }
+
         List<LoteFefoDisponibleProjection> lotesDisponibles = loteProductoRepository
                 .findFefoDisponibles(productoInsumoId, Integer.MAX_VALUE);
 
@@ -69,7 +96,6 @@ public class DisponibilidadInsumoService {
                 .filter(this::esLotePermitido)
                 .toList();
 
-        List<Long> preferidos = almacenesPreferidos == null ? List.of() : List.copyOf(almacenesPreferidos);
         List<LoteFefoDisponibleProjection> lotesSeleccionados = new ArrayList<>(lotesElegibles);
         boolean usoFallback = false;
         String motivoFallback = null;
@@ -158,9 +184,11 @@ public class DisponibilidadInsumoService {
         if (productoInsumoId != null
                 && stockFisicoTotal.compareTo(requerida) >= 0
                 && stockLibreTotal.compareTo(requerida) < 0) {
-            String codigo = productoRepository.findById(productoInsumoId)
+            String codigo = Optional.ofNullable(producto)
                     .map(Producto::getCodigoSku)
-                    .orElse(null);
+                    .orElseGet(() -> productoRepository.findById(productoInsumoId)
+                            .map(Producto::getCodigoSku)
+                            .orElse(null));
             log.warn("Disponibilidad FEFO detectó stock libre insuficiente pese a stock físico: insumoId={} codigo={} requerido={} stockFisicoTotal={} stockReservadoTotal={} stockLibreFefo={} faltante={} almacenes={}",
                     productoInsumoId,
                     codigo,

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -45,6 +45,7 @@ import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
 import com.willyes.clemenintegra.produccion.dto.LoteProductoResponse;
 import com.willyes.clemenintegra.inventario.dto.AlmacenResponseDTO;
 import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
@@ -276,6 +277,9 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 throw new IllegalArgumentException("Insumo no encontrado: ID " + insumoId);
             }
 
+            ModoControlInventario modoControl = Optional.ofNullable(productoInsumo.getModoControlInventario())
+                    .orElse(ModoControlInventario.CONTROL_STOCK);
+
             BigDecimal cantidadRequerida = insumo.getCantidadNecesaria().multiply(cantidadProgramada);
 
             List<Long> almacenesValidos = disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo.getInsumo());
@@ -313,7 +317,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     faltanteFefo,
                     maxProducible);
 
-            if (!distribucionPreview.isSuficiente()) {
+            if (modoControl == ModoControlInventario.CONTROL_STOCK && !distribucionPreview.isSuficiente()) {
                 stockSuficiente = false;
                 faltantes.add(InsumoFaltanteDTO.builder()
                         .productoId(insumoId)
@@ -907,6 +911,15 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     .multiply(orden.getCantidadProgramada())
                     .setScale(8, RoundingMode.HALF_UP);
             if (requerida.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+
+            ModoControlInventario modoControl = Optional.ofNullable(insumo.getInsumo())
+                    .map(Producto::getModoControlInventario)
+                    .orElse(ModoControlInventario.CONTROL_STOCK);
+
+            if (modoControl == ModoControlInventario.SIN_CONTROL_STOCK) {
+                log.debug("OP-reserva: insumo {} configurado sin control de stock, se omite reserva e inventario", insumoId);
                 continue;
             }
             BigDecimal requeridaSolicitud = requerida.setScale(6, RoundingMode.HALF_UP);

--- a/src/main/resources/db/migration/V20251119__add_modo_control_inventario_productos.sql
+++ b/src/main/resources/db/migration/V20251119__add_modo_control_inventario_productos.sql
@@ -1,0 +1,10 @@
+ALTER TABLE productos
+    ADD COLUMN modo_control_inventario VARCHAR(30) NOT NULL DEFAULT 'CONTROL_STOCK';
+
+UPDATE productos
+SET modo_control_inventario = 'CONTROL_STOCK'
+WHERE modo_control_inventario IS NULL;
+
+UPDATE productos
+SET modo_control_inventario = 'SIN_CONTROL_STOCK'
+WHERE codigo_sku = 'SM0001';

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.inventario.dto.LoteFefoDisponibleProjection;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
@@ -21,6 +22,10 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -126,6 +131,22 @@ class DisponibilidadInsumoServiceTest {
                 .map(det -> det.getCantidadReserva() == null ? BigDecimal.ZERO : det.getCantidadReserva())
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
         assertThat(totalDistribuido).isEqualByComparingTo(new BigDecimal("139650.000000"));
+    }
+
+    @Test
+    @DisplayName("calcularDisponibilidad omite FEFO cuando el insumo es SIN_CONTROL_STOCK")
+    void calcularDisponibilidad_insumoSinControlStock() {
+        Producto insumo = new Producto();
+        insumo.setId(99);
+        insumo.setModoControlInventario(ModoControlInventario.SIN_CONTROL_STOCK);
+        when(productoRepository.findById(99L)).thenReturn(Optional.of(insumo));
+
+        DistribucionFefoResult resultado = service.calcularDisponibilidad(99L, new BigDecimal("15"), List.of(7L), false);
+
+        assertThat(resultado.isSuficiente()).isTrue();
+        assertThat(resultado.getFaltante()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+        assertThat(resultado.getStockLibreTotal()).isEqualByComparingTo(new BigDecimal("15.000000"));
+        verify(loteProductoRepository, never()).findFefoDisponibles(anyLong(), anyInt());
     }
 
     private LoteFefoDisponibleProjection lote(Long id, String codigo, BigDecimal stockLibre,

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -16,6 +16,7 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.*;
@@ -224,6 +225,57 @@ class OrdenProduccionServiceImplTest {
 
         assertThat(resultado.isEsValida()).isTrue();
         assertThat(resultado.getOrden()).isNotNull();
+        assertThat(resultado.getInsumosFaltantes()).isNull();
+    }
+
+    @Test
+    @DisplayName("guardarConValidacionStock permite insumos SIN_CONTROL_STOCK aunque la simulación no tenga stock")
+    void guardarConValidacionStock_insumoSinControlStock() {
+        Producto producto = new Producto();
+        producto.setId(20);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setSimbolo("LTS");
+        producto.setUnidadMedida(unidad);
+
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setProducto(producto);
+        orden.setCantidadProgramada(new BigDecimal("5"));
+        orden.setEstado(EstadoProduccion.CREADA);
+
+        Producto agua = new Producto();
+        agua.setId(21);
+        agua.setNombre("AGUA PURIFICADA");
+        UnidadMedida umAgua = new UnidadMedida();
+        umAgua.setSimbolo("LTS");
+        agua.setUnidadMedida(umAgua);
+        agua.setModoControlInventario(ModoControlInventario.SIN_CONTROL_STOCK);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(agua);
+        detalle.setCantidadNecesaria(BigDecimal.ONE);
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setProducto(producto);
+        formula.setDetalles(List.of(detalle));
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(20L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+        when(productoRepository.findAllById(any())).thenReturn(List.of(agua));
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(agua)).thenReturn(List.of());
+
+        DistribucionFefoResult sinStock = DistribucionFefoResult.builder()
+                .productoInsumoId(21L)
+                .requerido(new BigDecimal("5.000000"))
+                .stockLibreTotal(BigDecimal.ZERO.setScale(6))
+                .faltante(new BigDecimal("5.000000"))
+                .suficiente(false)
+                .build();
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(21L), any(BigDecimal.class), eq(List.of()), eq(true)))
+                .thenReturn(sinStock);
+
+        ResultadoValidacionOrdenDTO resultado = service.guardarConValidacionStock(orden);
+
+        assertThat(resultado.isEsValida()).isTrue();
         assertThat(resultado.getInsumosFaltantes()).isNull();
     }
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -48,6 +48,7 @@ import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoDetalle;
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -75,6 +76,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
@@ -274,6 +276,32 @@ class OrdenProduccionServiceReservaTest {
         assertThatThrownBy(() -> service.reservarInsumosParaOP(orden.getId()))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessage("422 UNPROCESSABLE_ENTITY \"STOCK_INSUFICIENTE: insumo MP-COLRO - COLORANTE NATURAL ROJO, faltan 47.500000 MILILITRO\"");
+    }
+
+    @Test
+    @DisplayName("reservarInsumosParaOP omite insumos configurados como SIN_CONTROL_STOCK")
+    void reservarInsumosParaOp_omiteSinControlStock() {
+        Producto insumoSinControl = new Producto();
+        insumoSinControl.setId(120);
+        insumoSinControl.setModoControlInventario(ModoControlInventario.SIN_CONTROL_STOCK);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setNombre("LITRO");
+        insumoSinControl.setUnidadMedida(unidad);
+
+        FormulaProducto formulaEscenario = new FormulaProducto();
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(insumoSinControl);
+        detalle.setCantidadNecesaria(new BigDecimal("3"));
+        formulaEscenario.setDetalles(List.of(detalle));
+        formulaEscenario.setProducto(orden.getProducto());
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaEscenario));
+
+        service.reservarInsumosParaOP(1L);
+
+        verify(solicitudMovimientoService, never()).registrarSolicitud(any(SolicitudMovimientoRequestDTO.class));
+        verify(disponibilidadInsumoService, never()).calcularDisponibilidad(anyLong(), any(BigDecimal.class), anyList(), anyBoolean());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add inventory control mode on products with default CONTROL_STOCK and migration updating SM0001 to SIN_CONTROL_STOCK
- adjust availability validation, reservations, and batch record handling so non-stock-controlled supplies bypass stock checks while remaining visible
- extend FEFO and order service tests to cover the new mode and ensure reservations are skipped for supplies without stock control

## Testing
- mvn -Dtest=DisponibilidadInsumoServiceTest,OrdenProduccionServiceImplTest,OrdenProduccionServiceReservaTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ffc3b43083339d9c8329acd25545)