### PR TITLE
Support QM evaluation upsert and microbiology PDF handling

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
@@ -30,6 +30,9 @@ public class EvaluacionConsolidadaResponseDTO {
     private boolean tieneResultadosMicro;
     private boolean tieneAdjuntosFisico;
     private boolean tieneAdjuntosQuimicoMicro;
+    private Long evaluacionQuimicoMicroId;
+    private Long evaluacionFisicaId;
+    private List<ArchivoEvaluacionDTO> adjuntosQuimicoMicro;
     private String resultadoGlobal;
     private List<EvaluacionSimpleDTO> evaluaciones;
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
@@ -18,10 +18,13 @@ import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Optional;
 
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereFisico;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereMicro;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereQuimico;
+import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.validarDisciplinasCompletas;
 
 @Component
 public class EvaluacionCalidadMapper {
@@ -96,28 +99,44 @@ public class EvaluacionCalidadMapper {
         java.util.List<EvaluacionCalidad> fisicos = agrupado.getOrDefault(TipoEvaluacion.FISICO, java.util.List.of());
         java.util.List<EvaluacionCalidad> micros = agrupado.getOrDefault(TipoEvaluacion.QUIMICO_MICROBIOLOGICO, java.util.List.of());
 
-        boolean fisicoCargado = !fisicos.isEmpty();
-        boolean microCargado = !micros.isEmpty();
+        Optional<EvaluacionCalidad> evaluacionFisica = fisicos.stream()
+                .max(Comparator.comparing(EvaluacionCalidad::getFechaEvaluacion, Comparator.nullsLast(LocalDateTime::compareTo)));
+        Optional<EvaluacionCalidad> evaluacionQuimicoMicro = micros.stream()
+                .max(Comparator.comparing(EvaluacionCalidad::getFechaEvaluacion, Comparator.nullsLast(LocalDateTime::compareTo)));
 
-        boolean fisicoConforme = fisicos.stream().anyMatch(e -> e.getResultado() == ResultadoEvaluacion.CONFORME);
-        boolean microConforme = micros.stream().anyMatch(e -> e.getResultado() == ResultadoEvaluacion.CONFORME);
+        boolean fisicoCargado = evaluacionFisica.isPresent();
+        boolean microCargado = evaluacionQuimicoMicro.isPresent();
 
-        boolean fisicoAnyOk = fisicos.stream().anyMatch(e ->
-                e.getResultado() == ResultadoEvaluacion.CONFORME ||
-                        e.getResultado() == ResultadoEvaluacion.CONDICIONADO);
+        boolean fisicoConforme = evaluacionFisica
+                .map(EvaluacionCalidad::getResultado)
+                .map(r -> r == ResultadoEvaluacion.CONFORME)
+                .orElse(false);
+        boolean microConforme = evaluacionQuimicoMicro
+                .map(EvaluacionCalidad::getResultado)
+                .map(r -> r == ResultadoEvaluacion.CONFORME)
+                .orElse(false);
 
-        boolean microAnyOk = micros.stream().anyMatch(e ->
-                e.getResultado() == ResultadoEvaluacion.CONFORME ||
-                        e.getResultado() == ResultadoEvaluacion.CONDICIONADO);
+        boolean fisicoAnyOk = evaluacionFisica
+                .map(EvaluacionCalidad::getResultado)
+                .map(r -> r == ResultadoEvaluacion.CONFORME || r == ResultadoEvaluacion.CONDICIONADO)
+                .orElse(false);
 
-        boolean tieneResultadosMicro = micros.stream()
+        boolean microAnyOk = evaluacionQuimicoMicro
+                .map(EvaluacionCalidad::getResultado)
+                .map(r -> r == ResultadoEvaluacion.CONFORME || r == ResultadoEvaluacion.CONDICIONADO)
+                .orElse(false);
+
+        boolean tieneResultadosMicro = evaluacionQuimicoMicro
                 .map(EvaluacionCalidad::getId)
-                .anyMatch(id -> evaluacionesConResultadosMicro != null && evaluacionesConResultadosMicro.contains(id));
+                .map(id -> evaluacionesConResultadosMicro != null && evaluacionesConResultadosMicro.contains(id))
+                .orElse(false);
 
         boolean tieneAdjuntosFisico = fisicos.stream()
                 .anyMatch(e -> e.getArchivosAdjuntos() != null && !e.getArchivosAdjuntos().isEmpty());
-        boolean tieneAdjuntosQuimicoMicro = micros.stream()
-                .anyMatch(e -> e.getArchivosAdjuntos() != null && !e.getArchivosAdjuntos().isEmpty());
+        boolean tieneAdjuntosQuimicoMicro = evaluacionQuimicoMicro
+                .map(EvaluacionCalidad::getArchivosAdjuntos)
+                .map(lista -> lista != null && !lista.isEmpty())
+                .orElse(false);
 
         boolean algunNoConforme = evals.stream().anyMatch(e -> e.getResultado() == ResultadoEvaluacion.NO_CONFORME);
 
@@ -128,9 +147,10 @@ public class EvaluacionCalidadMapper {
 
         boolean requiereQuimicoOMicro = requiereQuimico || requiereMicro;
 
-        boolean disciplinasCompletas = (!requiereFisico || fisicoCargado)
-                && (!requiereQuimicoOMicro || microCargado)
-                && (!requiereMicro || tieneResultadosMicro);
+        var validacion = validarDisciplinasCompletas(lote, evals,
+                id -> evaluacionesConResultadosMicro != null && evaluacionesConResultadosMicro.contains(id));
+
+        boolean disciplinasCompletas = validacion.esValido();
 
         boolean evaluacionesCompletas = (!requiereFisico || fisicoAnyOk)
                 && (!requiereQuimicoOMicro || microAnyOk)
@@ -174,6 +194,11 @@ public class EvaluacionCalidadMapper {
                 .tieneResultadosMicro(tieneResultadosMicro)
                 .tieneAdjuntosFisico(tieneAdjuntosFisico)
                 .tieneAdjuntosQuimicoMicro(tieneAdjuntosQuimicoMicro)
+                .evaluacionQuimicoMicroId(evaluacionQuimicoMicro.map(EvaluacionCalidad::getId).orElse(null))
+                .evaluacionFisicaId(evaluacionFisica.map(EvaluacionCalidad::getId).orElse(null))
+                .adjuntosQuimicoMicro(evaluacionQuimicoMicro
+                        .map(this::mapearArchivos)
+                        .orElse(java.util.List.of()))
                 .evaluaciones(evals.stream()
                         .map(this::toSimpleDTO)
                         .toList())

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
@@ -21,6 +21,8 @@ public interface EvaluacionCalidadRepository extends JpaRepository<EvaluacionCal
             @Param("fin") LocalDateTime fin,
             Pageable pageable);
 
+    java.util.Optional<EvaluacionCalidad> findFirstByLoteProductoIdAndTipoEvaluacion(Long loteId, TipoEvaluacion tipoEvaluacion);
+
     @EntityGraph(attributePaths = {"loteProducto.producto", "usuarioEvaluador"})
     @Query("SELECT e FROM EvaluacionCalidad e")
     java.util.List<EvaluacionCalidad> findAllWithRelations();

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -108,41 +108,40 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
 
         validarRolEvaluador(user, dto.getTipoEvaluacion());
 
-        java.util.List<ArchivoEvaluacion> adjuntos = new java.util.ArrayList<>();
-        java.util.List<ArchivoEvaluacionDTO> datosArchivos = dto.getArchivosAdjuntos();
+        java.util.List<ArchivoEvaluacion> adjuntos = guardarAdjuntos(archivos, dto.getArchivosAdjuntos());
 
-        for (int i = 0; archivos != null && i < archivos.size(); i++) {
-            MultipartFile archivo = archivos.get(i);
-            if (archivo == null || archivo.isEmpty()) continue;
-            try {
-                String nombreOriginal = archivo.getOriginalFilename();
-                String nombreSanitizado = (nombreOriginal != null ? nombreOriginal : "archivo")
-                        .replaceAll("[^a-zA-Z0-9._-]", "_");
+        EvaluacionCalidad entidad;
+        if (dto.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO) {
+            entidad = repository.findFirstByLoteProductoIdAndTipoEvaluacion(lote.getId(), TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                    .map(existing -> {
+                        existing.setResultado(dto.getResultado());
+                        existing.setObservaciones(dto.getObservaciones());
+                        existing.setFechaEvaluacion(LocalDateTime.now());
+                        existing.setUsuarioEvaluador(user);
+                        existing.setTipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO);
+                        existing.setLoteProducto(lote);
 
-                String nombreArchivo = System.currentTimeMillis() + "_" + nombreSanitizado;
-
-                Path uploadRoot = Paths.get(System.getProperty("user.dir"), "uploads", "evaluaciones");
-                Files.createDirectories(uploadRoot);
-
-                Path destino = uploadRoot.resolve(nombreArchivo);
-                archivo.transferTo(destino.toFile());
-
-                String nombreVisible = (datosArchivos != null && datosArchivos.size() > i)
-                        ? datosArchivos.get(i).getNombreVisible()
-                        : nombreOriginal;
-
-                adjuntos.add(ArchivoEvaluacion.builder()
-                        .nombreArchivo(nombreArchivo)
-                        .nombreVisible(nombreVisible)
-                        .build());
-            } catch (IOException e) {
-                throw new RuntimeException("Error al guardar el archivo adjunto: " + e.getMessage(), e);
-            }
+                        if (adjuntos != null && !adjuntos.isEmpty()) {
+                            java.util.List<ArchivoEvaluacion> actuales = existing.getArchivosAdjuntos();
+                            if (actuales == null) {
+                                actuales = new java.util.ArrayList<>();
+                            }
+                            actuales.addAll(adjuntos);
+                            existing.setArchivosAdjuntos(actuales);
+                        }
+                        return existing;
+                    })
+                    .orElseGet(() -> {
+                        EvaluacionCalidad nueva = mapper.toEntity(dto, lote, user);
+                        nueva.setFechaEvaluacion(LocalDateTime.now());
+                        nueva.setArchivosAdjuntos(adjuntos);
+                        return nueva;
+                    });
+        } else {
+            entidad = mapper.toEntity(dto, lote, user);
+            entidad.setFechaEvaluacion(LocalDateTime.now());
+            entidad.setArchivosAdjuntos(adjuntos);
         }
-
-        EvaluacionCalidad entidad = mapper.toEntity(dto, lote, user);
-        entidad.setFechaEvaluacion(LocalDateTime.now());
-        entidad.setArchivosAdjuntos(adjuntos);
 
         entidad = repository.save(entidad);
 
@@ -221,6 +220,7 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
     }
 
     @Override
+    @org.springframework.transaction.annotation.Transactional(readOnly = true)
     public EvaluacionCalidadDetalleDTO obtenerDetalle(Long id) {
         EvaluacionCalidad evaluacion = repository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Evaluación no encontrada"));
@@ -265,6 +265,40 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
 
     public void eliminar(Long id) {
         repository.deleteById(id);
+    }
+
+    private java.util.List<ArchivoEvaluacion> guardarAdjuntos(java.util.List<MultipartFile> archivos,
+                                                              java.util.List<ArchivoEvaluacionDTO> datosArchivos) {
+        java.util.List<ArchivoEvaluacion> adjuntos = new java.util.ArrayList<>();
+        for (int i = 0; archivos != null && i < archivos.size(); i++) {
+            MultipartFile archivo = archivos.get(i);
+            if (archivo == null || archivo.isEmpty()) continue;
+            try {
+                String nombreOriginal = archivo.getOriginalFilename();
+                String nombreSanitizado = (nombreOriginal != null ? nombreOriginal : "archivo")
+                        .replaceAll("[^a-zA-Z0-9._-]", "_");
+
+                String nombreArchivo = System.currentTimeMillis() + "_" + nombreSanitizado;
+
+                Path uploadRoot = Paths.get(System.getProperty("user.dir"), "uploads", "evaluaciones");
+                Files.createDirectories(uploadRoot);
+
+                Path destino = uploadRoot.resolve(nombreArchivo);
+                archivo.transferTo(destino.toFile());
+
+                String nombreVisible = (datosArchivos != null && datosArchivos.size() > i)
+                        ? datosArchivos.get(i).getNombreVisible()
+                        : nombreOriginal;
+
+                adjuntos.add(ArchivoEvaluacion.builder()
+                        .nombreArchivo(nombreArchivo)
+                        .nombreVisible(nombreVisible)
+                        .build());
+            } catch (IOException e) {
+                throw new RuntimeException("Error al guardar el archivo adjunto: " + e.getMessage(), e);
+            }
+        }
+        return adjuntos;
     }
 
     private String buildOperacion(String prefijo, TipoEvaluacion tipo) {

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImpl.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.ParametroAnalisisMicrobiologico;
 import com.willyes.clemenintegra.calidad.model.PlantillaAnalisisMicrobiologico;
 import com.willyes.clemenintegra.calidad.model.ResultadoAnalisisMicrobiologico;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
 import com.willyes.clemenintegra.calidad.repository.ResultadoAnalisisMicrobiologicoRepository;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
@@ -14,6 +15,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 
 @Service
@@ -22,6 +26,7 @@ public class ResultadoAnalisisMicroServiceImpl implements ResultadoAnalisisMicro
 
     private final EvaluacionCalidadRepository evaluacionRepository;
     private final ResultadoAnalisisMicrobiologicoRepository resultadoRepository;
+    private final AnalisisMicroPdfService analisisMicroPdfService;
 
     @Override
     @Transactional
@@ -38,12 +43,18 @@ public class ResultadoAnalisisMicroServiceImpl implements ResultadoAnalisisMicro
                     "El producto asociado no tiene una plantilla microbiológica configurada.");
         }
 
+        if (evaluacion.getTipoEvaluacion() != TipoEvaluacion.QUIMICO_MICROBIOLOGICO) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Solo se pueden registrar resultados microbiológicos sobre evaluaciones QM.");
+        }
+
         Map<Long, ParametroAnalisisMicrobiologico> parametrosValidos = plantilla.getParametros().stream()
                 .collect(java.util.stream.Collectors.toMap(ParametroAnalisisMicrobiologico::getId, p -> p));
 
         List<ResultadoAnalisisMicrobiologico> existentes = resultadoRepository.findByEvaluacionId(evaluacionId);
-        Map<Long, ResultadoAnalisisMicrobiologico> indexExistentes = new HashMap<>();
-        existentes.forEach(r -> indexExistentes.put(r.getParametro().getId(), r));
+        if (!existentes.isEmpty()) {
+            resultadoRepository.deleteAll(existentes);
+        }
 
         List<ResultadoAnalisisMicrobiologico> aGuardar = new ArrayList<>();
         for (ResultadoAnalisisMicroRequestDTO dto : payload) {
@@ -52,13 +63,10 @@ public class ResultadoAnalisisMicroServiceImpl implements ResultadoAnalisisMicro
                 throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
                         "El parámetro " + dto.getParametroId() + " no pertenece a la plantilla del producto.");
             }
-            // El resultado siempre queda vinculado a la evaluación recibida y al parámetro de la plantilla
-            // (FKs evaluacion_id y parametro_id en resultados_analisis_microbiologico).
-            ResultadoAnalisisMicrobiologico entidad = indexExistentes.getOrDefault(dto.getParametroId(),
-                    ResultadoAnalisisMicrobiologico.builder()
-                            .evaluacion(evaluacion)
-                            .parametro(parametro)
-                            .build());
+            ResultadoAnalisisMicrobiologico entidad = ResultadoAnalisisMicrobiologico.builder()
+                    .evaluacion(evaluacion)
+                    .parametro(parametro)
+                    .build();
             entidad.setResultado(dto.getResultado());
             entidad.setCumple(dto.getCumple());
             entidad.setObservaciones(dto.getObservaciones());
@@ -66,6 +74,7 @@ public class ResultadoAnalisisMicroServiceImpl implements ResultadoAnalisisMicro
         }
 
         List<ResultadoAnalisisMicrobiologico> guardados = resultadoRepository.saveAll(aGuardar);
+        registrarPdfMicrobiologico(evaluacion);
         return mapear(guardados);
     }
 
