### PR TITLE
Add fabricable product autocomplete endpoint

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -68,6 +68,17 @@ public class ProductoController {
         return ResponseEntity.ok(page);
     }
 
+    @GetMapping("/buscar-fabricables")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Page<ProductoResponseDTO>> buscarProductosFabricablesAutocomplete(
+            @RequestParam("term") String term,
+            Pageable pageable
+    ) {
+        Page<Producto> page = productoService.buscarProductosFabricablesAutocomplete(term, pageable);
+        Page<ProductoResponseDTO> dtoPage = page.map(productoMapper::toDto);
+        return ResponseEntity.ok(dtoPage);
+    }
+
     @GetMapping("/categoria/{nombre}")
     public ResponseEntity<List<ProductoResponseDTO>> buscarPorCategoria(
             @PathVariable String nombre) {

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -117,5 +117,21 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
             @Param("term") String term,
             Pageable pageable
     );
+
+    @Query("""
+    SELECT p
+    FROM Producto p
+    WHERE p.categoriaProducto.tipo IN :tipos
+      AND p.activo = true
+      AND (
+           UPPER(p.nombre) LIKE CONCAT('%', UPPER(:term), '%')
+        OR UPPER(p.codigoSku) LIKE CONCAT('%', UPPER(:term), '%')
+      )
+    """)
+    Page<Producto> buscarFabricablesAutocomplete(
+            @Param("tipos") Collection<TipoCategoria> tipos,
+            @Param("term") String term,
+            Pageable pageable
+    );
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -43,4 +43,6 @@ public interface ProductoService {
     List<ProductoResponseDTO> findProductosFabricables();
 
     Page<Producto> buscarInsumosAutocomplete(String term, Pageable pageable);
+
+    Page<Producto> buscarProductosFabricablesAutocomplete(String term, Pageable pageable);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -577,6 +577,23 @@ public class ProductoServiceImpl implements ProductoService {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<Producto> buscarProductosFabricablesAutocomplete(String term, Pageable pageable) {
+        if (term == null || term.trim().isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        String cleaned = term.trim();
+
+        List<TipoCategoria> tiposFabricables = List.of(
+                TipoCategoria.PRODUCTO_TERMINADO,
+                TipoCategoria.PRODUCTO_SEMI_ELABORADO
+        );
+
+        return productoRepository.buscarFabricablesAutocomplete(tiposFabricables, cleaned, pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Page<Producto> buscarInsumosAutocomplete(String term, Pageable pageable) {
         if (term == null || term.trim().isEmpty()) {
             return Page.empty(pageable);

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -261,6 +261,42 @@ class ProductoServiceImplTest {
         assertThat(termCaptor.getValue()).isEqualTo("mp");
     }
 
+    @Test
+    @DisplayName("Debe devolver página vacía si el término de fabricables está vacío")
+    void buscarProductosFabricablesAutocomplete_sinTermino_devuelveVacio() {
+        Pageable pageable = PageRequest.of(0, 5);
+
+        Page<Producto> resultado = service.buscarProductosFabricablesAutocomplete("   ", pageable);
+
+        assertThat(resultado).isEmpty();
+        verify(productoRepository, never()).buscarFabricablesAutocomplete(anyList(), anyString(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("Debe buscar fabricables en PT y PS y normalizar el término")
+    void buscarProductosFabricablesAutocomplete_conTermino_invocaRepositorioConFiltros() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Producto producto = new Producto();
+        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
+        when(productoRepository.buscarFabricablesAutocomplete(anyList(), anyString(), any(Pageable.class)))
+                .thenReturn(page);
+
+        Page<Producto> resultado = service.buscarProductosFabricablesAutocomplete("  ps ", pageable);
+
+        assertThat(resultado.getContent()).containsExactly(producto);
+
+        ArgumentCaptor<List<TipoCategoria>> tiposCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<String> termCaptor = ArgumentCaptor.forClass(String.class);
+        verify(productoRepository).buscarFabricablesAutocomplete(tiposCaptor.capture(), termCaptor.capture(), any(Pageable.class));
+
+        assertThat(tiposCaptor.getValue())
+                .containsExactlyInAnyOrder(
+                        TipoCategoria.PRODUCTO_TERMINADO,
+                        TipoCategoria.PRODUCTO_SEMI_ELABORADO
+                );
+        assertThat(termCaptor.getValue()).isEqualTo("ps");
+    }
+
     private CategoriaProducto categoria(TipoCategoria tipo) {
         CategoriaProducto categoria = new CategoriaProducto();
         categoria.setTipo(tipo);


### PR DESCRIPTION
## Summary
- add repository query, service method, and controller endpoint for paginated fabricable product autocomplete
- ensure fabricable search includes finished and semi-finished categories with term filtering
- extend service tests to cover fabricable autocomplete behavior

## Testing
- mvn -Dtest=ProductoServiceImplTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928a89f1fa88333b5de0e09e9668b3f)