### PR TITLE
Enforce production consumption filtering and closure validation

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -95,10 +95,24 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     Page<MovimientoInventario> findByOrdenProduccionId(Long ordenProduccionId, Pageable pageable);
 
+    Page<MovimientoInventario> findByOrdenProduccionIdAndClasificacion(Long ordenProduccionId,
+                                                                       ClasificacionMovimientoInventario clasificacion,
+                                                                       Pageable pageable);
+
     @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m where m.ordenProduccion.id = :ordenId and m.producto.id = :productoId and m.tipoMovimientoDetalle.id = :detalleId")
     BigDecimal sumaCantidadPorOrdenYProducto(@Param("ordenId") Long ordenId,
                                              @Param("productoId") Long productoId,
                                              @Param("detalleId") Long detalleId);
+
+    @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m " +
+            "where m.ordenProduccion.id = :ordenId " +
+            "and m.producto.id = :productoId " +
+            "and m.clasificacion = :clasificacion " +
+            "and m.tipoMovimiento = :tipoMovimiento")
+    BigDecimal sumaCantidadPorOrdenProductoClasificacion(@Param("ordenId") Long ordenId,
+                                                         @Param("productoId") Long productoId,
+                                                         @Param("clasificacion") ClasificacionMovimientoInventario clasificacion,
+                                                         @Param("tipoMovimiento") TipoMovimiento tipoMovimiento);
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "almacenOrigen", "almacenDestino",

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/CierreProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/CierreProduccionRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CierreProduccionRepository extends JpaRepository<CierreProduccion, Long> {
     Page<CierreProduccion> findByOrdenProduccionId(Long ordenId, Pageable pageable);
+
+    long countByOrdenProduccionId(Long ordenId);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
@@ -12,6 +12,8 @@ import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.ReservaLote;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
@@ -189,10 +191,17 @@ public class BatchRecordServiceImpl implements BatchRecordService {
 
     private List<BatchRecordDTO.ConsumoDTO> mapConsumos(Long ordenProduccionId) {
         List<MovimientoInventario> movimientos = movimientoInventarioRepository
-                .findByOrdenProduccionId(ordenProduccionId, Pageable.unpaged())
+                .findByOrdenProduccionIdAndClasificacion(
+                        ordenProduccionId,
+                        ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                        Pageable.unpaged())
                 .getContent();
         List<BatchRecordDTO.ConsumoDTO> consumos = new ArrayList<>();
         for (MovimientoInventario movimiento : movimientos) {
+            // Solo se consideran consumos reales de producción (SALIDA_PRODUCCION desde Pre-Bodega)
+            if (movimiento.getTipoMovimiento() != TipoMovimiento.SALIDA) {
+                continue;
+            }
             BatchRecordDTO.ConsumoDTO consumoDTO = new BatchRecordDTO.ConsumoDTO();
             consumoDTO.tipoMovimiento = movimiento.getTipoMovimiento() != null ? movimiento.getTipoMovimiento().name() : null;
             consumoDTO.clasificacionMovimiento = movimiento.getClasificacion() != null ? movimiento.getClasificacion().name() : null;

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -503,6 +503,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             BigDecimal producidaDespues = producidaAntes.add(cantidad);
             EstadoProduccion estadoObjetivo = calcularEstadoObjetivo(orden, producidaDespues);
 
+            // Esta validación actúa por cierre individual; la regla global para evitar cerrar la OP sin cierres
+            // se aplica en recalcularEstadoOrden cuando todas las etapas terminan.
             if ((estadoObjetivo == EstadoProduccion.FINALIZADA || estadoObjetivo == EstadoProduccion.CERRADA_INCOMPLETA)
                     && producidaDespues.compareTo(BigDecimal.ZERO) == 0) {
                 ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.CONFLICT);
@@ -1163,8 +1165,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
         BigDecimal programada = Optional.ofNullable(orden.getCantidadProgramada()).orElse(BigDecimal.ZERO);
         BigDecimal producida = Optional.ofNullable(orden.getCantidadProducidaAcumulada()).orElse(BigDecimal.ZERO);
+        long cierresRegistrados = cierreProduccionRepository.countByOrdenProduccionId(orden.getId());
 
         if (todasFinalizadas) {
+            if (producida.compareTo(BigDecimal.ZERO) <= 0 || cierresRegistrados == 0) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "OP_SIN_CIERRES_PRODUCCION");
+            }
             if (producida.compareTo(programada) >= 0) {
                 orden.setEstado(EstadoProduccion.FINALIZADA);
             } else {
@@ -1238,15 +1244,18 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         FormulaProducto formula = formulaProductoRepository
                 .findByProductoIdAndEstadoAndActivoTrue(orden.getProducto().getId().longValue(), EstadoFormula.APROBADA)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "FORMULA_NO_ENCONTRADA"));
-        TipoMovimientoDetalle detalleSalida = tipoMovimientoDetalleRepository.findById(catalogResolver.getTipoDetalleSalidaId())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "DETALLE_MOVIMIENTO_NO_ENCONTRADO"));
-        Long detalleId = detalleSalida.getId();
         List<InsumoOPDTO> lista = new ArrayList<>();
         for (DetalleFormula det : formula.getDetalles()) {
             BigDecimal requerida = det.getCantidadNecesaria().multiply(orden.getCantidadProgramada());
             Long insumoId = det.getInsumo().getId().longValue();
+            // Solo se consideran consumos reales de producción (SALIDA_PRODUCCION). Traslados o preparaciones no suman aquí.
             BigDecimal consumidaMov = Optional.ofNullable(
-                    movimientoInventarioRepository.sumaCantidadPorOrdenYProducto(id, insumoId, detalleId)
+                    movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacion(
+                            id,
+                            insumoId,
+                            ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                            TipoMovimiento.SALIDA
+                    )
             ).orElse(BigDecimal.ZERO);
             BigDecimal consumidaReservas = Optional.ofNullable(
                     reservaLoteRepository.sumConsumidaByOrdenAndProducto(id, insumoId, EstadoReservaLote.CONSUMIDA)

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
@@ -112,7 +112,10 @@ class BatchRecordServiceImplTest {
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
                 .thenReturn(Optional.of(formula));
 
-        when(movimientoInventarioRepository.findByOrdenProduccionId(1L, Pageable.unpaged()))
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                1L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                Pageable.unpaged()))
                 .thenReturn(new PageImpl<>(Collections.emptyList()));
         when(reservaLoteRepository.findBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionId(1L))
                 .thenReturn(Collections.emptyList());
@@ -156,7 +159,10 @@ class BatchRecordServiceImplTest {
         movimiento.setLote(loteMp);
         movimiento.setCantidad(BigDecimal.ONE);
         movimiento.setFechaIngreso(LocalDateTime.now());
-        when(movimientoInventarioRepository.findByOrdenProduccionId(1L, Pageable.unpaged()))
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                1L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                Pageable.unpaged()))
                 .thenReturn(new PageImpl<>(List.of(movimiento)));
 
         when(reservaLoteRepository.findBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionId(1L))
