### PR TITLE
Add closed lifecycle state for weekly production plan

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
@@ -48,6 +48,13 @@ public class PlanProduccionController {
         return ResponseEntity.ok(toDto(plan));
     }
 
+    @PostMapping("/{id}/cerrar")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    public ResponseEntity<PlanProduccionSemanalDTO> cerrar(@PathVariable Long id) {
+        PlanProduccionSemanal plan = planProduccionService.cerrar(id);
+        return ResponseEntity.ok(toDto(plan));
+    }
+
     @GetMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<Page<PlanProduccionSemanalDTO>> listar(

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/EstadoPlanProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/EstadoPlanProduccion.java
@@ -2,5 +2,6 @@ package com.willyes.clemenintegra.planeacion.model.enums;
 
 public enum EstadoPlanProduccion {
     BORRADOR,
-    CONFIRMADO
+    CONFIRMADO,
+    CERRADO
 }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/PlanProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/PlanProduccionService.java
@@ -14,6 +14,8 @@ public interface PlanProduccionService {
 
     PlanProduccionSemanal confirmar(Long id);
 
+    PlanProduccionSemanal cerrar(Long id);
+
     Optional<PlanProduccionSemanal> buscarPorId(Long id);
 
     Page<PlanProduccionSemanal> listar(LocalDate semanaInicio, LocalDate semanaFin, String estado, Pageable pageable);

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
@@ -44,6 +44,12 @@ public class MrpServiceImpl implements MrpService {
         if (plan == null) {
             throw new IllegalArgumentException("El plan semanal es obligatorio");
         }
+        if (plan.getEstado() == EstadoPlanProduccion.BORRADOR) {
+            throw new IllegalStateException("No se puede ejecutar MRP sobre un plan en BORRADOR; primero debe confirmarse");
+        }
+        if (plan.getEstado() == EstadoPlanProduccion.CERRADO) {
+            throw new IllegalStateException("No se puede ejecutar MRP sobre un plan CERRADO");
+        }
         if (plan.getEstado() != EstadoPlanProduccion.CONFIRMADO) {
             throw new IllegalStateException("El plan debe estar confirmado para ejecutar el MRP");
         }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
@@ -85,6 +85,18 @@ public class PlanProduccionServiceImpl implements PlanProduccionService {
     }
 
     @Override
+    public PlanProduccionSemanal cerrar(Long id) {
+        PlanProduccionSemanal plan = planProduccionSemanalRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Plan semanal no encontrado"));
+        if (plan.getEstado() != EstadoPlanProduccion.CONFIRMADO) {
+            throw new IllegalStateException("Solo los planes en CONFIRMADO pueden cerrarse");
+        }
+        plan.setEstado(EstadoPlanProduccion.CERRADO);
+        // TODO: actualizar migración de base de datos si la columna estado usa un check/enum.
+        return planProduccionSemanalRepository.save(plan);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public Optional<PlanProduccionSemanal> buscarPorId(Long id) {
         return planProduccionSemanalRepository.findById(id);

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
@@ -1,0 +1,48 @@
+package com.willyes.clemenintegra.planeacion.service.impl;
+
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
+import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class MrpServiceImplTest {
+
+    @Mock
+    private FormulaProductoRepository formulaProductoRepository;
+
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+
+    @Mock
+    private CorridaMrpRepository corridaMrpRepository;
+
+    @InjectMocks
+    private MrpServiceImpl service;
+
+    @Test
+    void noPermiteEjecutarMrpConPlanBorrador() {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .estado(EstadoPlanProduccion.BORRADOR)
+                .build();
+
+        assertThrows(IllegalStateException.class, () -> service.ejecutarCorridaSemana(plan));
+    }
+
+    @Test
+    void noPermiteEjecutarMrpConPlanCerrado() {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .estado(EstadoPlanProduccion.CERRADO)
+                .build();
+
+        assertThrows(IllegalStateException.class, () -> service.ejecutarCorridaSemana(plan));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.planeacion.service.impl;
 
 import com.willyes.clemenintegra.planeacion.dto.PlanProduccionSemanalDTO;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import com.willyes.clemenintegra.planeacion.repository.PlanProduccionSemanalRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,6 +42,7 @@ class PlanProduccionServiceImplTest {
 
         assertEquals(inicio, plan.getSemanaInicio());
         assertEquals(fin, plan.getSemanaFin());
+        assertEquals(EstadoPlanProduccion.BORRADOR, plan.getEstado());
     }
 
     @Test
@@ -47,5 +50,105 @@ class PlanProduccionServiceImplTest {
         PlanProduccionSemanalDTO dto = new PlanProduccionSemanalDTO();
 
         assertThrows(IllegalArgumentException.class, () -> service.crearOActualizar(dto));
+    }
+
+    @Test
+    void editarPlanBorradorActualizaDatos() {
+        PlanProduccionSemanal existente = PlanProduccionSemanal.builder()
+                .id(10L)
+                .estado(EstadoPlanProduccion.BORRADOR)
+                .semanaInicio(LocalDate.of(2025, 11, 17))
+                .semanaFin(LocalDate.of(2025, 11, 23))
+                .build();
+        PlanProduccionSemanalDTO dto = PlanProduccionSemanalDTO.builder()
+                .id(10L)
+                .semanaInicio(LocalDate.of(2025, 11, 24))
+                .semanaFin(LocalDate.of(2025, 11, 30))
+                .comentarios("actualizado")
+                .build();
+
+        when(planProduccionSemanalRepository.findById(10L)).thenReturn(Optional.of(existente));
+        when(planProduccionSemanalRepository.save(any(PlanProduccionSemanal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        PlanProduccionSemanal plan = service.crearOActualizar(dto);
+
+        assertEquals(EstadoPlanProduccion.BORRADOR, plan.getEstado());
+        assertEquals(dto.getSemanaInicio(), plan.getSemanaInicio());
+        assertEquals(dto.getSemanaFin(), plan.getSemanaFin());
+        assertEquals(dto.getComentarios(), plan.getComentarios());
+    }
+
+    @Test
+    void confirmarPlanBorradorCambiaEstado() {
+        PlanProduccionSemanal existente = PlanProduccionSemanal.builder()
+                .id(20L)
+                .estado(EstadoPlanProduccion.BORRADOR)
+                .build();
+
+        when(planProduccionSemanalRepository.findById(20L)).thenReturn(Optional.of(existente));
+        when(planProduccionSemanalRepository.save(any(PlanProduccionSemanal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        PlanProduccionSemanal confirmado = service.confirmar(20L);
+
+        assertEquals(EstadoPlanProduccion.CONFIRMADO, confirmado.getEstado());
+    }
+
+    @Test
+    void editarPlanConfirmadoLanzaError() {
+        PlanProduccionSemanal existente = PlanProduccionSemanal.builder()
+                .id(30L)
+                .estado(EstadoPlanProduccion.CONFIRMADO)
+                .build();
+        PlanProduccionSemanalDTO dto = PlanProduccionSemanalDTO.builder()
+                .id(30L)
+                .semanaInicio(LocalDate.now())
+                .semanaFin(LocalDate.now())
+                .build();
+
+        when(planProduccionSemanalRepository.findById(30L)).thenReturn(Optional.of(existente));
+
+        assertThrows(IllegalStateException.class, () -> service.crearOActualizar(dto));
+    }
+
+    @Test
+    void confirmarPlanConfirmadoLanzaError() {
+        PlanProduccionSemanal existente = PlanProduccionSemanal.builder()
+                .id(40L)
+                .estado(EstadoPlanProduccion.CONFIRMADO)
+                .build();
+
+        when(planProduccionSemanalRepository.findById(40L)).thenReturn(Optional.of(existente));
+
+        assertThrows(IllegalStateException.class, () -> service.confirmar(40L));
+    }
+
+    @Test
+    void cerrarPlanConfirmadoCambiaEstado() {
+        PlanProduccionSemanal existente = PlanProduccionSemanal.builder()
+                .id(50L)
+                .estado(EstadoPlanProduccion.CONFIRMADO)
+                .build();
+
+        when(planProduccionSemanalRepository.findById(50L)).thenReturn(Optional.of(existente));
+        when(planProduccionSemanalRepository.save(any(PlanProduccionSemanal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        PlanProduccionSemanal cerrado = service.cerrar(50L);
+
+        assertEquals(EstadoPlanProduccion.CERRADO, cerrado.getEstado());
+    }
+
+    @Test
+    void cerrarPlanEnBorradorLanzaError() {
+        PlanProduccionSemanal existente = PlanProduccionSemanal.builder()
+                .id(60L)
+                .estado(EstadoPlanProduccion.BORRADOR)
+                .build();
+
+        when(planProduccionSemanalRepository.findById(60L)).thenReturn(Optional.of(existente));
+
+        assertThrows(IllegalStateException.class, () -> service.cerrar(60L));
     }
 }


### PR DESCRIPTION
## Summary
- add CERRADO status to EstadoPlanProduccion and enforce lifecycle rules for editing, confirming, and closing weekly plans
- expose a new endpoint to close production plans and block MRP execution for non-confirmed or closed plans
- expand unit tests for plan lifecycle validations and MRP state checks

## Testing
- mvn -q test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938555031888333911cdae1fc0bb4ae)