### PR TITLE
Allow public public endpoints to bypass JWT checks

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
@@ -32,7 +32,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         final String uri = request.getRequestURI();
 
         // 1) Deja pasar preflight CORS y endpoints públicos
-        if ("OPTIONS".equalsIgnoreCase(request.getMethod()) || uri.startsWith("/api/auth")) {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())
+                || uri.startsWith("/api/auth")
+                || uri.startsWith("/api/public/")
+                || "/auth/login".equals(uri)) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
                             "/configuration/ui",
                             "/configuration/security",
                             "/webjars/**",
-                            "/api/public/version"
+                            "/api/public/**"
                     ).permitAll();
 
                     auth.requestMatchers(


### PR DESCRIPTION
## Summary
- allow all `/api/public/**` routes to bypass JWT authentication in the filter
- configure security to permit all public routes

## Testing
- mvn clean package


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfb1d08f88333b017020e96067daa)