### PR TITLE
Add tipoSugerencia mapping to corrida MRP detalle DTO

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
@@ -123,6 +123,9 @@ public class MrpController {
                 .requerimientoNeto(detalle.getRequerimientoNeto())
                 .nivelBom(detalle.getNivelBom())
                 .mensajeValidacion(detalle.getMensajeValidacion())
+                .tipoSugerencia(detalle.getSugerencia() != null && detalle.getSugerencia().getTipo() != null
+                        ? detalle.getSugerencia().getTipo().name()
+                        : null)
                 .build();
     }
 

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
@@ -43,6 +43,7 @@ public class CorridaMrpResponseDTO {
         private BigDecimal requerimientoNeto;
         private Integer nivelBom;
         private String mensajeValidacion;
+        private String tipoSugerencia;
     }
 
     @Data


### PR DESCRIPTION
## Summary
- add the tipoSugerencia field to DetalleCorridaMrpDTO so the frontend can display the suggestion type per detalle
- map the suggestion type from DetalleCorridaMrp.sugerencia to the DTO while keeping null when no suggestion exists

## Testing
- mvn -DskipTests package

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261ca82d848333b658cd3688474ac8)