### PR TITLE
Fix BOM detail unit mapping and expand insumo catalog

### DIFF
--- a/docs/bom-diagnostico.md
+++ b/docs/bom-diagnostico.md
@@ -1,0 +1,10 @@
+# Diagnóstico BOM (insumos y detalle de fórmula)
+
+Este archivo resume los hallazgos solicitados sobre el manejo de insumos y el mapeo/persistencia de `DetalleFormula`.
+
+- **Modelo**: `src/main/java/com/willyes/clemenintegra/bom/model/DetalleFormula.java` define relaciones `@ManyToOne` hacia `FormulaProducto`, `Producto (insumo)` y `UnidadMedida` sin restricciones `nullable` explícitas.
+- **Mapper**: `BomMapper.toEntity(DetalleFormulaRequest, FormulaProducto, Producto, UnidadMedida)` no especifica un mapeo de `unidad` a `unidadMedida`, lo que explica registros con `unidad_medida_id` en `NULL`. El parámetro `insumo` sí coincide con el nombre del campo.
+- **Creación de detalles**: `DetalleFormulaController` construye instancias mínimas (solo IDs) y delega al mapper + `DetalleFormulaServiceImpl.guardar`, que reemplaza la fórmula por la cargada y luego guarda. No hay resolución explícita de `insumo`/`unidad`, por lo que el mapper es crítico.
+- **Catálogo de insumos**: `ProductoController.getProductosInsumo` expone `GET /api/productos/insumos` y filtra solo `MATERIA_PRIMA` y `MATERIAL_EMPAQUE` (sin `SUMINISTROS` ni `PRODUCTO_SEMI_ELABORADO`).
+
+Estos puntos sustentan los dos problemas reportados: pérdida de `unidad_medida_id` en nuevos detalles y exclusión de PS en el catálogo de insumos.

