### PR TITLE
Escalar insumos directos y simplificar PDF de Batch Record

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
@@ -183,7 +183,8 @@ public class BatchRecordServiceImpl implements BatchRecordService {
                         continue;
                     }
                 }
-                detalles.add(crearDetalleFormulaDTO(detalle, detalle.getCantidadNecesaria()));
+                detalles.add(crearDetalleFormulaDTO(detalle, calcularCantidadTeoricaPt(detalle.getCantidadNecesaria(),
+                        cantidadProgramada)));
             }
         }
         formulaDTO.detalles = detalles;
@@ -217,6 +218,14 @@ public class BatchRecordServiceImpl implements BatchRecordService {
         BigDecimal psPorPt = cantidadPsPorPt != null ? cantidadPsPorPt : BigDecimal.ZERO;
         BigDecimal cantidadPt = cantidadProgramadaPt != null ? cantidadProgramadaPt : BigDecimal.ONE;
         return cantidadMpPorPs.multiply(psPorPt).multiply(cantidadPt);
+    }
+
+    private BigDecimal calcularCantidadTeoricaPt(BigDecimal cantidadNecesariaPorUnidad, BigDecimal cantidadProgramadaPt) {
+        if (cantidadNecesariaPorUnidad == null) {
+            return null;
+        }
+        BigDecimal cantidadPt = cantidadProgramadaPt != null ? cantidadProgramadaPt : BigDecimal.ONE;
+        return cantidadNecesariaPorUnidad.multiply(cantidadPt);
     }
 
     private BatchRecordDTO.DetalleFormulaDTO crearDetalleFormulaDTO(DetalleFormula detalle, BigDecimal cantidadNecesaria) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteBatchRecordServiceImpl.java
@@ -68,7 +68,6 @@ public class ReporteBatchRecordServiceImpl implements ReporteBatchRecordService 
                 .replace("${op.responsable}", escape(nz(op != null ? op.responsableNombre : "")))
                 .replace("${op.porcentajeCumplimiento}", escape(formatDecimal(op != null ? op.porcentajeCumplimiento : null)));
 
-        template = template.replace("${formulaRows}", buildFormulaRows(batchRecord.formula));
         template = template.replace("${consumoRows}", buildConsumoRows(batchRecord.consumos));
         template = template.replace("${reservaRows}", buildReservaRows(batchRecord.reservas));
         template = template.replace("${controlProcesoRows}", buildControlProcesoRows(batchRecord.controlesProceso));
@@ -100,23 +99,6 @@ public class ReporteBatchRecordServiceImpl implements ReporteBatchRecordService 
                 .replace("${batchRecord.observacionesCalidad!'-'}",
                         escape(defaultWithDash(batchRecord != null ? batchRecord.observacionesCalidad : null)));
         return template;
