### PR TITLE
Documentar contrato de resultados microbiologicos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
@@ -122,6 +122,15 @@ public class EvaluacionCalidadController {
         }
     }
 
+    /**
+     * Endpoint para registrar o actualizar resultados microbiológicos de una evaluación existente.
+     * <ul>
+     *     <li><b>Método:</b> POST</li>
+     *     <li><b>Ruta:</b> {@code /api/calidad/evaluaciones/{evaluacionId}/resultados-micro}</li>
+     *     <li><b>Body:</b> arreglo JSON con objetos {@link ResultadoAnalisisMicroRequestDTO} (parametroId, resultado, cumple,
+     *     observaciones).</li>
+     * </ul>
+     */
     @PostMapping(path = "/{evaluacionId}/resultados-micro")
     @PreAuthorize("hasAnyAuthority('ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<java.util.List<ResultadoAnalisisMicroResponseDTO>> guardarResultadosMicro(

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImpl.java
@@ -52,6 +52,8 @@ public class ResultadoAnalisisMicroServiceImpl implements ResultadoAnalisisMicro
                 throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
                         "El parámetro " + dto.getParametroId() + " no pertenece a la plantilla del producto.");
             }
+            // El resultado siempre queda vinculado a la evaluación recibida y al parámetro de la plantilla
+            // (FKs evaluacion_id y parametro_id en resultados_analisis_microbiologico).
             ResultadoAnalisisMicrobiologico entidad = indexExistentes.getOrDefault(dto.getParametroId(),
                     ResultadoAnalisisMicrobiologico.builder()
                             .evaluacion(evaluacion)


### PR DESCRIPTION
## Summary
- Documented the microbiological results endpoint contract in the evaluation controller for frontend reference.
- Added a note in the service clarifying how saved results remain linked to the evaluation and template parameters.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b4b0a80688333be71f4fec4b86cc8)