### PR TITLE
Agregar tipo de cambio en corridas MRP semanales

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
@@ -128,6 +128,7 @@ public class MrpController {
                         ? detalle.getSugerencia().getTipo().name()
                         : null)
                 .criticidad(calcularCriticidad(detalle))
+                .tipoCambio(detalle.getTipoCambioMrp() != null ? detalle.getTipoCambioMrp().name() : null)
                 .build();
     }
 

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
@@ -49,6 +49,7 @@ public class CorridaMrpResponseDTO {
         private String mensajeValidacion;
         private String tipoSugerencia;
         private String criticidad;
+        private String tipoCambio;
     }
 
     @Data

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/DetalleCorridaMrp.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/DetalleCorridaMrp.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.planeacion.model;
 
 import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoCambioMrp;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -46,4 +47,7 @@ public class DetalleCorridaMrp {
 
     @OneToOne(mappedBy = "detalleCorrida", cascade = CascadeType.ALL, orphanRemoval = true)
     private SugerenciaAbastecimiento sugerencia;
+
+    @Transient
+    private TipoCambioMrp tipoCambioMrp;
 }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/TipoCambioMrp.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/enums/TipoCambioMrp.java
@@ -1,0 +1,12 @@
+package com.willyes.clemenintegra.planeacion.model.enums;
+
+/**
+ * Representa el tipo de variación del requerimiento neto de un insumo entre la corrida MRP actual
+ * y la última corrida completada del mismo plan de producción semanal.
+ */
+public enum TipoCambioMrp {
+    NUEVO,
+    AUMENTO,
+    REDUCCION,
+    SIN_CAMBIO
+}

--- a/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
@@ -1,6 +1,8 @@
 package com.willyes.clemenintegra.planeacion.repository;
 
 import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoCorridaMrp;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -20,4 +22,8 @@ public interface CorridaMrpRepository extends JpaRepository<CorridaMrp, Long> {
             "detalles.sugerencia.detalleCorrida"
     })
     Optional<CorridaMrp> findWithDetallesById(Long id);
+
+    Optional<CorridaMrp> findTopByPlanProduccionSemanalAndEstadoOrderByFechaEjecucionDesc(
+            PlanProduccionSemanal plan, EstadoCorridaMrp estado
+    );
 }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
@@ -17,6 +17,7 @@ import com.willyes.clemenintegra.planeacion.model.enums.EstadoCorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoSugerenciaAbastecimiento;
 import com.willyes.clemenintegra.planeacion.model.enums.TipoSugerenciaAbastecimiento;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoCambioMrp;
 import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
 import com.willyes.clemenintegra.planeacion.service.MrpService;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +56,12 @@ public class MrpServiceImpl implements MrpService {
         }
 
         log.info("Iniciando corrida MRP semanal para el plan {}", plan.getId());
+        Optional<CorridaMrp> corridaAnterior = corridaMrpRepository
+                .findTopByPlanProduccionSemanalAndEstadoOrderByFechaEjecucionDesc(
+                        plan, EstadoCorridaMrp.COMPLETADA
+                );
+        Map<String, BigDecimal> netosAnteriores = construirMapaNetos(corridaAnterior);
+
         CorridaMrp corrida = CorridaMrp.builder()
                 .planProduccionSemanal(plan)
                 .fechaEjecucion(LocalDateTime.now())
