### PR TITLE
Add fabricable product catalog endpoint

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -76,6 +76,13 @@ public class ProductoController {
         return ResponseEntity.ok(productos);
     }
 
+    @GetMapping("/fabricables")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<List<ProductoResponseDTO>> getProductosFabricables() {
+        List<ProductoResponseDTO> productos = productoService.findProductosFabricables();
+        return ResponseEntity.ok(productos);
+    }
+
     @GetMapping("/producto-terminado")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public List<ProductoResponseDTO> getProductosTerminados() {

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -39,4 +39,6 @@ public interface ProductoService {
     Page<ProductoResumenDTO> buscarInsumos(String term, Pageable pageable);
 
     Page<ProductoResumenDTO> buscarProductosTerminados(String term, Pageable pageable);
+
+    List<ProductoResponseDTO> findProductosFabricables();
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -205,6 +205,28 @@ public class ProductoServiceImpl implements ProductoService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<ProductoResponseDTO> findProductosFabricables() {
+        List<TipoCategoria> tiposFabricables = List.of(
+                TipoCategoria.PRODUCTO_TERMINADO,
+                TipoCategoria.PRODUCTO_SEMI_ELABORADO
+        );
+
+        List<Producto> lista = Optional.ofNullable(productoRepository.findByCategoriaProducto_TipoIn(tiposFabricables))
+                .orElse(Collections.emptyList())
+                .stream()
+                .filter(p -> p.getCategoriaProducto() != null && tiposFabricables.contains(p.getCategoriaProducto().getTipo()))
+                .toList();
+
+        Map<Long, BigDecimal> stockMap = stockQueryService.obtenerStockDisponible(
+                lista.stream().map(p -> p.getId().longValue()).toList());
+
+        return lista.stream()
+                .map(p -> buildDto(p, stockMap.getOrDefault(p.getId().longValue(), BigDecimal.ZERO)))
+                .toList();
+    }
+
+    @Override
     @Transactional
     public ProductoResponseDTO crearProducto(ProductoRequestDTO dto) {
         validarDuplicados(dto.getSku(), dto.getNombre());

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -32,12 +32,15 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,6 +76,7 @@ class ProductoServiceImplTest {
 
         when(productoMapper.toDto(any(Producto.class))).thenReturn(new ProductoResponseDTO());
         when(stockQueryService.obtenerStockDisponible(any(Long.class))).thenReturn(BigDecimal.ZERO);
+        when(stockQueryService.obtenerStockDisponible(anyList())).thenReturn(Collections.emptyMap());
         when(loteProductoRepository.existsByProducto(any(Producto.class))).thenReturn(false);
         when(movimientoInventarioRepository.existsByProductoId(any(Long.class))).thenReturn(false);
         when(productoRepository.save(any(Producto.class))).thenAnswer(invocation -> {
@@ -183,5 +187,39 @@ class ProductoServiceImplTest {
         assertThatThrownBy(() -> service.crearProducto(dto))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("rendimiento por unidad es obligatorio");
+    }
+
+    @Test
+    @DisplayName("Debe devolver solo productos fabricables (PT y PS)")
+    void findProductosFabricables_devuelveFabricables() {
+        CategoriaProducto categoriaPt = categoria(TipoCategoria.PRODUCTO_TERMINADO);
+        CategoriaProducto categoriaPs = categoria(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        CategoriaProducto categoriaMp = categoria(TipoCategoria.MATERIA_PRIMA);
+
+        Producto pt = Producto.builder().id(1).codigoSku("PT-001").categoriaProducto(categoriaPt).build();
+        Producto ps = Producto.builder().id(2).codigoSku("PS-001").categoriaProducto(categoriaPs).build();
+        Producto mp = Producto.builder().id(3).codigoSku("MP-001").categoriaProducto(categoriaMp).build();
+
+        when(productoRepository.findByCategoriaProducto_TipoIn(anyList()))
+                .thenReturn(List.of(pt, ps, mp));
+        when(stockQueryService.obtenerStockDisponible(List.of(1L, 2L)))
+                .thenReturn(Map.of(1L, BigDecimal.ONE, 2L, new BigDecimal("2.50")));
+        when(productoMapper.toDto(pt)).thenReturn(ProductoResponseDTO.builder().id(1L).sku("PT-001").build());
+        when(productoMapper.toDto(ps)).thenReturn(ProductoResponseDTO.builder().id(2L).sku("PS-001").build());
+
+        List<ProductoResponseDTO> resultado = service.findProductosFabricables();
+
+        assertThat(resultado)
+                .extracting(ProductoResponseDTO::getId)
+                .containsExactly(1L, 2L);
+        assertThat(resultado)
+                .extracting(ProductoResponseDTO::getSku)
+                .containsExactly("PT-001", "PS-001");
+    }
+
+    private CategoriaProducto categoria(TipoCategoria tipo) {
+        CategoriaProducto categoria = new CategoriaProducto();
+        categoria.setTipo(tipo);
+        return categoria;
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -149,4 +149,23 @@ class ProductoControllerSmokeTest {
                 .andExpect(jsonPath("$.totalElements").value(1))
                 .andExpect(jsonPath("$.totalPages").value(1));
     }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/productos/fabricables devuelve PT y PS")
+    void getProductosFabricables_deberiaRetornar200() throws Exception {
+        List<ProductoResponseDTO> productos = List.of(
+                ProductoResponseDTO.builder().id(1L).sku("PT-01").nombre("Producto PT").build(),
+                ProductoResponseDTO.builder().id(2L).sku("PS-01").nombre("Producto PS").build()
+        );
+
+        when(productoService.findProductosFabricables()).thenReturn(productos);
+
+        mockMvc.perform(get("/api/productos/fabricables"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].sku").value("PT-01"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].sku").value("PS-01"));
+    }
 }


### PR DESCRIPTION
## Summary
- add ProductoService method to fetch fabricable products (PT and PS) using existing repository filters
- expose /api/productos/fabricables endpoint with production-aligned roles
- cover the new catalog with service and controller smoke tests

## Testing
- mvn -Dtest=ProductoServiceImplTest,ProductoControllerSmokeTest test
- mvn -q test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288aeebaa88333bd90ced972f9fc84)