### PR TITLE
Restrict planning and MRP access roles

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
@@ -34,7 +34,7 @@ public class MrpController {
     private final MrpReporteService mrpReporteService;
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<CorridaMrpResponseDTO> ejecutar(@RequestBody CorridaMrpRequest request) {
         Optional<PlanProduccionSemanal> plan = planProduccionService.buscarPorId(request.getPlanSemanalId());
         if (plan.isEmpty()) {
@@ -45,7 +45,7 @@ public class MrpController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<?> obtener(@PathVariable Long id) {
         try {
             CorridaMrp corrida = mrpService.obtenerCorrida(id);
@@ -56,7 +56,7 @@ public class MrpController {
     }
 
     @GetMapping("/{id}/excel")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<?> exportarExcel(@PathVariable Long id) {
         try {
             byte[] excel = mrpReporteService.generarExcelCorrida(id);
@@ -70,7 +70,7 @@ public class MrpController {
     }
 
     @GetMapping("/{id}/pdf")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<?> exportarPdf(@PathVariable Long id) {
         try {
             byte[] pdf = mrpReporteService.generarPdfCorrida(id);

--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
@@ -25,12 +25,13 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/planeacion/planes-semanales")
 @RequiredArgsConstructor
+// El plan semanal es responsabilidad del rol Jefe de Producción.
 public class PlanProduccionController {
 
     private final PlanProduccionService planProduccionService;
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<PlanProduccionSemanalDTO> crearOActualizar(@RequestBody PlanProduccionSemanalDTO dto,
                                                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
         if (dto.getCreadoPorId() == null && userDetails != null) {
@@ -41,14 +42,14 @@ public class PlanProduccionController {
     }
 
     @PostMapping("/{id}/confirmar")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<PlanProduccionSemanalDTO> confirmar(@PathVariable Long id) {
         PlanProduccionSemanal plan = planProduccionService.confirmar(id);
         return ResponseEntity.ok(toDto(plan));
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<Page<PlanProduccionSemanalDTO>> listar(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate semanaInicio,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate semanaFin,
@@ -60,7 +61,7 @@ public class PlanProduccionController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<PlanProduccionSemanalDTO> obtener(@PathVariable Long id) {
         return planProduccionService.buscarPorId(id)
                 .map(plan -> ResponseEntity.ok(toDto(plan)))

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -114,11 +114,14 @@ public class SecurityConfig {
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
-                    auth.requestMatchers("/api/planeacion/**", "/api/mrp/**").hasAnyAuthority(
-                            RolUsuario.ROL_JEFE_ALMACENES.name(),
-                            RolUsuario.ROL_SUPER_ADMIN.name(),
+                    auth.requestMatchers("/api/planeacion/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
-                            RolUsuario.ROL_COMPRADOR.name()
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers("/api/mrp/**").hasAnyAuthority(
+                            RolUsuario.ROL_COMPRADOR.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
                     auth.requestMatchers("/api/calidad/**",

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
@@ -14,9 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -32,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = MrpController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(MrpControllerTest.MethodSecurityTestConfig.class)
 class MrpControllerTest {
 
     @Autowired
@@ -58,7 +62,7 @@ class MrpControllerTest {
     @MockBean
     private AuthenticationManager authenticationManager;
 
-    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    @WithMockUser(authorities = "ROL_COMPRADOR")
     @Test
     void obtenerIncluyeDatosDeInsumo() throws Exception {
         CategoriaProducto categoria = CategoriaProducto.builder()
@@ -109,5 +113,40 @@ class MrpControllerTest {
                 .andExpect(jsonPath("$.detalles[0].nombreInsumo").value("Botella 500ml"))
                 .andExpect(jsonPath("$.detalles[0].categoriaInsumo").value("Envases"))
                 .andExpect(jsonPath("$.detalles[0].tipoSugerencia").value("COMPRA"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void obtenerPermiteSuperAdmin() throws Exception {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(4L)
+                .semanaInicio(LocalDate.now())
+                .semanaFin(LocalDate.now().plusDays(7))
+                .build();
+
+        CorridaMrp corrida = CorridaMrp.builder()
+                .id(5L)
+                .planProduccionSemanal(plan)
+                .detalles(List.of())
+                .build();
+
+        when(mrpService.obtenerCorrida(anyLong())).thenReturn(corrida);
+
+        mockMvc.perform(get("/api/mrp/corridas/5")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void obtenerRechazaJefeProduccion() throws Exception {
+        mockMvc.perform(get("/api/mrp/corridas/2")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class MethodSecurityTestConfig {
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerTest.java
@@ -1,0 +1,92 @@
+package com.willyes.clemenintegra.planeacion.controller;
+
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlanProduccionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(PlanProduccionControllerTest.MethodSecurityTestConfig.class)
+class PlanProduccionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PlanProduccionService planProduccionService;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void crearPlanPermiteJefeProduccion() throws Exception {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(1L)
+                .detalles(List.of())
+                .build();
+        when(planProduccionService.crearOActualizar(any())).thenReturn(plan);
+
+        mockMvc.perform(post("/api/planeacion/planes-semanales")
+                        .content("{}")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void listarPlanPermiteSuperAdmin() throws Exception {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(2L)
+                .detalles(List.of())
+                .build();
+        when(planProduccionService.listar(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(plan)));
+
+        mockMvc.perform(get("/api/planeacion/planes-semanales"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void crearPlanRechazaComprador() throws Exception {
+        mockMvc.perform(post("/api/planeacion/planes-semanales")
+                        .content("{}")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class MethodSecurityTestConfig {
+    }
+}


### PR DESCRIPTION
## Summary
- limit PlanProduccionController endpoints to Jefe de Producción and super admin roles and document ownership
- restrict MRP controller operations and security configuration to Comprador and super admin roles
- add controller security tests covering allowed/forbidden access scenarios for planning and MRP APIs

## Testing
- mvn test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692624e54f448333ba6d3a631dbd8ac9)