@@ -91,6 +100,33 @@ public class ResultadoAnalisisMicroServiceImpl implements ResultadoAnalisisMicro
                         .build())
                 .sorted(Comparator.comparing(ResultadoAnalisisMicroResponseDTO::getOrden, Comparator.nullsLast(Integer::compareTo)))
                 .toList();
+    }
+
+    private void registrarPdfMicrobiologico(EvaluacionCalidad evaluacion) {
+        byte[] pdf = analisisMicroPdfService.generarPdf(evaluacion.getId());
+        String nombreArchivo = System.currentTimeMillis() + "_MICRO_" + evaluacion.getId() + ".pdf";
+
+        try {
+            Path uploadRoot = Paths.get(System.getProperty("user.dir"), "uploads", "evaluaciones");
+            Files.createDirectories(uploadRoot);
+            Files.write(uploadRoot.resolve(nombreArchivo), pdf);
+        } catch (Exception e) {
+            throw new IllegalStateException("No se pudo almacenar el PDF microbiológico", e);
+        }
+
+        java.util.List<com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion> adjuntos = evaluacion.getArchivosAdjuntos();
+        if (adjuntos == null) {
+            adjuntos = new ArrayList<>();
+        } else {
+            adjuntos = new ArrayList<>(adjuntos);
+        }
+        adjuntos.removeIf(a -> "Microbiológico".equalsIgnoreCase(a.getNombreVisible()));
+        adjuntos.add(com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion.builder()
+                .nombreArchivo(nombreArchivo)
+                .nombreVisible("Microbiológico")
+                .build());
+        evaluacion.setArchivosAdjuntos(adjuntos);
+        evaluacionRepository.save(evaluacion);
     }
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -275,21 +275,13 @@ public class LoteProductoServiceImpl implements LoteProductoService {
             return false;
         }
         List<EvaluacionCalidad> seguras = evaluaciones == null ? List.of() : evaluaciones;
