### PR TITLE
Ajustar liberación de lotes con control de calidad

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -515,6 +515,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
                     Map.of("loteId", id, "estadoActual", lote.getEstado() != null ? lote.getEstado().name() : null));
         }
         lote.setEstado(EstadoLote.LIBERADO);
+        lote.setFechaLiberacion(LocalDateTime.now());
         lote.setUsuarioLiberador(usuarioService.obtenerUsuarioAutenticado());
         loteRepo.save(lote);
         return loteProductoMapper.toResponseDTO(lote);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -2227,7 +2227,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         if (destino.getCategoria() == TipoCategoria.OBSOLETOS) {
             loteDestino.setEstado(EstadoLote.RECHAZADO);
         } else if (loteDestino.getEstado() == null) {
-            loteDestino.setEstado(EstadoLote.DISPONIBLE);
+            loteDestino.setEstado(obtenerEstadoInicial(producto));
         }
 
         recalcularAgotadoSegunDisponibilidad(loteDestino);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -115,7 +115,7 @@ inventory.vencidos.movimiento.clasificacion=RECHAZO_CALIDAD
 inventory.vencidos.almacenDestinoId=${inventory.almacen.obsoletos.id}
 
 # --- LOTE ---
-inventory.lote.estadoLiberado=DISPONIBLE
+inventory.lote.estadoLiberado=LIBERADO
 
 # --- SOLICITUDES ---
 inventory.solicitud.estados.pendientes=PENDIENTE,AUTORIZADA,RESERVADA

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImplTest.java
@@ -9,6 +9,8 @@ import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
 import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
 import com.willyes.clemenintegra.calidad.service.NoConformidadService;
 import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
+import com.willyes.clemenintegra.inventario.dto.LoteProductoRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
 import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
@@ -42,6 +44,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -79,7 +82,7 @@ class LoteProductoServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(service, "estadoLiberadoConf", "DISPONIBLE");
+        ReflectionTestUtils.setField(service, "estadoLiberadoConf", "LIBERADO");
         ReflectionTestUtils.setField(service, "clasificacionLiberacionConf", "LIBERACION_CALIDAD");
         ReflectionTestUtils.setField(service, "clasificacionRechazoCalidad", "RECHAZO_CALIDAD");
 
