### PR TITLE
Agregar exportes MRP y exponer datos de insumos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
@@ -7,13 +7,19 @@ import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
 import com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento;
 import com.willyes.clemenintegra.planeacion.service.MrpService;
+import com.willyes.clemenintegra.planeacion.service.MrpReporteService;
 import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.NoSuchElementException;
+import java.util.Map;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -25,6 +31,7 @@ public class MrpController {
 
     private final MrpService mrpService;
     private final PlanProduccionService planProduccionService;
+    private final MrpReporteService mrpReporteService;
 
     @PostMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
@@ -39,9 +46,41 @@ public class MrpController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
-    public ResponseEntity<CorridaMrpResponseDTO> obtener(@PathVariable Long id) {
-        CorridaMrp corrida = mrpService.obtenerCorrida(id);
-        return ResponseEntity.ok(toDto(corrida));
+    public ResponseEntity<?> obtener(@PathVariable Long id) {
+        try {
+            CorridaMrp corrida = mrpService.obtenerCorrida(id);
+            return ResponseEntity.ok(toDto(corrida));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/{id}/excel")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    public ResponseEntity<?> exportarExcel(@PathVariable Long id) {
+        try {
+            byte[] excel = mrpReporteService.generarExcelCorrida(id);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"mrp_corrida_" + id + ".xlsx\"")
+                    .body(excel);
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/{id}/pdf")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    public ResponseEntity<?> exportarPdf(@PathVariable Long id) {
+        try {
+            byte[] pdf = mrpReporteService.generarPdfCorrida(id);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_PDF)
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"mrp_corrida_" + id + ".pdf\"")
+                    .body(pdf);
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", e.getMessage()));
+        }
     }
 
     private CorridaMrpResponseDTO toDto(CorridaMrp corrida) {
@@ -75,6 +114,9 @@ public class MrpController {
                 .productoId(producto != null && producto.getId() != null ? producto.getId().longValue() : null)
                 .productoSku(producto != null ? producto.getCodigoSku() : null)
                 .productoNombre(producto != null ? producto.getNombre() : null)
+                .codigoInsumo(producto != null ? producto.getCodigoSku() : null)
+                .nombreInsumo(producto != null ? producto.getNombre() : null)
+                .categoriaInsumo(producto != null && producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getNombre() : null)
                 .requerimientoBruto(detalle.getRequerimientoBruto())
                 .inventarioDisponible(detalle.getInventarioDisponible())
                 .recepcionesProgramadas(detalle.getRecepcionesProgramadas())

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
@@ -34,6 +34,9 @@ public class CorridaMrpResponseDTO {
         private Long productoId;
         private String productoSku;
         private String productoNombre;
+        private String codigoInsumo;
+        private String nombreInsumo;
+        private String categoriaInsumo;
         private BigDecimal requerimientoBruto;
         private BigDecimal inventarioDisponible;
         private BigDecimal recepcionesProgramadas;

--- a/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
@@ -15,6 +15,7 @@ public interface CorridaMrpRepository extends JpaRepository<CorridaMrp, Long> {
             "planProduccionSemanal",
             "detalles",
             "detalles.producto",
+            "detalles.producto.categoriaProducto",
             "detalles.sugerencia",
             "detalles.sugerencia.detalleCorrida"
     })

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/MrpReporteService.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/MrpReporteService.java
@@ -1,0 +1,203 @@
+package com.willyes.clemenintegra.planeacion.service;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoSugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StreamUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.text.NumberFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MrpReporteService {
+
+    private static final Locale ES_CO = new Locale("es", "CO");
+
+    private final CorridaMrpRepository corridaMrpRepository;
+
+    @Transactional(readOnly = true)
+    public byte[] generarExcelCorrida(Long corridaId) {
+        CorridaMrp corrida = cargarCorrida(corridaId);
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("MRP");
+            int rowIdx = 0;
+
+            Row titulo = sheet.createRow(rowIdx++);
+            titulo.createCell(0).setCellValue("Resumen de Corrida MRP");
+
+            Row filaNumero = sheet.createRow(rowIdx++);
+            filaNumero.createCell(0).setCellValue("Número de corrida");
+            filaNumero.createCell(1).setCellValue(Optional.ofNullable(corrida.getId()).orElse(0L));
+
+            Row filaPlan = sheet.createRow(rowIdx++);
+            filaPlan.createCell(0).setCellValue("Plan semanal");
+            filaPlan.createCell(1).setCellValue(corrida.getPlanProduccionSemanal() != null ?
+                    String.valueOf(corrida.getPlanProduccionSemanal().getId()) : "");
+
+            Row filaFechas = sheet.createRow(rowIdx++);
+            filaFechas.createCell(0).setCellValue("Rango de fechas");
+            filaFechas.createCell(1).setCellValue(formatearFecha(corrida.getHorizonteInicio()) + " - " + formatearFecha(corrida.getHorizonteFin()));
+
+            Row filaEjecucion = sheet.createRow(rowIdx++);
+            filaEjecucion.createCell(0).setCellValue("Fecha de ejecución");
+            filaEjecucion.createCell(1).setCellValue(formatearFechaHora(corrida.getFechaEjecucion()));
+
+            rowIdx++;
+            Row encabezado = sheet.createRow(rowIdx++);
+            String[] columnas = new String[]{
+                    "Código insumo", "Nombre", "Categoría", "Requerimiento bruto",
+                    "Inventario disponible", "Requerimiento neto", "Tipo sugerencia"
+            };
+            for (int i = 0; i < columnas.length; i++) {
+                encabezado.createCell(i).setCellValue(columnas[i]);
+            }
+
+            for (DetalleCorridaMrp detalle : Optional.ofNullable(corrida.getDetalles()).orElse(List.of())) {
+                Row fila = sheet.createRow(rowIdx++);
+                Producto producto = detalle.getProducto();
+                CategoriaProducto categoria = producto != null ? producto.getCategoriaProducto() : null;
+                SugerenciaAbastecimiento sugerencia = detalle.getSugerencia();
+
+                int col = 0;
+                fila.createCell(col++).setCellValue(producto != null ? nz(producto.getCodigoSku()) : "");
+                fila.createCell(col++).setCellValue(producto != null ? nz(producto.getNombre()) : "");
+                fila.createCell(col++).setCellValue(categoria != null ? nz(categoria.getNombre()) : "");
+                setNumeric(fila.createCell(col++), detalle.getRequerimientoBruto());
+                setNumeric(fila.createCell(col++), detalle.getInventarioDisponible());
+                setNumeric(fila.createCell(col++), detalle.getRequerimientoNeto());
+                fila.createCell(col).setCellValue(formatearTipoSugerencia(sugerencia));
+            }
+
+            for (int i = 0; i < columnas.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(out);
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("No se pudo generar el Excel de la corrida MRP", e);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public byte[] generarPdfCorrida(Long corridaId) {
+        CorridaMrp corrida = cargarCorrida(corridaId);
+        String html = componerHtml(corrida);
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PdfRendererBuilder builder = new PdfRendererBuilder();
+            builder.useFastMode();
+            builder.withHtmlContent(html, null);
+            builder.toStream(out);
+            builder.run();
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("No se pudo generar el PDF de la corrida MRP", e);
+        }
+    }
+
+    private CorridaMrp cargarCorrida(Long corridaId) {
+        return corridaMrpRepository.findWithDetallesById(corridaId)
+                .orElseThrow(() -> new NoSuchElementException("Corrida MRP no encontrada"));
+    }
+
+    private String componerHtml(CorridaMrp corrida) {
+        String template = loadTemplate("templates/mrp/mrp-resumen.ftl");
+        template = template.replace("${numeroCorrida}", Optional.ofNullable(corrida.getId()).map(String::valueOf).orElse("-"));
+        template = template.replace("${planId}", corrida.getPlanProduccionSemanal() != null ? String.valueOf(corrida.getPlanProduccionSemanal().getId()) : "-");
+        template = template.replace("${fechaInicio}", formatearFecha(corrida.getHorizonteInicio()));
+        template = template.replace("${fechaFin}", formatearFecha(corrida.getHorizonteFin()));
+        template = template.replace("${fechaEjecucion}", formatearFechaHora(corrida.getFechaEjecucion()));
+
+        StringBuilder filas = new StringBuilder();
+        for (DetalleCorridaMrp detalle : Optional.ofNullable(corrida.getDetalles()).orElse(List.of())) {
+            Producto producto = detalle.getProducto();
+            CategoriaProducto categoria = producto != null ? producto.getCategoriaProducto() : null;
+            SugerenciaAbastecimiento sugerencia = detalle.getSugerencia();
+
+            filas.append("<tr>")
+                    .append("<td>").append(esc(producto != null ? producto.getCodigoSku() : "")).append("</td>")
+                    .append("<td>").append(esc(producto != null ? producto.getNombre() : "")).append("</td>")
+                    .append("<td>").append(esc(categoria != null ? categoria.getNombre() : "")).append("</td>")
+                    .append("<td class='right'>").append(formNum(detalle.getRequerimientoBruto())).append("</td>")
+                    .append("<td class='right'>").append(formNum(detalle.getInventarioDisponible())).append("</td>")
+                    .append("<td class='right'>").append(formNum(detalle.getRequerimientoNeto())).append("</td>")
+                    .append("<td>").append(esc(formatearTipoSugerencia(sugerencia))).append("</td>")
+                    .append("</tr>");
+        }
+
+        return template.replace("${detalleRows}", filas.toString());
+    }
+
+    private void setNumeric(Cell cell, BigDecimal value) {
+        if (value != null) {
+            cell.setCellValue(value.doubleValue());
+        }
+    }
+
+    private String formatearFecha(LocalDate fecha) {
+        return fecha != null ? fecha.toString() : "-";
+    }
+
+    private String formatearFechaHora(LocalDateTime fecha) {
+        return fecha != null ? fecha.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")) : "-";
+    }
+
+    private String formatearTipoSugerencia(SugerenciaAbastecimiento sugerencia) {
+        if (sugerencia == null || sugerencia.getTipo() == null) {
+            return "NINGUNA";
+        }
+        return sugerencia.getTipo() == TipoSugerenciaAbastecimiento.FABRICAR ? "OP" : "OC";
+    }
+
+    private String loadTemplate(String classpathLocation) {
+        try (InputStream is = new ClassPathResource(classpathLocation).getInputStream()) {
+            return StreamUtils.copyToString(is, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("No se encontró la plantilla: " + classpathLocation, e);
+        }
+    }
+
+    private String esc(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private String nz(String s) {
+        return s == null ? "" : s;
+    }
+
+    private String formNum(BigDecimal v) {
+        NumberFormat nf = NumberFormat.getNumberInstance(ES_CO);
+        nf.setMinimumFractionDigits(2);
+        nf.setMaximumFractionDigits(2);
+        return nf.format(Optional.ofNullable(v).orElse(BigDecimal.ZERO));
+    }
+}

--- a/src/main/resources/templates/mrp/mrp-resumen.ftl
+++ b/src/main/resources/templates/mrp/mrp-resumen.ftl
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <style>
+        body { font-family: Arial, sans-serif; margin: 24px; }
+        h2 { margin-bottom: 4px; }
+        .meta { margin-bottom: 16px; }
+        .meta span { display: inline-block; margin-right: 12px; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ccc; padding: 6px; font-size: 12px; }
+        th { background: #f2f2f2; }
+        .right { text-align: right; }
+    </style>
+</head>
+<body>
+<h2>Resumen corrida MRP</h2>
+<div class="meta">
+    <span><strong>Número:</strong> ${numeroCorrida}</span>
+    <span><strong>Plan semanal:</strong> ${planId}</span>
+    <span><strong>Fecha ejecución:</strong> ${fechaEjecucion}</span>
+    <div><strong>Rango:</strong> ${fechaInicio} - ${fechaFin}</div>
+</div>
+<table>
+    <thead>
+    <tr>
+        <th>Código insumo</th>
+        <th>Nombre</th>
+        <th>Categoría</th>
+        <th>Requerimiento bruto</th>
+        <th>Inventario disponible</th>
+        <th>Requerimiento neto</th>
+        <th>Tipo sugerencia</th>
+    </tr>
+    </thead>
+    <tbody>
+    ${detalleRows}
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
@@ -1,0 +1,102 @@
+package com.willyes.clemenintegra.planeacion.controller;
+
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.service.MrpReporteService;
+import com.willyes.clemenintegra.planeacion.service.MrpService;
+import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = MrpController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MrpControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MrpService mrpService;
+
+    @MockBean
+    private PlanProduccionService planProduccionService;
+
+    @MockBean
+    private MrpReporteService mrpReporteService;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    @Test
+    void obtenerIncluyeDatosDeInsumo() throws Exception {
+        CategoriaProducto categoria = CategoriaProducto.builder()
+                .id(5L)
+                .nombre("Envases")
+                .build();
+        Producto producto = Producto.builder()
+                .id(2)
+                .codigoSku("SKU-01")
+                .nombre("Botella 500ml")
+                .categoriaProducto(categoria)
+                .build();
+
+        DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
+                .id(10L)
+                .producto(producto)
+                .requerimientoBruto(BigDecimal.TEN)
+                .inventarioDisponible(BigDecimal.ONE)
+                .requerimientoNeto(BigDecimal.valueOf(9))
+                .build();
+
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(3L)
+                .semanaInicio(LocalDate.now())
+                .semanaFin(LocalDate.now().plusDays(7))
+                .build();
+
+        CorridaMrp corrida = CorridaMrp.builder()
+                .id(1L)
+                .planProduccionSemanal(plan)
+                .detalles(List.of(detalle))
+                .build();
+
+        when(mrpService.obtenerCorrida(anyLong())).thenReturn(corrida);
+
+        mockMvc.perform(get("/api/mrp/corridas/1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.detalles[0].codigoInsumo").value("SKU-01"))
+                .andExpect(jsonPath("$.detalles[0].nombreInsumo").value("Botella 500ml"))
+                .andExpect(jsonPath("$.detalles[0].categoriaInsumo").value("Envases"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/MrpReporteServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/MrpReporteServiceTest.java
@@ -1,0 +1,105 @@
+package com.willyes.clemenintegra.planeacion.service;
+
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoSugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MrpReporteServiceTest {
+
+    @Mock
+    private CorridaMrpRepository corridaMrpRepository;
+
+    @InjectMocks
+    private MrpReporteService mrpReporteService;
+
+    private CorridaMrp corrida;
+
+    @BeforeEach
+    void setUp() {
+        CategoriaProducto categoria = CategoriaProducto.builder()
+                .id(1L)
+                .nombre("Materia Prima")
+                .build();
+
+        Producto producto = Producto.builder()
+                .id(1)
+                .codigoSku("MAT-001")
+                .nombre("Ácido cítrico")
+                .categoriaProducto(categoria)
+                .build();
+
+        DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
+                .id(1L)
+                .producto(producto)
+                .requerimientoBruto(BigDecimal.valueOf(100))
+                .inventarioDisponible(BigDecimal.valueOf(20))
+                .requerimientoNeto(BigDecimal.valueOf(80))
+                .build();
+
+        SugerenciaAbastecimiento sugerencia = SugerenciaAbastecimiento.builder()
+                .id(5L)
+                .detalleCorrida(detalle)
+                .tipo(TipoSugerenciaAbastecimiento.COMPRA)
+                .cantidadSugerida(BigDecimal.valueOf(80))
+                .fechaNecesidad(LocalDate.now())
+                .estado(null)
+                .build();
+        detalle.setSugerencia(sugerencia);
+
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(3L)
+                .semanaInicio(LocalDate.now())
+                .semanaFin(LocalDate.now().plusDays(7))
+                .build();
+
+        corrida = CorridaMrp.builder()
+                .id(10L)
+                .planProduccionSemanal(plan)
+                .fechaEjecucion(LocalDateTime.now())
+                .detalles(List.of(detalle))
+                .build();
+    }
+
+    @Test
+    void generarExcelCorridaDevuelveContenido() {
+        when(corridaMrpRepository.findWithDetallesById(anyLong())).thenReturn(Optional.of(corrida));
+
+        byte[] excel = mrpReporteService.generarExcelCorrida(10L);
+
+        assertNotNull(excel);
+        assertNotEquals(0, excel.length);
+    }
+
+    @Test
+    void generarPdfCorridaDevuelveContenido() {
+        when(corridaMrpRepository.findWithDetallesById(anyLong())).thenReturn(Optional.of(corrida));
+
+        byte[] pdf = mrpReporteService.generarPdfCorrida(10L);
+
+        assertNotNull(pdf);
+        assertNotEquals(0, pdf.length);
+    }
+}


### PR DESCRIPTION
## Summary
- Añade información de código, nombre y categoría de insumos a la respuesta de corridas MRP y maneja 404 coherentes.
- Incorpora servicio y endpoints para exportar corridas MRP a Excel y PDF con plantilla dedicada.
- Agrega pruebas unitarias y de controlador para los nuevos campos y para la generación de reportes.

## Testing
- `mvn test -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261165628c8333aa8bde48588d64db)