### PR TITLE
Fix VidaUtilProducto shared PK mapping

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/VidaUtilProducto.java
@@ -20,12 +20,11 @@ public class VidaUtilProducto {
     @EqualsAndHashCode.Include
     private Integer productoId;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId
     @JoinColumn(
             name = "producto_id",
             referencedColumnName = "id",
-            insertable = false,
-            updatable = false,
             foreignKey = @ForeignKey(name = "fk_vida_util_productos_producto")
     )
     private Producto producto;
@@ -39,6 +38,13 @@ public class VidaUtilProducto {
 
     @Column(name = "fecha_actualizacion")
     private LocalDateTime fechaActualizacion;
+
+    public void setProducto(Producto producto) {
+        this.producto = producto;
+        if (producto != null) {
+            this.productoId = producto.getId();
+        }
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- map VidaUtilProducto to share primary key with Producto using @MapsId
- synchronize productoId when setting the Producto reference to avoid null identifiers on insert/update

## Testing
- mvn test -Dtest=VidaUtilProductoServiceImplTest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692daf0fd15c8333b71289bfeaeeaf6b)