### PR TITLE
Implement simple MRP backend module

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoRequestDTO.java
@@ -50,6 +50,18 @@ public class ProductoRequestDTO {
     @DecimalMin(value = "0.00", message = "Debe ser >= 0.00")
     private BigDecimal rendimientoUnidad;
 
+    private Integer leadTimeCompraDias;
+
+    private Integer leadTimeProduccionDias;
+
+    @Digits(integer = 19, fraction = 6, message = "Máximo 19 enteros y 6 decimales")
+    @DecimalMin(value = "0.00", message = "Debe ser >= 0.00")
+    private BigDecimal stockSeguridad;
+
+    @Digits(integer = 19, fraction = 6, message = "Máximo 19 enteros y 6 decimales")
+    @DecimalMin(value = "0.00", message = "Debe ser >= 0.00")
+    private BigDecimal stockMaximoPlaneacion;
+
     public String getTipoAnalisisCalidad() {return tipoAnalisisCalidad;}
     public void setTipoAnalisisCalidad(String tipoAnalisisCalidad) {this.tipoAnalisisCalidad = tipoAnalisisCalidad;}
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResponseDTO.java
@@ -23,6 +23,10 @@ public class ProductoResponseDTO {
     private BigDecimal stockDisponible;
     private BigDecimal stockMinimo;
     private BigDecimal stockMinimoProveedor;
+    private Integer leadTimeCompraDias;
+    private Integer leadTimeProduccionDias;
+    private BigDecimal stockSeguridad;
+    private BigDecimal stockMaximoPlaneacion;
     private Boolean activo;
     private String tipoAnalisisCalidad;
     private BigDecimal rendimiento;
@@ -46,6 +50,10 @@ public class ProductoResponseDTO {
         this.descripcionProducto = producto.getDescripcionProducto();
         this.stockMinimo = producto.getStockMinimo();
         this.stockMinimoProveedor = producto.getStockMinimoProveedor();
+        this.leadTimeCompraDias = producto.getLeadTimeCompraDias();
+        this.leadTimeProduccionDias = producto.getLeadTimeProduccionDias();
+        this.stockSeguridad = producto.getStockSeguridad();
+        this.stockMaximoPlaneacion = producto.getStockMaximoPlaneacion();
         this.activo = producto.isActivo();
         this.tipoAnalisisCalidad = producto.getTipoAnalisisCalidad() != null
                 ? producto.getTipoAnalisisCalidad().name()

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
@@ -80,6 +80,12 @@ public interface ProductoMapper {
                     entity.getRendimientoUnidad().setScale(2, RoundingMode.HALF_UP)
             );
         }
+        if (entity.getStockSeguridad() != null) {
+            entity.setStockSeguridad(entity.getStockSeguridad().setScale(6, RoundingMode.HALF_UP));
+        }
+        if (entity.getStockMaximoPlaneacion() != null) {
+            entity.setStockMaximoPlaneacion(entity.getStockMaximoPlaneacion().setScale(6, RoundingMode.HALF_UP));
+        }
     }
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/Producto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/Producto.java
@@ -41,6 +41,18 @@ public class Producto {
     @Column(name = "stock_minimo_proveedor")
     private BigDecimal stockMinimoProveedor;
 
+    @Column(name = "lead_time_compra_dias")
+    private Integer leadTimeCompraDias;
+
+    @Column(name = "lead_time_produccion_dias")
+    private Integer leadTimeProduccionDias;
+
+    @Column(name = "stock_seguridad", precision = 19, scale = 6)
+    private BigDecimal stockSeguridad;
+
+    @Column(name = "stock_maximo_planeacion", precision = 19, scale = 6)
+    private BigDecimal stockMaximoPlaneacion;
+
     /**
      * Rendimiento de producción expresado en la unidad del producto.
      * Representa, por ejemplo, el volumen por unidad de empaque.
@@ -130,6 +142,15 @@ public class Producto {
     public void setRendimientoUnidad(BigDecimal rendimientoUnidad) {this.rendimientoUnidad = rendimientoUnidad;}
     public ModoControlInventario getModoControlInventario() {return modoControlInventario;}
     public void setModoControlInventario(ModoControlInventario modoControlInventario) {this.modoControlInventario = modoControlInventario;}
+
+    public Integer getLeadTimeCompraDias() {return leadTimeCompraDias;}
+    public void setLeadTimeCompraDias(Integer leadTimeCompraDias) {this.leadTimeCompraDias = leadTimeCompraDias;}
+    public Integer getLeadTimeProduccionDias() {return leadTimeProduccionDias;}
+    public void setLeadTimeProduccionDias(Integer leadTimeProduccionDias) {this.leadTimeProduccionDias = leadTimeProduccionDias;}
+    public BigDecimal getStockSeguridad() {return stockSeguridad;}
+    public void setStockSeguridad(BigDecimal stockSeguridad) {this.stockSeguridad = stockSeguridad;}
+    public BigDecimal getStockMaximoPlaneacion() {return stockMaximoPlaneacion;}
+    public void setStockMaximoPlaneacion(BigDecimal stockMaximoPlaneacion) {this.stockMaximoPlaneacion = stockMaximoPlaneacion;}
 
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/OrdenCompraDetalleRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/OrdenCompraDetalleRepository.java
@@ -2,10 +2,13 @@ package com.willyes.clemenintegra.inventario.repository;
 
 import com.willyes.clemenintegra.inventario.model.OrdenCompra;
 import com.willyes.clemenintegra.inventario.model.OrdenCompraDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 public interface OrdenCompraDetalleRepository extends JpaRepository<OrdenCompraDetalle, Long> {
@@ -31,4 +34,14 @@ public interface OrdenCompraDetalleRepository extends JpaRepository<OrdenCompraD
     ORDER BY AVG(d.valorUnitario) DESC
     """)
     java.util.List<Object[]> productosMasCostosos(@Param("categoria") String categoria);
+
+    @Query("""
+            SELECT COALESCE(SUM(d.cantidad - d.cantidadRecibida), 0)
+            FROM OrdenCompraDetalle d
+            JOIN d.ordenCompra oc
+            WHERE d.producto.id = :productoId
+              AND oc.estado IN :estados
+            """)
+    BigDecimal sumarCantidadPendientePorProductoYEstados(@Param("productoId") Long productoId,
+                                                          @Param("estados") List<EstadoOrdenCompra> estados);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -95,6 +95,10 @@ public class ProductoServiceImpl implements ProductoService {
         return term == null ? "" : term.trim();
     }
 
+    private BigDecimal normalizeToScale6(BigDecimal value) {
+        return value != null ? value.setScale(6, RoundingMode.HALF_UP) : null;
+    }
+
     private ProductoResumenDTO mapToResumenDto(Producto producto) {
         if (producto == null) {
             return null;
@@ -212,6 +216,10 @@ public class ProductoServiceImpl implements ProductoService {
                 .descripcionProducto(dto.getDescripcionProducto())
                 .stockMinimo(dto.getStockMinimo())
                 .stockMinimoProveedor(dto.getStockMinimoProveedor())
+                .leadTimeCompraDias(dto.getLeadTimeCompraDias())
+                .leadTimeProduccionDias(dto.getLeadTimeProduccionDias())
+                .stockSeguridad(normalizeToScale6(dto.getStockSeguridad()))
+                .stockMaximoPlaneacion(normalizeToScale6(dto.getStockMaximoPlaneacion()))
                 .activo(true)
                 .tipoAnalisis(obtenerTipoAnalisisDesdeDto(dto.getTipoAnalisisCalidad()))
                 .fechaCreacion(LocalDateTime.now())
@@ -255,6 +263,10 @@ public class ProductoServiceImpl implements ProductoService {
         producto.setDescripcionProducto(dto.getDescripcionProducto());
         producto.setStockMinimo(dto.getStockMinimo());
         producto.setStockMinimoProveedor(dto.getStockMinimoProveedor());
+        producto.setLeadTimeCompraDias(dto.getLeadTimeCompraDias());
+        producto.setLeadTimeProduccionDias(dto.getLeadTimeProduccionDias());
+        producto.setStockSeguridad(normalizeToScale6(dto.getStockSeguridad()));
+        producto.setStockMaximoPlaneacion(normalizeToScale6(dto.getStockMaximoPlaneacion()));
         producto.setTipoAnalisis(obtenerTipoAnalisisDesdeDto(dto.getTipoAnalisisCalidad()));
         producto.setUnidadMedida(unidad);
         producto.setCategoriaProducto(categoria);

--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlaneacionMrpController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlaneacionMrpController.java
@@ -1,0 +1,67 @@
+package com.willyes.clemenintegra.planeacion.controller;
+
+import com.willyes.clemenintegra.planeacion.dto.CorridaMrpResponseDTO;
+import com.willyes.clemenintegra.planeacion.dto.MrpSimpleRequestDTO;
+import com.willyes.clemenintegra.planeacion.dto.SugerenciaAbastecimientoResponseDTO;
+import com.willyes.clemenintegra.planeacion.service.PlaneacionMrpService;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/planeacion/mrp")
+@RequiredArgsConstructor
+public class PlaneacionMrpController {
+
+    private final PlaneacionMrpService planeacionMrpService;
+
+    @PostMapping("/simple")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    public ResponseEntity<CorridaMrpResponseDTO> ejecutarMrpSimple(@RequestBody MrpSimpleRequestDTO request,
+                                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long usuarioId = userDetails != null ? userDetails.getId() : null;
+        CorridaMrpResponseDTO response = planeacionMrpService.ejecutarMrpSimple(request, usuarioId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/corridas")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Page<CorridaMrpResponseDTO>> listarCorridas(
+            @RequestParam(name = "fechaDesde", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaDesde,
+            @RequestParam(name = "fechaHasta", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaHasta,
+            @RequestParam(name = "modo", required = false) String modo,
+            @PageableDefault(size = 20, sort = "fechaEjecucion") Pageable pageable) {
+        Page<CorridaMrpResponseDTO> page = planeacionMrpService.listarCorridas(fechaDesde, fechaHasta, modo, pageable);
+        return ResponseEntity.ok(page);
+    }
+
+    @GetMapping("/corridas/{id}/sugerencias")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Page<SugerenciaAbastecimientoResponseDTO>> listarSugerenciasPorCorrida(
+            @PathVariable Long id,
+            @PageableDefault(size = 20, sort = "fechaRequerida") Pageable pageable) {
+        Page<SugerenciaAbastecimientoResponseDTO> page = planeacionMrpService.listarSugerenciasPorCorrida(id, pageable);
+        return ResponseEntity.ok(page);
+    }
+
+    @GetMapping("/sugerencias")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Page<SugerenciaAbastecimientoResponseDTO>> listarSugerencias(
+            @RequestParam(name = "corridaId", required = false) Long corridaId,
+            @RequestParam(name = "productoId", required = false) Long productoId,
+            @RequestParam(name = "estado", required = false) String estado,
+            @RequestParam(name = "tipo", required = false) String tipo,
+            @PageableDefault(size = 20, sort = "fechaRequerida") Pageable pageable) {
+        Page<SugerenciaAbastecimientoResponseDTO> page = planeacionMrpService.listarSugerencias(corridaId, productoId, estado, tipo, pageable);
+        return ResponseEntity.ok(page);
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
@@ -1,0 +1,26 @@
+package com.willyes.clemenintegra.planeacion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CorridaMrpResponseDTO {
+    private Long id;
+    private LocalDateTime fechaEjecucion;
+    private LocalDate horizonteDesde;
+    private LocalDate horizonteHasta;
+    private String modo;
+    private Long usuarioEjecutoId;
+    private String resumen;
+    private Integer totalSugerencias;
+    private List<SugerenciaAbastecimientoResponseDTO> sugerencias;
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/MrpSimpleRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/MrpSimpleRequestDTO.java
@@ -1,0 +1,21 @@
+package com.willyes.clemenintegra.planeacion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MrpSimpleRequestDTO {
+    private LocalDate horizonteDesde;
+    private LocalDate horizonteHasta;
+    private List<String> categoriasProducto;
+    private Boolean soloControlStock;
+    private Boolean incluirProductosSinParametros;
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/SugerenciaAbastecimientoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/SugerenciaAbastecimientoResponseDTO.java
@@ -1,0 +1,29 @@
+package com.willyes.clemenintegra.planeacion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SugerenciaAbastecimientoResponseDTO {
+    private Long id;
+    private Long corridaId;
+    private Long productoId;
+    private String productoSku;
+    private String productoNombre;
+    private String categoriaProducto;
+    private String tipoSugerencia;
+    private BigDecimal cantidadSugerida;
+    private LocalDate fechaRequerida;
+    private LocalDate fechaSugeridaPedido;
+    private String estado;
+    private String origen;
+    private String observaciones;
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/mapper/PlaneacionMrpMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/mapper/PlaneacionMrpMapper.java
@@ -1,0 +1,40 @@
+package com.willyes.clemenintegra.planeacion.mapper;
+
+import com.willyes.clemenintegra.planeacion.dto.CorridaMrpResponseDTO;
+import com.willyes.clemenintegra.planeacion.dto.SugerenciaAbastecimientoResponseDTO;
+import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento;
+import org.mapstruct.*;
+
+import java.util.Collections;
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface PlaneacionMrpMapper {
+
+    @Mapping(target = "corridaId", source = "corrida.id")
+    @Mapping(target = "productoId", source = "producto.id")
+    @Mapping(target = "productoSku", expression = "java(entidad.getProducto() != null ? entidad.getProducto().getCodigoSku() : null)")
+    @Mapping(target = "productoNombre", expression = "java(entidad.getProducto() != null ? entidad.getProducto().getNombre() : null)")
+    @Mapping(target = "categoriaProducto", expression = "java(entidad.getProducto() != null && entidad.getProducto().getCategoriaProducto() != null ? entidad.getProducto().getCategoriaProducto().getNombre() : null)")
+    @Mapping(target = "tipoSugerencia", expression = "java(entidad.getTipo() != null ? entidad.getTipo().name() : null)")
+    @Mapping(target = "estado", expression = "java(entidad.getEstado() != null ? entidad.getEstado().name() : null)")
+    @Mapping(target = "origen", expression = "java(entidad.getOrigen() != null ? entidad.getOrigen().name() : null)")
+    SugerenciaAbastecimientoResponseDTO toDto(SugerenciaAbastecimiento entidad);
+
+    List<SugerenciaAbastecimientoResponseDTO> toDtos(List<SugerenciaAbastecimiento> entidades);
+
+    @Mapping(target = "modo", expression = "java(\"MRP_SIMPLE\")")
+    @Mapping(target = "totalSugerencias", expression = "java(corrida.getSugerencias() != null ? corrida.getSugerencias().size() : 0)")
+    @Mapping(target = "sugerencias", source = "sugerencias")
+    CorridaMrpResponseDTO toDto(CorridaMrp corrida);
+
+    default CorridaMrpResponseDTO toDtoSinSugerencias(CorridaMrp corrida) {
+        if (corrida == null) {
+            return null;
+        }
+        CorridaMrpResponseDTO dto = toDto(corrida);
+        dto.setSugerencias(Collections.emptyList());
+        return dto;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/CorridaMrp.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/CorridaMrp.java
@@ -1,0 +1,48 @@
+package com.willyes.clemenintegra.planeacion.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "corridas_mrp")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CorridaMrp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "fecha_ejecucion", nullable = false)
+    private LocalDateTime fechaEjecucion;
+
+    @Column(name = "horizonte_desde")
+    private LocalDate horizonteDesde;
+
+    @Column(name = "horizonte_hasta")
+    private LocalDate horizonteHasta;
+
+    @Column(name = "usuario_ejecuto_id")
+    private Long usuarioEjecutoId;
+
+    @Column(name = "resumen", length = 1000)
+    private String resumen;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "corrida", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SugerenciaAbastecimiento> sugerencias = new ArrayList<>();
+
+    @PrePersist
+    public void prePersist() {
+        if (fechaEjecucion == null) {
+            fechaEjecucion = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/SugerenciaAbastecimiento.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/SugerenciaAbastecimiento.java
@@ -1,0 +1,62 @@
+package com.willyes.clemenintegra.planeacion.model;
+
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoSugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.model.enums.OrigenSugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoSugerenciaAbastecimiento;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "sugerencias_abastecimiento")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SugerenciaAbastecimiento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "corrida_mrp_id", nullable = false, foreignKey = @ForeignKey(name = "fk_sug_corrida"))
+    private CorridaMrp corrida;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "producto_id", nullable = false, foreignKey = @ForeignKey(name = "fk_sug_producto"))
+    private Producto producto;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false, length = 30)
+    private TipoSugerenciaAbastecimiento tipo;
+
+    @Column(name = "cantidad_sugerida", nullable = false, precision = 19, scale = 6)
+    private BigDecimal cantidadSugerida;
+
+    @Column(name = "fecha_requerida", nullable = false)
+    private LocalDate fechaRequerida;
+
+    @Column(name = "fecha_sugerida_pedido")
+    private LocalDate fechaSugeridaPedido;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado", nullable = false, length = 30)
+    private EstadoSugerenciaAbastecimiento estado;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "origen", nullable = false, length = 30)
+    private OrigenSugerenciaAbastecimiento origen;
+
+    @Column(name = "observaciones", length = 1000)
+    private String observaciones;
+
+    @Column(name = "orden_compra_id")
+    private Long ordenCompraId;
+
+    @Column(name = "orden_produccion_id")
+    private Long ordenProduccionId;
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/EstadoSugerenciaAbastecimiento.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/EstadoSugerenciaAbastecimiento.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.planeacion.model.enums;
+
+public enum EstadoSugerenciaAbastecimiento {
+    PENDIENTE,
+    APROBADA,
+    DESCARTADA,
+    CONVERTIDA
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/OrigenSugerenciaAbastecimiento.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/OrigenSugerenciaAbastecimiento.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.planeacion.model.enums;
+
+public enum OrigenSugerenciaAbastecimiento {
+    MRP_SIMPLE,
+    MRP_OP
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/TipoSugerenciaAbastecimiento.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/TipoSugerenciaAbastecimiento.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.planeacion.model.enums;
+
+public enum TipoSugerenciaAbastecimiento {
+    COMPRA,
+    PRODUCCION
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.planeacion.repository;
+
+import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CorridaMrpRepository extends JpaRepository<CorridaMrp, Long>, JpaSpecificationExecutor<CorridaMrp> {
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/repository/SugerenciaAbastecimientoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/repository/SugerenciaAbastecimientoRepository.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.planeacion.repository;
+
+import com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SugerenciaAbastecimientoRepository extends JpaRepository<SugerenciaAbastecimiento, Long>, JpaSpecificationExecutor<SugerenciaAbastecimiento> {
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpService.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpService.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.planeacion.service;
+
+import com.willyes.clemenintegra.planeacion.dto.CorridaMrpResponseDTO;
+import com.willyes.clemenintegra.planeacion.dto.MrpSimpleRequestDTO;
+import com.willyes.clemenintegra.planeacion.dto.SugerenciaAbastecimientoResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+
+public interface PlaneacionMrpService {
+
+    CorridaMrpResponseDTO ejecutarMrpSimple(MrpSimpleRequestDTO request, Long usuarioId);
+
+    Page<CorridaMrpResponseDTO> listarCorridas(LocalDate fechaDesde, LocalDate fechaHasta, String modo, Pageable pageable);
+
+    Page<SugerenciaAbastecimientoResponseDTO> listarSugerencias(Long corridaId, Long productoId, String estado, String tipo, Pageable pageable);
+
+    Page<SugerenciaAbastecimientoResponseDTO> listarSugerenciasPorCorrida(Long corridaId, Pageable pageable);
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpServiceImpl.java
@@ -1,0 +1,248 @@
+package com.willyes.clemenintegra.planeacion.service;
+
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraDetalleRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.planeacion.dto.CorridaMrpResponseDTO;
+import com.willyes.clemenintegra.planeacion.dto.MrpSimpleRequestDTO;
+import com.willyes.clemenintegra.planeacion.dto.SugerenciaAbastecimientoResponseDTO;
+import com.willyes.clemenintegra.planeacion.mapper.PlaneacionMrpMapper;
+import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoSugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.model.enums.OrigenSugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoSugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
+import com.willyes.clemenintegra.planeacion.repository.SugerenciaAbastecimientoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.criteria.JoinType;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlaneacionMrpServiceImpl implements PlaneacionMrpService {
+
+    private final ProductoRepository productoRepository;
+    private final LoteProductoRepository loteProductoRepository;
+    private final OrdenCompraDetalleRepository ordenCompraDetalleRepository;
+    private final CorridaMrpRepository corridaMrpRepository;
+    private final SugerenciaAbastecimientoRepository sugerenciaAbastecimientoRepository;
+    private final PlaneacionMrpMapper planeacionMrpMapper;
+
+    @Override
+    @Transactional
+    public CorridaMrpResponseDTO ejecutarMrpSimple(MrpSimpleRequestDTO request, Long usuarioId) {
+        MrpSimpleRequestDTO safeRequest = request != null ? request : new MrpSimpleRequestDTO();
+        List<Producto> candidatos = productoRepository.findAll(buildProductoSpecification(safeRequest));
+        log.info("Iniciando corrida MRP simple para {} productos candidatos", candidatos.size());
+
+        List<SugerenciaAbastecimiento> sugerencias = new ArrayList<>();
+        LocalDate fechaRequerida = safeRequest.getHorizonteDesde() != null ? safeRequest.getHorizonteDesde() : LocalDate.now();
+
+        for (Producto producto : candidatos) {
+            BigDecimal stockActual = obtenerStockActual(producto.getId().longValue());
+            BigDecimal pendienteRecepcion = obtenerPendienteRecepcion(producto.getId().longValue());
+            BigDecimal stockProyectado = stockActual.add(pendienteRecepcion);
+
+            BigDecimal stockSeguridad = producto.getStockSeguridad() != null ? producto.getStockSeguridad() : BigDecimal.ZERO;
+            BigDecimal stockMinimo = producto.getStockMinimo() != null ? producto.getStockMinimo() : BigDecimal.ZERO;
+            BigDecimal puntoAccion = stockMinimo.add(stockSeguridad);
+
+            if (stockProyectado.compareTo(puntoAccion) >= 0) {
+                continue;
+            }
+
+            BigDecimal cantidadSugerida = calcularCantidadSugerida(producto.getStockMaximoPlaneacion(), puntoAccion, stockProyectado);
+            LocalDate fechaSugeridaPedido = calcularFechaSugeridaPedido(producto.getLeadTimeCompraDias(), fechaRequerida);
+
+            SugerenciaAbastecimiento sugerencia = SugerenciaAbastecimiento.builder()
+                    .producto(producto)
+                    .tipo(TipoSugerenciaAbastecimiento.COMPRA)
+                    .cantidadSugerida(cantidadSugerida)
+                    .fechaRequerida(fechaRequerida)
+                    // Si no hay lead time de compra, proponemos la misma fecha requerida
+                    .fechaSugeridaPedido(fechaSugeridaPedido)
+                    .estado(EstadoSugerenciaAbastecimiento.PENDIENTE)
+                    .origen(OrigenSugerenciaAbastecimiento.MRP_SIMPLE)
+                    .observaciones(String.format("stockProyectado %s < puntoAccion %s", stockProyectado, puntoAccion))
+                    .build();
+
+            sugerencias.add(sugerencia);
+        }
+
+        CorridaMrp corrida = CorridaMrp.builder()
+                .fechaEjecucion(LocalDateTime.now())
+                .horizonteDesde(safeRequest.getHorizonteDesde())
+                .horizonteHasta(safeRequest.getHorizonteHasta())
+                .usuarioEjecutoId(usuarioId)
+                .resumen(String.format("Sugerencias generadas: %d", sugerencias.size()))
+                .build();
+
+        sugerencias.forEach(s -> s.setCorrida(corrida));
+        corrida.setSugerencias(sugerencias);
+
+        CorridaMrp persistida = corridaMrpRepository.save(corrida);
+        return planeacionMrpMapper.toDto(persistida);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CorridaMrpResponseDTO> listarCorridas(LocalDate fechaDesde, LocalDate fechaHasta, String modo, Pageable pageable) {
+        if (modo != null && !"MRP_SIMPLE".equalsIgnoreCase(modo)) {
+            return Page.empty(pageable);
+        }
+
+        Specification<CorridaMrp> spec = (root, query, cb) -> {
+            List<jakarta.persistence.criteria.Predicate> predicates = new ArrayList<>();
+            if (fechaDesde != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("fechaEjecucion"), fechaDesde.atStartOfDay()));
+            }
+            if (fechaHasta != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("fechaEjecucion"), fechaHasta.plusDays(1).atStartOfDay().minusSeconds(1)));
+            }
+            return cb.and(predicates.toArray(new jakarta.persistence.criteria.Predicate[0]));
+        };
+
+        return corridaMrpRepository.findAll(spec, pageable).map(planeacionMrpMapper::toDtoSinSugerencias);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<SugerenciaAbastecimientoResponseDTO> listarSugerencias(Long corridaId, Long productoId, String estado, String tipo, Pageable pageable) {
+        Specification<SugerenciaAbastecimiento> spec = (root, query, cb) -> {
+            List<jakarta.persistence.criteria.Predicate> predicates = new ArrayList<>();
+            if (corridaId != null) {
+                predicates.add(cb.equal(root.join("corrida", JoinType.INNER).get("id"), corridaId));
+            }
+            if (productoId != null) {
+                predicates.add(cb.equal(root.join("producto", JoinType.INNER).get("id"), productoId));
+            }
+
+            EstadoSugerenciaAbastecimiento estadoEnum = parseEstado(estado);
+            if (estadoEnum != null) {
+                predicates.add(cb.equal(root.get("estado"), estadoEnum));
+            }
+
+            TipoSugerenciaAbastecimiento tipoEnum = parseTipo(tipo);
+            if (tipoEnum != null) {
+                predicates.add(cb.equal(root.get("tipo"), tipoEnum));
+            }
+
+            return cb.and(predicates.toArray(new jakarta.persistence.criteria.Predicate[0]));
+        };
+
+        return sugerenciaAbastecimientoRepository.findAll(spec, pageable).map(planeacionMrpMapper::toDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<SugerenciaAbastecimientoResponseDTO> listarSugerenciasPorCorrida(Long corridaId, Pageable pageable) {
+        return listarSugerencias(corridaId, null, null, null, pageable);
+    }
+
+    private Specification<Producto> buildProductoSpecification(MrpSimpleRequestDTO request) {
+        MrpSimpleRequestDTO safeRequest = request != null ? request : new MrpSimpleRequestDTO();
+        return (root, query, cb) -> {
+            query.distinct(true);
+            List<jakarta.persistence.criteria.Predicate> predicates = new ArrayList<>();
+            boolean soloControlStock = safeRequest.getSoloControlStock() == null || Boolean.TRUE.equals(safeRequest.getSoloControlStock());
+            if (soloControlStock) {
+                predicates.add(cb.equal(root.get("modoControlInventario"), ModoControlInventario.CONTROL_STOCK));
+            }
+            predicates.add(cb.isTrue(root.get("activo")));
+
+            if (safeRequest.getCategoriasProducto() != null && !safeRequest.getCategoriasProducto().isEmpty()) {
+                predicates.add(root.join("categoriaProducto").get("nombre").in(safeRequest.getCategoriasProducto()));
+            }
+            return cb.and(predicates.toArray(new jakarta.persistence.criteria.Predicate[0]));
+        };
+    }
+
+    private BigDecimal obtenerStockActual(Long productoId) {
+        List<Object[]> resultados = loteProductoRepository.sumarPorEstado(productoId);
+        Map<EstadoLote, BigDecimal> porEstado = new EnumMap<>(EstadoLote.class);
+        for (Object[] fila : resultados) {
+            if (fila.length >= 2 && fila[0] instanceof EstadoLote estado) {
+                BigDecimal total = fila[1] != null ? (BigDecimal) fila[1] : BigDecimal.ZERO;
+                porEstado.put(estado, total);
+            }
+        }
+        BigDecimal disponible = porEstado.getOrDefault(EstadoLote.DISPONIBLE, BigDecimal.ZERO);
+        BigDecimal liberado = porEstado.getOrDefault(EstadoLote.LIBERADO, BigDecimal.ZERO);
+        return disponible.add(liberado);
+    }
+
+    private BigDecimal obtenerPendienteRecepcion(Long productoId) {
+        List<EstadoOrdenCompra> estados = List.of(
+                EstadoOrdenCompra.CREADA,
+                EstadoOrdenCompra.ENVIADA,
+                EstadoOrdenCompra.PARCIALMENTE_RECIBIDA
+        );
+        BigDecimal pendiente = ordenCompraDetalleRepository.sumarCantidadPendientePorProductoYEstados(productoId, estados);
+        return pendiente != null ? pendiente : BigDecimal.ZERO;
+    }
+
+    private BigDecimal calcularCantidadSugerida(BigDecimal stockMaximoPlaneacion, BigDecimal puntoAccion, BigDecimal stockProyectado) {
+        BigDecimal cantidad;
+        if (stockMaximoPlaneacion != null) {
+            cantidad = stockMaximoPlaneacion.subtract(stockProyectado);
+            if (cantidad.compareTo(BigDecimal.ZERO) < 0) {
+                cantidad = BigDecimal.ZERO;
+            }
+        } else {
+            cantidad = puntoAccion.subtract(stockProyectado);
+        }
+        return cantidad.setScale(6, RoundingMode.HALF_UP);
+    }
+
+    private LocalDate calcularFechaSugeridaPedido(Integer leadTimeCompraDias, LocalDate fechaRequerida) {
+        if (leadTimeCompraDias != null && leadTimeCompraDias > 0) {
+            return fechaRequerida.minusDays(leadTimeCompraDias);
+        }
+        // Sin lead time explícito, usamos la misma fecha requerida para simplificar la sugerencia.
+        return fechaRequerida;
+    }
+
+    private EstadoSugerenciaAbastecimiento parseEstado(String estado) {
+        if (estado == null || estado.isBlank()) {
+            return null;
+        }
+        try {
+            return EstadoSugerenciaAbastecimiento.valueOf(estado.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            log.warn("Estado de sugerencia inválido recibido: {}", estado);
+            return null;
+        }
+    }
+
+    private TipoSugerenciaAbastecimiento parseTipo(String tipo) {
+        if (tipo == null || tipo.isBlank()) {
+            return null;
+        }
+        try {
+            return TipoSugerenciaAbastecimiento.valueOf(tipo.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            log.warn("Tipo de sugerencia inválido recibido: {}", tipo);
+            return null;
+        }
+    }
+}

--- a/src/main/resources/db/migration/V20251120__planeacion_mrp_simple.sql
+++ b/src/main/resources/db/migration/V20251120__planeacion_mrp_simple.sql
@@ -1,0 +1,31 @@
+ALTER TABLE productos
+    ADD COLUMN lead_time_compra_dias INT NULL,
+    ADD COLUMN lead_time_produccion_dias INT NULL,
+    ADD COLUMN stock_seguridad DECIMAL(19,6) NULL,
+    ADD COLUMN stock_maximo_planeacion DECIMAL(19,6) NULL;
+
+CREATE TABLE corridas_mrp (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    fecha_ejecucion DATETIME NOT NULL,
+    horizonte_desde DATE NULL,
+    horizonte_hasta DATE NULL,
+    usuario_ejecuto_id BIGINT NULL,
+    resumen VARCHAR(1000) NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE sugerencias_abastecimiento (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    corrida_mrp_id BIGINT NOT NULL,
+    producto_id BIGINT NOT NULL,
+    tipo VARCHAR(30) NOT NULL,
+    cantidad_sugerida DECIMAL(19,6) NOT NULL,
+    fecha_requerida DATE NOT NULL,
+    fecha_sugerida_pedido DATE NULL,
+    estado VARCHAR(30) NOT NULL,
+    origen VARCHAR(30) NOT NULL,
+    observaciones VARCHAR(1000) NULL,
+    orden_compra_id BIGINT NULL,
+    orden_produccion_id BIGINT NULL,
+    CONSTRAINT fk_sug_corrida FOREIGN KEY (corrida_mrp_id) REFERENCES corridas_mrp (id),
+    CONSTRAINT fk_sug_producto FOREIGN KEY (producto_id) REFERENCES productos (id)
+) ENGINE=InnoDB;

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpServiceImplTest.java
@@ -1,0 +1,129 @@
+package com.willyes.clemenintegra.planeacion.service;
+
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraDetalleRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.planeacion.dto.CorridaMrpResponseDTO;
+import com.willyes.clemenintegra.planeacion.dto.MrpSimpleRequestDTO;
+import com.willyes.clemenintegra.planeacion.mapper.PlaneacionMrpMapper;
+import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
+import com.willyes.clemenintegra.planeacion.repository.SugerenciaAbastecimientoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlaneacionMrpServiceImplTest {
+
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private OrdenCompraDetalleRepository ordenCompraDetalleRepository;
+    @Mock
+    private CorridaMrpRepository corridaMrpRepository;
+    @Mock
+    private SugerenciaAbastecimientoRepository sugerenciaAbastecimientoRepository;
+
+    private PlaneacionMrpServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        PlaneacionMrpMapper mapper = Mappers.getMapper(PlaneacionMrpMapper.class);
+        service = new PlaneacionMrpServiceImpl(
+                productoRepository,
+                loteProductoRepository,
+                ordenCompraDetalleRepository,
+                corridaMrpRepository,
+                sugerenciaAbastecimientoRepository,
+                mapper
+        );
+
+        when(corridaMrpRepository.save(any(CorridaMrp.class))).thenAnswer(invocation -> {
+            CorridaMrp corrida = invocation.getArgument(0);
+            corrida.setId(1L);
+            if (corrida.getSugerencias() != null) {
+                long idx = 1;
+                for (var sugerencia : corrida.getSugerencias()) {
+                    sugerencia.setId(idx++);
+                }
+            }
+            return corrida;
+        });
+    }
+
+    @Test
+    void generarSugerenciaCuandoStockPorDebajoDePuntoAccion() {
+        Producto producto = Producto.builder()
+                .id(1)
+                .codigoSku("SKU-1")
+                .nombre("Producto 1")
+                .stockMinimo(new BigDecimal("10"))
+                .stockSeguridad(new BigDecimal("2"))
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .categoriaProducto(CategoriaProducto.builder().nombre("CAT").build())
+                .activo(true)
+                .build();
+
+        when(productoRepository.findAll(any(Specification.class))).thenReturn(List.of(producto));
+        List<Object[]> sumas = Collections.singletonList(new Object[]{EstadoLote.DISPONIBLE, new BigDecimal("5")});
+        when(loteProductoRepository.sumarPorEstado(1L)).thenReturn(sumas);
+        when(ordenCompraDetalleRepository.sumarCantidadPendientePorProductoYEstados(eq(1L), anyList()))
+                .thenReturn(new BigDecimal("1"));
+
+        MrpSimpleRequestDTO request = MrpSimpleRequestDTO.builder()
+                .horizonteDesde(LocalDate.of(2024, 1, 10))
+                .build();
+
+        CorridaMrpResponseDTO response = service.ejecutarMrpSimple(request, 10L);
+
+        assertThat(response.getTotalSugerencias()).isEqualTo(1);
+        assertThat(response.getSugerencias()).hasSize(1);
+        assertThat(response.getSugerencias().get(0).getCantidadSugerida())
+                .isEqualByComparingTo(new BigDecimal("6.000000"));
+    }
+
+    @Test
+    void noGenerarSugerenciaCuandoStockCubierto() {
+        Producto producto = Producto.builder()
+                .id(2)
+                .codigoSku("SKU-2")
+                .nombre("Producto 2")
+                .stockMinimo(new BigDecimal("5"))
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .activo(true)
+                .build();
+
+        when(productoRepository.findAll(any(Specification.class))).thenReturn(List.of(producto));
+        List<Object[]> sumas = Collections.singletonList(new Object[]{EstadoLote.DISPONIBLE, new BigDecimal("10")});
+        when(loteProductoRepository.sumarPorEstado(2L)).thenReturn(sumas);
+        when(ordenCompraDetalleRepository.sumarCantidadPendientePorProductoYEstados(eq(2L), anyList()))
+                .thenReturn(BigDecimal.ZERO);
+
+        CorridaMrpResponseDTO response = service.ejecutarMrpSimple(new MrpSimpleRequestDTO(), 20L);
+
+        assertThat(response.getTotalSugerencias()).isZero();
+        assertThat(response.getSugerencias()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- add planning parameters to products and Flyway migration for new planning tables
- introduce planeacion module with entities, DTOs, mapper, service, and controller to run simple MRP
- cover MRP suggestion logic with unit tests and integrate purchase order pending quantities

## Testing
- mvn -q -DskipITs test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69248ebf2e98833390101b6fe67d61c1)