### PR TITLE
Fill picklist with detail lots and origins

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -533,23 +533,25 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                         .setTextAlignment(TextAlignment.LEFT));
             }
 
+            List<PicklistItem> items = buildPicklistItems(solicitudes);
+
             int index = 0;
-            for (SolicitudMovimiento s : solicitudes) {
+            for (PicklistItem item : items) {
                 index++;
                 boolean zebra = index % 2 == 0;
                 DeviceRgb zebraColor = new DeviceRgb(0xFA, 0xFA, 0xFA);
 
-                String producto = s.getProducto() != null ? s.getProducto().getNombre() : "-";
-                String lote = s.getLote() != null ? s.getLote().getCodigoLote() : "-";
-                String cantidad = s.getCantidad() != null ? String.format(Locale.US, "%,.3f", s.getCantidad()) : "-";
-                String um = s.getProducto() != null && s.getProducto().getUnidadMedida() != null ? s.getProducto().getUnidadMedida().getNombre() : "-";
-                String almOrig = s.getAlmacenOrigen() != null ? s.getAlmacenOrigen().getNombre() : "-";
-                String ubicOrig = s.getAlmacenOrigen() != null ? s.getAlmacenOrigen().getUbicacion() : "-";
-                String almDest = s.getAlmacenDestino() != null ? s.getAlmacenDestino().getNombre() : "-";
-                String ubicDest = s.getAlmacenDestino() != null ? s.getAlmacenDestino().getUbicacion() : "-";
-                String obs = s.getObservaciones() != null ? s.getObservaciones() : "-";
-
-                String[] valores = {producto, lote, cantidad, um, almOrig, ubicOrig, almDest, ubicDest, obs};
+                String[] valores = {
+                        item.producto(),
+                        item.lote(),
+                        item.cantidad(),
+                        item.unidadMedida(),
+                        item.almacenOrigen(),
+                        item.ubicacionOrigen(),
+                        item.almacenDestino(),
+                        item.ubicacionDestino(),
+                        item.observaciones()
+                };
                 for (int i = 0; i < valores.length; i++) {
                     Cell cell = new Cell()
                             .add(new Paragraph(valores[i]).setFontSize(9))
@@ -584,6 +586,91 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
         } catch (Exception e) {
             throw new RuntimeException("Error generando PDF", e);
         }
+    }
+
+    List<PicklistItem> buildPicklistItems(List<SolicitudMovimiento> solicitudes) {
+        List<PicklistItem> items = new ArrayList<>();
+
+        for (SolicitudMovimiento solicitud : solicitudes) {
+            List<SolicitudMovimientoDetalle> detalles = Optional.ofNullable(solicitud.getDetalles())
+                    .orElseGet(Collections::emptyList);
+
+            if (!detalles.isEmpty()) {
+                for (SolicitudMovimientoDetalle detalle : detalles) {
+                    Almacen origen = detalle.getAlmacenOrigen() != null ? detalle.getAlmacenOrigen() : solicitud.getAlmacenOrigen();
+                    Almacen destino = detalle.getAlmacenDestino() != null ? detalle.getAlmacenDestino() : solicitud.getAlmacenDestino();
+
+                    String producto = solicitud.getProducto() != null ? solicitud.getProducto().getNombre() : "-";
+                    String lote = detalle.getLote() != null ? detalle.getLote().getCodigoLote() : "-";
+                    String cantidad = detalle.getCantidad() != null ? String.format(Locale.US, "%,.3f", detalle.getCantidad()) : "-";
+                    String um = solicitud.getProducto() != null && solicitud.getProducto().getUnidadMedida() != null
+                            ? solicitud.getProducto().getUnidadMedida().getNombre()
+                            : "-";
+                    String almOrigen = origen != null ? origen.getNombre() : "-";
+                    String ubicOrigen = origen != null && origen.getUbicacion() != null ? origen.getUbicacion() : "-";
+                    String almDestino = destino != null ? destino.getNombre() : "-";
+                    String ubicDestino = destino != null && destino.getUbicacion() != null ? destino.getUbicacion() : "-";
+                    String obs = solicitud.getObservaciones() != null ? solicitud.getObservaciones() : "-";
+
+                    items.add(new PicklistItem(
+                            producto,
+                            lote,
+                            cantidad,
+                            um,
+                            almOrigen,
+                            ubicOrigen,
+                            almDestino,
+                            ubicDestino,
+                            obs
+                    ));
+                }
+                continue;
+            }
+
+            String producto = solicitud.getProducto() != null ? solicitud.getProducto().getNombre() : "-";
+            String lote = solicitud.getLote() != null ? solicitud.getLote().getCodigoLote() : "-";
+            String cantidad = solicitud.getCantidad() != null ? String.format(Locale.US, "%,.3f", solicitud.getCantidad()) : "-";
+            String um = solicitud.getProducto() != null && solicitud.getProducto().getUnidadMedida() != null
+                    ? solicitud.getProducto().getUnidadMedida().getNombre()
+                    : "-";
+            String almOrigen = solicitud.getAlmacenOrigen() != null ? solicitud.getAlmacenOrigen().getNombre() : "-";
+            String ubicOrigen = solicitud.getAlmacenOrigen() != null ? solicitud.getAlmacenOrigen().getUbicacion() : "-";
+            String almDestino = solicitud.getAlmacenDestino() != null ? solicitud.getAlmacenDestino().getNombre() : "-";
+            String ubicDestino = solicitud.getAlmacenDestino() != null ? solicitud.getAlmacenDestino().getUbicacion() : "-";
+            String obs = solicitud.getObservaciones() != null ? solicitud.getObservaciones() : "-";
+
+            items.add(new PicklistItem(
+                    producto,
+                    lote,
+                    cantidad,
+                    um,
+                    almOrigen,
+                    ubicOrigen,
+                    almDestino,
+                    ubicDestino,
+                    obs
+            ));
+        }
+
+        return items;
+    }
+
+    /**
+     * Representa una fila del picklist. Los datos de lote y almacén de origen se toman del detalle
+     * porque las solicitudes de producción suelen almacenar esa información a nivel de detalle
+     * (multi-lote). Los valores de cabecera se mantienen como respaldo cuando no hay detalles.
+     */
+    static record PicklistItem(
+            String producto,
+            String lote,
+            String cantidad,
+            String unidadMedida,
+            String almacenOrigen,
+            String ubicacionOrigen,
+            String almacenDestino,
+            String ubicacionDestino,
+            String observaciones
+    ) {
     }
 
     private SolicitudMovimientoItemDTO toItemDTO(SolicitudMovimiento s, SolicitudMovimientoDetalle det) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServicePicklistTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServicePicklistTest.java
@@ -1,0 +1,211 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.PicklistDTO;
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SolicitudMovimientoServicePicklistTest {
+
+    @Mock
+    private SolicitudMovimientoRepository repository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private LoteProductoRepository loteRepository;
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private ReservaLoteService reservaLoteService;
+
+    @InjectMocks
+    private SolicitudMovimientoServiceImpl service;
+
+    @Test
+    @DisplayName("generarPicklist usa lote y origen del detalle cuando existen")
+    void generarPicklist_detalleIncluyeLoteYOrigen() throws Exception {
+        SolicitudMovimiento solicitud = crearSolicitudConDetalle(
+                "EQUINACEA POLVO",
+                "L-001",
+                "Bodega MP",
+                "Pasillo 1",
+                "Pre-Bodega",
+                "Zona F",
+                BigDecimal.valueOf(5)
+        );
+
+        when(repository.findWithDetalles(eq(1L), isNull(), isNull(), isNull(), eq(false), anyList()))
+                .thenReturn(List.of(solicitud));
+
+        List<SolicitudMovimientoServiceImpl.PicklistItem> items = service.buildPicklistItems(List.of(solicitud));
+
+        assertThat(items).hasSize(1);
+        SolicitudMovimientoServiceImpl.PicklistItem item = items.getFirst();
+        assertThat(item.producto()).isEqualTo("EQUINACEA POLVO");
+        assertThat(item.lote()).isEqualTo("L-001");
+        assertThat(item.almacenOrigen()).isEqualTo("Bodega MP");
+        assertThat(item.ubicacionOrigen()).isEqualTo("Pasillo 1");
+        assertThat(item.almacenDestino()).isEqualTo("Pre-Bodega");
+        assertThat(item.ubicacionDestino()).isEqualTo("Zona F");
+
+        PicklistDTO picklist = service.generarPicklist(1L, true);
+        assertThat(picklist.getArchivo()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("generarPicklist crea una fila por cada detalle con su lote")
+    void generarPicklist_multiDetalleGeneraMultiplesFilas() throws Exception {
+        SolicitudMovimientoDetalle detalle1 = crearDetalle("L-001", "Bodega 1", "Rack A", BigDecimal.valueOf(2));
+        SolicitudMovimientoDetalle detalle2 = crearDetalle("L-002", "Bodega 2", "Rack B", BigDecimal.valueOf(3));
+
+        SolicitudMovimiento solicitud = crearSolicitudBase("Producto multi", "UNI");
+        detalle1.setSolicitudMovimiento(solicitud);
+        detalle2.setSolicitudMovimiento(solicitud);
+        solicitud.setDetalles(List.of(detalle1, detalle2));
+
+        List<SolicitudMovimientoServiceImpl.PicklistItem> items = service.buildPicklistItems(List.of(solicitud));
+
+        assertThat(items)
+                .hasSize(2)
+                .extracting(SolicitudMovimientoServiceImpl.PicklistItem::lote)
+                .containsExactlyInAnyOrder("L-001", "L-002");
+        assertThat(items)
+                .extracting(SolicitudMovimientoServiceImpl.PicklistItem::almacenOrigen)
+                .contains("Bodega 1", "Bodega 2");
+    }
+
+    @Test
+    @DisplayName("generarPicklist usa cabecera como respaldo cuando no hay detalles")
+    void generarPicklist_sinDetallesUsaCabecera() throws Exception {
+        Producto producto = new Producto();
+        producto.setNombre("Producto sin detalle");
+        UnidadMedida um = new UnidadMedida();
+        um.setNombre("KG");
+        producto.setUnidadMedida(um);
+
+        Almacen origen = Almacen.builder().nombre("Almacen Cabecera").ubicacion("Zona C").build();
+        LoteProducto loteCabecera = new LoteProducto();
+        loteCabecera.setCodigoLote("CAB-001");
+
+        SolicitudMovimiento solicitud = SolicitudMovimiento.builder()
+                .id(3L)
+                .tipoMovimiento(TipoMovimiento.SALIDA)
+                .producto(producto)
+                .lote(loteCabecera)
+                .cantidad(BigDecimal.ONE)
+                .almacenOrigen(origen)
+                .estado(EstadoSolicitudMovimiento.PENDIENTE)
+                .fechaSolicitud(LocalDateTime.now())
+                .detalles(List.of())
+                .build();
+
+        List<SolicitudMovimientoServiceImpl.PicklistItem> items = service.buildPicklistItems(List.of(solicitud));
+
+        assertThat(items)
+                .hasSize(1)
+                .first()
+                .satisfies(item -> {
+                    assertThat(item.lote()).isEqualTo("CAB-001");
+                    assertThat(item.almacenOrigen()).isEqualTo("Almacen Cabecera");
+                    assertThat(item.ubicacionOrigen()).isEqualTo("Zona C");
+                    assertThat(item.producto()).isEqualTo("Producto sin detalle");
+                });
+    }
+
+    private SolicitudMovimiento crearSolicitudConDetalle(String nombreProducto,
+                                                         String codigoLote,
+                                                         String nombreAlmacenOrigen,
+                                                         String ubicacionAlmacenOrigen,
+                                                         String nombreAlmacenDestino,
+                                                         String ubicacionDestino,
+                                                         BigDecimal cantidad) {
+        SolicitudMovimiento solicitud = crearSolicitudBase(nombreProducto, "GRM");
+
+        Almacen origen = Almacen.builder().nombre(nombreAlmacenOrigen).ubicacion(ubicacionAlmacenOrigen).build();
+        Almacen destino = Almacen.builder().nombre(nombreAlmacenDestino).ubicacion(ubicacionDestino).build();
+        LoteProducto lote = new LoteProducto();
+        lote.setCodigoLote(codigoLote);
+
+        SolicitudMovimientoDetalle detalle = SolicitudMovimientoDetalle.builder()
+                .lote(lote)
+                .cantidad(cantidad)
+                .almacenOrigen(origen)
+                .almacenDestino(destino)
+                .build();
+        detalle.setSolicitudMovimiento(solicitud);
+        solicitud.setDetalles(List.of(detalle));
+
+        return solicitud;
+    }
+
+    private SolicitudMovimientoDetalle crearDetalle(String codigoLote, String nombreAlmacen, String ubicacion, BigDecimal cantidad) {
+        LoteProducto lote = new LoteProducto();
+        lote.setCodigoLote(codigoLote);
+        Almacen origen = Almacen.builder().nombre(nombreAlmacen).ubicacion(ubicacion).build();
+
+        return SolicitudMovimientoDetalle.builder()
+                .lote(lote)
+                .cantidad(cantidad)
+                .almacenOrigen(origen)
+                .build();
+    }
+
+    private SolicitudMovimiento crearSolicitudBase(String nombreProducto, String nombreUnidad) {
+        UnidadMedida um = new UnidadMedida();
+        um.setNombre(nombreUnidad);
+
+        Producto producto = new Producto();
+        producto.setNombre(nombreProducto);
+        producto.setUnidadMedida(um);
+
+        OrdenProduccion ordenProduccion = OrdenProduccion.builder()
+                .id(1L)
+                .codigoOrden("OP-TEST")
+                .fechaInicio(LocalDateTime.now())
+                .build();
+
+        return SolicitudMovimiento.builder()
+                .id(1L)
+                .tipoMovimiento(TipoMovimiento.SALIDA)
+                .producto(producto)
+                .ordenProduccion(ordenProduccion)
+                .usuarioSolicitante(new Usuario())
+                .estado(EstadoSolicitudMovimiento.PENDIENTE)
+                .fechaSolicitud(LocalDateTime.now())
+                .observaciones("Observacion prueba")
+                .build();
+    }
+
+}


### PR DESCRIPTION
## Summary
- build picklist rows from movement details so lot and origin data reach the PDF
- add a reusable PicklistItem builder that falls back to header data when there are no details
- cover single, multiple, and header-only picklist scenarios with unit tests

## Testing
- mvn -q -DskipITs -Dtest=SolicitudMovimientoServicePicklistTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224c06cb508333a695f047be34aa41)