--- a/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
@@ -46,9 +46,9 @@ public interface BomMapper {
     FormulaActivaProduccionDTO toFormulaActivaProduccionDTO(FormulaProducto formula);
 
     @Mapping(target = "id", ignore = true)
-    //@Mapping(target = "formula", source = "formula")
-    //@Mapping(target = "insumo", source = "insumo")
-    //@Mapping(target = "unidadMedida", source = "unidad")
+    @Mapping(target = "formula", source = "formula")
+    @Mapping(target = "insumo", source = "insumo")
+    @Mapping(target = "unidadMedida", source = "unidad")
     //@Mapping(target = "cantidadNecesaria", expression = "java(java.math.BigDecimal.valueOf(dto.cantidadNecesaria))")
     DetalleFormula toEntity(DetalleFormulaRequest dto, FormulaProducto formula, Producto insumo, UnidadMedida unidad);
 

--- a/src/main/java/com/willyes/clemenintegra/bom/service/DetalleFormulaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/DetalleFormulaServiceImpl.java
@@ -34,6 +34,14 @@ public class DetalleFormulaServiceImpl implements DetalleFormulaService {
     public DetalleFormula guardar(DetalleFormula detalle) {
         FormulaProducto formula = obtenerFormula(detalle);
         verificarFormulaEditable(formula);
+        if (detalle.getInsumo() == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "El insumo es obligatorio para los detalles de fórmula.");
+        }
+        if (detalle.getUnidadMedida() == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "La unidad de medida del insumo es obligatoria para los detalles de fórmula.");
+        }
         detalle.setFormula(formula);
         return detalleRepository.save(detalle);
     }

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -85,7 +85,12 @@ public class ProductoController {
     @GetMapping("/insumos")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public List<ProductoResponseDTO> getProductosInsumo() {
-        return productoService.findByCategoriaTipoIn(List.of("MATERIA_PRIMA", "MATERIAL_EMPAQUE"));
+        return productoService.findByCategoriaTipoIn(List.of(
+                "MATERIA_PRIMA",
+                "MATERIAL_EMPAQUE",
+                "SUMINISTROS",
+                "PRODUCTO_SEMI_ELABORADO"
+        ));
     }
 
     @GetMapping("/terminados")

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -53,13 +53,13 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
     Page<Producto> buscarPorTexto(@Param("q") String q, Pageable pageable);
 
     /**
-     * Busca insumos (MP, ME y suministros) por nombre.
+     * Busca insumos (MP, ME, suministros y semielaborados) por nombre.
      */
     @Query("""
             select p
             from Producto p
             where lower(p.nombre) like lower(concat('%', :term, '%'))
-              and p.categoriaProducto.tipo in ('MATERIA_PRIMA','MATERIAL_EMPAQUE','SUMINISTROS')
+              and p.categoriaProducto.tipo in ('MATERIA_PRIMA','MATERIAL_EMPAQUE','SUMINISTROS','PRODUCTO_SEMI_ELABORADO')
             """)
     Page<Producto> searchInsumosByNombre(@Param("term") String term, Pageable pageable);
 

--- a/src/test/java/com/willyes/clemenintegra/bom/mapper/BomMapperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/mapper/BomMapperTest.java
@@ -1,0 +1,44 @@
+package com.willyes.clemenintegra.bom.mapper;
+
+import com.willyes.clemenintegra.bom.dto.DetalleFormulaRequest;
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BomMapperTest {
+
+    private final BomMapper mapper = Mappers.getMapper(BomMapper.class);
+
+    @Test
+    @DisplayName("toEntity asigna insumo y unidad de medida al detalle de fórmula")
+    void toEntityAsignaRelaciones() {
+        DetalleFormulaRequest request = new DetalleFormulaRequest();
+        request.formulaId = 1L;
+        request.insumoId = 2L;
+        request.unidadMedidaId = 3L;
+        request.cantidadNecesaria = 5.0;
+        request.obligatorio = Boolean.TRUE;
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(1L);
+
+        Producto insumo = new Producto();
+        insumo.setId(2);
+
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(3L);
+
+        DetalleFormula detalle = mapper.toEntity(request, formula, insumo, unidad);
+
+        assertThat(detalle.getInsumo()).isNotNull();
+        assertThat(detalle.getInsumo().getId()).isEqualTo(2);
+        assertThat(detalle.getUnidadMedida()).isNotNull();
+        assertThat(detalle.getUnidadMedida().getId()).isEqualTo(3);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/bom/service/DetalleFormulaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/DetalleFormulaServiceImplTest.java
@@ -6,6 +6,8 @@ import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 import com.willyes.clemenintegra.bom.repository.DetalleFormulaRepository;
 import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +46,8 @@ class DetalleFormulaServiceImplTest {
 
         DetalleFormula detalle = new DetalleFormula();
         detalle.setFormula(formula);
+        detalle.setInsumo(new Producto());
+        detalle.setUnidadMedida(new UnidadMedida());
 
         when(formulaRepository.findById(1L)).thenReturn(Optional.of(formula));
         when(detalleRepository.save(any(DetalleFormula.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -61,6 +65,8 @@ class DetalleFormulaServiceImplTest {
 
         DetalleFormula detalle = new DetalleFormula();
         detalle.setFormula(formula);
+        detalle.setInsumo(new Producto());
+        detalle.setUnidadMedida(new UnidadMedida());
 
         when(formulaRepository.findById(5L)).thenReturn(Optional.of(formula));
         when(detalleRepository.save(any(DetalleFormula.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -69,6 +75,46 @@ class DetalleFormulaServiceImplTest {
 
         assertThat(resultado.getFormula()).isEqualTo(formula);
         verify(detalleRepository).save(detalle);
+    }
+
+    @Test
+    @DisplayName("guardar rechaza cuando falta la unidad de medida")
+    void guardarRechazaUnidadMedidaNula() {
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(3L);
+        formula.setEstado(EstadoFormula.BORRADOR);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setFormula(formula);
+        detalle.setInsumo(new Producto());
+
+        when(formulaRepository.findById(3L)).thenReturn(Optional.of(formula));
+
+        assertThatThrownBy(() -> service.guardar(detalle))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("unidad de medida del insumo es obligatoria");
+
+        verify(detalleRepository, never()).save(any(DetalleFormula.class));
+    }
+
+    @Test
+    @DisplayName("guardar rechaza cuando falta el insumo")
+    void guardarRechazaInsumoNulo() {
+        FormulaProducto formula = new FormulaProducto();
+        formula.setId(4L);
+        formula.setEstado(EstadoFormula.BORRADOR);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setFormula(formula);
+        detalle.setUnidadMedida(new UnidadMedida());
+
+        when(formulaRepository.findById(4L)).thenReturn(Optional.of(formula));
+
+        assertThatThrownBy(() -> service.guardar(detalle))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("insumo es obligatorio");
+
+        verify(detalleRepository, never()).save(any(DetalleFormula.class));
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -148,5 +150,29 @@ class ProductoControllerSmokeTest {
                 .andExpect(jsonPath("$.content[0].sku").value("SKU-010"))
                 .andExpect(jsonPath("$.totalElements").value(1))
                 .andExpect(jsonPath("$.totalPages").value(1));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/productos/insumos incluye MP, ME, SU y PS")
+    void listarInsumosIncluyeCategoriasEsperadas() throws Exception {
+        List<ProductoResponseDTO> productos = List.of(
+                ProductoResponseDTO.builder().id(1L).nombre("MP").build(),
+                ProductoResponseDTO.builder().id(2L).nombre("ME").build(),
+                ProductoResponseDTO.builder().id(3L).nombre("SU").build(),
+                ProductoResponseDTO.builder().id(4L).nombre("PS").build()
+        );
+
+        when(productoService.findByCategoriaTipoIn(any(List.class))).thenReturn(productos);
+
+        mockMvc.perform(get("/api/productos/insumos"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].nombre").value("MP"))
+                .andExpect(jsonPath("$[1].nombre").value("ME"))
+                .andExpect(jsonPath("$[2].nombre").value("SU"))
+                .andExpect(jsonPath("$[3].nombre").value("PS"));
+
+        verify(productoService).findByCategoriaTipoIn(argThat(tipos ->
+                tipos.containsAll(List.of("MATERIA_PRIMA", "MATERIAL_EMPAQUE", "SUMINISTROS", "PRODUCTO_SEMI_ELABORADO"))));
     }
 }


### PR DESCRIPTION
## Summary
- map DetalleFormula unidades de medida en BomMapper y agregar validaciones de insumo/unidad en el servicio
- ampliar el catálogo de insumos para incluir SUMINISTROS y PRODUCTO_SEMI_ELABORADO (incluyendo autocomplete)
- añadir pruebas unitarias para el mapper, el servicio y el endpoint de insumos

## Testing
- mvn -q -Dtest=DetalleFormulaServiceImplTest,BomMapperTest,ProductoControllerSmokeTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288e76c2148333885be90cff165d2a)