+        LoteProducto loteTemporal = new LoteProducto();
+        loteTemporal.setProducto(producto);
 
-        boolean fisicoOk = seguras.stream().anyMatch(e ->
-                e.getTipoEvaluacion() == TipoEvaluacion.FISICO &&
-                        (e.getResultado() == ResultadoEvaluacion.CONFORME
-                                || e.getResultado() == ResultadoEvaluacion.CONDICIONADO));
+        var validacion = validarDisciplinasCompletas(loteTemporal, seguras,
+                resultadoAnalisisMicrobiologicoRepository::existsByEvaluacionId);
 
-        boolean microOk = seguras.stream().anyMatch(e ->
-                e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO &&
-                        (e.getResultado() == ResultadoEvaluacion.CONFORME
-                                || e.getResultado() == ResultadoEvaluacion.CONDICIONADO));
-
-        boolean requiereFisico = requiereFisico(producto);
-        boolean requiereMicro = requiereMicro(producto) || requiereQuimico(producto);
-
-        return (!requiereFisico || fisicoOk) && (!requiereMicro || microOk);
+        return validacion.esValido();
     }
 
     @Override

--- a/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.calidad.mapper;
 
+import com.willyes.clemenintegra.calidad.dto.ArchivoEvaluacionDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroDetalleDTO;
 import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