@@ -67,7 +74,10 @@ public class MrpServiceImpl implements MrpService {
 
         Map<Producto, BigDecimal> requerimientosBrutos = calcularRequerimientosBrutos(plan);
         List<DetalleCorridaMrp> requerimientosNetos = calcularRequerimientosNetos(requerimientosBrutos);
-        requerimientosNetos.forEach(detalle -> detalle.setCorrida(corrida));
+        requerimientosNetos.forEach(detalle -> {
+            detalle.setCorrida(corrida);
+            asignarTipoCambio(detalle, netosAnteriores);
+        });
         corrida.setDetalles(requerimientosNetos);
 
         generarSugerencias(requerimientosNetos);
@@ -181,6 +191,43 @@ public class MrpServiceImpl implements MrpService {
     public CorridaMrp obtenerCorrida(Long id) {
         return corridaMrpRepository.findWithDetallesById(id)
                 .orElseThrow(() -> new NoSuchElementException("Corrida MRP no encontrada"));
+    }
+
+    private Map<String, BigDecimal> construirMapaNetos(Optional<CorridaMrp> corridaAnterior) {
+        Map<String, BigDecimal> netos = new HashMap<>();
+        if (corridaAnterior.isEmpty() || corridaAnterior.get().getDetalles() == null) {
+            return netos;
+        }
+        for (DetalleCorridaMrp detalle : corridaAnterior.get().getDetalles()) {
+            String clave = construirClaveDetalle(detalle.getProducto(), detalle.getNivelBom());
+            BigDecimal neto = Optional.ofNullable(detalle.getRequerimientoNeto()).orElse(BigDecimal.ZERO);
+            netos.put(clave, neto);
+        }
+        return netos;
+    }
+
+    private void asignarTipoCambio(DetalleCorridaMrp detalle, Map<String, BigDecimal> netosAnteriores) {
+        String clave = construirClaveDetalle(detalle.getProducto(), detalle.getNivelBom());
+        BigDecimal netoActual = Optional.ofNullable(detalle.getRequerimientoNeto()).orElse(BigDecimal.ZERO);
+        BigDecimal netoAnterior = netosAnteriores.get(clave);
+        if (netoAnterior == null) {
+            detalle.setTipoCambioMrp(TipoCambioMrp.NUEVO);
+            return;
+        }
+        int comparacion = netoActual.compareTo(netoAnterior);
+        if (comparacion > 0) {
+            detalle.setTipoCambioMrp(TipoCambioMrp.AUMENTO);
+        } else if (comparacion < 0) {
+            detalle.setTipoCambioMrp(TipoCambioMrp.REDUCCION);
+        } else {
+            detalle.setTipoCambioMrp(TipoCambioMrp.SIN_CAMBIO);
+        }
+    }
+
+    private String construirClaveDetalle(Producto producto, Integer nivelBom) {
+        String productoId = producto != null && producto.getId() != null ? producto.getId().toString() : "null";
+        String nivel = nivelBom != null ? nivelBom.toString() : "";
+        return productoId + "#" + nivel;
     }
 
     private BigDecimal obtenerInventarioDisponible(Producto producto) {

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
@@ -5,6 +5,7 @@ import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.planeacion.dto.CorridaMrpResponseDTO;
 import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoCambioMrp;
 import com.willyes.clemenintegra.planeacion.service.MrpReporteService;
 import com.willyes.clemenintegra.planeacion.service.MrpService;
 import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
@@ -48,6 +49,7 @@ class MrpControllerTest {
                 .recepcionesProgramadas(BigDecimal.ZERO)
                 .requerimientoNeto(BigDecimal.ZERO)
                 .nivelBom(1)
+                .tipoCambioMrp(TipoCambioMrp.NUEVO)
                 .build();
 
         DetalleCorridaMrp criticidadAlta = DetalleCorridaMrp.builder()
@@ -58,6 +60,7 @@ class MrpControllerTest {
                 .recepcionesProgramadas(BigDecimal.ZERO)
                 .requerimientoNeto(BigDecimal.valueOf(5))
                 .nivelBom(1)
+                .tipoCambioMrp(TipoCambioMrp.AUMENTO)
                 .build();
 
         DetalleCorridaMrp criticidadMedia = DetalleCorridaMrp.builder()
@@ -68,6 +71,7 @@ class MrpControllerTest {
                 .recepcionesProgramadas(BigDecimal.ZERO)
                 .requerimientoNeto(BigDecimal.valueOf(3))
                 .nivelBom(1)
+                .tipoCambioMrp(TipoCambioMrp.SIN_CAMBIO)
                 .build();
 
         CorridaMrp corrida = CorridaMrp.builder().build();
@@ -81,6 +85,9 @@ class MrpControllerTest {
         assertEquals("BAJA", dto.getDetalles().get(0).getCriticidad());
         assertEquals("ALTA", dto.getDetalles().get(1).getCriticidad());
         assertEquals("MEDIA", dto.getDetalles().get(2).getCriticidad());
+        assertEquals(TipoCambioMrp.NUEVO.name(), dto.getDetalles().get(0).getTipoCambio());
+        assertEquals(TipoCambioMrp.AUMENTO.name(), dto.getDetalles().get(1).getTipoCambio());
+        assertEquals(TipoCambioMrp.SIN_CAMBIO.name(), dto.getDetalles().get(2).getTipoCambio());
     }
 }
 

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
@@ -2,16 +2,34 @@ package com.willyes.clemenintegra.planeacion.service.impl;
 
 import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.model.enums.EstadoCorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoCambioMrp;
 import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MrpServiceImplTest {
@@ -26,6 +44,7 @@ class MrpServiceImplTest {
     private CorridaMrpRepository corridaMrpRepository;
 
     @InjectMocks
+    @Spy
     private MrpServiceImpl service;
 
     @Test
@@ -44,5 +63,66 @@ class MrpServiceImplTest {
                 .build();
 
         assertThrows(IllegalStateException.class, () -> service.ejecutarCorridaSemana(plan));
+    }
+
+    @Test
+    void asignaTipoCambioComparandoConCorridaAnterior() {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(1L)
+                .estado(EstadoPlanProduccion.CONFIRMADO)
+                .build();
+
+        Producto insumoNuevo = Producto.builder().id(1).build();
+        Producto insumoAumenta = Producto.builder().id(2).build();
+        Producto insumoReduce = Producto.builder().id(3).build();
+        Producto insumoIgual = Producto.builder().id(4).build();
+
+        DetalleCorridaMrp detalleAnteriorAumenta = DetalleCorridaMrp.builder()
+                .producto(insumoAumenta)
+                .requerimientoNeto(BigDecimal.valueOf(5))
+                .nivelBom(1)
+                .build();
+        DetalleCorridaMrp detalleAnteriorReduce = DetalleCorridaMrp.builder()
+                .producto(insumoReduce)
+                .requerimientoNeto(BigDecimal.valueOf(4))
+                .nivelBom(1)
+                .build();
+        DetalleCorridaMrp detalleAnteriorIgual = DetalleCorridaMrp.builder()
+                .producto(insumoIgual)
+                .requerimientoNeto(BigDecimal.valueOf(7))
+                .nivelBom(1)
+                .build();
+
+        CorridaMrp corridaAnterior = CorridaMrp.builder()
+                .planProduccionSemanal(plan)
+                .estado(EstadoCorridaMrp.COMPLETADA)
+                .detalles(new ArrayList<>(List.of(detalleAnteriorAumenta, detalleAnteriorReduce, detalleAnteriorIgual)))
+                .build();
+        corridaAnterior.getDetalles().forEach(d -> d.setCorrida(corridaAnterior));
+
+        when(corridaMrpRepository.findTopByPlanProduccionSemanalAndEstadoOrderByFechaEjecucionDesc(
+                plan, EstadoCorridaMrp.COMPLETADA)).thenReturn(Optional.of(corridaAnterior));
+
+        List<DetalleCorridaMrp> nuevosDetalles = List.of(
+                DetalleCorridaMrp.builder().producto(insumoNuevo).requerimientoNeto(BigDecimal.valueOf(3)).nivelBom(1).build(),
+                DetalleCorridaMrp.builder().producto(insumoAumenta).requerimientoNeto(BigDecimal.TEN).nivelBom(1).build(),
+                DetalleCorridaMrp.builder().producto(insumoReduce).requerimientoNeto(BigDecimal.valueOf(2)).nivelBom(1).build(),
+                DetalleCorridaMrp.builder().producto(insumoIgual).requerimientoNeto(BigDecimal.valueOf(7)).nivelBom(1).build()
+        );
+
+        doReturn(Collections.emptyMap()).when(service).calcularRequerimientosBrutos(plan);
+        doReturn(nuevosDetalles).when(service).calcularRequerimientosNetos(anyMap());
+        doReturn(Collections.emptyList()).when(service).generarSugerencias(any());
+        when(corridaMrpRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CorridaMrp resultado = service.ejecutarCorridaSemana(plan);
+
+        Map<Producto, TipoCambioMrp> cambios = resultado.getDetalles().stream()
+                .collect(java.util.stream.Collectors.toMap(DetalleCorridaMrp::getProducto, DetalleCorridaMrp::getTipoCambioMrp));
+
+        assertEquals(TipoCambioMrp.NUEVO, cambios.get(insumoNuevo));
+        assertEquals(TipoCambioMrp.AUMENTO, cambios.get(insumoAumenta));
+        assertEquals(TipoCambioMrp.REDUCCION, cambios.get(insumoReduce));
+        assertEquals(TipoCambioMrp.SIN_CAMBIO, cambios.get(insumoIgual));
     }
 }


### PR DESCRIPTION
## Summary
- añade enum transitorio para representar el tipo de cambio de requerimientos netos entre corridas MRP
- compara contra la última corrida completada del plan y asigna el tipo de cambio en cada detalle y DTO
- agrega pruebas de servicio y controlador para validar los nuevos valores de tipo de cambio

## Testing
- mvn -q test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938658d161c8333a9ea2c6b94e8d944)