### PR TITLE
Expose product and unit summaries in weekly plan details

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.planeacion.controller;
 
+import com.willyes.clemenintegra.inventario.dto.ProductoResumenDTO;
+import com.willyes.clemenintegra.inventario.dto.UnidadMedidaResponseDTO;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.planeacion.dto.PlanProduccionSemanalDTO;
@@ -93,6 +95,23 @@ public class PlanProduccionController {
     private PlanProduccionSemanalDTO.PlanProduccionDetalleDTO toDetalleDto(PlanProduccionDetalle detalle) {
         Producto producto = detalle.getProducto();
         UnidadMedida unidad = detalle.getUnidadMedida();
+        ProductoResumenDTO productoDto = null;
+        if (producto != null) {
+            productoDto = ProductoResumenDTO.builder()
+                    .id(producto.getId() != null ? producto.getId().longValue() : null)
+                    .codigoSku(producto.getCodigoSku())
+                    .nombre(producto.getNombre())
+                    .build();
+        }
+
+        UnidadMedidaResponseDTO unidadDto = null;
+        if (unidad != null) {
+            unidadDto = UnidadMedidaResponseDTO.builder()
+                    .id(unidad.getId())
+                    .nombre(unidad.getNombre())
+                    .simbolo(unidad.getSimbolo())
+                    .build();
+        }
         return PlanProduccionSemanalDTO.PlanProduccionDetalleDTO.builder()
                 .id(detalle.getId())
                 .productoId(producto != null && producto.getId() != null ? producto.getId().longValue() : null)
@@ -101,6 +120,8 @@ public class PlanProduccionController {
                 .prioridad(detalle.getPrioridad())
                 .origenDemanda(detalle.getOrigenDemanda())
                 .observacion(detalle.getObservacion())
+                .producto(productoDto)
+                .unidadMedida(unidadDto)
                 .build();
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/PlanProduccionSemanalDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/PlanProduccionSemanalDTO.java
@@ -1,6 +1,8 @@
 package com.willyes.clemenintegra.planeacion.dto;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.willyes.clemenintegra.inventario.dto.ProductoResumenDTO;
+import com.willyes.clemenintegra.inventario.dto.UnidadMedidaResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -39,5 +41,7 @@ public class PlanProduccionSemanalDTO {
         private Integer prioridad;
         private String origenDemanda;
         private String observacion;
+        private ProductoResumenDTO producto;
+        private UnidadMedidaResponseDTO unidadMedida;
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerTest.java
@@ -1,6 +1,9 @@
 package com.willyes.clemenintegra.planeacion.controller;
 
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.planeacion.dto.PlanProduccionResumenDTO;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionDetalle;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
@@ -17,8 +20,10 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -108,6 +113,49 @@ class PlanProduccionControllerTest {
                         .content("{}")
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void obtenerDetalleIncluyeProductoYUnidad() throws Exception {
+        PlanProduccionDetalle detalle = PlanProduccionDetalle.builder()
+                .id(1L)
+                .producto(Producto.builder()
+                        .id(807)
+                        .codigoSku("SKU-001")
+                        .nombre("Producto Terminado")
+                        .build())
+                .cantidadPlanificada(BigDecimal.valueOf(2500))
+                .unidadMedida(UnidadMedida.builder()
+                        .id(5L)
+                        .nombre("Kilogramo")
+                        .simbolo("KG")
+                        .build())
+                .prioridad(1)
+                .origenDemanda("Demanda")
+                .observacion("Obs")
+                .build();
+
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(5L)
+                .semanaInicio(LocalDate.of(2025, 11, 30))
+                .semanaFin(LocalDate.of(2025, 12, 6))
+                .estado(EstadoPlanProduccion.BORRADOR)
+                .detalles(List.of(detalle))
+                .build();
+
+        when(planProduccionService.buscarPorId(5L)).thenReturn(Optional.of(plan));
+
+        mockMvc.perform(get("/api/planeacion/planes-semanales/5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.detalles[0].productoId").value(807))
+                .andExpect(jsonPath("$.detalles[0].producto.id").value(807))
+                .andExpect(jsonPath("$.detalles[0].producto.codigoSku").value("SKU-001"))
+                .andExpect(jsonPath("$.detalles[0].producto.nombre").value("Producto Terminado"))
+                .andExpect(jsonPath("$.detalles[0].unidadMedidaId").value(5))
+                .andExpect(jsonPath("$.detalles[0].unidadMedida.id").value(5))
+                .andExpect(jsonPath("$.detalles[0].unidadMedida.nombre").value("Kilogramo"))
+                .andExpect(jsonPath("$.detalles[0].unidadMedida.simbolo").value("KG"));
     }
 
     @TestConfiguration


### PR DESCRIPTION
## Summary
- add product and unit of measure summaries to weekly production plan detail DTOs without changing write contracts
- map product SKU/name and unit name/symbol into GET detail responses
- add controller test ensuring the enriched fields are exposed in the API response

## Testing
- mvn -q -Dtest=PlanProduccionControllerTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69389c0745508333a273d894c0ed2072)