### PR TITLE
Allow life span for semi-finished products

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
@@ -48,12 +48,7 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
                         "Producto no encontrado"
                 ));
 
-        if (!esProductoTerminado(producto)) {
-            throw new CustomBusinessException(
-                    ApiErrorCode.VIDA_UTIL_SOLO_PRODUCTO_TERMINADO,
-                    "La vida útil solo puede configurarse para productos terminados"
-            );
-        }
+        validarProductoAdmiteVidaUtil(producto);
 
         if (semanasVigencia == null || semanasVigencia <= 0) {
             throw new CustomBusinessException(
@@ -90,10 +85,7 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
     public void eliminar(Integer productoId) {
         Producto producto = productoRepository.findById(Long.valueOf(productoId))
                 .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "Producto no encontrado"));
-        if (!esProductoTerminado(producto)) {
-            throw new CustomBusinessException(ApiErrorCode.VIDA_UTIL_SOLO_PRODUCTO_TERMINADO,
-                    "La vida útil solo puede configurarse para productos terminados");
-        }
+        validarProductoAdmiteVidaUtil(producto);
         vidaUtilProductoRepository.findById(productoId)
                 .ifPresent(vidaUtilProductoRepository::delete);
     }
@@ -128,9 +120,18 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
                 .build());
     }
 