-    }
-
-    private String buildFormulaRows(BatchRecordDTO.FormulaDTO formula) {
-        StringBuilder sb = new StringBuilder();
-        List<BatchRecordDTO.DetalleFormulaDTO> detalles = formula != null ? formula.detalles : null;
-        if (detalles != null) {
-            for (BatchRecordDTO.DetalleFormulaDTO detalle : detalles) {
-                sb.append("<tr>")
-                        .append(td(detalle.codigoSku))
-                        .append(td(detalle.nombre))
-                        .append(td(detalle.unidad))
-                        .append(td(formatDecimal(detalle.cantidadNecesaria)))
-                        .append(td(detalle.obligatorio ? "Sí" : "No"))
-                        .append("</tr>");
-            }
-        }
-        return sb.toString();
     }
 
     private String buildConsumoRows(List<BatchRecordDTO.ConsumoDTO> consumos) {

--- a/src/main/resources/templates/produccion/batch-record.ftl
+++ b/src/main/resources/templates/produccion/batch-record.ftl
@@ -35,21 +35,7 @@
     <div><span class="label">Fin:</span> ${op.fechaFin}</div>
 </div>
 
-<h2>1. Fórmula / Componentes requeridos</h2>
-<table>
-    <thead>
-    <tr>
-        <th>Código insumo</th>
-        <th>Nombre</th>
-        <th>Unidad</th>
-        <th>Cantidad necesaria</th>
-        <th>Obligatorio</th>
-    </tr>
-    </thead>
-    <tbody>${formulaRows}</tbody>
-</table>
-
-<h2>2. Consumos reales / reservas</h2>
+<h2>1. Materiales utilizados (consumos y reservas)</h2>
 <table>
     <thead>
     <tr>
@@ -76,7 +62,7 @@
     <tbody>${reservaRows}</tbody>
 </table>
 
-<h2>3. Controles en proceso</h2>
+<h2>2. Controles en proceso</h2>
 <table>
     <thead>
     <tr>
@@ -93,7 +79,7 @@
     <tbody>${controlProcesoRows}</tbody>
 </table>
 
-<h2>4. Controles de empaque</h2>
+<h2>3. Controles de empaque</h2>
 <table>
     <thead>
     <tr>
@@ -109,7 +95,7 @@
     <tbody>${controlEmpaqueRows}</tbody>
 </table>
 
-<h2>5. Producción final y calidad</h2>
+<h2>4. Producción final y calidad</h2>
 <table>
     <thead>
     <tr>
@@ -178,7 +164,7 @@
     <tbody>${retencionRows}</tbody>
 </table>
 
-<h2>6. Revisión y aprobación de Calidad</h2>
+<h2>5. Revisión y aprobación de Calidad</h2>
 <table>
     <tbody>
     <tr>
@@ -200,7 +186,7 @@
     </tbody>
 </table>
 
-<h2>7. Observaciones</h2>
+<h2>6. Observaciones</h2>
 <table>
     <thead>
     <tr>

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
@@ -50,7 +50,9 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -171,7 +173,8 @@ class BatchRecordServiceImplTest {
 
         assertThat(result.formula.detalles).hasSize(1);
         assertThat(result.formula.detalles.get(0).codigoSku).isEqualTo("MP-1");
-        assertThat(result.formula.detalles.get(0).cantidadNecesaria).isEqualByComparingTo(BigDecimal.TEN);
+        assertThat(result.formula.detalles.get(0).cantidadNecesaria)
+                .isEqualByComparingTo(new BigDecimal("100"));
     }
 
     @Test
@@ -223,6 +226,115 @@ class BatchRecordServiceImplTest {
                         new BigDecimal("3.0"), // 0.5 * 2 * 3
                         new BigDecimal("7.50")  // 1.25 * 2 * 3
                 );
+    }
+
+    @Test
+    @DisplayName("mapFormula escala componentes directos del PT por cantidad programada cuando no hay PS")
+    void mapFormulaEscalaComponentesDirectosSinPs() {
+        OrdenProduccion orden = buildOrdenProduccion();
+        orden.setCantidadProgramada(new BigDecimal("100"));
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+
+        Producto capsula = productoConCategoria(21, "ME-CAP", "Cápsula", TipoCategoria.MATERIA_PRIMA);
+        Producto etiqueta = productoConCategoria(22, "ME-ETI", "Etiqueta", TipoCategoria.MATERIA_PRIMA);
+        Producto linner = productoConCategoria(23, "ME-LIN", "Linner", TipoCategoria.MATERIA_PRIMA);
+
+        FormulaProducto formula = buildFormulaConDetalles(orden.getProducto(), List.of(
+                detalleFormula(capsula, BigDecimal.ONE),
+                detalleFormula(etiqueta, BigDecimal.ONE),
+                detalleFormula(linner, BigDecimal.ONE)
+        ));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                1L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+        when(reservaLoteRepository.findBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionId(1L))
+                .thenReturn(Collections.emptyList());
+        when(cierreProduccionRepository.findByOrdenProduccionId(1L, Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(1L, 10L))
+                .thenReturn(Optional.empty());
+        when(controlProcesoProduccionRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(controlEmpaqueLoteRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(observacionProcesoRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+
+        BatchRecordDTO result = service.buildByOrdenProduccion(1L);
+
+        Map<String, BigDecimal> cantidades = result.formula.detalles.stream()
+                .collect(Collectors.toMap(d -> d.codigoSku, d -> d.cantidadNecesaria));
+
+        assertThat(cantidades)
+                .containsEntry("ME-CAP", new BigDecimal("100"))
+                .containsEntry("ME-ETI", new BigDecimal("100"))
+                .containsEntry("ME-LIN", new BigDecimal("100"));
+    }
+
+    @Test
+    @DisplayName("mapFormula escala insumos directos y mantiene expansión de PS sin duplicar cantidades")
+    void mapFormulaEscalaComponentesConPs() {
+        OrdenProduccion orden = buildOrdenProduccion();
+        orden.setCantidadProgramada(new BigDecimal("30"));
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+
+        Producto envase = productoConCategoria(24, "ME-ENV", "Envase", TipoCategoria.MATERIA_PRIMA);
+        Producto etiqueta = productoConCategoria(25, "ME-ETQ", "Etiqueta", TipoCategoria.MATERIA_PRIMA);
+        Producto linner = productoConCategoria(26, "ME-LIN", "Linner", TipoCategoria.MATERIA_PRIMA);
+        Producto tapa = productoConCategoria(27, "ME-TAP", "Tapa", TipoCategoria.MATERIA_PRIMA);
+        Producto capsula = productoConCategoria(28, "ME-CAP", "Cápsula", TipoCategoria.MATERIA_PRIMA);
+        Producto ps = productoConCategoria(30, "PS-1", "Semi", TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+
+        FormulaProducto formulaPt = buildFormulaConDetalles(orden.getProducto(), List.of(
+                detalleFormula(envase, BigDecimal.ONE),
+                detalleFormula(etiqueta, BigDecimal.ONE),
+                detalleFormula(linner, BigDecimal.ONE),
+                detalleFormula(tapa, BigDecimal.ONE),
+                detalleFormula(capsula, BigDecimal.ONE),
+                detalleFormula(ps, BigDecimal.ONE)
+        ));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaPt));
+
+        Producto uva = productoConCategoria(40, "MP-UVA", "UVA", TipoCategoria.MATERIA_PRIMA);
+        Producto maltodextrina = productoConCategoria(41, "MP-MAL", "Maltodextrina", TipoCategoria.MATERIA_PRIMA);
+        FormulaProducto formulaPs = buildFormulaConDetalles(ps, List.of(
+                detalleFormula(uva, new BigDecimal("0.5")),
+                detalleFormula(maltodextrina, new BigDecimal("0.25"))
+        ));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(30L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaPs));
+
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                1L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+        when(reservaLoteRepository.findBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionId(1L))
+                .thenReturn(Collections.emptyList());
+        when(cierreProduccionRepository.findByOrdenProduccionId(1L, Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(1L, 10L))
+                .thenReturn(Optional.empty());
+        when(controlProcesoProduccionRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(controlEmpaqueLoteRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(observacionProcesoRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+
+        BatchRecordDTO result = service.buildByOrdenProduccion(1L);
+
+        Map<String, BigDecimal> cantidades = result.formula.detalles.stream()
+                .collect(Collectors.toMap(d -> d.codigoSku, d -> d.cantidadNecesaria));
+
+        assertThat(cantidades)
+                .containsEntry("ME-ENV", new BigDecimal("30"))
+                .containsEntry("ME-ETQ", new BigDecimal("30"))
+                .containsEntry("ME-LIN", new BigDecimal("30"))
+                .containsEntry("ME-TAP", new BigDecimal("30"))
+                .containsEntry("ME-CAP", new BigDecimal("30"))
+                .containsEntry("MP-UVA", new BigDecimal("15.0"))
+                .containsEntry("MP-MAL", new BigDecimal("7.50"));
     }
 
     @Test
@@ -464,11 +576,15 @@ class BatchRecordServiceImplTest {
     }
 
     private FormulaProducto buildFormulaConDetalle(Producto producto, Producto insumo, BigDecimal cantidad) {
+        return buildFormulaConDetalles(producto, List.of(detalleFormula(insumo, cantidad)));
+    }
+
+    private FormulaProducto buildFormulaConDetalles(Producto producto, List<DetalleFormula> detalles) {
         FormulaProducto formula = new FormulaProducto();
         formula.setProducto(producto);
         formula.setVersion("v1");
         formula.setEstado(EstadoFormula.APROBADA);
-        formula.setDetalles(List.of(detalleFormula(insumo, cantidad)));
+        formula.setDetalles(detalles);
         return formula;
     }
 


### PR DESCRIPTION
## Summary
- Escalé las cantidades de componentes directos del producto terminado al tamaño de lote en el batch record, conservando la expansión correcta de productos semi elaborados.
- Simplifiqué el PDF del Batch Record eliminando la tabla de fórmula y renumerando las secciones para mostrar solo materiales utilizados.
- Amplié las pruebas de BatchRecordServiceImpl para cubrir casos con y sin productos semi elaborados.

## Testing
- `mvn -q -Dtest=BatchRecordServiceImplTest test` *(falló: repositorio Maven respondió 502 al resolver org.springframework.data:spring-data-jpa)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69307ac5d57c8333a4cc77eddc408fe0)