@@ -105,7 +108,7 @@ class LoteProductoServiceImplTest {
 
         service.liberarLotePorCalidad(10L, jefeCalidad);
 
-        assertThat(lote.getEstado()).isEqualTo(EstadoLote.DISPONIBLE);
+        assertThat(lote.getEstado()).isEqualTo(EstadoLote.LIBERADO);
         assertThat(lote.getAlmacen().getId()).isEqualTo(2L);
 
         ArgumentCaptor<com.willyes.clemenintegra.inventario.model.MovimientoInventario> movCaptor = ArgumentCaptor.forClass(com.willyes.clemenintegra.inventario.model.MovimientoInventario.class);
@@ -130,13 +133,94 @@ class LoteProductoServiceImplTest {
 
         service.liberarLotePorCalidad(20L, jefeCalidad);
 
-        assertThat(lote.getEstado()).isEqualTo(EstadoLote.DISPONIBLE);
+        assertThat(lote.getEstado()).isEqualTo(EstadoLote.LIBERADO);
         assertThat(lote.getAlmacen().getId()).isEqualTo(8L);
 
         ArgumentCaptor<com.willyes.clemenintegra.inventario.model.MovimientoInventario> movCaptor = ArgumentCaptor.forClass(com.willyes.clemenintegra.inventario.model.MovimientoInventario.class);
         verify(movimientoInventarioRepository).save(movCaptor.capture());
         assertThat(movCaptor.getValue().getAlmacenDestino().getId()).isEqualTo(8L);
         assertThat(movCaptor.getValue().getAlmacenOrigen().getId()).isEqualTo(7L);
+    }
+
+    @Test
+    @DisplayName("Crear lote sin análisis de calidad lo deja DISPONIBLE")
+    void crearLoteSinAnalisisQuedaDisponible() {
+        LoteProductoRequestDTO request = LoteProductoRequestDTO.builder()
+                .productoId(1L)
+                .almacenId(2L)
+                .codigoLote("L-001")
+                .stockLote(BigDecimal.ONE)
+                .fechaVencimiento(LocalDateTime.now().plusDays(30))
+                .build();
+
+        Producto producto = new Producto();
+        producto.setId(1);
+        producto.setTipoAnalisisCalidad(TipoAnalisisCalidad.NINGUNO);
+        Almacen almacen = almacenConId(2);
+        Usuario usuario = usuarioConRol(RolUsuario.ROL_JEFE_CALIDAD);
+
+        LoteProducto entidad = new LoteProducto();
+
+        when(productoRepo.findById(1L)).thenReturn(Optional.of(producto));
+        when(almacenRepo.findById(2L)).thenReturn(Optional.of(almacen));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(loteProductoMapper.toEntity(request, producto, almacen, usuario)).thenReturn(entidad);
+        when(loteProductoRepository.saveAndFlush(entidad)).thenReturn(entidad);
+        when(loteProductoMapper.toResponseDTO(entidad)).thenAnswer(inv -> LoteProductoResponseDTO.builder()
+                .estado(entidad.getEstado())
+                .build());
+
+        LoteProductoResponseDTO respuesta = service.crearLote(request);
+
+        assertThat(entidad.getEstado()).isEqualTo(EstadoLote.DISPONIBLE);
+        assertThat(respuesta.getEstado()).isEqualTo(EstadoLote.DISPONIBLE);
+    }
+
+    @Test
+    @DisplayName("Crear y liberar lote con análisis cambia de CUARENTENA a LIBERADO")
+    void crearYLiberarLoteConAnalisis() {
+        LoteProductoRequestDTO request = LoteProductoRequestDTO.builder()
+                .productoId(5L)
+                .almacenId(9L)
+                .codigoLote("L-002")
+                .stockLote(BigDecimal.TEN)
+                .fechaVencimiento(LocalDateTime.now().plusDays(60))
+                .build();
+
+        Producto producto = new Producto();
+        producto.setId(5);
+        producto.setTipoAnalisisCalidad(TipoAnalisisCalidad.FISICO);
+        Almacen almacen = almacenConId(9);
+        Usuario usuario = usuarioConRol(RolUsuario.ROL_ANALISTA_CALIDAD);
+
+        LoteProducto entidad = LoteProducto.builder()
+                .id(44L)
+                .estado(null)
+                .stockReservado(BigDecimal.ZERO)
+                .build();
+
+        when(productoRepo.findById(5L)).thenReturn(Optional.of(producto));
+        when(almacenRepo.findById(9L)).thenReturn(Optional.of(almacen));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(loteProductoMapper.toEntity(request, producto, almacen, usuario)).thenReturn(entidad);
+        when(loteProductoRepository.saveAndFlush(entidad)).thenReturn(entidad);
+        when(loteProductoMapper.toResponseDTO(entidad)).thenAnswer(inv -> LoteProductoResponseDTO.builder()
+                .estado(entidad.getEstado())
+                .build());
+        when(loteProductoRepository.findById(44L)).thenReturn(Optional.of(entidad));
+        when(evaluacionRepository.findByLoteProductoId(44L)).thenReturn(evaluacionesConforme());
+
+        LoteProductoResponseDTO creado = service.crearLote(request);
+
+        assertThat(entidad.getEstado()).isEqualTo(EstadoLote.EN_CUARENTENA);
+        assertThat(creado.getEstado()).isEqualTo(EstadoLote.EN_CUARENTENA);
+
+        LoteProductoResponseDTO liberado = service.liberarLote(44L);
+
+        assertThat(entidad.getEstado()).isEqualTo(EstadoLote.LIBERADO);
+        assertThat(entidad.getFechaLiberacion()).isNotNull();
+        assertThat(entidad.getUsuarioLiberador()).isEqualTo(usuario);
+        assertThat(liberado.getEstado()).isEqualTo(EstadoLote.LIBERADO);
     }
 
     private void mockCatalogosBasicos(Long motivoId, Long tipoDetalleId) {


### PR DESCRIPTION
## Summary
- Garantizar que los lotes que pasan por Calidad se liberen en estado LIBERADO y registren fecha/usuario de liberación
- Ajustar el estado inicial de lotes creados en movimientos según el tipo de análisis requerido y actualizar la configuración por defecto
- Añadir pruebas que cubren creación y liberación de lotes con y sin control de calidad

## Testing
- mvn -q test -Dtest="*LoteProductoService*,*DisponibilidadInsumoService*,*OrdenProduccionService*"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da67e41a88333bf6402e18a830842)