### PR TITLE
Expand batch record materials for semi-finished inputs

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDTO.java
@@ -65,6 +65,9 @@ public class BatchRecordDTO {
         public BigDecimal cantidad;
         public String unidad;
         public LocalDateTime fechaMovimiento;
+        public Boolean fromPs;
+        public String psDescripcion;
+        public String psCodigoSku;
     }
 
     public static class ReservaDTO {

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
@@ -119,7 +119,7 @@ public class BatchRecordServiceImpl implements BatchRecordService {
         BatchRecordDTO dto = new BatchRecordDTO();
         dto.op = mapOp(ordenProduccion);
         dto.formula = mapFormula(ordenProduccion);
-        dto.consumos = mapConsumos(ordenProduccionId);
+        dto.consumos = mapConsumos(ordenProduccion);
         dto.reservas = mapReservas(ordenProduccionId);
         dto.cierres = mapCierres(ordenProduccionId);
         dto.produccionFinal = mapProduccionFinal(ordenProduccion, dto.cierres);
@@ -257,7 +257,8 @@ public class BatchRecordServiceImpl implements BatchRecordService {
                 && detalle.getInsumo().getCategoriaProducto().getTipo() == TipoCategoria.PRODUCTO_SEMI_ELABORADO;
     }
 
-    private List<BatchRecordDTO.ConsumoDTO> mapConsumos(Long ordenProduccionId) {
+    private List<BatchRecordDTO.ConsumoDTO> mapConsumos(OrdenProduccion ordenProduccion) {
+        Long ordenProduccionId = ordenProduccion != null ? ordenProduccion.getId() : null;
         List<MovimientoInventario> movimientos = movimientoInventarioRepository
                 .findByOrdenProduccionIdAndClasificacion(
                         ordenProduccionId,
@@ -265,28 +266,123 @@ public class BatchRecordServiceImpl implements BatchRecordService {
                         Pageable.unpaged())
                 .getContent();
         List<BatchRecordDTO.ConsumoDTO> consumos = new ArrayList<>();
+        List<MovimientoInventario> consumosPs = new ArrayList<>();
+
+        List<Long> productosSemiElaborados = obtenerProductosSemiElaboradosEnFormula(ordenProduccion);
         for (MovimientoInventario movimiento : movimientos) {
             // Solo se consideran consumos reales de producción (SALIDA_PRODUCCION desde Pre-Bodega)
             if (movimiento.getTipoMovimiento() != TipoMovimiento.SALIDA) {
                 continue;
             }
-            BatchRecordDTO.ConsumoDTO consumoDTO = new BatchRecordDTO.ConsumoDTO();
-            consumoDTO.tipoMovimiento = movimiento.getTipoMovimiento() != null ? movimiento.getTipoMovimiento().name() : null;
-            consumoDTO.clasificacionMovimiento = movimiento.getClasificacion() != null ? movimiento.getClasificacion().name() : null;
-            consumoDTO.productoId = movimiento.getProducto() != null ? movimiento.getProducto().getId().longValue() : null;
-            consumoDTO.codigoSku = movimiento.getProducto() != null ? movimiento.getProducto().getCodigoSku() : null;
-            consumoDTO.nombreProducto = movimiento.getProducto() != null ? movimiento.getProducto().getNombre() : null;
-            consumoDTO.loteId = movimiento.getLote() != null ? movimiento.getLote().getId() : null;
-            consumoDTO.codigoLote = movimiento.getLote() != null ? movimiento.getLote().getCodigoLote() : null;
-            consumoDTO.almacenOrigen = movimiento.getAlmacenOrigen() != null ? movimiento.getAlmacenOrigen().getNombre() : null;
-            consumoDTO.cantidad = movimiento.getCantidad();
-            consumoDTO.unidad = movimiento.getProducto() != null && movimiento.getProducto().getUnidadMedida() != null
-                    ? movimiento.getProducto().getUnidadMedida().getNombre()
-                    : null;
-            consumoDTO.fechaMovimiento = movimiento.getFechaIngreso();
+            if (esMovimientoDePs(movimiento, productosSemiElaborados)) {
+                consumosPs.add(movimiento);
+                continue;
+            }
+            consumos.add(crearConsumoDtoDesdeMovimiento(movimiento));
+        }
+
+        for (MovimientoInventario movimientoPs : consumosPs) {
+            List<BatchRecordDTO.ConsumoDTO> consumosExpandido = expandirConsumoPs(movimientoPs);
+            if (consumosExpandido == null) {
+                consumos.add(crearConsumoDtoDesdeMovimiento(movimientoPs));
+                continue;
+            }
+            consumos.addAll(consumosExpandido);
+        }
+        return consumos;
+    }
+
+    private List<BatchRecordDTO.ConsumoDTO> expandirConsumoPs(MovimientoInventario movimientoPs) {
+        if (movimientoPs == null || movimientoPs.getProducto() == null || movimientoPs.getProducto().getId() == null) {
+            return null;
+        }
+        FormulaProducto formulaPs = obtenerFormulaProducto(movimientoPs.getProducto());
+        if (formulaPs == null || formulaPs.getDetalles() == null || formulaPs.getDetalles().isEmpty()) {
+            return null;
+        }
+        List<BatchRecordDTO.ConsumoDTO> consumos = new ArrayList<>();
+        for (DetalleFormula detalle : formulaPs.getDetalles()) {
+            BigDecimal cantidadTeorica = calcularCantidadDesdeConsumoPs(movimientoPs.getCantidad(), detalle.getCantidadNecesaria());
+            BatchRecordDTO.ConsumoDTO consumoDTO = crearConsumoDesdeDetallePs(detalle, movimientoPs, cantidadTeorica);
             consumos.add(consumoDTO);
         }
         return consumos;
+    }
+
+    private List<Long> obtenerProductosSemiElaboradosEnFormula(OrdenProduccion ordenProduccion) {
+        List<Long> productosPs = new ArrayList<>();
+        if (ordenProduccion == null || ordenProduccion.getProducto() == null) {
+            return productosPs;
+        }
+        FormulaProducto formulaPt = obtenerFormulaProducto(ordenProduccion.getProducto());
+        if (formulaPt == null || formulaPt.getDetalles() == null) {
+            return productosPs;
+        }
+        for (DetalleFormula detalle : formulaPt.getDetalles()) {
+            if (detalle.getInsumo() != null
+                    && detalle.getInsumo().getId() != null
+                    && esProductoSemiElaborado(detalle)) {
+                productosPs.add(detalle.getInsumo().getId().longValue());
+            }
+        }
+        return productosPs;
+    }
+
+    private boolean esMovimientoDePs(MovimientoInventario movimiento, List<Long> productosPs) {
+        if (movimiento == null || movimiento.getProducto() == null || movimiento.getProducto().getId() == null) {
+            return false;
+        }
+        return productosPs.contains(movimiento.getProducto().getId().longValue());
+    }
+
+    private BatchRecordDTO.ConsumoDTO crearConsumoDtoDesdeMovimiento(MovimientoInventario movimiento) {
+        BatchRecordDTO.ConsumoDTO consumoDTO = new BatchRecordDTO.ConsumoDTO();
+        consumoDTO.tipoMovimiento = movimiento.getTipoMovimiento() != null ? movimiento.getTipoMovimiento().name() : null;
+        consumoDTO.clasificacionMovimiento = movimiento.getClasificacion() != null ? movimiento.getClasificacion().name() : null;
+        consumoDTO.productoId = movimiento.getProducto() != null ? movimiento.getProducto().getId().longValue() : null;
+        consumoDTO.codigoSku = movimiento.getProducto() != null ? movimiento.getProducto().getCodigoSku() : null;
+        consumoDTO.nombreProducto = movimiento.getProducto() != null ? movimiento.getProducto().getNombre() : null;
+        consumoDTO.loteId = movimiento.getLote() != null ? movimiento.getLote().getId() : null;
+        consumoDTO.codigoLote = movimiento.getLote() != null ? movimiento.getLote().getCodigoLote() : null;
+        consumoDTO.almacenOrigen = movimiento.getAlmacenOrigen() != null ? movimiento.getAlmacenOrigen().getNombre() : null;
+        consumoDTO.cantidad = movimiento.getCantidad();
+        consumoDTO.unidad = movimiento.getProducto() != null && movimiento.getProducto().getUnidadMedida() != null
+                ? movimiento.getProducto().getUnidadMedida().getNombre()
+                : null;
+        consumoDTO.fechaMovimiento = movimiento.getFechaIngreso();
+        return consumoDTO;
+    }
+
+    private BatchRecordDTO.ConsumoDTO crearConsumoDesdeDetallePs(DetalleFormula detalle,
+                                                                 MovimientoInventario movimientoPs,
+                                                                 BigDecimal cantidadTeorica) {
+        BatchRecordDTO.ConsumoDTO consumoDTO = new BatchRecordDTO.ConsumoDTO();
+        consumoDTO.tipoMovimiento = movimientoPs.getTipoMovimiento() != null ? movimientoPs.getTipoMovimiento().name() : null;
+        consumoDTO.clasificacionMovimiento = movimientoPs.getClasificacion() != null ? movimientoPs.getClasificacion().name() : null;
+        consumoDTO.productoId = detalle.getInsumo() != null ? detalle.getInsumo().getId().longValue() : null;
+        consumoDTO.codigoSku = detalle.getInsumo() != null ? detalle.getInsumo().getCodigoSku() : null;
+        consumoDTO.nombreProducto = detalle.getInsumo() != null ? detalle.getInsumo().getNombre() : null;
+        consumoDTO.loteId = movimientoPs.getLote() != null ? movimientoPs.getLote().getId() : null;
+        consumoDTO.codigoLote = movimientoPs.getLote() != null ? movimientoPs.getLote().getCodigoLote() : null;
+        consumoDTO.almacenOrigen = movimientoPs.getAlmacenOrigen() != null ? movimientoPs.getAlmacenOrigen().getNombre() : null;
+        consumoDTO.cantidad = cantidadTeorica;
+        consumoDTO.unidad = detalle.getUnidadMedida() != null
+                ? detalle.getUnidadMedida().getNombre()
+                : movimientoPs.getProducto() != null && movimientoPs.getProducto().getUnidadMedida() != null
+                ? movimientoPs.getProducto().getUnidadMedida().getNombre()
+                : null;
+        consumoDTO.fechaMovimiento = movimientoPs.getFechaIngreso();
+        consumoDTO.fromPs = true;
+        consumoDTO.psDescripcion = movimientoPs.getProducto() != null ? movimientoPs.getProducto().getNombre() : null;
+        consumoDTO.psCodigoSku = movimientoPs.getProducto() != null ? movimientoPs.getProducto().getCodigoSku() : null;
+        return consumoDTO;
+    }
+
+    private BigDecimal calcularCantidadDesdeConsumoPs(BigDecimal cantidadPsConsumida, BigDecimal cantidadDetalle) {
+        if (cantidadPsConsumida == null || cantidadDetalle == null) {
+            return null;
+        }
+        return cantidadPsConsumida.multiply(cantidadDetalle);
     }
 
     private List<BatchRecordDTO.ReservaDTO> mapReservas(Long ordenProduccionId) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
@@ -9,6 +9,7 @@ import com.willyes.clemenintegra.calidad.model.RetencionLote;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
 import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
 import com.willyes.clemenintegra.calidad.repository.RetencionLoteRepository;
+import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.Producto;
@@ -478,6 +479,105 @@ class BatchRecordServiceImplTest {
     }
 
     @Test
+    @DisplayName("mapConsumos mantiene insumos directos cuando el PT no usa PS")
+    void mapConsumosSinProductoSemiElaborado() {
+        OrdenProduccion orden = buildOrdenProduccion();
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+
+        Producto mp = productoConCategoria(20, "MP-1", "Materia prima", TipoCategoria.MATERIA_PRIMA);
+        FormulaProducto formulaPt = buildFormulaConDetalle(orden.getProducto(), mp, BigDecimal.ONE);
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaPt));
+
+        MovimientoInventario movimientoMp = movimientoProduccion(mp, "L-MP", "Principal MP", new BigDecimal("5"));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                1L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(List.of(movimientoMp)));
+
+        when(reservaLoteRepository.findBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionId(1L))
+                .thenReturn(Collections.emptyList());
+        when(cierreProduccionRepository.findByOrdenProduccionId(1L, Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(1L, 10L))
+                .thenReturn(Optional.empty());
+        when(controlProcesoProduccionRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(controlEmpaqueLoteRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(observacionProcesoRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+
+        BatchRecordDTO result = service.buildByOrdenProduccion(1L);
+
+        assertThat(result.consumos).hasSize(1);
+        BatchRecordDTO.ConsumoDTO consumo = result.consumos.get(0);
+        assertThat(consumo.productoId).isEqualTo(mp.getId().longValue());
+        assertThat(consumo.cantidad).isEqualByComparingTo(new BigDecimal("5"));
+        assertThat(consumo.fromPs).isNull();
+    }
+
+    @Test
+    @DisplayName("mapConsumos explota componentes de PS y elimina el renglón del PS")
+    void mapConsumosConProductoSemiElaborado() {
+        OrdenProduccion orden = buildOrdenProduccion();
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+
+        Producto ps = productoConCategoria(30, "PS-1", "Semi", TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        FormulaProducto formulaPt = buildFormulaConDetalle(orden.getProducto(), ps, BigDecimal.ONE);
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaPt));
+
+        Producto mp1 = productoConCategoria(40, "MP-1", "Materia 1", TipoCategoria.MATERIA_PRIMA);
+        Producto mp2 = productoConCategoria(41, "MP-2", "Materia 2", TipoCategoria.MATERIA_PRIMA);
+        FormulaProducto formulaPs = buildFormulaConDetalles(ps, List.of(
+                detalleFormula(mp1, new BigDecimal("0.50")),
+                detalleFormula(mp2, new BigDecimal("1.25"))
+        ));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(30L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaPs));
+
+        MovimientoInventario movimientoPs = movimientoProduccion(ps, "L-PS", "Principal Semi Elaborados", new BigDecimal("30"));
+        LocalDateTime fechaMovimiento = LocalDateTime.now();
+        movimientoPs.setFechaIngreso(fechaMovimiento);
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                1L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(List.of(movimientoPs)));
+
+        when(reservaLoteRepository.findBySolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionId(1L))
+                .thenReturn(Collections.emptyList());
+        when(cierreProduccionRepository.findByOrdenProduccionId(1L, Pageable.unpaged()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(1L, 10L))
+                .thenReturn(Optional.empty());
+        when(controlProcesoProduccionRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(controlEmpaqueLoteRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+        when(observacionProcesoRepository.findByOrdenProduccionId(1L)).thenReturn(Collections.emptyList());
+
+        BatchRecordDTO result = service.buildByOrdenProduccion(1L);
+
+        assertThat(result.consumos)
+                .extracting(c -> c.productoId)
+                .doesNotContain(ps.getId().longValue());
+
+        Map<String, BatchRecordDTO.ConsumoDTO> consumosPorSku = result.consumos.stream()
+                .collect(Collectors.toMap(c -> c.codigoSku, c -> c));
+
+        assertThat(consumosPorSku.get("MP-1").cantidad)
+                .isEqualByComparingTo(new BigDecimal("15.00")); // 0.5 * 30
+        assertThat(consumosPorSku.get("MP-2").cantidad)
+                .isEqualByComparingTo(new BigDecimal("37.50")); // 1.25 * 30
+
+        assertThat(consumosPorSku.values())
+                .allSatisfy(consumo -> {
+                    assertThat(consumo.fromPs).isTrue();
+                    assertThat(consumo.codigoLote).isEqualTo("L-PS");
+                    assertThat(consumo.almacenOrigen).isEqualTo("Principal Semi Elaborados");
+                    assertThat(consumo.fechaMovimiento).isEqualTo(fechaMovimiento);
+                });
+    }
+
+    @Test
     @DisplayName("buildByOrdenProduccion lanza excepción cuando la OP no existe")
     void buildByOrdenProduccionOrdenInexistente() {
         when(ordenProduccionRepository.findById(99L)).thenReturn(Optional.empty());
@@ -559,6 +659,23 @@ class BatchRecordServiceImplTest {
                 "ROL_JEFE_CALIDAD");
         token.setAuthenticated(true);
         return token;
+    }
+
+    private MovimientoInventario movimientoProduccion(Producto producto, String codigoLote, String nombreAlmacen, BigDecimal cantidad) {
+        MovimientoInventario movimiento = new MovimientoInventario();
+        movimiento.setProducto(producto);
+        movimiento.setCantidad(cantidad);
+        movimiento.setTipoMovimiento(TipoMovimiento.SALIDA);
+        movimiento.setClasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+        LoteProducto lote = new LoteProducto();
+        lote.setId(100L);
+        lote.setCodigoLote(codigoLote);
+        movimiento.setLote(lote);
+        Almacen almacen = new Almacen();
+        almacen.setNombre(nombreAlmacen);
+        movimiento.setAlmacenOrigen(almacen);
+        movimiento.setFechaIngreso(LocalDateTime.now());
+        return movimiento;
     }
 
     private Producto productoConCategoria(Integer id, String sku, String nombre, TipoCategoria tipoCategoria) {


### PR DESCRIPTION
## Summary
- Expand batch record consumption mapping to explode semi-finished inputs into their component materials using approved formulas.
- Add metadata to batch record consumption DTOs to mark rows originating from semi-finished products.
- Extend batch record service tests to cover PT orders with and without semi-finished inputs.

## Testing
- mvn -q test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69308933a73c833388b8d29855e8a3c6)