@@ -201,6 +207,41 @@ class BatchRecordServiceImplTest {
         assertThat(result.loteProductoTerminado.usuarioLiberador).isEqualTo("Jefe Calidad");
         assertThat(result.calidad.evaluaciones).isNotNull();
         assertThat(result.calidad.retenciones).isNotNull();
+    }
+
+    @Test
+    @DisplayName("mapConsumos ignora movimientos clasificados como producción que no sean salidas")
+    void buildByOrdenProduccionIgnoraTiposNoSalida() {
+        OrdenProduccion orden = buildOrdenProduccion();
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(buildFormula(orden.getProducto())));
+
+        MovimientoInventario movimiento = new MovimientoInventario();
+        movimiento.setTipoMovimiento(TipoMovimiento.TRANSFERENCIA);
+        movimiento.setClasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+        movimiento.setProducto(orden.getProducto());
+        movimiento.setCantidad(BigDecimal.ONE);
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                1L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(List.of(movimiento)));
+
+        when(reservaLoteRepository.findBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionId(1L))
+                .thenReturn(Collections.emptyList());
+        when(cierreProduccionRepository.findByOrdenProduccionId(1L, Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(1L, 10L))
+                .thenReturn(Optional.empty());
+        when(controlProcesoProduccionRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(controlEmpaqueLoteRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(observacionProcesoRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+
+        BatchRecordDTO result = service.buildByOrdenProduccion(1L);
+
+        assertThat(result.consumos).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -12,11 +12,13 @@ import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.VidaUtilProducto;
 import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.*;
@@ -575,6 +577,7 @@ class OrdenProduccionServiceImplTest {
 
         when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(50L))
                 .thenReturn(List.of(etapa));
+        when(cierreProduccionRepository.countByOrdenProduccionId(50L)).thenReturn(1L);
 
         ReflectionTestUtils.invokeMethod(service, "recalcularEstadoOrden", orden);
 
@@ -598,6 +601,7 @@ class OrdenProduccionServiceImplTest {
 
         when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(60L))
                 .thenReturn(List.of(etapa));
+        when(cierreProduccionRepository.countByOrdenProduccionId(60L)).thenReturn(1L);
 
         ReflectionTestUtils.invokeMethod(service, "recalcularEstadoOrden", orden);
 
@@ -633,6 +637,65 @@ class OrdenProduccionServiceImplTest {
     }
 
     @Test
+    @DisplayName("recalcularEstadoOrden rechaza cierre sin cierres registrados")
+    void recalcularEstadoOrden_rechazaSinCierres() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(80L);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+        orden.setCantidadProgramada(new BigDecimal("50"));
+        orden.setCantidadProducidaAcumulada(BigDecimal.ZERO);
+
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(5L)
+                .estado(EstadoEtapa.FINALIZADA)
+                .build();
+
+        when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(80L))
+                .thenReturn(List.of(etapa));
+        when(cierreProduccionRepository.countByOrdenProduccionId(80L)).thenReturn(0L);
+
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "recalcularEstadoOrden", orden))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException rse = (ResponseStatusException) ex;
+                    assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+                    assertThat(rse.getReason()).isEqualTo("OP_SIN_CIERRES_PRODUCCION");
+                });
+
+        assertThat(orden.getEstado()).isEqualTo(EstadoProduccion.EN_PROCESO);
+        assertThat(orden.getFechaFin()).isNull();
+    }
+
+    @Test
+    @DisplayName("recalcularEstadoOrden exige cierres incluso cuando hay producción acumulada")
+    void recalcularEstadoOrden_rechazaSinCierresConProduccion() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(81L);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+        orden.setCantidadProgramada(new BigDecimal("200"));
+        orden.setCantidadProducidaAcumulada(new BigDecimal("50"));
+
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(6L)
+                .estado(EstadoEtapa.FINALIZADA)
+                .build();
+
+        when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(81L))
+                .thenReturn(List.of(etapa));
+        when(cierreProduccionRepository.countByOrdenProduccionId(81L)).thenReturn(0L);
+
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "recalcularEstadoOrden", orden))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException rse = (ResponseStatusException) ex;
+                    assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+                    assertThat(rse.getReason()).isEqualTo("OP_SIN_CIERRES_PRODUCCION");
+                });
+
+        assertThat(orden.getEstado()).isEqualTo(EstadoProduccion.EN_PROCESO);
+    }
+
+    @Test
     @DisplayName("listarInsumos refleja consumido en cero con reservas activas")
     void listarInsumos_conReservasActivas() {
         OrdenProduccion orden = new OrdenProduccion();
@@ -659,11 +722,11 @@ class OrdenProduccionServiceImplTest {
         when(ordenProduccionRepository.findById(200L)).thenReturn(Optional.of(orden));
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
                 .thenReturn(Optional.of(formula));
-        when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(11L);
-        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
-        tipoDetalle.setId(11L);
-        when(tipoMovimientoDetalleRepository.findById(11L)).thenReturn(Optional.of(tipoDetalle));
-        when(movimientoInventarioRepository.sumaCantidadPorOrdenYProducto(200L, 300L, 11L))
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacion(
+                200L,
+                300L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                TipoMovimiento.SALIDA))
                 .thenReturn(BigDecimal.ZERO);
         when(reservaLoteRepository.sumConsumidaByOrdenAndProducto(200L, 300L, EstadoReservaLote.CONSUMIDA))
                 .thenReturn(BigDecimal.ZERO);
@@ -704,11 +767,11 @@ class OrdenProduccionServiceImplTest {
         when(ordenProduccionRepository.findById(201L)).thenReturn(Optional.of(orden));
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
                 .thenReturn(Optional.of(formula));
-        when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(12L);
-        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
-        tipoDetalle.setId(12L);
-        when(tipoMovimientoDetalleRepository.findById(12L)).thenReturn(Optional.of(tipoDetalle));
-        when(movimientoInventarioRepository.sumaCantidadPorOrdenYProducto(201L, 301L, 12L))
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacion(
+                201L,
+                301L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                TipoMovimiento.SALIDA))
                 .thenReturn(BigDecimal.ONE);
         when(reservaLoteRepository.sumConsumidaByOrdenAndProducto(201L, 301L, EstadoReservaLote.CONSUMIDA))
                 .thenReturn(new BigDecimal("3"));


### PR DESCRIPTION
## Summary
- filter Batch Record consumption and insumo calculations to only production consumption movements
- require production closures with positive output before allowing orders to be closed
- cover new behaviors with service-level unit tests

## Testing
- mvn -q -Dtest=BatchRecordServiceImplTest,OrdenProduccionServiceImplTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69221aba3e5c83339cdacc8537e4c6cc)