-    private boolean esProductoTerminado(Producto producto) {
-        return producto != null
-                && producto.getCategoriaProducto() != null
-                && producto.getCategoriaProducto().getTipo() == TipoCategoria.PRODUCTO_TERMINADO;
+    private void validarProductoAdmiteVidaUtil(Producto producto) {
+        if (producto == null || producto.getCategoriaProducto() == null) {
+            throw new IllegalArgumentException("El producto es obligatorio para definir vida útil.");
+        }
+
+        TipoCategoria tipo = producto.getCategoriaProducto().getTipo();
+        if (tipo != TipoCategoria.PRODUCTO_TERMINADO
+                && tipo != TipoCategoria.PRODUCTO_SEMI_ELABORADO) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.VIDA_UTIL_SOLO_PRODUCTO_TERMINADO,
+                    "Solo se puede registrar vida útil para productos terminados o semielaborados."
+            );
+        }
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -189,10 +189,16 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     }
 
     private Integer obtenerSemanasVigenciaProductoTerminado(Producto producto) {
-        TipoCategoria tipoCategoria = obtenerTipoCategoriaProducto(producto);
+        // Ahora aplica para productos terminados (PT) y semielaborados (PS).
+        if (producto == null || producto.getCategoriaProducto() == null) {
+            throw new IllegalArgumentException("Producto inválido para calcular vida útil");
+        }
+        TipoCategoria tipoCategoria = producto.getCategoriaProducto().getTipo();
         if (tipoCategoria != TipoCategoria.PRODUCTO_TERMINADO
                 && tipoCategoria != TipoCategoria.PRODUCTO_SEMI_ELABORADO) {
-            return null;
+            throw new IllegalArgumentException(
+                    "Solo productos terminados o semielaborados pueden tener vida útil registrada."
+            );
         }
         return vidaUtilProductoService.buscarPorProductoId(producto.getId())
                 .map(VidaUtilProducto::getSemanasVigencia)

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
@@ -49,6 +49,7 @@ class VidaUtilProductoServiceImplTest {
     private VidaUtilProductoServiceImpl service;
 
     private Producto productoTerminado;
+    private Producto productoSemielaborado;
     private Usuario usuarioAutenticado;
 
     @BeforeEach
@@ -61,6 +62,15 @@ class VidaUtilProductoServiceImplTest {
         productoTerminado.setCodigoSku("PT-001");
         productoTerminado.setNombre("Producto Terminado");
         productoTerminado.setCategoriaProducto(categoria);
+
+        CategoriaProducto categoriaPs = new CategoriaProducto();
+        categoriaPs.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+
+        productoSemielaborado = new Producto();
+        productoSemielaborado.setId(20);
+        productoSemielaborado.setCodigoSku("PS-001");
+        productoSemielaborado.setNombre("Producto Semielaborado");
+        productoSemielaborado.setCategoriaProducto(categoriaPs);
 
         usuarioAutenticado = Usuario.builder()
                 .id(5L)
@@ -166,6 +176,21 @@ class VidaUtilProductoServiceImplTest {
                 .isInstanceOf(CustomBusinessException.class)
                 .extracting("code")
                 .isEqualTo(ApiErrorCode.VIDA_UTIL_SOLO_PRODUCTO_TERMINADO);
+    }
+
+    @Test
+    void guardar_deberiaCrearCuandoProductoSemielaboradoValido() {
+        when(productoRepository.findById(20L)).thenReturn(Optional.of(productoSemielaborado));
+        when(vidaUtilProductoRepository.findById(productoSemielaborado.getId())).thenReturn(Optional.empty());
+        when(vidaUtilProductoRepository.save(any(VidaUtilProducto.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuarioAutenticado);
+
+        VidaUtilProducto resultado = service.guardar(productoSemielaborado.getId(), 10);
+
+        assertThat(resultado.getSemanasVigencia()).isEqualTo(10);
+        assertThat(resultado.getProducto()).isEqualTo(productoSemielaborado);
+        assertThat(resultado.getProductoId()).isEqualTo(productoSemielaborado.getId());
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -20,6 +20,7 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimient
 import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.repository.*;
@@ -565,6 +566,75 @@ class OrdenProduccionServiceImplTest {
 
         assertThat(loteGenerado.getFechaVencimiento())
                 .isEqualTo(loteGenerado.getFechaFabricacion().plusWeeks(6));
+        assertThat(resultado.getEstado()).isEqualTo(EstadoEtapa.EN_PROCESO);
+    }
+
+    @Test
+    @DisplayName("iniciarEtapa genera lote de producto semielaborado usando semanas de vigencia configuradas")
+    void iniciarEtapa_conVidaUtilParaPs() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(6L);
+        orden.setEstado(EstadoProduccion.CREADA);
+        orden.setCodigoOrden("OP-006");
+
+        CategoriaProducto categoria = new CategoriaProducto();
+        categoria.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+
+        Producto producto = new Producto();
+        producto.setId(25);
+        producto.setNombre("PS-Probador");
+        producto.setCodigoSku("PS-025");
+        producto.setCategoriaProducto(categoria);
+        producto.setTipoAnalisis(TipoAnalisisCalidad.FISICO);
+        orden.setProducto(producto);
+
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(16L)
+                .ordenProduccion(orden)
+                .estado(EstadoEtapa.PENDIENTE)
+                .secuencia(1)
+                .build();
+
+        SolicitudMovimiento solicitud = SolicitudMovimiento.builder()
+                .estado(EstadoSolicitudMovimiento.EJECUTADA)
+                .ordenProduccion(orden)
+                .build();
+
+        Usuario usuario = new Usuario();
+        usuario.setId(10L);
+        usuario.setNombreCompleto("Usuario Ps");
+
+        when(ordenProduccionRepository.findById(6L)).thenReturn(Optional.of(orden));
+        when(etapaProduccionRepository.findById(16L)).thenReturn(Optional.of(etapa));
+        when(solicitudMovimientoRepository.findByOrdenProduccionId(6L)).thenReturn(List.of(solicitud));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(catalogResolver.getAlmacenPtId()).thenReturn(1L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(2L);
+        when(almacenRepository.findById(1L)).thenReturn(Optional.of(new Almacen(1)));
+        when(almacenRepository.findById(2L)).thenReturn(Optional.of(new Almacen(2)));
+        when(vidaUtilProductoService.buscarPorProductoId(25)).thenReturn(Optional.of(VidaUtilProducto.builder()
+                .productoId(25)
+                .producto(producto)
+                .semanasVigencia(4)
+                .build()));
+        when(loteProductoRepository.save(any(LoteProducto.class))).thenAnswer(invocation -> {
+            LoteProducto lote = invocation.getArgument(0);
+            lote.setId(100L);
+            return lote;
+        });
+        when(ordenProduccionRepository.save(any(OrdenProduccion.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(etapaProduccionRepository.save(any(EtapaProduccion.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        EtapaProduccion resultado = service.iniciarEtapa(6L, 16L);
+
+        ArgumentCaptor<LoteProducto> captor = ArgumentCaptor.forClass(LoteProducto.class);
+        verify(loteProductoRepository).save(captor.capture());
+        LoteProducto loteGenerado = captor.getValue();
+
+        assertThat(loteGenerado.getFechaVencimiento())
+                .isEqualTo(loteGenerado.getFechaFabricacion().plusWeeks(4));
+        assertThat(loteGenerado.getEstado()).isEqualTo(EstadoLote.EN_CUARENTENA);
+        assertThat(loteGenerado.getAlmacen().getId()).isEqualTo(2L);
         assertThat(resultado.getEstado()).isEqualTo(EstadoEtapa.EN_PROCESO);
     }
 


### PR DESCRIPTION
## Summary
- allow registering vida útil for both productos terminados and semielaborados with updated validation
- update production expiry retrieval to handle both fabricable product types
- extend unit tests to cover semielaborated products in vida útil and order production flows

## Testing
- mvn -q -Dtest=VidaUtilProductoServiceImplTest,OrdenProduccionServiceImplTest test
- mvn -q test *(fails: ProductoControllerSmokeTest cannot load context due to missing ProductoMapper bean)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b4f7a35c8333ad8801df784044b8)