### PR TITLE
Ajustar MRP simple para filtrar por tipo de categoría

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.inventario.repository;
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +14,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import com.willyes.clemenintegra.inventario.dto.StockDisponibleProjection;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,6 +28,13 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
     List<Producto> findByCategoriaProducto_Tipo(String tipo);
     List<Producto> findByCategoriaProducto_TipoIn(List<TipoCategoria> tipos);
     List<Producto> findByCategoriaProducto_TipoAndActivoTrueOrderByNombreAsc(TipoCategoria tipo);
+
+    List<Producto> findByModoControlInventarioAndActivoTrue(ModoControlInventario modo);
+
+    List<Producto> findByModoControlInventarioAndActivoTrueAndCategoriaProducto_TipoIn(
+            ModoControlInventario modo,
+            java.util.Collection<TipoCategoria> tipos
+    );
 
     Optional<Producto> findByCodigoSku(String codigoSku);
     Optional<Producto> findByNombre(String nombre);

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpServiceImpl.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.planeacion.service;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.OrdenCompraDetalleRepository;
@@ -32,9 +33,11 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -52,7 +55,23 @@ public class PlaneacionMrpServiceImpl implements PlaneacionMrpService {
     @Transactional
     public CorridaMrpResponseDTO ejecutarMrpSimple(MrpSimpleRequestDTO request, Long usuarioId) {
         MrpSimpleRequestDTO safeRequest = request != null ? request : new MrpSimpleRequestDTO();
-        List<Producto> candidatos = productoRepository.findAll(buildProductoSpecification(safeRequest));
+        List<TipoCategoria> tiposCategorias = parseTiposCategorias(safeRequest.getCategoriasProducto());
+
+        boolean soloControlStock = safeRequest.getSoloControlStock() == null || Boolean.TRUE.equals(safeRequest.getSoloControlStock());
+
+        List<Producto> candidatos;
+        if (soloControlStock) {
+            if (tiposCategorias.isEmpty()) {
+                candidatos = productoRepository.findByModoControlInventarioAndActivoTrue(ModoControlInventario.CONTROL_STOCK);
+            } else {
+                candidatos = productoRepository.findByModoControlInventarioAndActivoTrueAndCategoriaProducto_TipoIn(
+                        ModoControlInventario.CONTROL_STOCK,
+                        tiposCategorias
+                );
+            }
+        } else {
+            candidatos = productoRepository.findAll(buildProductoSpecification(safeRequest, tiposCategorias));
+        }
         log.info("Iniciando corrida MRP simple para {} productos candidatos", candidatos.size());
 
         List<SugerenciaAbastecimiento> sugerencias = new ArrayList<>();
@@ -159,7 +178,7 @@ public class PlaneacionMrpServiceImpl implements PlaneacionMrpService {
         return listarSugerencias(corridaId, null, null, null, pageable);
     }
 
-    private Specification<Producto> buildProductoSpecification(MrpSimpleRequestDTO request) {
+    private Specification<Producto> buildProductoSpecification(MrpSimpleRequestDTO request, List<TipoCategoria> tiposCategorias) {
         MrpSimpleRequestDTO safeRequest = request != null ? request : new MrpSimpleRequestDTO();
         return (root, query, cb) -> {
             query.distinct(true);
@@ -170,11 +189,32 @@ public class PlaneacionMrpServiceImpl implements PlaneacionMrpService {
             }
             predicates.add(cb.isTrue(root.get("activo")));
 
-            if (safeRequest.getCategoriasProducto() != null && !safeRequest.getCategoriasProducto().isEmpty()) {
-                predicates.add(root.join("categoriaProducto").get("nombre").in(safeRequest.getCategoriasProducto()));
+            if (tiposCategorias != null && !tiposCategorias.isEmpty()) {
+                predicates.add(root.join("categoriaProducto").get("tipo").in(tiposCategorias));
             }
             return cb.and(predicates.toArray(new jakarta.persistence.criteria.Predicate[0]));
         };
+    }
+
+    private List<TipoCategoria> parseTiposCategorias(List<String> categoriasProducto) {
+        if (categoriasProducto == null || categoriasProducto.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return categoriasProducto.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(categoria -> {
+                    try {
+                        return TipoCategoria.valueOf(categoria);
+                    } catch (IllegalArgumentException ex) {
+                        log.warn("Tipo de categoría inválido recibido: {}", categoria);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     private BigDecimal obtenerStockActual(Long productoId) {

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/PlaneacionMrpServiceImplTest.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.OrdenCompraDetalleRepository;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
@@ -19,12 +20,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.jpa.domain.Specification;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -82,11 +82,12 @@ class PlaneacionMrpServiceImplTest {
                 .stockMinimo(new BigDecimal("10"))
                 .stockSeguridad(new BigDecimal("2"))
                 .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
-                .categoriaProducto(CategoriaProducto.builder().nombre("CAT").build())
+                .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.MATERIA_PRIMA).build())
                 .activo(true)
                 .build();
 
-        when(productoRepository.findAll(any(Specification.class))).thenReturn(List.of(producto));
+        when(productoRepository.findByModoControlInventarioAndActivoTrue(ModoControlInventario.CONTROL_STOCK))
+                .thenReturn(List.of(producto));
         List<Object[]> sumas = Collections.singletonList(new Object[]{EstadoLote.DISPONIBLE, new BigDecimal("5")});
         when(loteProductoRepository.sumarPorEstado(1L)).thenReturn(sumas);
         when(ordenCompraDetalleRepository.sumarCantidadPendientePorProductoYEstados(eq(1L), anyList()))
@@ -112,10 +113,12 @@ class PlaneacionMrpServiceImplTest {
                 .nombre("Producto 2")
                 .stockMinimo(new BigDecimal("5"))
                 .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.MATERIA_PRIMA).build())
                 .activo(true)
                 .build();
 
-        when(productoRepository.findAll(any(Specification.class))).thenReturn(List.of(producto));
+        when(productoRepository.findByModoControlInventarioAndActivoTrue(ModoControlInventario.CONTROL_STOCK))
+                .thenReturn(List.of(producto));
         List<Object[]> sumas = Collections.singletonList(new Object[]{EstadoLote.DISPONIBLE, new BigDecimal("10")});
         when(loteProductoRepository.sumarPorEstado(2L)).thenReturn(sumas);
         when(ordenCompraDetalleRepository.sumarCantidadPendientePorProductoYEstados(eq(2L), anyList()))
@@ -125,5 +128,39 @@ class PlaneacionMrpServiceImplTest {
 
         assertThat(response.getTotalSugerencias()).isZero();
         assertThat(response.getSugerencias()).isEmpty();
+    }
+
+    @Test
+    void generarSugerenciaFiltrandoPorTipoCategoria() {
+        Producto producto = Producto.builder()
+                .id(3)
+                .codigoSku("SKU-3")
+                .nombre("Producto 3")
+                .stockMinimo(new BigDecimal("8"))
+                .stockSeguridad(new BigDecimal("2"))
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.MATERIA_PRIMA).build())
+                .activo(true)
+                .build();
+
+        when(productoRepository.findByModoControlInventarioAndActivoTrueAndCategoriaProducto_TipoIn(
+                eq(ModoControlInventario.CONTROL_STOCK),
+                eq(List.of(TipoCategoria.MATERIA_PRIMA))
+        )).thenReturn(List.of(producto));
+
+        List<Object[]> sumas = Collections.singletonList(new Object[]{EstadoLote.DISPONIBLE, new BigDecimal("3")});
+        when(loteProductoRepository.sumarPorEstado(3L)).thenReturn(sumas);
+        when(ordenCompraDetalleRepository.sumarCantidadPendientePorProductoYEstados(eq(3L), anyList()))
+                .thenReturn(BigDecimal.ZERO);
+
+        MrpSimpleRequestDTO request = MrpSimpleRequestDTO.builder()
+                .categoriasProducto(List.of("MATERIA_PRIMA"))
+                .build();
+
+        CorridaMrpResponseDTO response = service.ejecutarMrpSimple(request, 30L);
+
+        assertThat(response.getTotalSugerencias()).isEqualTo(1);
+        assertThat(response.getSugerencias()).hasSize(1);
+        assertThat(response.getSugerencias().get(0).getProductoId()).isEqualTo(3);
     }
 }


### PR DESCRIPTION
## Summary
- Update MRP candidate selection to map requested categories to TipoCategoria and query by category type
- Add repository helpers for CONTROL_STOCK products using category type filters
- Extend service tests to cover category type filtering scenarios

## Testing
- mvn -q test -Dtest=PlaneacionMrpServiceImplTest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924cf67d9008333b47f5a34f9c3434f)