@@ -64,5 +65,43 @@ class EvaluacionCalidadMapperTest {
         assertThat(dto.isTieneResultadosMicro()).isTrue();
         assertThat(dto.getResultadosMicro()).hasSize(1);
         assertThat(dto.getArchivosAdjuntos()).hasSize(1);
+    }
+
+    @Test
+    void consolidaEvaluacionesQMConIdsYAdjuntos() {
+        Producto producto = new Producto();
+        producto.setNombre("Producto B");
+        producto.setRequiereAnalisisFisico(false);
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(20L);
+        lote.setCodigoLote("L002");
+        lote.setProducto(producto);
+        lote.setEstado(com.willyes.clemenintegra.inventario.model.enums.EstadoLote.EN_CUARENTENA);
+
+        var usuario = new com.willyes.clemenintegra.shared.model.Usuario();
+        usuario.setNombreCompleto("Micro");
+
+        EvaluacionCalidad evalQuimicoMicro = EvaluacionCalidad.builder()
+                .id(30L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .usuarioEvaluador(usuario)
+                .fechaEvaluacion(LocalDateTime.now())
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreArchivo("quim.pdf")
+                        .nombreVisible("Químico")
+                        .build()))
+                .build();
+
+        var dto = mapper.toConsolidadoDTO(lote, List.of(evalQuimicoMicro), java.util.Set.of(30L));
+
+        assertThat(dto.getEvaluacionQuimicoMicroId()).isEqualTo(30L);
+        assertThat(dto.isEvaluacionesRequeridasCompletas()).isTrue();
+        assertThat(dto.getAdjuntosQuimicoMicro()).extracting(ArchivoEvaluacionDTO::getNombreVisible)
+                .containsExactly("Químico");
+        assertThat(dto.isTieneResultadosMicro()).isTrue();
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
@@ -70,4 +70,28 @@ class AnalisisCalidadHelperTest {
         assertThat(resultado.esValido()).isTrue();
         assertThat(resultado.getPrimerMensaje()).isNull();
     }
