### PR TITLE
Fix weekly plan date mapping and validation

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/PlanProduccionSemanalDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/PlanProduccionSemanalDTO.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.planeacion.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,7 +16,11 @@ import java.util.List;
 @AllArgsConstructor
 public class PlanProduccionSemanalDTO {
     private Long id;
+
+    @JsonAlias({"fechaInicio"})
     private LocalDate semanaInicio;
+
+    @JsonAlias({"fechaFin"})
     private LocalDate semanaFin;
     private String estado;
     private String comentarios;

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
@@ -66,6 +66,10 @@ public class PlanProduccionServiceImpl implements PlanProduccionService {
             });
         }
 
+        if (plan.getSemanaInicio() == null || plan.getSemanaFin() == null) {
+            throw new IllegalArgumentException("La semana objetivo debe tener fecha de inicio y fecha de fin.");
+        }
+
         return planProduccionSemanalRepository.save(plan);
     }
 

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
@@ -1,0 +1,51 @@
+package com.willyes.clemenintegra.planeacion.service.impl;
+
+import com.willyes.clemenintegra.planeacion.dto.PlanProduccionSemanalDTO;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.repository.PlanProduccionSemanalRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlanProduccionServiceImplTest {
+
+    @Mock
+    private PlanProduccionSemanalRepository planProduccionSemanalRepository;
+
+    @InjectMocks
+    private PlanProduccionServiceImpl service;
+
+    @Test
+    void crearPlanAsignaSemanas() {
+        LocalDate inicio = LocalDate.of(2025, 11, 24);
+        LocalDate fin = LocalDate.of(2025, 11, 30);
+        PlanProduccionSemanalDTO dto = PlanProduccionSemanalDTO.builder()
+                .semanaInicio(inicio)
+                .semanaFin(fin)
+                .build();
+
+        when(planProduccionSemanalRepository.save(any(PlanProduccionSemanal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        PlanProduccionSemanal plan = service.crearOActualizar(dto);
+
+        assertEquals(inicio, plan.getSemanaInicio());
+        assertEquals(fin, plan.getSemanaFin());
+    }
+
+    @Test
+    void crearPlanSinSemanasLanzaError() {
+        PlanProduccionSemanalDTO dto = new PlanProduccionSemanalDTO();
+
+        assertThrows(IllegalArgumentException.class, () -> service.crearOActualizar(dto));
+    }
+}


### PR DESCRIPTION
## Summary
- accept frontend date fields for weekly plans via JSON aliases
- validate semanaInicio y semanaFin before persisting planes semanales
- add unit tests covering date assignment and null date validation

## Testing
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925eb135ff883338490e64902198b91)