### PR TITLE
Add bulk authorization for solicitudes with tests

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
@@ -103,4 +103,14 @@ public class SolicitudMovimientoController {
         Long usuarioId = usuario.getId();
         return ResponseEntity.ok(service.revertirAutorizacion(id, usuarioId));
     }
+
+    @PostMapping("/{id}/autorizar-todo")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    public ResponseEntity<SolicitudMovimientoResponseDTO> autorizarCompleta(@PathVariable Long id,
+                                                                            Authentication authentication) {
+        String username = authentication.getName();
+        Usuario usuario = usuarioService.buscarPorNombreUsuario(username);
+        Long usuarioId = usuario.getId();
+        return ResponseEntity.ok(service.autorizarSolicitudCompleta(id, usuarioId));
+    }
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoService.java
@@ -23,6 +23,7 @@ public interface SolicitudMovimientoService {
     SolicitudMovimientoResponseDTO aprobarSolicitud(Long id, Long responsableId);
     SolicitudMovimientoResponseDTO rechazarSolicitud(Long id, Long responsableId, String observaciones);
     SolicitudMovimientoResponseDTO revertirAutorizacion(Long id, Long responsableId);
+    SolicitudMovimientoResponseDTO autorizarSolicitudCompleta(Long solicitudId, Long usuarioAutorizadorId);
 
     Page<SolicitudesPorOrdenDTO> listGroupByOrden(List<EstadoSolicitudMovimiento> estados,
                                                   LocalDateTime inicio,

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.inventario.dto.*;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoDetalleRepository.OpDetalleCount;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
@@ -359,6 +360,96 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
         solicitud.setFechaResolucion(null);
         SolicitudMovimiento actualizada = repository.save(solicitud);
         return toResponse(actualizada);
+    }
+
+    @Override
+    @Transactional
+    public SolicitudMovimientoResponseDTO autorizarSolicitudCompleta(Long solicitudId, Long usuarioAutorizadorId) {
+        validarAutenticacion();
+        SolicitudMovimiento solicitud = repository.findByIdWithLock(solicitudId)
+                .orElseThrow(() -> new NoSuchElementException("Solicitud no encontrada"));
+
+        if (solicitud.getEstado() == EstadoSolicitudMovimiento.CANCELADA
+                || solicitud.getEstado() == EstadoSolicitudMovimiento.CERRADA
+                || solicitud.getEstado() == EstadoSolicitudMovimiento.RECHAZADO) {
+            throw new IllegalStateException("La solicitud no admite nuevas autorizaciones en su estado actual: "
+                    + solicitud.getEstado());
+        }
+
+        Usuario responsable = usuarioRepository.findById(usuarioAutorizadorId)
+                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado"));
+
+        int totalPendientes = 0;
+        int totalAutorizados = 0;
+        List<String> errores = new ArrayList<>();
+
+        List<SolicitudMovimientoDetalle> detalles = Optional.ofNullable(solicitud.getDetalles())
+                .orElseGet(Collections::emptyList);
+        for (SolicitudMovimientoDetalle detalle : detalles) {
+            if (!estaPendienteDeAutorizacion(detalle)) {
+                continue;
+            }
+
+            totalPendientes++;
+
+            try {
+                autorizarDetalleInterno(solicitud, detalle, responsable);
+                totalAutorizados++;
+            } catch (RuntimeException ex) {
+                String nombreProducto = obtenerNombreProducto(detalle, solicitud);
+                errores.add(nombreProducto + ": " + ex.getMessage());
+            }
+        }
+
+        if (totalPendientes > 0) {
+            solicitud.setUsuarioResponsable(responsable);
+            solicitud.setFechaResolucion(LocalDateTime.now());
+
+            if (totalAutorizados == totalPendientes && errores.isEmpty()) {
+                solicitud.setEstado(EstadoSolicitudMovimiento.AUTORIZADA);
+            } else if (totalAutorizados > 0 || !errores.isEmpty()) {
+                solicitud.setEstado(EstadoSolicitudMovimiento.PARCIAL);
+            }
+        }
+
+        SolicitudMovimiento actualizada = repository.saveAndFlush(solicitud);
+        reservaLoteService.sincronizarReservasSolicitud(actualizada);
+        return toResponse(actualizada);
+    }
+
+    private void autorizarDetalleInterno(SolicitudMovimiento solicitud,
+                                         SolicitudMovimientoDetalle detalle,
+                                         Usuario responsable) {
+        if (solicitud.getEstado() == EstadoSolicitudMovimiento.CANCELADA
+                || solicitud.getEstado() == EstadoSolicitudMovimiento.CERRADA
+                || solicitud.getEstado() == EstadoSolicitudMovimiento.RECHAZADO) {
+            throw new IllegalStateException("La solicitud no admite nuevas autorizaciones");
+        }
+
+        if (!estaPendienteDeAutorizacion(detalle)) {
+            throw new IllegalStateException("El detalle ya fue procesado");
+        }
+        if (detalle.getLote() == null || detalle.getLote().getId() == null) {
+            throw new IllegalArgumentException("El detalle no tiene lote asignado");
+        }
+
+        solicitud.setUsuarioResponsable(responsable);
+        reservaLoteService.crearOActualizarDesdeDetalle(detalle);
+    }
+
+    private boolean estaPendienteDeAutorizacion(SolicitudMovimientoDetalle detalle) {
+        EstadoSolicitudMovimientoDetalle estado = detalle != null ? detalle.getEstado() : null;
+        return estado == null
+                || estado == EstadoSolicitudMovimientoDetalle.PENDIENTE
+                || estado == EstadoSolicitudMovimientoDetalle.PARCIAL;
+    }
+
+    private String obtenerNombreProducto(SolicitudMovimientoDetalle detalle, SolicitudMovimiento solicitud) {
+        Producto producto = Optional.ofNullable(detalle)
+                .map(SolicitudMovimientoDetalle::getLote)
+                .map(LoteProducto::getProducto)
+                .orElseGet(() -> solicitud != null ? solicitud.getProducto() : null);
+        return producto != null ? producto.getNombre() : "Insumo";
     }
 
     private void validarAutenticacion() {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceAutorizacionCompletaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceAutorizacionCompletaTest.java
@@ -1,0 +1,163 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SolicitudMovimientoServiceAutorizacionCompletaTest {
+
+    @Mock
+    private SolicitudMovimientoRepository repository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private LoteProductoRepository loteRepository;
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private ReservaLoteService reservaLoteService;
+
+    @InjectMocks
+    private SolicitudMovimientoServiceImpl service;
+
+    private static final AtomicLong DETALLE_ID = new AtomicLong(1);
+
+    @Test
+    @DisplayName("autorizarSolicitudCompleta aprueba todos los detalles pendientes")
+    void autorizarSolicitudCompleta_casoFeliz() {
+        SolicitudMovimiento solicitud = crearSolicitudConDetalles(List.of(
+                crearDetalle("L-1", "Insumo 1"),
+                crearDetalle("L-2", "Insumo 2"),
+                crearDetalle("L-3", "Insumo 3")
+        ));
+
+        Usuario responsable = new Usuario();
+        responsable.setId(10L);
+
+        ArgumentCaptor<SolicitudMovimiento> captor = ArgumentCaptor.forClass(SolicitudMovimiento.class);
+
+        when(repository.findByIdWithLock(1L)).thenReturn(Optional.of(solicitud));
+        when(usuarioRepository.findById(10L)).thenReturn(Optional.of(responsable));
+        when(repository.saveAndFlush(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        mockAutenticacion();
+
+        assertThat(solicitud.getDetalles()).hasSize(3);
+        var respuesta = service.autorizarSolicitudCompleta(1L, 10L);
+
+        assertThat(respuesta.getEstado()).isEqualTo(EstadoSolicitudMovimiento.AUTORIZADA);
+        assertThat(respuesta.getFechaResolucion()).isNotNull();
+        verify(reservaLoteService, times(3)).crearOActualizarDesdeDetalle(any());
+        assertThat(captor.getValue().getEstado()).isEqualTo(EstadoSolicitudMovimiento.AUTORIZADA);
+    }
+
+    @Test
+    @DisplayName("autorizarSolicitudCompleta marca PARCIAL cuando algún detalle falla")
+    void autorizarSolicitudCompleta_casoParcial() {
+        SolicitudMovimientoDetalle detalleFallido = crearDetalle("L-1", "Insumo sin stock");
+        SolicitudMovimiento solicitud = crearSolicitudConDetalles(List.of(
+                crearDetalle("L-2", "Insumo ok 1"),
+                crearDetalle("L-3", "Insumo ok 2"),
+                detalleFallido
+        ));
+        solicitud.setId(2L);
+
+        Usuario responsable = new Usuario();
+        responsable.setId(20L);
+
+        ArgumentCaptor<SolicitudMovimiento> captor = ArgumentCaptor.forClass(SolicitudMovimiento.class);
+
+        when(repository.findByIdWithLock(2L)).thenReturn(Optional.of(solicitud));
+        when(usuarioRepository.findById(20L)).thenReturn(Optional.of(responsable));
+        when(repository.saveAndFlush(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        doThrow(new RuntimeException("STOCK_INSUFICIENTE"))
+                .when(reservaLoteService).crearOActualizarDesdeDetalle(detalleFallido);
+
+        mockAutenticacion();
+
+        assertThat(solicitud.getDetalles()).hasSize(3);
+        var respuesta = service.autorizarSolicitudCompleta(2L, 20L);
+
+        assertThat(respuesta.getEstado()).isEqualTo(EstadoSolicitudMovimiento.PARCIAL);
+        assertThat(respuesta.getFechaResolucion()).isNotNull();
+        verify(reservaLoteService, times(3)).crearOActualizarDesdeDetalle(any());
+        assertThat(captor.getValue().getEstado()).isEqualTo(EstadoSolicitudMovimiento.PARCIAL);
+    }
+
+    private SolicitudMovimiento crearSolicitudConDetalles(List<SolicitudMovimientoDetalle> detalles) {
+        SolicitudMovimiento solicitud = SolicitudMovimiento.builder()
+                .id(1L)
+                .estado(EstadoSolicitudMovimiento.PENDIENTE)
+                .fechaSolicitud(LocalDateTime.now())
+                .detalles(detalles)
+                .build();
+        return solicitud;
+    }
+
+    private SolicitudMovimientoDetalle crearDetalle(String codigoLote, String nombreProducto) {
+        Producto producto = new Producto();
+        producto.setNombre(nombreProducto);
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId((long) codigoLote.hashCode());
+        lote.setCodigoLote(codigoLote);
+        lote.setProducto(producto);
+
+        return SolicitudMovimientoDetalle.builder()
+                .id(DETALLE_ID.getAndIncrement())
+                .lote(lote)
+                .cantidad(BigDecimal.ONE)
+                .estado(EstadoSolicitudMovimientoDetalle.PENDIENTE)
+                .build();
+    }
+
+    private void mockAutenticacion() {
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        SecurityContext context = mock(SecurityContext.class);
+        when(context.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+}


### PR DESCRIPTION
## Summary
- add a service method to authorize all pending detalles in a solicitud with shared validation logic
- expose a bulk authorization endpoint on SolicitudMovimientoController with appropriate roles
- add unit tests covering full and partial authorization scenarios

## Testing
- mvn -q -Dtest=SolicitudMovimientoServiceAutorizacionCompletaTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e29cc6448333bc123d7d568e8e2d)