### PR TITLE
Add autocomplete search for insumo products

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.controller;
 
 import com.willyes.clemenintegra.inventario.dto.*;
+import com.willyes.clemenintegra.inventario.mapper.ProductoMapper;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.ProductoService;
@@ -36,6 +37,7 @@ public class ProductoController {
     private final MovimientoInventarioRepository movimientoInventarioRepository;
     private final UnidadMedidaRepository unidadMedidaRepository;
     private final UsuarioRepository usuarioRepository;
+    private final ProductoMapper productoMapper;
 
     @GetMapping("/buscar")
     @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR')")
@@ -98,6 +100,17 @@ public class ProductoController {
                 "SUMINISTROS",
                 "PRODUCTO_SEMI_ELABORADO"
         ));
+    }
+
+    @GetMapping("/insumos/autocomplete")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Page<ProductoResponseDTO>> buscarInsumosAutocomplete(
+            @RequestParam("term") String term,
+            Pageable pageable
+    ) {
+        Page<Producto> page = productoService.buscarInsumosAutocomplete(term, pageable);
+        Page<ProductoResponseDTO> dtoPage = page.map(productoMapper::toDto);
+        return ResponseEntity.ok(dtoPage);
     }
 
     @GetMapping("/terminados")

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -14,6 +14,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import com.willyes.clemenintegra.inventario.dto.StockDisponibleProjection;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -100,5 +101,21 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
             GROUP BY p.id
             """, nativeQuery = true)
     List<StockDisponibleProjection> calcularStockDisponiblePorProductoEnAlmacenes(List<Long> ids, List<Long> almacenes);
+
+    @Query("""
+    SELECT p
+    FROM Producto p
+    WHERE p.categoriaProducto.tipo IN :tipos
+      AND p.activo = true
+      AND (
+           UPPER(p.nombre) LIKE CONCAT('%', UPPER(:term), '%')
+        OR UPPER(p.codigoSku) LIKE CONCAT('%', UPPER(:term), '%')
+      )
+    """)
+    Page<Producto> buscarInsumosAutocomplete(
+            @Param("tipos") Collection<TipoCategoria> tipos,
+            @Param("term") String term,
+            Pageable pageable
+    );
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -41,4 +41,6 @@ public interface ProductoService {
     Page<ProductoResumenDTO> buscarProductosTerminados(String term, Pageable pageable);
 
     List<ProductoResponseDTO> findProductosFabricables();
+
+    Page<Producto> buscarInsumosAutocomplete(String term, Pageable pageable);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -575,5 +575,21 @@ public class ProductoServiceImpl implements ProductoService {
         return page.map(this::mapToResumenDto);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Producto> buscarInsumosAutocomplete(String term, Pageable pageable) {
+        if (term == null || term.trim().isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<TipoCategoria> tipos = List.of(
+                TipoCategoria.MATERIA_PRIMA,
+                TipoCategoria.MATERIAL_EMPAQUE,
+                TipoCategoria.SUMINISTROS,
+                TipoCategoria.PRODUCTO_SEMI_ELABORADO
+        );
+        return productoRepository.buscarInsumosAutocomplete(tipos, term.trim(), pageable);
+    }
+
 }
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -27,6 +27,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -41,7 +45,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -215,6 +221,44 @@ class ProductoServiceImplTest {
         assertThat(resultado)
                 .extracting(ProductoResponseDTO::getSku)
                 .containsExactly("PT-001", "PS-001");
+    }
+
+    @Test
+    @DisplayName("Debe devolver página vacía si el término de autocomplete está vacío")
+    void buscarInsumosAutocomplete_sinTermino_devuelveVacio() {
+        Pageable pageable = PageRequest.of(0, 5);
+
+        Page<Producto> resultado = service.buscarInsumosAutocomplete("   ", pageable);
+
+        assertThat(resultado).isEmpty();
+        verify(productoRepository, never()).buscarInsumosAutocomplete(anyList(), anyString(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("Debe buscar insumos en categorías permitidas y mapear término recortado")
+    void buscarInsumosAutocomplete_conTermino_invocaRepositorioConFiltros() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Producto producto = new Producto();
+        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
+        when(productoRepository.buscarInsumosAutocomplete(anyList(), anyString(), any(Pageable.class)))
+                .thenReturn(page);
+
+        Page<Producto> resultado = service.buscarInsumosAutocomplete("  mp ", pageable);
+
+        assertThat(resultado.getContent()).containsExactly(producto);
+
+        ArgumentCaptor<List<TipoCategoria>> tiposCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<String> termCaptor = ArgumentCaptor.forClass(String.class);
+        verify(productoRepository).buscarInsumosAutocomplete(tiposCaptor.capture(), termCaptor.capture(), any(Pageable.class));
+
+        assertThat(tiposCaptor.getValue())
+                .containsExactlyInAnyOrder(
+                        TipoCategoria.MATERIA_PRIMA,
+                        TipoCategoria.MATERIAL_EMPAQUE,
+                        TipoCategoria.SUMINISTROS,
+                        TipoCategoria.PRODUCTO_SEMI_ELABORADO
+                );
+        assertThat(termCaptor.getValue()).isEqualTo("mp");
     }
 
     private CategoriaProducto categoria(TipoCategoria tipo) {


### PR DESCRIPTION
## Summary
- add repository search and service flow to fetch insumos with term filtering and allowed categories
- expose /api/productos/insumos/autocomplete endpoint using existing product DTO mapping
- cover autocomplete behavior with service unit tests

## Testing
- mvn -Dtest=ProductoServiceImplTest test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69289e253e80833383b6492ce7e77035)