### PR TITLE
Refuerza evaluaciones de calidad con detalle y validaciones de disciplinas

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.calidad.controller;
 
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaResponseDTO;
@@ -71,6 +72,12 @@ public class EvaluacionCalidadController {
     @GetMapping("/{id}")
     public ResponseEntity<EvaluacionCalidadResponseDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerPorId(id));
+    }
+
+    @GetMapping("/{id}/detalle")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_SUPER_ADMIN')")
+    public ResponseEntity<EvaluacionCalidadDetalleDTO> obtenerDetalle(@PathVariable Long id) {
+        return ResponseEntity.ok(service.obtenerDetalle(id));
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -156,6 +163,26 @@ public class EvaluacionCalidadController {
     @PreAuthorize("hasAnyAuthority('ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<java.util.List<ResultadoAnalisisMicroResponseDTO>> obtenerResultadosMicro(@PathVariable Long evaluacionId) {
         return ResponseEntity.ok(resultadoAnalisisMicroService.obtenerPorEvaluacion(evaluacionId));
+    }
+
+    @GetMapping(path = "/{evaluacionId}/micro-pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    @PreAuthorize("hasAnyAuthority('ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<byte[]> descargarPdfMicroConNombre(@PathVariable Long evaluacionId) {
+        byte[] pdf = analisisMicroPdfService.generarPdf(evaluacionId);
+        String nombreArchivo = "MICRO_" + evaluacionId + ".pdf";
+        try {
+            EvaluacionCalidadResponseDTO dto = service.obtenerPorId(evaluacionId);
+            if (dto != null && dto.getNombreLote() != null) {
+                nombreArchivo = "MICRO_" + dto.getNombreLote() + ".pdf";
+            }
+        } catch (Exception ignored) {
+            // Se mantiene el nombre por defecto si no se puede resolver el lote
+        }
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + nombreArchivo)
+                .body(pdf);
     }
 
     @GetMapping(path = "/{evaluacionId}/microbiologico/pdf", produces = MediaType.APPLICATION_PDF_VALUE)

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCalidadDetalleDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCalidadDetalleDTO.java
@@ -1,0 +1,35 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EvaluacionCalidadDetalleDTO {
+    private Long idEvaluacion;
+    private Long loteId;
+    private String codigoLote;
+    private String nombreProducto;
+    private String tipoEvaluacion;
+    private LocalDateTime fechaEvaluacion;
+    private String resultado;
+    private String observaciones;
+
+    private boolean requiereAnalisisFisico;
+    private boolean requiereAnalisisQuimico;
+    private boolean requiereAnalisisMicrobiologico;
+
+    private boolean tieneResultadosFisicos;
+    private boolean tieneResultadosQuimicos;
+    private boolean tieneResultadosMicro;
+
+    private List<ResultadoAnalisisMicroDetalleDTO> resultadosMicro;
+    private List<ArchivoEvaluacionDTO> archivosAdjuntos;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
@@ -22,6 +22,14 @@ public class EvaluacionConsolidadaResponseDTO {
     private boolean fisicoQuimicoCargado;
     private boolean microbiologicoCargado;
     private boolean evaluacionesRequeridasCompletas;
+    private boolean requiereAnalisisFisico;
+    private boolean requiereAnalisisQuimico;
+    private boolean requiereAnalisisMicrobiologico;
+    private boolean tieneEvaluacionFisica;
+    private boolean tieneEvaluacionQuimicaMicro;
+    private boolean tieneResultadosMicro;
+    private boolean tieneAdjuntosFisico;
+    private boolean tieneAdjuntosQuimicoMicro;
     private String resultadoGlobal;
     private List<EvaluacionSimpleDTO> evaluaciones;
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/ResultadoAnalisisMicroDetalleDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/ResultadoAnalisisMicroDetalleDTO.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResultadoAnalisisMicroDetalleDTO {
+    private Long parametroId;
+    private String nombreEnsayo;
+    private String especificacion;
+    private String unidad;
+    private String resultado;
+    private Boolean cumple;
+    private String observaciones;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
@@ -1,14 +1,18 @@
 package com.willyes.clemenintegra.calidad.mapper;
 
 import com.willyes.clemenintegra.calidad.dto.ArchivoEvaluacionDTO;
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
-import com.willyes.clemenintegra.calidad.dto.EvaluacionSimpleDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.EvaluacionSimpleDTO;
+import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroDetalleDTO;
+import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.stereotype.Component;
@@ -78,7 +82,8 @@ public class EvaluacionCalidadMapper {
     }
 
     public EvaluacionConsolidadaResponseDTO toConsolidadoDTO(LoteProducto lote,
-                                                             java.util.List<EvaluacionCalidad> evaluaciones) {
+                                                             java.util.List<EvaluacionCalidad> evaluaciones,
+                                                             java.util.Set<Long> evaluacionesConResultadosMicro) {
         if (lote == null) return null;
 
         java.util.List<EvaluacionCalidad> evals = (evaluaciones == null)
@@ -105,6 +110,15 @@ public class EvaluacionCalidadMapper {
                 e.getResultado() == ResultadoEvaluacion.CONFORME ||
                         e.getResultado() == ResultadoEvaluacion.CONDICIONADO);
 
+        boolean tieneResultadosMicro = micros.stream()
+                .map(EvaluacionCalidad::getId)
+                .anyMatch(id -> evaluacionesConResultadosMicro != null && evaluacionesConResultadosMicro.contains(id));
+
+        boolean tieneAdjuntosFisico = fisicos.stream()
+                .anyMatch(e -> e.getArchivosAdjuntos() != null && !e.getArchivosAdjuntos().isEmpty());
+        boolean tieneAdjuntosQuimicoMicro = micros.stream()
+                .anyMatch(e -> e.getArchivosAdjuntos() != null && !e.getArchivosAdjuntos().isEmpty());
+
         boolean algunNoConforme = evals.stream().anyMatch(e -> e.getResultado() == ResultadoEvaluacion.NO_CONFORME);
 
         TipoAnalisisCalidad tipoAnalisis = lote.getProducto().getTipoAnalisisCalidad();
@@ -112,8 +126,15 @@ public class EvaluacionCalidadMapper {
         boolean requiereQuimico = requiereQuimico(lote.getProducto());
         boolean requiereMicro = requiereMicro(lote.getProducto());
 
-        boolean completas = (requiereFisico ? fisicoAnyOk : true)
-                && ((requiereQuimico || requiereMicro) ? microAnyOk : true);
+        boolean requiereQuimicoOMicro = requiereQuimico || requiereMicro;
+
+        boolean disciplinasCompletas = (!requiereFisico || fisicoCargado)
+                && (!requiereQuimicoOMicro || microCargado)
+                && (!requiereMicro || tieneResultadosMicro);
+
+        boolean evaluacionesCompletas = (!requiereFisico || fisicoAnyOk)
+                && (!requiereQuimicoOMicro || microAnyOk)
+                && (!requiereMicro || tieneResultadosMicro);
 
         String resultadoGlobal;
         if (tipoAnalisis == null) {
@@ -123,13 +144,14 @@ public class EvaluacionCalidadMapper {
         } else if (algunNoConforme) {
             resultadoGlobal = ResultadoEvaluacion.NO_CONFORME.name();
         } else if ((!requiereFisico || fisicoConforme)
-                && (!(requiereQuimico || requiereMicro) || microConforme)) {
+                && (!requiereQuimicoOMicro || (microConforme && (!requiereMicro || tieneResultadosMicro)))) {
             resultadoGlobal = ResultadoEvaluacion.CONFORME.name();
-        } else if (completas) {
+        } else if (evaluacionesCompletas) {
             resultadoGlobal = ResultadoEvaluacion.CONDICIONADO.name();
         } else {
             boolean avances = (requiereFisico && fisicoCargado)
-                    || ((requiereQuimico || requiereMicro) && microCargado);
+                    || (requiereQuimicoOMicro && microCargado)
+                    || (requiereMicro && tieneResultadosMicro);
             resultadoGlobal = avances ? "EN_PROCESO" : "PENDIENTE";
         }
 
@@ -142,8 +164,16 @@ public class EvaluacionCalidadMapper {
                 .tipoAnalisisRequerido(mapearAnalisisRequerido(tipoAnalisis))
                 .fisicoQuimicoCargado(fisicoCargado)
                 .microbiologicoCargado(microCargado)
-                .evaluacionesRequeridasCompletas(completas)
+                .evaluacionesRequeridasCompletas(disciplinasCompletas)
                 .resultadoGlobal(resultadoGlobal)
+                .requiereAnalisisFisico(requiereFisico)
+                .requiereAnalisisQuimico(requiereQuimico)
+                .requiereAnalisisMicrobiologico(requiereMicro)
+                .tieneEvaluacionFisica(fisicoCargado)
+                .tieneEvaluacionQuimicaMicro(microCargado)
+                .tieneResultadosMicro(tieneResultadosMicro)
+                .tieneAdjuntosFisico(tieneAdjuntosFisico)
+                .tieneAdjuntosQuimicoMicro(tieneAdjuntosQuimicoMicro)
                 .evaluaciones(evals.stream()
                         .map(this::toSimpleDTO)
                         .toList())
@@ -159,5 +189,62 @@ public class EvaluacionCalidadMapper {
             case QUIMICO_MICROBIOLOGICO -> "MICROBIOLOGICO";
             default -> tipoAnalisis.name();
         };
+    }
+
+    public EvaluacionCalidadDetalleDTO toDetalleDTO(EvaluacionCalidad evaluacion,
+                                                    Producto producto,
+                                                    java.util.List<ResultadoAnalisisMicroDetalleDTO> resultadosMicro) {
+        if (evaluacion == null || producto == null) {
+            return null;
+        }
+
+        boolean esFisico = evaluacion.getTipoEvaluacion() == TipoEvaluacion.FISICO;
+        boolean esQuimicoMicro = evaluacion.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO;
+
+        return EvaluacionCalidadDetalleDTO.builder()
+                .idEvaluacion(evaluacion.getId())
+                .loteId(evaluacion.getLoteProducto().getId())
+                .codigoLote(evaluacion.getLoteProducto().getCodigoLote())
+                .nombreProducto(producto.getNombre())
+                .tipoEvaluacion(evaluacion.getTipoEvaluacion().name())
+                .fechaEvaluacion(evaluacion.getFechaEvaluacion())
+                .resultado(evaluacion.getResultado() != null ? evaluacion.getResultado().name() : null)
+                .observaciones(evaluacion.getObservaciones())
+                .requiereAnalisisFisico(requiereFisico(producto))
+                .requiereAnalisisQuimico(requiereQuimico(producto))
+                .requiereAnalisisMicrobiologico(requiereMicro(producto))
+                .tieneResultadosFisicos(esFisico)
+                .tieneResultadosQuimicos(esQuimicoMicro)
+                .tieneResultadosMicro(resultadosMicro != null && !resultadosMicro.isEmpty())
+                .resultadosMicro(resultadosMicro == null ? java.util.List.of() : resultadosMicro)
+                .archivosAdjuntos(mapearArchivos(evaluacion))
+                .build();
+    }
+
+    public java.util.List<ResultadoAnalisisMicroDetalleDTO> mapearResultadosMicro(java.util.List<ResultadoAnalisisMicroResponseDTO> resultados) {
+        if (resultados == null) {
+            return java.util.List.of();
+        }
+        return resultados.stream()
+                .map(r -> ResultadoAnalisisMicroDetalleDTO.builder()
+                        .parametroId(r.getParametroId())
+                        .nombreEnsayo(r.getNombreEnsayo())
+                        .especificacion(r.getEspecificacion())
+                        .unidad(r.getUnidad())
+                        .resultado(r.getResultado())
+                        .cumple(r.getCumple())
+                        .observaciones(r.getObservaciones())
+                        .build())
+                .toList();
+    }
+
+    private java.util.List<ArchivoEvaluacionDTO> mapearArchivos(EvaluacionCalidad evaluacion) {
+        return evaluacion.getArchivosAdjuntos() == null ? java.util.List.of() :
+                evaluacion.getArchivosAdjuntos().stream()
+                        .map(a -> ArchivoEvaluacionDTO.builder()
+                                .nombreArchivo(a.getNombreArchivo())
+                                .nombreVisible(a.getNombreVisible())
+                                .build())
+                        .toList();
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/ResultadoAnalisisMicrobiologicoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/ResultadoAnalisisMicrobiologicoRepository.java
@@ -7,5 +7,9 @@ import java.util.List;
 
 public interface ResultadoAnalisisMicrobiologicoRepository extends JpaRepository<ResultadoAnalisisMicrobiologico, Long> {
     List<ResultadoAnalisisMicrobiologico> findByEvaluacionId(Long evaluacionId);
+
+    List<ResultadoAnalisisMicrobiologico> findByEvaluacionIdIn(List<Long> evaluacionIds);
+
+    boolean existsByEvaluacionId(Long evaluacionId);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
@@ -1,6 +1,9 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import java.util.Optional;
 
 /**
  * Utilidades para determinar los análisis de calidad requeridos por producto.
@@ -21,5 +24,66 @@ public final class AnalisisCalidadHelper {
 
     public static boolean requiereMicro(Producto producto) {
         return producto != null && producto.isRequiereAnalisisMicrobiologico();
+    }
+
+    public static ResultadoValidacionDisciplinas validarDisciplinasCompletas(
+            com.willyes.clemenintegra.inventario.model.LoteProducto lote,
+            java.util.List<EvaluacionCalidad> evaluaciones,
+            java.util.function.LongPredicate existeResultadoMicro) {
+
+        ResultadoValidacionDisciplinas.ResultadoValidacionDisciplinasBuilder builder = ResultadoValidacionDisciplinas.builder();
+        if (lote == null || lote.getProducto() == null) {
+            return builder.build();
+        }
+
+        Producto producto = lote.getProducto();
+        java.util.List<EvaluacionCalidad> evals = evaluaciones == null ? java.util.List.of() : evaluaciones;
+
+        boolean requiereFisico = requiereFisico(producto);
+        boolean requiereQuimico = requiereQuimico(producto);
+        boolean requiereMicro = requiereMicro(producto);
+
+        boolean tieneEvaluacionFisica = evals.stream().anyMatch(e -> e.getTipoEvaluacion() == TipoEvaluacion.FISICO);
+        java.util.Optional<EvaluacionCalidad> evaluacionQuimicaMicro = evals.stream()
+                .filter(e -> e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .findFirst();
+
+        boolean tieneEvaluacionQuimica = evaluacionQuimicaMicro.isPresent();
+        boolean tieneResultadosMicro = evaluacionQuimicaMicro
+                .map(EvaluacionCalidad::getId)
+                .filter(id -> existeResultadoMicro != null)
+                .map(existeResultadoMicro::test)
+                .orElse(false);
+
+        return builder
+                .faltaEvaluacionFisica(requiereFisico && !tieneEvaluacionFisica)
+                .faltaEvaluacionQuimica(requiereQuimico && !tieneEvaluacionQuimica)
+                .faltanResultadosMicro(requiereMicro && (!tieneEvaluacionQuimica || !tieneResultadosMicro))
+                .build();
+    }
+
+    @lombok.Builder
+    @lombok.Value
+    public static class ResultadoValidacionDisciplinas {
+        boolean faltaEvaluacionFisica;
+        boolean faltaEvaluacionQuimica;
+        boolean faltanResultadosMicro;
+
+        public boolean esValido() {
+            return !faltaEvaluacionFisica && !faltaEvaluacionQuimica && !faltanResultadosMicro;
+        }
+
+        public String getPrimerMensaje() {
+            if (faltaEvaluacionFisica) {
+                return "Falta evaluación física";
+            }
+            if (faltaEvaluacionQuimica) {
+                return "Falta evaluación química";
+            }
+            if (faltanResultadosMicro) {
+                return "Faltan resultados microbiológicos";
+            }
+            return null;
+        }
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
@@ -16,6 +16,7 @@ public interface EvaluacionCalidadService {
     EvaluacionCalidadResponseDTO crear(EvaluacionCalidadRequestDTO dto, List<MultipartFile> archivos);
     EvaluacionCalidadResponseDTO actualizar(Long id, EvaluacionCalidadRequestDTO dto);
     EvaluacionCalidadResponseDTO obtenerPorId(Long id);
+    com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO obtenerDetalle(Long id);
     java.util.List<EvaluacionCalidadResponseDTO> listarPorLote(Long loteId);
     java.util.List<EvaluacionConsolidadaResponseDTO> obtenerEvaluacionesConsolidadas(LocalDate fechaInicio, LocalDate fechaFin);
     void eliminar(Long id);

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -1,17 +1,20 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.ArchivoEvaluacionDTO;
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.CondicionUsoCreateDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCondicionDTO;
+import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
 import com.willyes.clemenintegra.calidad.mapper.EvaluacionCalidadMapper;
 import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import com.willyes.clemenintegra.calidad.repository.ResultadoAnalisisMicrobiologicoRepository;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
 import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
@@ -32,6 +35,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -41,6 +46,7 @@ import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -60,6 +66,8 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
     private final CondicionUsoService condicionUsoService;
     private final RetencionLoteService retencionLoteService;
     private final NoConformidadService noConformidadService;
+    private final ResultadoAnalisisMicroService resultadoAnalisisMicroService;
+    private final ResultadoAnalisisMicrobiologicoRepository resultadoAnalisisMicrobiologicoRepository;
 
     public Page<EvaluacionCalidadResponseDTO> listar(ResultadoEvaluacion resultado, Pageable pageable) {
         Page<EvaluacionCalidad> page = (resultado != null)
@@ -213,6 +221,15 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
     }
 
     @Override
+    public EvaluacionCalidadDetalleDTO obtenerDetalle(Long id) {
+        EvaluacionCalidad evaluacion = repository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Evaluación no encontrada"));
+        java.util.List<ResultadoAnalisisMicroResponseDTO> resultados = resultadoAnalisisMicroService.obtenerPorEvaluacion(id);
+        return mapper.toDetalleDTO(evaluacion, evaluacion.getLoteProducto().getProducto(),
+                mapper.mapearResultadosMicro(resultados));
+    }
+
+    @Override
     public java.util.List<EvaluacionCalidadResponseDTO> listarPorLote(Long loteId) {
         return repository.findByLoteProductoId(loteId)
                 .stream()
@@ -229,8 +246,20 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         java.util.Map<LoteProducto, java.util.List<EvaluacionCalidad>> agrupado = evaluaciones.stream()
                 .collect(java.util.stream.Collectors.groupingBy(EvaluacionCalidad::getLoteProducto));
 
+        java.util.Set<Long> evaluacionesQuimicoMicro = evaluaciones.stream()
+                .filter(e -> e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .map(EvaluacionCalidad::getId)
+                .collect(java.util.stream.Collectors.toSet());
+
+        java.util.Set<Long> evaluacionesConResultadosMicro = evaluacionesQuimicoMicro.isEmpty()
+                ? java.util.Collections.emptySet()
+                : resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(evaluacionesQuimicoMicro.stream().toList())
+                .stream()
+                .map(r -> r.getEvaluacion().getId())
+                .collect(java.util.stream.Collectors.toSet());
+
         return agrupado.entrySet().stream()
-                .map(entry -> mapper.toConsolidadoDTO(entry.getKey(), entry.getValue()))
+                .map(entry -> mapper.toConsolidadoDTO(entry.getKey(), entry.getValue(), evaluacionesConResultadosMicro))
                 .toList();
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -62,6 +62,8 @@ import org.slf4j.LoggerFactory;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereFisico;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereMicro;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereQuimico;
+import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.validarDisciplinasCompletas;
+import com.willyes.clemenintegra.calidad.repository.ResultadoAnalisisMicrobiologicoRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -76,6 +78,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     private final UsuarioService usuarioService;
     private final LoteProductoRepository loteProductoRepository;
     private final EvaluacionCalidadRepository evaluacionRepository;
+    private final ResultadoAnalisisMicrobiologicoRepository resultadoAnalisisMicrobiologicoRepository;
     private final StockQueryService stockQueryService;
     private final MovimientoInventarioRepository movimientoInventarioRepository;
     private final MotivoMovimientoRepository motivoMovimientoRepository;
@@ -598,16 +601,10 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         }
 
         List<EvaluacionCalidad> evaluaciones = evaluacionRepository.findByLoteProductoId(loteId);
-
-        boolean requiereFisico = requiereFisico(producto);
-        boolean requiereQuimico = requiereQuimico(producto);
-        boolean requiereMicro = requiereMicro(producto);
-
-        if (requiereFisico) {
-            validarEvaluacion(evaluaciones, TipoEvaluacion.FISICO);
-        }
-        if (requiereQuimico || requiereMicro) {
-            validarEvaluacion(evaluaciones, TipoEvaluacion.QUIMICO_MICROBIOLOGICO);
+        var validacion = validarDisciplinasCompletas(lote, evaluaciones,
+                resultadoAnalisisMicrobiologicoRepository::existsByEvaluacionId);
+        if (!validacion.esValido()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, validacion.getPrimerMensaje());
         }
 
         validarNoConformidadesParaLiberacion(loteId);

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerTest.java
@@ -1,0 +1,79 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO;
+import com.willyes.clemenintegra.calidad.service.AnalisisMicroPdfService;
+import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
+import com.willyes.clemenintegra.calidad.service.ResultadoAnalisisMicroService;
+import com.willyes.clemenintegra.calidad.service.PlantillaAnalisisMicroService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(EvaluacionCalidadController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class EvaluacionCalidadControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EvaluacionCalidadService evaluacionCalidadService;
+    @MockBean
+    private ResultadoAnalisisMicroService resultadoAnalisisMicroService;
+    @MockBean
+    private AnalisisMicroPdfService analisisMicroPdfService;
+    @MockBean
+    private PlantillaAnalisisMicroService plantillaAnalisisMicroService;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    void obtieneDetalleEvaluacion() throws Exception {
+        EvaluacionCalidadDetalleDTO detalle = EvaluacionCalidadDetalleDTO.builder()
+                .idEvaluacion(1L)
+                .codigoLote("LOT-01")
+                .nombreProducto("Producto X")
+                .tipoEvaluacion("QUIMICO_MICROBIOLOGICO")
+                .fechaEvaluacion(LocalDateTime.now())
+                .resultado("CONFORME")
+                .archivosAdjuntos(Collections.emptyList())
+                .resultadosMicro(Collections.emptyList())
+                .build();
+
+        when(evaluacionCalidadService.obtenerDetalle(1L)).thenReturn(detalle);
+
+        mockMvc.perform(get("/api/calidad/evaluaciones/1/detalle")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.codigoLote").value("LOT-01"))
+                .andExpect(jsonPath("$.nombreProducto").value("Producto X"));
+    }
+
+    @Test
+    void retornaNotFoundCuandoNoExisteEvaluacion() throws Exception {
+        when(evaluacionCalidadService.obtenerDetalle(anyLong()))
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Evaluación no encontrada"));
+
+        mockMvc.perform(get("/api/calidad/evaluaciones/999/detalle"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
@@ -1,0 +1,68 @@
+package com.willyes.clemenintegra.calidad.mapper;
+
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO;
+import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroDetalleDTO;
+import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EvaluacionCalidadMapperTest {
+
+    private final EvaluacionCalidadMapper mapper = new EvaluacionCalidadMapper();
+
+    @Test
+    void debeConstruirDetalleConMicroResultados() {
+        Producto producto = new Producto();
+        producto.setNombre("Producto A");
+        producto.setRequiereAnalisisFisico(true);
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(10L);
+        lote.setCodigoLote("L001");
+        lote.setProducto(producto);
+
+        EvaluacionCalidad evaluacion = EvaluacionCalidad.builder()
+                .id(5L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .observaciones("Todo OK")
+                .fechaEvaluacion(LocalDateTime.now())
+                .loteProducto(lote)
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreArchivo("archivo.pdf")
+                        .nombreVisible("Archivo")
+                        .build()))
+                .build();
+
+        List<ResultadoAnalisisMicroDetalleDTO> resultadosMicro = List.of(
+                ResultadoAnalisisMicroDetalleDTO.builder()
+                        .parametroId(1L)
+                        .nombreEnsayo("Ensayo 1")
+                        .resultado("10")
+                        .build()
+        );
+
+        EvaluacionCalidadDetalleDTO dto = mapper.toDetalleDTO(evaluacion, producto, resultadosMicro);
+
+        assertThat(dto.getIdEvaluacion()).isEqualTo(5L);
+        assertThat(dto.getCodigoLote()).isEqualTo("L001");
+        assertThat(dto.isRequiereAnalisisFisico()).isTrue();
+        assertThat(dto.isRequiereAnalisisQuimico()).isTrue();
+        assertThat(dto.isRequiereAnalisisMicrobiologico()).isTrue();
+        assertThat(dto.isTieneResultadosQuimicos()).isTrue();
+        assertThat(dto.isTieneResultadosMicro()).isTrue();
+        assertThat(dto.getResultadosMicro()).hasSize(1);
+        assertThat(dto.getArchivosAdjuntos()).hasSize(1);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
@@ -1,0 +1,73 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnalisisCalidadHelperTest {
+
+    @Test
+    void validaSoloFisico() {
+        Producto producto = new Producto();
+        producto.setRequiereAnalisisFisico(true);
+        LoteProducto lote = new LoteProducto();
+        lote.setProducto(producto);
+
+        AnalisisCalidadHelper.ResultadoValidacionDisciplinas resultado = AnalisisCalidadHelper
+                .validarDisciplinasCompletas(lote, List.of(), id -> false);
+
+        assertThat(resultado.esValido()).isFalse();
+        assertThat(resultado.getPrimerMensaje()).isEqualTo("Falta evaluación física");
+
+        EvaluacionCalidad evalFisico = EvaluacionCalidad.builder()
+                .tipoEvaluacion(TipoEvaluacion.FISICO)
+                .build();
+
+        resultado = AnalisisCalidadHelper.validarDisciplinasCompletas(lote, List.of(evalFisico), id -> false);
+        assertThat(resultado.esValido()).isTrue();
+    }
+
+    @Test
+    void validaQuimicoYMicro() {
+        Producto producto = new Producto();
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+        LoteProducto lote = new LoteProducto();
+        lote.setProducto(producto);
+
+        EvaluacionCalidad evaluacionQuimica = EvaluacionCalidad.builder()
+                .id(3L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .build();
+
+        AnalisisCalidadHelper.ResultadoValidacionDisciplinas resultado = AnalisisCalidadHelper
+                .validarDisciplinasCompletas(lote, List.of(evaluacionQuimica), id -> false);
+
+        assertThat(resultado.esValido()).isFalse();
+        assertThat(resultado.isFaltanResultadosMicro()).isTrue();
+
+        resultado = AnalisisCalidadHelper
+                .validarDisciplinasCompletas(lote, List.of(evaluacionQuimica), id -> id == 3L);
+
+        assertThat(resultado.esValido()).isTrue();
+    }
+
+    @Test
+    void validaSinRequerimientos() {
+        Producto producto = new Producto();
+        LoteProducto lote = new LoteProducto();
+        lote.setProducto(producto);
+
+        AnalisisCalidadHelper.ResultadoValidacionDisciplinas resultado = AnalisisCalidadHelper
+                .validarDisciplinasCompletas(lote, List.of(), id -> false);
+
+        assertThat(resultado.esValido()).isTrue();
+        assertThat(resultado.getPrimerMensaje()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- añade un DTO y endpoint de detalle de evaluación, incluyendo resultados microbiológicos y descarga de PDF con nombre por lote
- enriquece la consolidación de evaluaciones y valida disciplinas requeridas con presencia de resultados microbiológicos reales
- agrega pruebas unitarias para el mapper de detalle, el helper de disciplinas y el endpoint de detalle

## Testing
- mvn -Dtest=EvaluacionCalidadMapperTest,AnalisisCalidadHelperTest,EvaluacionCalidadControllerTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b63e4e9e48333a2a08d6529cf7877)