### PR TITLE
Corrige inicialización de PK en vida útil de producto

### DIFF
--- a/docs/vida-util-mapeo.md
+++ b/docs/vida-util-mapeo.md
@@ -1,0 +1,5 @@
+# Mapeo de `VidaUtilProducto`
+
+- **El @Id real es `productoId`** (tipo `Integer`).
+- La columna PK en la tabla `vida_util_productos` es `producto_id`.
+- El atributo `producto` es una relación `@OneToOne` marcada como `insertable = false` y `updatable = false`; se usa solo para navegación y no define la clave primaria.

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
@@ -74,16 +74,16 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
         VidaUtilProducto vidaUtil = vidaUtilProductoRepository.findById(productoIdPersistencia)
                 .orElseGet(() -> {
                     VidaUtilProducto nuevo = new VidaUtilProducto();
-                    nuevo.setProducto(producto);
                     nuevo.setProductoId(productoIdPersistencia);
+                    nuevo.setProducto(producto);
                     return nuevo;
                 });
 
-        if (vidaUtil.getProducto() == null) {
-            vidaUtil.setProducto(producto);
-        }
         if (vidaUtil.getProductoId() == null) {
             vidaUtil.setProductoId(productoIdPersistencia);
+        }
+        if (vidaUtil.getProducto() == null) {
+            vidaUtil.setProducto(producto);
         }
         vidaUtil.setSemanasVigencia(semanasVigencia);
 
@@ -91,8 +91,8 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
         vidaUtil.setActualizadoPor(usuarioActual);
         vidaUtil.setFechaActualizacion(LocalDateTime.now());
 
-        if (vidaUtil.getProductoId() == null) {
-            throw new IllegalStateException("VidaUtilProducto sin productoId antes de guardar");
+        if (vidaUtil.getProductoId() == null && (vidaUtil.getProducto() == null || vidaUtil.getProducto().getId() == null)) {
+            throw new IllegalStateException("Intento de guardar VidaUtilProducto sin PK configurada (productoId=" + productoId + ")");
         }
 
         return vidaUtilProductoRepository.save(vidaUtil);

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImplTest.java
@@ -226,6 +226,36 @@ class VidaUtilProductoServiceImplTest {
     }
 
     @Test
+    void deberiaCrearVidaUtilParaProductoTerminadoConPkValida() {
+        when(productoRepository.findById(10L)).thenReturn(Optional.of(productoTerminado));
+        when(vidaUtilProductoRepository.findById(productoTerminado.getId())).thenReturn(Optional.empty());
+        when(vidaUtilProductoRepository.save(any(VidaUtilProducto.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuarioAutenticado);
+
+        VidaUtilProducto resultado = service.guardar(productoTerminado.getId(), 14);
+
+        assertThat(resultado.getProductoId()).isEqualTo(productoTerminado.getId());
+        assertThat(resultado.getProducto()).isEqualTo(productoTerminado);
+        assertThat(resultado.getSemanasVigencia()).isEqualTo(14);
+    }
+
+    @Test
+    void deberiaCrearVidaUtilParaProductoSemielaboradoConPkValida() {
+        when(productoRepository.findById(20L)).thenReturn(Optional.of(productoSemielaborado));
+        when(vidaUtilProductoRepository.findById(productoSemielaborado.getId())).thenReturn(Optional.empty());
+        when(vidaUtilProductoRepository.save(any(VidaUtilProducto.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuarioAutenticado);
+
+        VidaUtilProducto resultado = service.guardar(productoSemielaborado.getId(), 18);
+
+        assertThat(resultado.getProductoId()).isEqualTo(productoSemielaborado.getId());
+        assertThat(resultado.getProducto()).isEqualTo(productoSemielaborado);
+        assertThat(resultado.getSemanasVigencia()).isEqualTo(18);
+    }
+
+    @Test
     void guardar_deberiaFallarCuandoSemanasInvalidas() {
         when(productoRepository.findById(10L)).thenReturn(Optional.of(productoTerminado));
 


### PR DESCRIPTION
## Summary
- Documenta el mapeo de clave primaria de `VidaUtilProducto` en un archivo de soporte
- Ajusta el servicio de vida útil para inicializar siempre la PK y validar antes de persistir
- Agrega pruebas que verifican la creación de vida útil con identificador no nulo para PT y PS

## Testing
- mvn -q -Dtest=VidaUtilProductoServiceImplTest test
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c531f6e08333bbbfb4cde2784ef9)