+
+    @Test
+    void validaFisicoQuimicoMicroCompletos() {
+        Producto producto = new Producto();
+        producto.setRequiereAnalisisFisico(true);
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        LoteProducto lote = new LoteProducto();
+        lote.setProducto(producto);
+
+        EvaluacionCalidad evalFisico = EvaluacionCalidad.builder()
+                .tipoEvaluacion(TipoEvaluacion.FISICO)
+                .build();
+        EvaluacionCalidad evalMicro = EvaluacionCalidad.builder()
+                .id(15L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .build();
+
+        AnalisisCalidadHelper.ResultadoValidacionDisciplinas resultado = AnalisisCalidadHelper
+                .validarDisciplinasCompletas(lote, List.of(evalFisico, evalMicro), id -> id == 15L);
+
+        assertThat(resultado.esValido()).isTrue();
+    }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -1,0 +1,160 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
+import com.willyes.clemenintegra.calidad.mapper.EvaluacionCalidadMapper;
+import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import com.willyes.clemenintegra.calidad.repository.ResultadoAnalisisMicrobiologicoRepository;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EvaluacionCalidadServiceImplTest {
+
+    @Mock
+    private EvaluacionCalidadRepository repository;
+    @Mock
+    private LoteProductoRepository loteRepository;
+    @Mock
+    private UsuarioService usuarioService;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private InventoryCatalogResolver catalogResolver;
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private CondicionUsoService condicionUsoService;
+    @Mock
+    private RetencionLoteService retencionLoteService;
+    @Mock
+    private NoConformidadService noConformidadService;
+    @Mock
+    private ResultadoAnalisisMicroService resultadoAnalisisMicroService;
+    @Mock
+    private ResultadoAnalisisMicrobiologicoRepository resultadoAnalisisMicrobiologicoRepository;
+
+    @Spy
+    private EvaluacionCalidadMapper mapper = new EvaluacionCalidadMapper();
+
+    @InjectMocks
+    private EvaluacionCalidadServiceImpl service;
+
+    private Usuario evaluador;
+    private LoteProducto lote;
+
+    @BeforeEach
+    void setUp() {
+        evaluador = new Usuario();
+        evaluador.setId(99L);
+        evaluador.setRol(RolUsuario.ROL_MICROBIOLOGO);
+        evaluador.setNombreCompleto("Micro Biólogo");
+
+        Producto producto = new Producto();
+        producto.setId(1);
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        Almacen almacen = new Almacen(5);
+
+        lote = new LoteProducto();
+        lote.setId(10L);
+        lote.setProducto(producto);
+        lote.setEstado(EstadoLote.EN_CUARENTENA);
+        lote.setAlmacen(almacen);
+
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(evaluador);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(5L);
+        when(loteRepository.findById(10L)).thenReturn(Optional.of(lote));
+    }
+
+    @Test
+    void creaNuevaEvaluacionQMCuandoNoExiste() {
+        EvaluacionCalidadRequestDTO dto = EvaluacionCalidadRequestDTO.builder()
+                .loteProductoId(10L)
+                .usuarioEvaluadorId(99L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .observaciones("OK")
+                .build();
+
+        when(repository.findFirstByLoteProductoIdAndTipoEvaluacion(10L, TipoEvaluacion.QUIMICO_MICROBIOLOGICO))
+                .thenReturn(Optional.empty());
+        when(repository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> {
+            EvaluacionCalidad eval = invocation.getArgument(0);
+            eval.setId(50L);
+            return eval;
+        });
+
+        var respuesta = service.crear(dto, null);
+
+        assertThat(respuesta.getId()).isEqualTo(50L);
+        assertThat(respuesta.getTipoEvaluacion()).isEqualTo(TipoEvaluacion.QUIMICO_MICROBIOLOGICO);
+        assertThat(respuesta.getResultado()).isEqualTo(ResultadoEvaluacion.CONFORME);
+    }
+
+    @Test
+    void reutilizaEvaluacionQMExistente() {
+        EvaluacionCalidad existente = EvaluacionCalidad.builder()
+                .id(60L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .observaciones("Inicial")
+                .resultado(ResultadoEvaluacion.CONDICIONADO)
+                .loteProducto(lote)
+                .usuarioEvaluador(evaluador)
+                .fechaEvaluacion(LocalDateTime.now().minusDays(1))
+                .archivosAdjuntos(new ArrayList<>(List.of(ArchivoEvaluacion.builder()
+                        .nombreVisible("Químico")
+                        .nombreArchivo("quim.pdf")
+                        .build())))
+                .build();
+
+        when(repository.findFirstByLoteProductoIdAndTipoEvaluacion(10L, TipoEvaluacion.QUIMICO_MICROBIOLOGICO))
+                .thenReturn(Optional.of(existente));
+        when(repository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        EvaluacionCalidadRequestDTO dto = EvaluacionCalidadRequestDTO.builder()
+                .loteProductoId(10L)
+                .usuarioEvaluadorId(99L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .observaciones("Actualizada")
+                .build();
+
+        var respuesta = service.crear(dto, null);
+
+        assertThat(respuesta.getId()).isEqualTo(60L);
+        assertThat(existente.getObservaciones()).isEqualTo("Actualizada");
+        assertThat(existente.getArchivosAdjuntos())
+                .extracting(ArchivoEvaluacion::getNombreVisible)
+                .contains("Químico");
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImplTest.java
@@ -9,7 +9,6 @@ import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +30,9 @@ class ResultadoAnalisisMicroServiceImplTest {
 
     @Mock
     private ResultadoAnalisisMicrobiologicoRepository resultadoRepository;
+
+    @Mock
+    private AnalisisMicroPdfService analisisMicroPdfService;
 
     @InjectMocks
     private ResultadoAnalisisMicroServiceImpl service;
@@ -51,13 +54,18 @@ class ResultadoAnalisisMicroServiceImplTest {
 
         Producto producto = Producto.builder().id(1).nombre("Prod").plantillaAnalisisMicrobiologico(plantilla).build();
         LoteProducto lote = LoteProducto.builder().id(2L).producto(producto).codigoLote("L-1").build();
-        EvaluacionCalidad evaluacion = EvaluacionCalidad.builder().id(3L).loteProducto(lote)
-                .fechaEvaluacion(LocalDateTime.now()).build();
+        EvaluacionCalidad evaluacion = EvaluacionCalidad.builder()
+                .id(3L)
+                .loteProducto(lote)
+                .tipoEvaluacion(com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .archivosAdjuntos(new java.util.ArrayList<>())
+                .fechaEvaluacion(LocalDateTime.now())
+                .build();
 
         when(evaluacionRepository.findById(3L)).thenReturn(Optional.of(evaluacion));
         when(resultadoRepository.findByEvaluacionId(3L)).thenReturn(List.of());
-        ArgumentCaptor<List<ResultadoAnalisisMicrobiologico>> captor = ArgumentCaptor.forClass(List.class);
         when(resultadoRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(analisisMicroPdfService.generarPdf(3L)).thenReturn("pdf".getBytes());
 
         var payload = List.of(ResultadoAnalisisMicroRequestDTO.builder()
                 .parametroId(5L)
@@ -70,6 +78,50 @@ class ResultadoAnalisisMicroServiceImplTest {
         assertThat(res).hasSize(1);
         assertThat(res.get(0).getResultado()).isEqualTo("10");
         assertThat(res.get(0).getNombreEnsayo()).isEqualTo("Mesófilos");
+    }
+
+    @Test
+    void conservaAdjuntosQuimicosYRegistraPdfMicro() {
+        PlantillaAnalisisMicrobiologico plantilla = PlantillaAnalisisMicrobiologico.builder()
+                .id(11L)
+                .build();
+        ParametroAnalisisMicrobiologico parametro = ParametroAnalisisMicrobiologico.builder()
+                .id(7L)
+                .plantilla(plantilla)
+                .nombreEnsayo("Moho")
+                .tipoResultado(TipoResultadoAnalisis.NUMERICO)
+                .orden(1)
+                .build();
+        plantilla.setParametros(List.of(parametro));
+
+        Producto producto = Producto.builder().id(3).nombre("Prod B").plantillaAnalisisMicrobiologico(plantilla).build();
+        LoteProducto lote = LoteProducto.builder().id(4L).producto(producto).codigoLote("L-2").build();
+        EvaluacionCalidad evaluacion = EvaluacionCalidad.builder()
+                .id(8L)
+                .loteProducto(lote)
+                .tipoEvaluacion(com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .archivosAdjuntos(new java.util.ArrayList<>(List.of(
+                        ArchivoEvaluacion.builder().nombreVisible("Químico").nombreArchivo("quim.pdf").build())))
+                .fechaEvaluacion(LocalDateTime.now())
+                .build();
+
+        when(evaluacionRepository.findById(8L)).thenReturn(Optional.of(evaluacion));
+        when(resultadoRepository.findByEvaluacionId(8L)).thenReturn(List.of());
+        when(resultadoRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(analisisMicroPdfService.generarPdf(8L)).thenReturn("pdf".getBytes());
+        when(evaluacionRepository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var payload = List.of(ResultadoAnalisisMicroRequestDTO.builder()
+                .parametroId(7L)
+                .resultado("5")
+                .cumple(true)
+                .build());
+
+        service.guardarResultados(8L, payload);
+
+        assertThat(evaluacion.getArchivosAdjuntos())
+                .extracting(ArchivoEvaluacion::getNombreVisible)
+                .contains("Químico", "Microbiológico");
     }
 }
 


### PR DESCRIPTION
## Summary
- reuse existing QUIMICO_MICROBIOLOGICO evaluations per lote when creating new records and expose consolidated IDs/attachments in responses
- store microbiology results with generated PDF attachments while keeping existing chemical files and discipline validation based on product flags
- expand unit coverage for QM upsert, consolidated mapping, microbiology persistence, and discipline validation

## Testing
- mvn -Dtest=AnalisisCalidadHelperTest,EvaluacionCalidadMapperTest,EvaluacionCalidadControllerTest,PlantillaAnalisisMicroServiceImplTest,ResultadoAnalisisMicroServiceImplTest,AnalisisMicroPdfServiceTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b70c90f088333ac0a958a51dfe824)