### PR TITLE
Expose lot expiration date on production order detail

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionResponseDTO.java
@@ -24,4 +24,5 @@ public class OrdenProduccionResponseDTO {
     public String unidadMedidaSimbolo;
     public String unidadMedidaBaseSimbolo;
     public String nombreResponsable;
+    public LocalDateTime fechaVencimientoLotePt;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
@@ -49,6 +49,7 @@ public class ProduccionMapper {
         dto.unidadMedida = entidad.getUnidadMedida() != null ? entidad.getUnidadMedida().getNombre() : null;
         dto.unidadMedidaSimbolo = entidad.getUnidadMedida() != null ? entidad.getUnidadMedida().getSimbolo() : null;
         dto.nombreResponsable = entidad.getResponsable() != null ? entidad.getResponsable().getNombreCompleto() : null;
+        dto.fechaVencimientoLotePt = entidad.getFechaVencimientoLotePt();
         return dto;
     }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
@@ -27,6 +27,9 @@ public class OrdenProduccion {
     @Column(name = "lote_producto_id")
     private Long loteId;
 
+    @Transient
+    private LocalDateTime fechaVencimientoLotePt;
+
     @Column(nullable = false)
     private LocalDateTime fechaInicio;
     private LocalDateTime fechaFin;

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -556,7 +556,20 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     }
 
     public Optional<OrdenProduccion> buscarPorId(Long id) {
-        return repository.findById(id);
+        return repository.findById(id).map(this::adjuntarFechaVencimientoLotePt);
+    }
+
+    private OrdenProduccion adjuntarFechaVencimientoLotePt(OrdenProduccion orden) {
+        if (orden == null || orden.getProducto() == null || orden.getProducto().getId() == null) {
+            orden.setFechaVencimientoLotePt(null);
+            return orden;
+        }
+
+        Optional<LoteProducto> lotePt = loteProductoRepository
+                .findByOrdenProduccionIdAndProductoId(orden.getId(), orden.getProducto().getId().longValue());
+
+        orden.setFechaVencimientoLotePt(lotePt.map(LoteProducto::getFechaVencimiento).orElse(null));
+        return orden;
     }
 
     public void eliminar(Long id) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -28,12 +28,14 @@ import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.*;
 import com.willyes.clemenintegra.produccion.dto.OrdenProduccionRequestDTO;
+import com.willyes.clemenintegra.produccion.dto.OrdenProduccionResponseDTO;
 import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
 import com.willyes.clemenintegra.produccion.dto.CierreProduccionRequestDTO;
 import com.willyes.clemenintegra.calidad.service.VidaUtilProductoService;
 import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.mapper.ProduccionMapper;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
 import com.willyes.clemenintegra.produccion.model.enums.TipoCierre;
@@ -1298,6 +1300,58 @@ class OrdenProduccionServiceImplTest {
 
         assertThat(productosSolicitados)
                 .containsExactlyInAnyOrder(401L, 402L);
+    }
+
+    @Test
+    @DisplayName("buscarPorId retorna fecha de vencimiento del lote PT cuando existe")
+    void buscarPorId_conLotePtIncluyeFechaVencimiento() {
+        Producto producto = new Producto();
+        producto.setId(1);
+
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .id(10L)
+                .producto(producto)
+                .estado(EstadoProduccion.CREADA)
+                .build();
+
+        LocalDateTime fechaVencimiento = LocalDateTime.now().plusMonths(6);
+        LoteProducto lote = LoteProducto.builder()
+                .id(5L)
+                .fechaVencimiento(fechaVencimiento)
+                .build();
+
+        when(ordenProduccionRepository.findById(10L)).thenReturn(Optional.of(orden));
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(10L, 1L))
+                .thenReturn(Optional.of(lote));
+
+        Optional<OrdenProduccion> resultado = service.buscarPorId(10L);
+
+        assertThat(resultado).isPresent();
+        OrdenProduccionResponseDTO dto = ProduccionMapper.toResponse(resultado.get());
+        assertThat(dto.fechaVencimientoLotePt).isEqualTo(fechaVencimiento);
+    }
+
+    @Test
+    @DisplayName("buscarPorId deja fecha de vencimiento del lote PT en null cuando no hay lote")
+    void buscarPorId_sinLotePtDevuelveFechaNull() {
+        Producto producto = new Producto();
+        producto.setId(2);
+
+        OrdenProduccion orden = OrdenProduccion.builder()
+                .id(20L)
+                .producto(producto)
+                .estado(EstadoProduccion.CREADA)
+                .build();
+
+        when(ordenProduccionRepository.findById(20L)).thenReturn(Optional.of(orden));
+        when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(20L, 2L))
+                .thenReturn(Optional.empty());
+
+        Optional<OrdenProduccion> resultado = service.buscarPorId(20L);
+
+        assertThat(resultado).isPresent();
+        OrdenProduccionResponseDTO dto = ProduccionMapper.toResponse(resultado.get());
+        assertThat(dto.fechaVencimientoLotePt).isNull();
     }
 
     private void stubInfraReserva() {


### PR DESCRIPTION
## Summary
- add the PT lot expiration date to the production order detail response DTO
- populate the expiration date by resolving the associated lot from the production order
- cover detail retrieval with tests for orders with and without PT lots

## Testing
- mvn -q -Dtest=OrdenProduccionServiceImplTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930cc8d614883339486d1c98ae7ae95)