### PR TITLE
Agregar filtros y DTO resumido para listado de planes semanales

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
@@ -3,14 +3,16 @@ package com.willyes.clemenintegra.planeacion.controller;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.planeacion.dto.PlanProduccionSemanalDTO;
+import com.willyes.clemenintegra.planeacion.dto.PlanProduccionResumenDTO;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionDetalle;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
 import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +22,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/planeacion/planes-semanales")
@@ -57,14 +58,13 @@ public class PlanProduccionController {
 
     @GetMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_SUPER_ADMIN')")
-    public ResponseEntity<Page<PlanProduccionSemanalDTO>> listar(
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate semanaInicio,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate semanaFin,
-            @RequestParam(required = false) String estado,
-            @PageableDefault(size = 20, sort = "semanaInicio") Pageable pageable) {
-        Page<PlanProduccionSemanal> planes = planProduccionService.listar(semanaInicio, semanaFin, estado, pageable);
-        List<PlanProduccionSemanalDTO> contenido = planes.getContent().stream().map(this::toDto).collect(Collectors.toList());
-        return ResponseEntity.ok(new PageImpl<>(contenido, pageable, planes.getTotalElements()));
+    public ResponseEntity<Page<PlanProduccionResumenDTO>> listar(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate semanaInicioDesde,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate semanaInicioHasta,
+            @RequestParam(required = false) EstadoPlanProduccion estado,
+            @PageableDefault(size = 20, sort = "semanaInicio", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<PlanProduccionResumenDTO> planes = planProduccionService.listar(semanaInicioDesde, semanaInicioHasta, estado, pageable);
+        return ResponseEntity.ok(planes);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/PlanProduccionResumenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/PlanProduccionResumenDTO.java
@@ -1,0 +1,24 @@
+package com.willyes.clemenintegra.planeacion.dto;
+
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlanProduccionResumenDTO {
+    private Long id;
+    private LocalDate semanaInicio;
+    private LocalDate semanaFin;
+    private EstadoPlanProduccion estado;
+    private String creadoPorNombre;
+    private LocalDateTime fechaCreacion;
+    private LocalDateTime fechaConfirmacion;
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/repository/PlanProduccionSemanalRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/repository/PlanProduccionSemanalRepository.java
@@ -13,8 +13,8 @@ import java.time.LocalDate;
 public interface PlanProduccionSemanalRepository extends JpaRepository<PlanProduccionSemanal, Long> {
 
     @Query("select p from PlanProduccionSemanal p where (:inicio is null or p.semanaInicio >= :inicio) " +
-            "and (:fin is null or p.semanaFin <= :fin) " +
-            "and (:estado is null or p.estado = :estado)" )
+            "and (:fin is null or p.semanaInicio <= :fin) " +
+            "and (:estado is null or p.estado = :estado)")
     Page<PlanProduccionSemanal> buscarPorFiltros(@Param("inicio") LocalDate inicio,
                                                  @Param("fin") LocalDate fin,
                                                  @Param("estado") EstadoPlanProduccion estado,

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/PlanProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/PlanProduccionService.java
@@ -1,7 +1,9 @@
 package com.willyes.clemenintegra.planeacion.service;
 
 import com.willyes.clemenintegra.planeacion.dto.PlanProduccionSemanalDTO;
+import com.willyes.clemenintegra.planeacion.dto.PlanProduccionResumenDTO;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -18,5 +20,5 @@ public interface PlanProduccionService {
 
     Optional<PlanProduccionSemanal> buscarPorId(Long id);
 
-    Page<PlanProduccionSemanal> listar(LocalDate semanaInicio, LocalDate semanaFin, String estado, Pageable pageable);
+    Page<PlanProduccionResumenDTO> listar(LocalDate semanaInicioDesde, LocalDate semanaInicioHasta, EstadoPlanProduccion estado, Pageable pageable);
 }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.planeacion.service.impl;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.planeacion.dto.PlanProduccionSemanalDTO;
+import com.willyes.clemenintegra.planeacion.dto.PlanProduccionResumenDTO;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionDetalle;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
@@ -12,7 +13,9 @@ import com.willyes.clemenintegra.shared.model.Usuario;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -104,15 +107,25 @@ public class PlanProduccionServiceImpl implements PlanProduccionService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<PlanProduccionSemanal> listar(LocalDate semanaInicio, LocalDate semanaFin, String estado, Pageable pageable) {
-        EstadoPlanProduccion estadoEnum = null;
-        if (estado != null && !estado.isBlank()) {
-            try {
-                estadoEnum = EstadoPlanProduccion.valueOf(estado.toUpperCase());
-            } catch (IllegalArgumentException ex) {
-                estadoEnum = null;
-            }
+    public Page<PlanProduccionResumenDTO> listar(LocalDate semanaInicioDesde, LocalDate semanaInicioHasta, EstadoPlanProduccion estado, Pageable pageable) {
+        Pageable pageableToUse = pageable;
+        if (pageable.getSort().isUnsorted()) {
+            pageableToUse = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "semanaInicio"));
         }
-        return planProduccionSemanalRepository.buscarPorFiltros(semanaInicio, semanaFin, estadoEnum, pageable);
+
+        return planProduccionSemanalRepository.buscarPorFiltros(semanaInicioDesde, semanaInicioHasta, estado, pageableToUse)
+                .map(this::toResumenDto);
+    }
+
+    private PlanProduccionResumenDTO toResumenDto(PlanProduccionSemanal plan) {
+        return PlanProduccionResumenDTO.builder()
+                .id(plan.getId())
+                .semanaInicio(plan.getSemanaInicio())
+                .semanaFin(plan.getSemanaFin())
+                .estado(plan.getEstado())
+                .creadoPorNombre(plan.getCreadoPor() != null ? plan.getCreadoPor().getNombreCompleto() : null)
+                .fechaCreacion(plan.getFechaCreacion())
+                .fechaConfirmacion(null)
+                .build();
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerTest.java
@@ -1,6 +1,8 @@
 package com.willyes.clemenintegra.planeacion.controller;
 
+import com.willyes.clemenintegra.planeacion.dto.PlanProduccionResumenDTO;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,14 +17,18 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @WebMvcTest(controllers = PlanProduccionController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -65,15 +71,34 @@ class PlanProduccionControllerTest {
     @Test
     @WithMockUser(authorities = "ROL_SUPER_ADMIN")
     void listarPlanPermiteSuperAdmin() throws Exception {
-        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+        PlanProduccionResumenDTO plan = PlanProduccionResumenDTO.builder()
                 .id(2L)
-                .detalles(List.of())
+                .estado(EstadoPlanProduccion.CONFIRMADO)
+                .semanaInicio(LocalDate.of(2024, 1, 1))
+                .semanaFin(LocalDate.of(2024, 1, 7))
                 .build();
         when(planProduccionService.listar(any(), any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(plan)));
 
         mockMvc.perform(get("/api/planeacion/planes-semanales"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(2))
+                .andExpect(jsonPath("$.content[0].estado").value("CONFIRMADO"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void listarConFiltrosPasaParametrosAlServicio() throws Exception {
+        when(planProduccionService.listar(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/planeacion/planes-semanales")
+                        .param("semanaInicioDesde", "2024-04-01")
+                        .param("semanaInicioHasta", "2024-04-07")
+                        .param("estado", "BORRADOR"))
                 .andExpect(status().isOk());
+
+        verify(planProduccionService).listar(eq(LocalDate.of(2024, 4, 1)), eq(LocalDate.of(2024, 4, 7)), eq(EstadoPlanProduccion.BORRADOR), any());
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.planeacion.service.impl;
 
 import com.willyes.clemenintegra.planeacion.dto.PlanProduccionSemanalDTO;
+import com.willyes.clemenintegra.planeacion.dto.PlanProduccionResumenDTO;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import com.willyes.clemenintegra.planeacion.repository.PlanProduccionSemanalRepository;
@@ -8,14 +9,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 class PlanProduccionServiceImplTest {
@@ -150,5 +161,80 @@ class PlanProduccionServiceImplTest {
         when(planProduccionSemanalRepository.findById(60L)).thenReturn(Optional.of(existente));
 
         assertThrows(IllegalStateException.class, () -> service.cerrar(60L));
+    }
+
+    @Test
+    void listarSinFiltrosUsaOrdenPorSemanaDesc() {
+        PlanProduccionSemanal planReciente = PlanProduccionSemanal.builder()
+                .id(1L)
+                .semanaInicio(LocalDate.of(2024, 1, 8))
+                .semanaFin(LocalDate.of(2024, 1, 14))
+                .estado(EstadoPlanProduccion.CONFIRMADO)
+                .build();
+        PlanProduccionSemanal planAnterior = PlanProduccionSemanal.builder()
+                .id(2L)
+                .semanaInicio(LocalDate.of(2023, 12, 31))
+                .semanaFin(LocalDate.of(2024, 1, 6))
+                .estado(EstadoPlanProduccion.CERRADO)
+                .build();
+
+        when(planProduccionSemanalRepository.buscarPorFiltros(any(), any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(planReciente, planAnterior)));
+
+        Page<PlanProduccionResumenDTO> resultado = service.listar(null, null, null, PageRequest.of(0, 10));
+
+        assertEquals(2, resultado.getContent().size());
+        assertEquals(planReciente.getSemanaInicio(), resultado.getContent().get(0).getSemanaInicio());
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(planProduccionSemanalRepository, times(1))
+                .buscarPorFiltros(eq(null), eq(null), eq(null), pageableCaptor.capture());
+        Sort.Order sortOrder = pageableCaptor.getValue().getSort().getOrderFor("semanaInicio");
+        assertNotNull(sortOrder);
+        assertEquals(Sort.Direction.DESC, sortOrder.getDirection());
+    }
+
+    @Test
+    void listarFiltradoPorEstado() {
+        PlanProduccionSemanal planConfirmado = PlanProduccionSemanal.builder()
+                .id(3L)
+                .semanaInicio(LocalDate.of(2024, 2, 5))
+                .semanaFin(LocalDate.of(2024, 2, 11))
+                .estado(EstadoPlanProduccion.CONFIRMADO)
+                .build();
+
+        when(planProduccionSemanalRepository.buscarPorFiltros(any(), any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(planConfirmado)));
+
+        service.listar(null, null, EstadoPlanProduccion.CONFIRMADO, PageRequest.of(0, 5, Sort.by("semanaInicio")));
+
+        ArgumentCaptor<EstadoPlanProduccion> estadoCaptor = ArgumentCaptor.forClass(EstadoPlanProduccion.class);
+        verify(planProduccionSemanalRepository).buscarPorFiltros(eq(null), eq(null), estadoCaptor.capture(), any(Pageable.class));
+        assertEquals(EstadoPlanProduccion.CONFIRMADO, estadoCaptor.getValue());
+    }
+
+    @Test
+    void listarFiltradoPorRangoSemanaInicio() {
+        LocalDate desde = LocalDate.of(2024, 3, 4);
+        LocalDate hasta = LocalDate.of(2024, 3, 18);
+        PlanProduccionSemanal planDentroDeRango = PlanProduccionSemanal.builder()
+                .id(4L)
+                .semanaInicio(LocalDate.of(2024, 3, 11))
+                .semanaFin(LocalDate.of(2024, 3, 17))
+                .estado(EstadoPlanProduccion.BORRADOR)
+                .build();
+
+        when(planProduccionSemanalRepository.buscarPorFiltros(any(), any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(planDentroDeRango)));
+
+        Page<PlanProduccionResumenDTO> resultado = service.listar(desde, hasta, null, PageRequest.of(0, 5));
+
+        assertEquals(1, resultado.getTotalElements());
+        assertEquals(planDentroDeRango.getSemanaInicio(), resultado.getContent().get(0).getSemanaInicio());
+
+        ArgumentCaptor<LocalDate> fechaCaptor = ArgumentCaptor.forClass(LocalDate.class);
+        verify(planProduccionSemanalRepository).buscarPorFiltros(fechaCaptor.capture(), fechaCaptor.capture(), eq(null), any(Pageable.class));
+        List<LocalDate> capturedDates = fechaCaptor.getAllValues();
+        assertEquals(desde, capturedDates.get(0));
+        assertEquals(hasta, capturedDates.get(1));
     }
 }


### PR DESCRIPTION
## Summary
- Añadir DTO de resumen y mapeo de servicio para listar planes semanales con orden por semana de inicio descendente
- Extender endpoint de listado para aceptar filtros por estado y rango de semana usando respuesta paginada de resúmenes
- Incorporar pruebas de servicio y controlador que cubren filtros, orden y forma del JSON devuelto

## Testing
- `mvn -q test` *(falla: no se pudo resolver el parent spring-boot-starter-parent por error 502 en Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693861b9c83c8333b7f57082c3ed9dad)