### PR TITLE
Ensure rendimiento is required for PT and PS products

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -68,19 +68,16 @@ public class ProductoServiceImpl implements ProductoService {
         throw new IllegalStateException("No se pudo extraer el token JWT");
     }
 
-    private boolean esCategoriaPT(com.willyes.clemenintegra.inventario.model.CategoriaProducto categoria) {
-        if (categoria == null) return false;
-        // Si tu entidad tiene getTipo(): TipoCategoria (MP, ME, SU, PT)
-        TipoCategoria tipo = categoria.getTipo();
-        if (tipo != null && tipo == TipoCategoria.PRODUCTO_TERMINADO) return true;
-
-        // Fallback por nombre, por si acaso
-        String nombre = categoria.getNombre() != null ? categoria.getNombre().toUpperCase() : "";
-        return nombre.contains("PRODUCTO TERMINADO");
-    }
-
-    private boolean skuEmpiezaConPT(String sku) {
-        return sku != null && sku.trim().toUpperCase().startsWith("PT");
+    private boolean esProductoFabricable(com.willyes.clemenintegra.inventario.model.CategoriaProducto categoria, String sku) {
+        if (categoria == null || categoria.getTipo() == null || sku == null) {
+            return false;
+        }
+        String skuNormalizado = sku.trim().toUpperCase();
+        return switch (categoria.getTipo()) {
+            case PRODUCTO_TERMINADO -> skuNormalizado.startsWith("PT");
+            case PRODUCTO_SEMI_ELABORADO -> skuNormalizado.startsWith("PS");
+            default -> false;
+        };
     }
 
     private BigDecimal sanitizeRendimiento(BigDecimal val) {
@@ -89,6 +86,19 @@ public class ProductoServiceImpl implements ProductoService {
             throw new IllegalArgumentException("Rendimiento × Unidad debe ser >= 0.00");
         }
         return val.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal resolverRendimientoUnidad(ProductoRequestDTO dto, com.willyes.clemenintegra.inventario.model.CategoriaProducto categoria) {
+        if (!esProductoFabricable(categoria, dto.getSku())) {
+            return null;
+        }
+
+        BigDecimal rendimiento = sanitizeRendimiento(dto.getRendimientoUnidad());
+        if (rendimiento == null || rendimiento.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException(
+                    "El rendimiento por unidad es obligatorio y debe ser mayor que cero para productos terminados y semielaborados.");
+        }
+        return rendimiento;
     }
 
     private String sanitizeBusqueda(String term) {
@@ -228,11 +238,7 @@ public class ProductoServiceImpl implements ProductoService {
                 .creadoPor(usuario)
                 .build();
 
-        if (esCategoriaPT(categoria) && skuEmpiezaConPT(dto.getSku())) {
-            producto.setRendimientoUnidad(sanitizeRendimiento(dto.getRendimientoUnidad()));
-        } else {
-            producto.setRendimientoUnidad(null);
-        }
+        producto.setRendimientoUnidad(resolverRendimientoUnidad(dto, categoria));
 
         productoRepository.save(producto);
         return buildDto(producto);
@@ -272,11 +278,7 @@ public class ProductoServiceImpl implements ProductoService {
         producto.setCategoriaProducto(categoria);
         producto.setCreadoPor(usuario);
 
-        if (esCategoriaPT(categoria) && skuEmpiezaConPT(dto.getSku())) {
-            producto.setRendimientoUnidad(sanitizeRendimiento(dto.getRendimientoUnidad()));
-        } else {
-            producto.setRendimientoUnidad(null);
-        }
+        producto.setRendimientoUnidad(resolverRendimientoUnidad(dto, categoria));
 
         productoRepository.save(producto);
         BigDecimal stock = stockQueryService.obtenerStockDisponible(producto.getId().longValue());

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -207,6 +207,31 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 .orElse(null);
     }
 
+    private boolean esProductoFabricable(TipoCategoria tipoCategoria) {
+        return tipoCategoria == TipoCategoria.PRODUCTO_TERMINADO
+                || tipoCategoria == TipoCategoria.PRODUCTO_SEMI_ELABORADO;
+    }
+
+    private void validarRendimientoProductoFabricable(Producto producto) {
+        TipoCategoria tipoCategoria = obtenerTipoCategoriaProducto(producto);
+        if (tipoCategoria == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "El producto de la orden de producción no tiene categoría válida configurada.");
+        }
+        if (!esProductoFabricable(tipoCategoria)) {
+            return;
+        }
+        BigDecimal rendimiento = Optional.ofNullable(producto)
+                .map(Producto::getRendimientoUnidad)
+                .orElse(null);
+        if (rendimiento == null || rendimiento.compareTo(BigDecimal.ZERO) <= 0) {
+            String identificador = Optional.ofNullable(producto.getCodigoSku())
+                    .orElse(Optional.ofNullable(producto.getNombre()).orElse("producto"));
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    String.format("El producto %s requiere un rendimiento por unidad definido y mayor que cero para crear una orden de producción.", identificador));
+        }
+    }
+
     private List<DetalleFormula> obtenerDetallesFormulaSeguro(FormulaProducto formula) {
         return Optional.ofNullable(formula)
                 .map(FormulaProducto::getDetalles)
@@ -461,6 +486,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             unidadBase = unidadProducto;
             dto.setUnidadMedidaSimbolo(unidadBase);
         }
+        validarRendimientoProductoFabricable(producto);
         BigDecimal cantidadConvertida = unidadConversionService.convertir(cantidadBase, unidadBase, unidadProducto);
 
         BigDecimal unidadesProducidas = unidadConversionService.dividirNormalizado(

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -1,0 +1,187 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.ProductoRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.mapper.ProductoMapper;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
+import io.jsonwebtoken.impl.DefaultClaims;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProductoServiceImplTest {
+
+    @Mock private ProductoRepository productoRepository;
+    @Mock private UnidadMedidaRepository unidadMedidaRepository;
+    @Mock private CategoriaProductoRepository categoriaProductoRepository;
+    @Mock private UsuarioRepository usuarioRepository;
+    @Mock private LoteProductoRepository loteProductoRepository;
+    @Mock private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock private ProductoMapper productoMapper;
+    @Mock private JwtTokenService jwtTokenService;
+    @Mock private StockQueryService stockQueryService;
+
+    @InjectMocks
+    private ProductoServiceImpl service;
+
+    @BeforeEach
+    void setUpSecurity() {
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getCredentials()).thenReturn("token-mock");
+        SecurityContext context = mock(SecurityContext.class);
+        when(context.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(context);
+
+        DefaultClaims claims = new DefaultClaims(Map.of("usuarioId", 1L));
+        when(jwtTokenService.extraerClaims("token-mock")).thenReturn(claims);
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(new Usuario()));
+
+        when(productoMapper.toDto(any(Producto.class))).thenReturn(new ProductoResponseDTO());
+        when(stockQueryService.obtenerStockDisponible(any(Long.class))).thenReturn(BigDecimal.ZERO);
+        when(loteProductoRepository.existsByProducto(any(Producto.class))).thenReturn(false);
+        when(movimientoInventarioRepository.existsByProductoId(any(Long.class))).thenReturn(false);
+        when(productoRepository.save(any(Producto.class))).thenAnswer(invocation -> {
+            Producto producto = invocation.getArgument(0);
+            producto.setId(10);
+            return producto;
+        });
+    }
+
+    @AfterEach
+    void clearSecurity() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("Debe conservar rendimiento para PT y SKU válido")
+    void crearProducto_conservaRendimientoParaPt() {
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(5L);
+        when(unidadMedidaRepository.findById(5L)).thenReturn(Optional.of(unidad));
+
+        CategoriaProducto categoriaPt = new CategoriaProducto();
+        categoriaPt.setId(3L);
+        categoriaPt.setTipo(TipoCategoria.PRODUCTO_TERMINADO);
+        when(categoriaProductoRepository.findById(3L)).thenReturn(Optional.of(categoriaPt));
+
+        when(productoRepository.existsByCodigoSku("PT0001")).thenReturn(false);
+        when(productoRepository.existsByNombre("Producto PT")).thenReturn(false);
+
+        ProductoRequestDTO dto = ProductoRequestDTO.builder()
+                .sku("PT0001")
+                .nombre("Producto PT")
+                .descripcionProducto("desc")
+                .stockMinimo(BigDecimal.ONE)
+                .unidadMedidaId(5L)
+                .categoriaProductoId(3L)
+                .rendimientoUnidad(new BigDecimal("100.234"))
+                .build();
+
+        ArgumentCaptor<Producto> captor = ArgumentCaptor.forClass(Producto.class);
+
+        service.crearProducto(dto);
+
+        verify(productoRepository).save(captor.capture());
+        assertThat(captor.getValue().getRendimientoUnidad())
+                .isEqualByComparingTo(new BigDecimal("100.23"));
+    }
+
+    @Test
+    @DisplayName("Debe conservar rendimiento para PS con SKU válido")
+    void crearProducto_conservaRendimientoParaPs() {
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(6L);
+        when(unidadMedidaRepository.findById(6L)).thenReturn(Optional.of(unidad));
+
+        CategoriaProducto categoriaPs = new CategoriaProducto();
+        categoriaPs.setId(4L);
+        categoriaPs.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        when(categoriaProductoRepository.findById(4L)).thenReturn(Optional.of(categoriaPs));
+
+        when(productoRepository.existsByCodigoSku("PS0001")).thenReturn(false);
+        when(productoRepository.existsByNombre("Producto PS")).thenReturn(false);
+
+        ProductoRequestDTO dto = ProductoRequestDTO.builder()
+                .sku("PS0001")
+                .nombre("Producto PS")
+                .descripcionProducto("desc")
+                .stockMinimo(BigDecimal.ONE)
+                .unidadMedidaId(6L)
+                .categoriaProductoId(4L)
+                .rendimientoUnidad(new BigDecimal("50"))
+                .build();
+
+        ArgumentCaptor<Producto> captor = ArgumentCaptor.forClass(Producto.class);
+        service.crearProducto(dto);
+        verify(productoRepository).save(captor.capture());
+
+        assertThat(captor.getValue().getRendimientoUnidad())
+                .isEqualByComparingTo(new BigDecimal("50.00"));
+    }
+
+    @Test
+    @DisplayName("Debe rechazar PS sin rendimiento")
+    void crearProducto_psSinRendimiento_lanzaExcepcion() {
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(7L);
+        when(unidadMedidaRepository.findById(7L)).thenReturn(Optional.of(unidad));
+
+        CategoriaProducto categoriaPs = new CategoriaProducto();
+        categoriaPs.setId(8L);
+        categoriaPs.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        when(categoriaProductoRepository.findById(8L)).thenReturn(Optional.of(categoriaPs));
+
+        when(productoRepository.existsByCodigoSku("PS0002")).thenReturn(false);
+        when(productoRepository.existsByNombre("PS Sin Rend"))
+                .thenReturn(false);
+
+        ProductoRequestDTO dto = ProductoRequestDTO.builder()
+                .sku("PS0002")
+                .nombre("PS Sin Rend")
+                .descripcionProducto("desc")
+                .stockMinimo(BigDecimal.ONE)
+                .unidadMedidaId(7L)
+                .categoriaProductoId(8L)
+                .rendimientoUnidad(null)
+                .build();
+
+        assertThatThrownBy(() -> service.crearProducto(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("rendimiento por unidad es obligatorio");
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -24,6 +24,7 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.*;
+import com.willyes.clemenintegra.produccion.dto.OrdenProduccionRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
 import com.willyes.clemenintegra.produccion.dto.CierreProduccionRequestDTO;
 import com.willyes.clemenintegra.calidad.service.VidaUtilProductoService;
@@ -72,6 +73,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -197,6 +199,71 @@ class OrdenProduccionServiceImplTest {
         assertThat(resultado.getInsumosFaltantes().get(0).getProductoId()).isEqualTo(2L);
         assertThat(resultado.getInsumosFaltantes().get(0).getRequerido()).isEqualByComparingTo(new BigDecimal("10"));
         assertThat(resultado.getInsumosFaltantes().get(0).getDisponible()).isEqualByComparingTo(new BigDecimal("8.000000"));
+    }
+
+    @Test
+    @DisplayName("crearOrden valida rendimiento obligatorio para PS")
+    void crearOrden_conPsSinRendimientoLanzaExcepcion() {
+        Producto producto = new Producto();
+        producto.setId(20);
+        producto.setCodigoSku("PS-001");
+        CategoriaProducto categoria = new CategoriaProducto();
+        categoria.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        producto.setCategoriaProducto(categoria);
+        UnidadMedida unidadMedida = new UnidadMedida();
+        unidadMedida.setSimbolo("UND");
+        producto.setUnidadMedida(unidadMedida);
+
+        when(productoRepository.findById(20L)).thenReturn(Optional.of(producto));
+        when(usuarioRepository.findById(5L)).thenReturn(Optional.of(new Usuario()));
+
+        OrdenProduccionRequestDTO dto = new OrdenProduccionRequestDTO();
+        dto.setProductoId(20L);
+        dto.setResponsableId(5L);
+        dto.setCantidadProgramada(new BigDecimal("10"));
+        dto.setUnidadMedidaSimbolo("UND");
+
+        assertThatThrownBy(() -> service.crearOrden(dto))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("rendimiento por unidad definido y mayor que cero");
+    }
+
+    @Test
+    @DisplayName("crearOrden usa rendimiento válido para PS")
+    void crearOrden_conPsValidoUtilizaRendimiento() {
+        Producto producto = new Producto();
+        producto.setId(21);
+        producto.setCodigoSku("PS-002");
+        producto.setRendimientoUnidad(new BigDecimal("8"));
+        CategoriaProducto categoria = new CategoriaProducto();
+        categoria.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        producto.setCategoriaProducto(categoria);
+        UnidadMedida unidadMedida = new UnidadMedida();
+        unidadMedida.setSimbolo("UND");
+        producto.setUnidadMedida(unidadMedida);
+
+        when(productoRepository.findById(21L)).thenReturn(Optional.of(producto));
+        when(usuarioRepository.findById(6L)).thenReturn(Optional.of(new Usuario()));
+        when(unidadConversionService.convertir(any(BigDecimal.class), any(), any())).thenReturn(new BigDecimal("10"));
+        when(unidadConversionService.dividirNormalizado(any(BigDecimal.class), any(), any(), any()))
+                .thenReturn(new BigDecimal("1.25"));
+        doReturn(ResultadoValidacionOrdenDTO.builder().esValida(true).build())
+                .when(service).guardarConValidacionStock(any(OrdenProduccion.class));
+
+        OrdenProduccionRequestDTO dto = new OrdenProduccionRequestDTO();
+        dto.setProductoId(21L);
+        dto.setResponsableId(6L);
+        dto.setCantidadProgramada(new BigDecimal("10"));
+        dto.setUnidadMedidaSimbolo("UND");
+        dto.setEstado("CREADA");
+
+        service.crearOrden(dto);
+
+        verify(unidadConversionService).dividirNormalizado(
+                new BigDecimal("10"),
+                "UND",
+                new BigDecimal("8"),
+                "UND");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Preserve and validate rendimientoUnidad for both finished and semi-finished products when creating or updating items, and raise clear errors when missing.
- Enforce rendimiento validation in production order creation for PT/PS products to avoid invalid calculations.
- Add unit tests covering rendimiento handling in product creation and production orders.

## Testing
- mvn -q -Dtest=ProductoServiceImplTest,OrdenProduccionServiceImplTest test
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928764a235c8333bee1ed2a4c174b2e)