### PR TITLE
Soportar PS en listado de vida útil y validar identificador

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -42,6 +43,13 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
     @Override
     @Transactional
     public VidaUtilProducto guardar(Integer productoId, Integer semanasVigencia) {
+        if (productoId == null) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.NEGOCIO_GENERICO,
+                    "El identificador del producto es obligatorio para registrar vida útil"
+            );
+        }
+
         Producto producto = productoRepository.findById(Long.valueOf(productoId))
                 .orElseThrow(() -> new CustomBusinessException(
                         ApiErrorCode.RECURSO_NO_ENCONTRADO,
@@ -50,6 +58,12 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
 
         validarProductoAdmiteVidaUtil(producto);
 
+        Integer productoIdPersistencia = Optional.ofNullable(producto.getId())
+                .orElseThrow(() -> new CustomBusinessException(
+                        ApiErrorCode.NEGOCIO_GENERICO,
+                        "El producto no posee identificador para registrar vida útil"
+                ));
+
         if (semanasVigencia == null || semanasVigencia <= 0) {
             throw new CustomBusinessException(
                     ApiErrorCode.VIDA_UTIL_SEMANAS_INVALIDAS,
@@ -57,11 +71,11 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
             );
         }
 
-        VidaUtilProducto vidaUtil = vidaUtilProductoRepository.findById(productoId)
+        VidaUtilProducto vidaUtil = vidaUtilProductoRepository.findById(productoIdPersistencia)
                 .orElseGet(() -> {
                     VidaUtilProducto nuevo = new VidaUtilProducto();
                     nuevo.setProducto(producto);
-                    nuevo.setProductoId(productoId);
+                    nuevo.setProductoId(productoIdPersistencia);
                     return nuevo;
                 });
 
@@ -69,7 +83,7 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
             vidaUtil.setProducto(producto);
         }
         if (vidaUtil.getProductoId() == null) {
-            vidaUtil.setProductoId(productoId);
+            vidaUtil.setProductoId(productoIdPersistencia);
         }
         vidaUtil.setSemanasVigencia(semanasVigencia);
 
@@ -100,7 +114,10 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
     public Page<VidaUtilProductoDTO> listarProductosTerminados(String filtro, Pageable pageable) {
         Specification<Producto> spec = Specification
                 .where(textoLibre(filtro))
-                .and(tipoCategoriaEquals(TipoCategoria.PRODUCTO_TERMINADO));
+                .and(tipoCategoriaIn(List.of(
+                        TipoCategoria.PRODUCTO_TERMINADO,
+                        TipoCategoria.PRODUCTO_SEMI_ELABORADO
+                )));
 
         Page<Producto> productos = productoRepository.findAll(spec, pageable);
         Map<Integer, VidaUtilProducto> vidaUtilMap = vidaUtilProductoRepository

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/spec/ProductoSpecifications.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/spec/ProductoSpecifications.java
@@ -3,6 +3,9 @@ package com.willyes.clemenintegra.inventario.service.spec;
 import org.springframework.data.jpa.domain.Specification;
 import jakarta.persistence.criteria.Join;
 import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+
+import java.util.Collection;
 
 public final class ProductoSpecifications {
 
@@ -65,6 +68,19 @@ public final class ProductoSpecifications {
             }
             Join<Object, Object> cat = root.join("categoriaProducto");
             return cb.equal(cat.get("tipo"), tipo);
+        };
+    }
+
+    public static Specification<Producto> tipoCategoriaIn(Collection<TipoCategoria> tipos) {
+        return (root, cq, cb) -> {
+            if (tipos == null || tipos.isEmpty()) {
+                return cb.conjunction();
+            }
+
+            Join<Object, Object> cat = root.join("categoriaProducto");
+            var inClause = cb.in(cat.get("tipo"));
+            tipos.forEach(inClause::value);
+            return inClause;
         };
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -163,6 +164,14 @@ class VidaUtilProductoServiceImplTest {
     }
 
     @Test
+    void guardar_deberiaFallarCuandoProductoIdEsNulo() {
+        assertThatThrownBy(() -> service.guardar(null, 8))
+                .isInstanceOf(CustomBusinessException.class)
+                .extracting("code")
+                .isEqualTo(ApiErrorCode.NEGOCIO_GENERICO);
+    }
+
+    @Test
     void guardar_deberiaFallarCuandoProductoNoEsTerminado() {
         CategoriaProducto categoria = new CategoriaProducto();
         categoria.setTipo(TipoCategoria.MATERIA_PRIMA);
@@ -176,6 +185,21 @@ class VidaUtilProductoServiceImplTest {
                 .isInstanceOf(CustomBusinessException.class)
                 .extracting("code")
                 .isEqualTo(ApiErrorCode.VIDA_UTIL_SOLO_PRODUCTO_TERMINADO);
+    }
+
+    @Test
+    void guardar_deberiaFallarCuandoProductoNoTieneIdPersistente() {
+        CategoriaProducto categoria = new CategoriaProducto();
+        categoria.setTipo(TipoCategoria.PRODUCTO_TERMINADO);
+        Producto sinId = new Producto();
+        sinId.setCategoriaProducto(categoria);
+
+        when(productoRepository.findById(30L)).thenReturn(Optional.of(sinId));
+
+        assertThatThrownBy(() -> service.guardar(30, 6))
+                .isInstanceOf(CustomBusinessException.class)
+                .extracting("code")
+                .isEqualTo(ApiErrorCode.NEGOCIO_GENERICO);
     }
 
     @Test
@@ -249,5 +273,33 @@ class VidaUtilProductoServiceImplTest {
         assertThat(dto.getSemanasVigencia()).isNull();
         assertThat(dto.getActualizadoPorNombre()).isNull();
         assertThat(dto.getFechaActualizacion()).isNull();
+    }
+
+    @Test
+    void listarProductosTerminados_deberiaIncluirProductosSemielaborados() {
+        VidaUtilProducto vidaUtilPs = VidaUtilProducto.builder()
+                .productoId(productoSemielaborado.getId())
+                .producto(productoSemielaborado)
+                .semanasVigencia(10)
+                .actualizadoPor(usuarioAutenticado)
+                .fechaActualizacion(LocalDateTime.now())
+                .build();
+
+        when(productoRepository.findAll(any(Specification.class), eq(PageRequest.of(0, 10))))
+                .thenReturn(new PageImpl<>(List.of(productoTerminado, productoSemielaborado)));
+        when(vidaUtilProductoRepository.findAllById(List.of(productoTerminado.getId(), productoSemielaborado.getId())))
+                .thenReturn(List.of(vidaUtilPs));
+
+        Page<VidaUtilProductoDTO> page = service.listarProductosTerminados(null, PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).hasSize(2);
+        VidaUtilProductoDTO dtoSemielaborado = page.getContent().stream()
+                .filter(dto -> productoSemielaborado.getId().equals(dto.getProductoId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(dtoSemielaborado.getSemanasVigencia()).isEqualTo(10);
+        assertThat(dtoSemielaborado.getActualizadoPorNombre()).isEqualTo(usuarioAutenticado.getNombreCompleto());
+        assertThat(dtoSemielaborado.getFechaActualizacion()).isEqualTo(vidaUtilPs.getFechaActualizacion());
     }
 }


### PR DESCRIPTION
## Summary
- incluye productos semielaborados en el listado de vida útil mediante un filtro de categorías compartido
- refuerza el guardado de vida útil validando productoId y mapeando errores de negocio antes de persistir
- amplía las pruebas de servicio para cubrir PS, identificadores nulos y nuevos escenarios de listado

## Testing
- mvn -Dtest=VidaUtilProductoServiceImplTest test
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c00e74a083338c2c098d181c57b8)