### PR TITLE
Fill creator name in production summary DTO

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
@@ -118,12 +118,22 @@ public class PlanProduccionServiceImpl implements PlanProduccionService {
     }
 
     private PlanProduccionResumenDTO toResumenDto(PlanProduccionSemanal plan) {
+        String creadoPorNombre = null;
+        if (plan.getCreadoPor() != null) {
+            String nombreCompleto = plan.getCreadoPor().getNombreCompleto();
+            if (nombreCompleto != null && !nombreCompleto.isBlank()) {
+                creadoPorNombre = nombreCompleto;
+            } else {
+                creadoPorNombre = plan.getCreadoPor().getNombreUsuario();
+            }
+        }
+
         return PlanProduccionResumenDTO.builder()
                 .id(plan.getId())
                 .semanaInicio(plan.getSemanaInicio())
                 .semanaFin(plan.getSemanaFin())
                 .estado(plan.getEstado())
-                .creadoPorNombre(plan.getCreadoPor() != null ? plan.getCreadoPor().getNombreCompleto() : null)
+                .creadoPorNombre(creadoPorNombre)
                 .fechaCreacion(plan.getFechaCreacion())
                 .fechaConfirmacion(null)
                 .build();

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
@@ -5,6 +5,7 @@ import com.willyes.clemenintegra.planeacion.dto.PlanProduccionResumenDTO;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import com.willyes.clemenintegra.planeacion.repository.PlanProduccionSemanalRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -210,6 +211,49 @@ class PlanProduccionServiceImplTest {
         ArgumentCaptor<EstadoPlanProduccion> estadoCaptor = ArgumentCaptor.forClass(EstadoPlanProduccion.class);
         verify(planProduccionSemanalRepository).buscarPorFiltros(eq(null), eq(null), estadoCaptor.capture(), any(Pageable.class));
         assertEquals(EstadoPlanProduccion.CONFIRMADO, estadoCaptor.getValue());
+    }
+
+    @Test
+    void listarIncluyeNombreCompletoDelCreador() {
+        Usuario creador = Usuario.builder()
+                .nombreCompleto("Juan Pérez")
+                .nombreUsuario("JPEREZ")
+                .build();
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(5L)
+                .semanaInicio(LocalDate.of(2024, 4, 1))
+                .semanaFin(LocalDate.of(2024, 4, 7))
+                .estado(EstadoPlanProduccion.BORRADOR)
+                .creadoPor(creador)
+                .build();
+
+        when(planProduccionSemanalRepository.buscarPorFiltros(any(), any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(plan)));
+
+        Page<PlanProduccionResumenDTO> resultado = service.listar(null, null, null, PageRequest.of(0, 1));
+
+        assertEquals("Juan Pérez", resultado.getContent().get(0).getCreadoPorNombre());
+    }
+
+    @Test
+    void listarUsaNombreUsuarioCuandoNoHayNombreCompleto() {
+        Usuario creador = Usuario.builder()
+                .nombreUsuario("JPEREZ")
+                .build();
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(6L)
+                .semanaInicio(LocalDate.of(2024, 4, 8))
+                .semanaFin(LocalDate.of(2024, 4, 14))
+                .estado(EstadoPlanProduccion.BORRADOR)
+                .creadoPor(creador)
+                .build();
+
+        when(planProduccionSemanalRepository.buscarPorFiltros(any(), any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(plan)));
+
+        Page<PlanProduccionResumenDTO> resultado = service.listar(null, null, null, PageRequest.of(0, 1));
+
+        assertEquals("JPEREZ", resultado.getContent().get(0).getCreadoPorNombre());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- populate PlanProduccionResumenDTO with the creator's visible name using full name or username fallback
- add service tests covering creator name mapping with full name and username fallback

## Testing
- mvn test -Dtest=PlanProduccionServiceImplTest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693897642e8883338ae307ab3049fb82)