### PR TITLE
Ensure MRP detail DTO exposes suggestion metadata

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
@@ -108,15 +108,15 @@ public class MrpController {
     }
 
     private CorridaMrpResponseDTO.DetalleCorridaMrpDTO toDetalleDto(DetalleCorridaMrp detalle) {
-        Producto producto = detalle.getProducto();
+        Producto insumo = detalle.getProducto();
         return CorridaMrpResponseDTO.DetalleCorridaMrpDTO.builder()
                 .id(detalle.getId())
-                .productoId(producto != null && producto.getId() != null ? producto.getId().longValue() : null)
-                .productoSku(producto != null ? producto.getCodigoSku() : null)
-                .productoNombre(producto != null ? producto.getNombre() : null)
-                .codigoInsumo(producto != null ? producto.getCodigoSku() : null)
-                .nombreInsumo(producto != null ? producto.getNombre() : null)
-                .categoriaInsumo(producto != null && producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getNombre() : null)
+                .productoId(insumo != null && insumo.getId() != null ? insumo.getId().longValue() : null)
+                .productoSku(insumo != null ? insumo.getCodigoSku() : null)
+                .productoNombre(insumo != null ? insumo.getNombre() : null)
+                .codigoInsumo(insumo != null ? insumo.getCodigoSku() : null)
+                .nombreInsumo(insumo != null ? insumo.getNombre() : null)
+                .categoriaInsumo(insumo != null && insumo.getCategoriaProducto() != null ? insumo.getCategoriaProducto().getNombre() : null)
                 .requerimientoBruto(detalle.getRequerimientoBruto())
                 .inventarioDisponible(detalle.getInventarioDisponible())
                 .recepcionesProgramadas(detalle.getRecepcionesProgramadas())

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
@@ -36,6 +36,10 @@ public class CorridaMrpResponseDTO {
         private String productoNombre;
         private String codigoInsumo;
         private String nombreInsumo;
+        /**
+         * Nombre de la categoría del insumo (ej. "Materia Prima", "Material de Empaque").
+         * El frontend puede usar este valor directamente para filtros.
+         */
         private String categoriaInsumo;
         private BigDecimal requerimientoBruto;
         private BigDecimal inventarioDisponible;

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
@@ -5,6 +5,8 @@ import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoSugerenciaAbastecimiento;
 import com.willyes.clemenintegra.planeacion.service.MrpReporteService;
 import com.willyes.clemenintegra.planeacion.service.MrpService;
 import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
@@ -78,6 +80,14 @@ class MrpControllerTest {
                 .requerimientoNeto(BigDecimal.valueOf(9))
                 .build();
 
+        SugerenciaAbastecimiento sugerencia = SugerenciaAbastecimiento.builder()
+                .id(11L)
+                .detalleCorrida(detalle)
+                .tipo(TipoSugerenciaAbastecimiento.COMPRA)
+                .cantidadSugerida(BigDecimal.valueOf(9))
+                .build();
+        detalle.setSugerencia(sugerencia);
+
         PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
                 .id(3L)
                 .semanaInicio(LocalDate.now())
@@ -97,6 +107,7 @@ class MrpControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.detalles[0].codigoInsumo").value("SKU-01"))
                 .andExpect(jsonPath("$.detalles[0].nombreInsumo").value("Botella 500ml"))
-                .andExpect(jsonPath("$.detalles[0].categoriaInsumo").value("Envases"));
+                .andExpect(jsonPath("$.detalles[0].categoriaInsumo").value("Envases"))
+                .andExpect(jsonPath("$.detalles[0].tipoSugerencia").value("COMPRA"));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/MrpReporteServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/MrpReporteServiceTest.java
@@ -8,6 +8,11 @@ import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
 import com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento;
 import com.willyes.clemenintegra.planeacion.model.enums.TipoSugerenciaAbastecimiento;
 import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,14 +20,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
+import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
@@ -84,22 +93,55 @@ class MrpReporteServiceTest {
     }
 
     @Test
-    void generarExcelCorridaDevuelveContenido() {
+    void generarExcelCorridaDevuelveContenidoConFilaDatos() throws Exception {
         when(corridaMrpRepository.findWithDetallesById(anyLong())).thenReturn(Optional.of(corrida));
 
         byte[] excel = mrpReporteService.generarExcelCorrida(10L);
 
         assertNotNull(excel);
         assertNotEquals(0, excel.length);
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(excel))) {
+            Sheet sheet = workbook.getSheetAt(0);
+            Row header = findHeaderRow(sheet);
+            Row dataRow = sheet.getRow(header.getRowNum() + 1);
+
+            assertNotNull(dataRow);
+            assertEquals("MAT-001", dataRow.getCell(0).getStringCellValue());
+            assertEquals("Ácido cítrico", dataRow.getCell(1).getStringCellValue());
+            assertEquals("Materia Prima", dataRow.getCell(2).getStringCellValue());
+            assertEquals("OC", dataRow.getCell(6).getStringCellValue());
+        }
     }
 
     @Test
-    void generarPdfCorridaDevuelveContenido() {
+    void generarPdfCorridaDevuelveContenidoConDatos() throws Exception {
         when(corridaMrpRepository.findWithDetallesById(anyLong())).thenReturn(Optional.of(corrida));
 
         byte[] pdf = mrpReporteService.generarPdfCorrida(10L);
 
         assertNotNull(pdf);
         assertNotEquals(0, pdf.length);
+
+        try (PDDocument document = PDDocument.load(pdf)) {
+            String text = new PDFTextStripper().getText(document);
+            String normalized = Normalizer.normalize(text, Normalizer.Form.NFD)
+                    .replaceAll("\\p{M}", "")
+                    .toLowerCase();
+            String flattened = normalized.replaceAll("\\s+", "");
+            assertTrue(flattened.contains("mat-001"));
+            assertTrue(flattened.contains("acidocitrico"));
+            assertTrue(flattened.contains("materiaprima"));
+            assertTrue(flattened.contains("oc"));
+        }
+    }
+
+    private Row findHeaderRow(Sheet sheet) {
+        for (Row row : sheet) {
+            if (row.getCell(0) != null && "Código insumo".equals(row.getCell(0).getStringCellValue())) {
+                return row;
+            }
+        }
+        throw new IllegalStateException("No se encontró la fila de encabezado en el Excel generado");
     }
 }


### PR DESCRIPTION
## Summary
- document the stable category field in `DetalleCorridaMrpDTO` and keep mappings aligned with insumo data
- populate MRP detail DTOs with insumo info including suggestion type from the controller
- extend controller and report service tests to verify JSON and Excel/PDF exports include insumo category and suggestion type

## Testing
- mvn -q test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261fa9ab808333b9d3f607f75fcd67)