### PR TITLE
Add security tests for buyer weekly plan access

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerTest.java
@@ -158,6 +158,30 @@ class PlanProduccionControllerTest {
                 .andExpect(jsonPath("$.detalles[0].unidadMedida.simbolo").value("KG"));
     }
 
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void obtenerPlanPermiteComprador() throws Exception {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(10L)
+                .semanaInicio(LocalDate.of(2024, 6, 10))
+                .semanaFin(LocalDate.of(2024, 6, 16))
+                .detalles(List.of())
+                .build();
+
+        when(planProduccionService.buscarPorId(10L)).thenReturn(Optional.of(plan));
+
+        mockMvc.perform(get("/api/planeacion/planes-semanales/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(10));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void confirmarPlanRechazaComprador() throws Exception {
+        mockMvc.perform(post("/api/planeacion/planes-semanales/99/confirmar"))
+                .andExpect(status().isForbidden());
+    }
+
     @TestConfiguration
     @EnableMethodSecurity
     static class MethodSecurityTestConfig {


### PR DESCRIPTION
## Summary
- add controller coverage ensuring comprador users can read weekly plans and are blocked from confirmation
- keep existing plan controller behaviors unchanged for other roles

## Testing
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938b4b3cf048333821db596717008a3)