### PR TITLE
Expose microbiological analysis rule to frontend

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
@@ -3,12 +3,14 @@ package com.willyes.clemenintegra.calidad.controller;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.PlantillaAnalisisMicroDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.service.AnalisisMicroPdfService;
 import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
 import com.willyes.clemenintegra.calidad.service.ResultadoAnalisisMicroService;
+import com.willyes.clemenintegra.calidad.service.PlantillaAnalisisMicroService;
 
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
@@ -41,6 +43,7 @@ public class EvaluacionCalidadController {
     private final EvaluacionCalidadService service;
     private final ResultadoAnalisisMicroService resultadoAnalisisMicroService;
     private final AnalisisMicroPdfService analisisMicroPdfService;
+    private final PlantillaAnalisisMicroService plantillaAnalisisMicroService;
 
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_SUPER_ADMIN')")
     @GetMapping("/consolidadas")
@@ -125,6 +128,19 @@ public class EvaluacionCalidadController {
             @PathVariable Long evaluacionId,
             @RequestBody java.util.List<ResultadoAnalisisMicroRequestDTO> resultados) {
         return ResponseEntity.ok(resultadoAnalisisMicroService.guardarResultados(evaluacionId, resultados));
+    }
+
+    /**
+     * Fuente de verdad para frontend: solo si {@code requiereAnalisisMicro} es true y existe plantilla
+     * se debe renderizar la tabla de parámetros microbiológicos.
+     */
+    @GetMapping("/plantillas/micro/producto/{productoId}")
+    public ResponseEntity<PlantillaAnalisisMicroDTO> obtenerPlantillaMicro(@PathVariable Long productoId) {
+        PlantillaAnalisisMicroDTO dto = plantillaAnalisisMicroService.obtenerPorProducto(productoId);
+        if (dto == null || !dto.isRequiereAnalisisMicro()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(dto);
     }
 
     @GetMapping(path = "/{evaluacionId}/resultados-micro")

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/PlantillaAnalisisMicroDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/PlantillaAnalisisMicroDTO.java
@@ -17,5 +17,6 @@ public class PlantillaAnalisisMicroDTO {
     private String descripcion;
     private boolean activo;
     private List<ParametroAnalisisMicroDTO> parametros;
+    private boolean requiereAnalisisMicro;
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/PlantillaAnalisisMicroService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/PlantillaAnalisisMicroService.java
@@ -3,6 +3,10 @@ package com.willyes.clemenintegra.calidad.service;
 import com.willyes.clemenintegra.calidad.dto.PlantillaAnalisisMicroDTO;
 
 public interface PlantillaAnalisisMicroService {
+    /**
+     * Backend como fuente de verdad: determina si el producto requiere análisis microbiológico
+     * y, de ser así, devuelve la plantilla asociada con sus parámetros.
+     */
     PlantillaAnalisisMicroDTO obtenerPorProducto(Long productoId);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/PlantillaAnalisisMicroServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/PlantillaAnalisisMicroServiceImpl.java
@@ -8,6 +8,7 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
 
@@ -17,20 +18,23 @@ public class PlantillaAnalisisMicroServiceImpl implements PlantillaAnalisisMicro
 
     private final ProductoRepository productoRepository;
 
+    /**
+     * El backend decide si corresponde mostrar la tabla microbiológica y entrega los parámetros
+     * únicamente cuando se cumplen las condiciones de negocio.
+     */
+    @Transactional(readOnly = true)
     @Override
     public PlantillaAnalisisMicroDTO obtenerPorProducto(Long productoId) {
         Producto producto = productoRepository.findById(productoId)
                 .orElseThrow(() -> new NoSuchElementException("Producto no encontrado con ID: " + productoId));
 
-        if (producto.getTipoAnalisisCalidad() == null ||
-                (producto.getTipoAnalisisCalidad() != TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO
-                        && producto.getTipoAnalisisCalidad() != TipoAnalisisCalidad.AMBOS)) {
-            return null;
-        }
-
         PlantillaAnalisisMicrobiologico plantilla = producto.getPlantillaAnalisisMicrobiologico();
-        if (plantilla == null) {
-            return null;
+        boolean requiereAnalisisMicro = requiereAnalisisMicro(producto, plantilla);
+
+        if (!requiereAnalisisMicro) {
+            return PlantillaAnalisisMicroDTO.builder()
+                    .requiereAnalisisMicro(false)
+                    .build();
         }
 
         return PlantillaAnalisisMicroDTO.builder()
@@ -38,6 +42,7 @@ public class PlantillaAnalisisMicroServiceImpl implements PlantillaAnalisisMicro
                 .nombre(plantilla.getNombre())
                 .descripcion(plantilla.getDescripcion())
                 .activo(plantilla.isActivo())
+                .requiereAnalisisMicro(true)
                 .parametros(plantilla.getParametros().stream()
                         .map(p -> ParametroAnalisisMicroDTO.builder()
                                 .id(p.getId())
@@ -49,6 +54,16 @@ public class PlantillaAnalisisMicroServiceImpl implements PlantillaAnalisisMicro
                                 .build())
                         .toList())
                 .build();
+    }
+
+    boolean requiereAnalisisMicro(Producto producto, PlantillaAnalisisMicrobiologico plantilla) {
+        TipoAnalisisCalidad tipo = producto.getTipoAnalisisCalidad();
+        boolean tipoRequiereMicro = tipo == TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO
+                || tipo == TipoAnalisisCalidad.AMBOS;
+        boolean plantillaValida = plantilla != null
+                && plantilla.getParametros() != null
+                && !plantilla.getParametros().isEmpty();
+        return tipoRequiereMicro && plantillaValida;
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoResponseDTO.java
@@ -22,6 +22,10 @@ public class LoteProductoResponseDTO {
     private Double temperaturaAlmacenamiento;
     private LocalDateTime fechaLiberacion;
     private String nombreProducto;
+    private Long productoId;
+    private String tipoAnalisisCalidad;
+    private Long plantillaMicroId;
+    private boolean requiereAnalisisMicro;
     private String nombreAlmacen;
     private String ubicacionAlmacen;
     private String nombreUsuarioLiberador;

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/LoteProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/LoteProductoMapper.java
@@ -20,6 +20,10 @@ public interface LoteProductoMapper {
     @Mapping(target = "nombreAlmacen", expression = "java(lote.getAlmacen()!=null ? lote.getAlmacen().getNombre() : null)")
     @Mapping(target = "ubicacionAlmacen", expression = "java(lote.getAlmacen()!=null ? lote.getAlmacen().getUbicacion() : null)")
     @Mapping(target = "nombreProducto", expression = "java(lote.getProducto()!=null ? lote.getProducto().getNombre() : null)")
+    @Mapping(target = "productoId", expression = "java(lote.getProducto()!=null && lote.getProducto().getId()!=null ? lote.getProducto().getId().longValue() : null)")
+    @Mapping(target = "tipoAnalisisCalidad", expression = "java(mapTipoAnalisisCalidadString(lote.getProducto()!=null ? lote.getProducto().getTipoAnalisisCalidad() : null))")
+    @Mapping(target = "plantillaMicroId", expression = "java(lote.getProducto()!=null && lote.getProducto().getPlantillaAnalisisMicrobiologico()!=null ? lote.getProducto().getPlantillaAnalisisMicrobiologico().getId() : null)")
+    @Mapping(target = "requiereAnalisisMicro", ignore = true)
     @Mapping(target = "nombreUsuarioLiberador", expression = "java(lote.getUsuarioLiberador()!=null ? lote.getUsuarioLiberador().getNombreCompleto() : null)")
     @Mapping(target = "evaluaciones", ignore = true)
     @Mapping(target = "lotePsOrigenId", expression = "java(lote.getLotePsOrigen()!=null ? lote.getLotePsOrigen().getId() : null)")
@@ -27,6 +31,10 @@ public interface LoteProductoMapper {
     LoteProductoResponseDTO toResponseDTO(LoteProducto lote);
 
     @Mapping(source = "producto.nombre", target = "nombreProducto")
+    @Mapping(target = "productoId", expression = "java(entity.getProducto()!=null && entity.getProducto().getId()!=null ? entity.getProducto().getId().longValue() : null)")
+    @Mapping(target = "tipoAnalisisCalidad", expression = "java(mapTipoAnalisisCalidadString(entity.getProducto()!=null ? entity.getProducto().getTipoAnalisisCalidad() : null))")
+    @Mapping(target = "plantillaMicroId", expression = "java(entity.getProducto()!=null && entity.getProducto().getPlantillaAnalisisMicrobiologico()!=null ? entity.getProducto().getPlantillaAnalisisMicrobiologico().getId() : null)")
+    @Mapping(target = "requiereAnalisisMicro", ignore = true)
     @Mapping(source = "almacen.nombre", target = "nombreAlmacen")
     @Mapping(source = "almacen.ubicacion", target = "ubicacionAlmacen")
     @Mapping(source = "usuarioLiberador.nombreCompleto", target = "nombreUsuarioLiberador")
@@ -34,6 +42,17 @@ public interface LoteProductoMapper {
     @Mapping(source = "lotePsOrigen.id", target = "lotePsOrigenId")
     @Mapping(source = "lotePsOrigen.codigoLote", target = "codigoLotePsOrigen")
     LoteProductoResponseDTO toDto(LoteProducto entity);
+
+    default String mapTipoAnalisisCalidadString(com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad valor) {
+        if (valor == null) {
+            return null;
+        }
+        return switch (valor) {
+            case FISICO -> "FISICO_QUIMICO";
+            case QUIMICO_MICROBIOLOGICO -> "MICROBIOLOGICO";
+            default -> valor.name();
+        };
+    }
 
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
@@ -30,7 +30,7 @@ public interface ProductoMapper {
     @Mapping(source = "codigoSku", target = "sku")
     @Mapping(target = "unidadMedida", source = "unidadMedida")
     @Mapping(target = "categoria", expression = "java(producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getNombre() : null)")
-    @Mapping(target = "tipoAnalisisCalidad", expression = "java(producto.getTipoAnalisisCalidad() != null ? producto.getTipoAnalisisCalidad().name() : null)")
+    @Mapping(target = "tipoAnalisisCalidad", expression = "java(mapTipoAnalisisCalidadString(producto.getTipoAnalisisCalidad()))")
     @Mapping(target = "rendimiento", source = "rendimientoUnidad")
     @Mapping(target = "unidadMedidaId", expression = "java(producto.getUnidadMedida() != null ? producto.getUnidadMedida().getId() : null)")
     @Mapping(target = "categoriaProductoId", expression = "java(producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getId() : null)")
@@ -52,15 +52,22 @@ public interface ProductoMapper {
         }
         String normalizado = valor.trim().toUpperCase();
         return switch (normalizado) {
-            case "FISICO_QUIMICO" -> TipoAnalisisCalidad.AMBOS;
-            case "MICROBIOLOGICO" -> TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO;
+            case "FISICO", "FISICO_QUIMICO" -> TipoAnalisisCalidad.FISICO;
+            case "MICROBIOLOGICO", "QUIMICO_MICROBIOLOGICO" -> TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO;
             default -> TipoAnalisisCalidad.valueOf(normalizado);
         };
     }
 
     @Named("mapTipoAnalisisCalidadString")
     default String mapTipoAnalisisCalidadString(TipoAnalisisCalidad valor) {
-        return valor != null ? valor.name() : null;
+        if (valor == null) {
+            return null;
+        }
+        return switch (valor) {
+            case FISICO -> "FISICO_QUIMICO";
+            case QUIMICO_MICROBIOLOGICO -> "MICROBIOLOGICO";
+            default -> valor.name();
+        };
     }
 
     @AfterMapping

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/enums/TipoAnalisisCalidad.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/enums/TipoAnalisisCalidad.java
@@ -1,5 +1,14 @@
 package com.willyes.clemenintegra.inventario.model.enums;
 
+/**
+ * Define qué tipo de evaluación de calidad aplica al producto.
+ * <ul>
+ *     <li>NINGUNO: el lote no requiere evaluaciones de calidad.</li>
+ *     <li>FISICO: equivale al rótulo de interfaz "FISICO_QUIMICO" e indica solo análisis físico/químico.</li>
+ *     <li>QUIMICO_MICROBIOLOGICO: equivale al rótulo "MICROBIOLOGICO" e indica solo análisis microbiológico.</li>
+ *     <li>AMBOS: se requieren los dos (físico/químico y microbiológico).</li>
+ * </ul>
+ */
 public enum TipoAnalisisCalidad {
     NINGUNO,
     FISICO,

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.calidad.dto.CondicionUsoResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.PlantillaAnalisisMicroDTO;
 import com.willyes.clemenintegra.calidad.mapper.CondicionUsoMapper;
 import com.willyes.clemenintegra.calidad.model.CondicionUso;
 import com.willyes.clemenintegra.calidad.model.enums.*;
@@ -22,6 +23,7 @@ import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
 import com.willyes.clemenintegra.calidad.service.NoConformidadService;
 import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
+import com.willyes.clemenintegra.calidad.service.PlantillaAnalisisMicroService;
 
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
@@ -78,6 +80,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     private final RetencionLoteService retencionLoteService;
     private final NoConformidadService noConformidadService;
     private final CondicionUsoService condicionUsoService;
+    private final PlantillaAnalisisMicroService plantillaAnalisisMicroService;
     private final CondicionUsoRepository condicionUsoRepository;
     private final CondicionUsoMapper mapper;
     private final BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
@@ -166,6 +169,13 @@ public class LoteProductoServiceImpl implements LoteProductoService {
                     dto.setEvaluaciones(evaluaciones.stream()
                             .map(EvaluacionCalidad::getTipoEvaluacion)
                             .toList());
+                    PlantillaAnalisisMicroDTO plantillaDto = plantillaAnalisisMicroService.obtenerPorProducto(lote.getProducto().getId().longValue());
+                    if (plantillaDto != null) {
+                        dto.setRequiereAnalisisMicro(plantillaDto.isRequiereAnalisisMicro());
+                        if (plantillaDto.getId() != null) {
+                            dto.setPlantillaMicroId(plantillaDto.getId());
+                        }
+                    }
                     return dto;
                 })
                 .filter(java.util.Objects::nonNull)

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -140,8 +140,8 @@ public class ProductoServiceImpl implements ProductoService {
         }
         String normalizado = valor.trim().toUpperCase();
         return switch (normalizado) {
-            case "FISICO_QUIMICO" -> TipoAnalisisCalidad.AMBOS;
-            case "MICROBIOLOGICO" -> TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO;
+            case "FISICO", "FISICO_QUIMICO" -> TipoAnalisisCalidad.FISICO;
+            case "MICROBIOLOGICO", "QUIMICO_MICROBIOLOGICO" -> TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO;
             default -> TipoAnalisisCalidad.valueOf(normalizado);
         };
     }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/PlantillaAnalisisMicroServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/PlantillaAnalisisMicroServiceImplTest.java
@@ -1,0 +1,126 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.PlantillaAnalisisMicroDTO;
+import com.willyes.clemenintegra.calidad.model.ParametroAnalisisMicrobiologico;
+import com.willyes.clemenintegra.calidad.model.PlantillaAnalisisMicrobiologico;
+import com.willyes.clemenintegra.calidad.model.enums.TipoResultadoAnalisis;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlantillaAnalisisMicroServiceImplTest {
+
+    @Mock
+    private ProductoRepository productoRepository;
+
+    @InjectMocks
+    private PlantillaAnalisisMicroServiceImpl service;
+
+    @Test
+    void debeRequerirAnalisisCuandoProductoEsMicroYHayPlantillaConParametros() {
+        PlantillaAnalisisMicrobiologico plantilla = crearPlantilla();
+        Producto producto = Producto.builder()
+                .id(1)
+                .tipoAnalisis(TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO)
+                .plantillaAnalisisMicrobiologico(plantilla)
+                .build();
+        when(productoRepository.findById(1L)).thenReturn(Optional.of(producto));
+
+        PlantillaAnalisisMicroDTO dto = service.obtenerPorProducto(1L);
+
+        assertThat(dto.isRequiereAnalisisMicro()).isTrue();
+        assertThat(dto.getParametros()).hasSize(1);
+    }
+
+    @Test
+    void noDebeRequerirAnalisisCuandoTipoEsFisicoAunqueExistaPlantilla() {
+        PlantillaAnalisisMicrobiologico plantilla = crearPlantilla();
+        Producto producto = Producto.builder()
+                .id(2)
+                .tipoAnalisis(TipoAnalisisCalidad.FISICO)
+                .plantillaAnalisisMicrobiologico(plantilla)
+                .build();
+        when(productoRepository.findById(2L)).thenReturn(Optional.of(producto));
+
+        PlantillaAnalisisMicroDTO dto = service.obtenerPorProducto(2L);
+
+        assertThat(dto.isRequiereAnalisisMicro()).isFalse();
+        assertThat(dto.getId()).isNull();
+    }
+
+    @Test
+    void debeRequerirAnalisisCuandoTipoEsAmbosYHayPlantilla() {
+        PlantillaAnalisisMicrobiologico plantilla = crearPlantilla();
+        Producto producto = Producto.builder()
+                .id(3)
+                .tipoAnalisis(TipoAnalisisCalidad.AMBOS)
+                .plantillaAnalisisMicrobiologico(plantilla)
+                .build();
+        when(productoRepository.findById(3L)).thenReturn(Optional.of(producto));
+
+        PlantillaAnalisisMicroDTO dto = service.obtenerPorProducto(3L);
+
+        assertThat(dto.isRequiereAnalisisMicro()).isTrue();
+        assertThat(dto.getId()).isEqualTo(plantilla.getId());
+    }
+
+    @Test
+    void noDebeRequerirAnalisisCuandoNoHayPlantilla() {
+        Producto producto = Producto.builder()
+                .id(4)
+                .tipoAnalisis(TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO)
+                .build();
+        when(productoRepository.findById(4L)).thenReturn(Optional.of(producto));
+
+        PlantillaAnalisisMicroDTO dto = service.obtenerPorProducto(4L);
+
+        assertThat(dto.isRequiereAnalisisMicro()).isFalse();
+        assertThat(dto.getParametros()).isNull();
+    }
+
+    @Test
+    void noDebeRequerirAnalisisCuandoPlantillaNoTieneParametros() {
+        PlantillaAnalisisMicrobiologico plantilla = PlantillaAnalisisMicrobiologico.builder()
+                .id(5L)
+                .nombre("Plantilla sin params")
+                .build();
+        Producto producto = Producto.builder()
+                .id(5)
+                .tipoAnalisis(TipoAnalisisCalidad.AMBOS)
+                .plantillaAnalisisMicrobiologico(plantilla)
+                .build();
+        when(productoRepository.findById(5L)).thenReturn(Optional.of(producto));
+
+        PlantillaAnalisisMicroDTO dto = service.obtenerPorProducto(5L);
+
+        assertThat(dto.isRequiereAnalisisMicro()).isFalse();
+    }
+
+    private PlantillaAnalisisMicrobiologico crearPlantilla() {
+        ParametroAnalisisMicrobiologico parametro = ParametroAnalisisMicrobiologico.builder()
+                .id(10L)
+                .nombreEnsayo("Mesofilos")
+                .tipoResultado(TipoResultadoAnalisis.NUMERICO)
+                .orden(1)
+                .build();
+        PlantillaAnalisisMicrobiologico plantilla = PlantillaAnalisisMicrobiologico.builder()
+                .id(20L)
+                .nombre("Plantilla micro")
+                .build();
+        plantilla.setParametros(List.of(parametro));
+        return plantilla;
+    }
+}
+


### PR DESCRIPTION
## Summary
- Documented and normalized `TipoAnalisisCalidad` values, ensuring DTOs expose frontend-friendly strings
- Centralized the rule that determines when microbiological analysis applies and exposed a dedicated endpoint returning the template with the `requiereAnalisisMicro` flag
- Enriched lote responses with product, analysis type, template data, and added unit tests covering the microbiological requirement scenarios

## Testing
- `mvn -q -Dtest=PlantillaAnalisisMicroServiceImplTest test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f14cfcb88333a4c4a8e126159af1)