### PR TITLE
Asegurar sincronización de VidaUtilProducto con Producto

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/VidaUtilProductoServiceImpl.java
@@ -72,19 +72,10 @@ public class VidaUtilProductoServiceImpl implements VidaUtilProductoService {
         }
 
         VidaUtilProducto vidaUtil = vidaUtilProductoRepository.findById(productoIdPersistencia)
-                .orElseGet(() -> {
-                    VidaUtilProducto nuevo = new VidaUtilProducto();
-                    nuevo.setProductoId(productoIdPersistencia);
-                    nuevo.setProducto(producto);
-                    return nuevo;
-                });
+                .orElseGet(VidaUtilProducto::new);
 
-        if (vidaUtil.getProductoId() == null) {
-            vidaUtil.setProductoId(productoIdPersistencia);
-        }
-        if (vidaUtil.getProducto() == null) {
-            vidaUtil.setProducto(producto);
-        }
+        // Sincronizar siempre la relación @MapsId antes de persistir
+        vidaUtil.setProducto(producto);
         vidaUtil.setSemanasVigencia(semanasVigencia);
 
         Usuario usuarioActual = usuarioService.obtenerUsuarioAutenticado();


### PR DESCRIPTION
## Summary
- Reuse or create VidaUtilProducto instances and always bind the Producto relationship before persisting to honor @MapsId.
- Simplify the guard rails around VidaUtilProducto creation/update to avoid null identifiers when saving.

## Testing
- `mvn -q test -Dtest=VidaUtilProductoServiceImplTest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db488ce848333904f1fd2c74884ce)