### PR TITLE
Add public backend version endpoint with build metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,14 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+              <goal>build-info</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <excludes>
             <exclude>
@@ -243,6 +251,24 @@
           </excludes>
           <!-- Prevent spring-boot:run from compiling test sources -->
           <useTestClasspath>false</useTestClasspath>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>6.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <gitPropertiesFileName>git.properties</gitPropertiesFileName>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -63,7 +63,8 @@ public class SecurityConfig {
                             "/swagger-resources",
                             "/configuration/ui",
                             "/configuration/security",
-                            "/webjars/**"
+                            "/webjars/**",
+                            "/api/public/version"
                     ).permitAll();
 
                     auth.requestMatchers(

--- a/src/main/java/com/willyes/clemenintegra/shared/version/VersionController.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/version/VersionController.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.shared.version;
+
+import com.willyes.clemenintegra.shared.version.dto.VersionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/public/version")
+@RequiredArgsConstructor
+public class VersionController {
+
+    private final VersionService versionService;
+
+    @GetMapping
+    public VersionResponse getVersion() {
+        return versionService.getVersionInfo();
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/version/VersionService.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/version/VersionService.java
@@ -1,0 +1,46 @@
+package com.willyes.clemenintegra.shared.version;
+
+import com.willyes.clemenintegra.shared.version.dto.VersionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class VersionService {
+
+    private final BuildProperties buildProperties;
+    private final ObjectProvider<GitProperties> gitPropertiesProvider;
+
+    public VersionResponse getVersionInfo() {
+        GitProperties gitProperties = gitPropertiesProvider.getIfAvailable();
+
+        String gitTag = Optional.ofNullable(gitProperties)
+                .map(properties -> properties.get("tags"))
+                .filter(tag -> !tag.isBlank())
+                .orElse(null);
+
+        String gitCommitId = Optional.ofNullable(gitProperties)
+                .map(GitProperties::getShortCommitId)
+                .orElse(null);
+
+        if ((gitTag == null || gitTag.isBlank()) && gitCommitId != null) {
+            gitTag = gitCommitId;
+        }
+
+        Instant buildInstant = buildProperties.getTime();
+
+        return VersionResponse.builder()
+                .appName(buildProperties.getName())
+                .version(buildProperties.getVersion())
+                .buildTime(buildInstant != null ? buildInstant.toString() : null)
+                .gitTag(gitTag)
+                .gitCommitId(gitCommitId)
+                .build();
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/version/dto/VersionResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/version/dto/VersionResponse.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.shared.version.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VersionResponse {
+    private String appName;
+    private String version;
+    private String buildTime;
+    private String gitTag;
+    private String gitCommitId;
+}


### PR DESCRIPTION
## Summary
- add build-info generation and git commit metadata via Maven plugins
- create version DTO/service/controller exposing `/api/public/version` with build and git info
- allow unauthenticated access to the version endpoint in security configuration

## Testing
- mvn clean package -DskipTests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692def55d3348333b5d224d90dfbb7f8)