### PR TITLE
Add evaluation state calculation for consolidated quality responses

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad;
 
 import java.util.List;
 
@@ -32,6 +33,7 @@ public class EvaluacionConsolidadaResponseDTO {
     private boolean tieneAdjuntosQuimicoMicro;
     private Long evaluacionQuimicoMicroId;
     private Long evaluacionFisicaId;
+    private EstadoEvaluacionCalidad estadoEvaluacion;
     private List<ArchivoEvaluacionDTO> adjuntosQuimicoMicro;
     private String resultadoGlobal;
     private List<EvaluacionSimpleDTO> evaluaciones;

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
@@ -10,6 +10,7 @@ import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroDetalleDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
@@ -24,6 +25,7 @@ import java.util.Optional;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereFisico;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereMicro;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereQuimico;
+import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.calcularEstadoEvaluacion;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.validarDisciplinasCompletas;
 
 @Component
@@ -156,6 +158,15 @@ public class EvaluacionCalidadMapper {
                 && (!requiereQuimicoOMicro || microAnyOk)
                 && (!requiereMicro || tieneResultadosMicro);
 
+        boolean microEvaluacionCompleta = microCargado && (!requiereMicro || tieneResultadosMicro);
+        EstadoEvaluacionCalidad estadoEvaluacion = calcularEstadoEvaluacion(
+                requiereFisico,
+                fisicoCargado,
+                requiereQuimico,
+                microCargado,
+                requiereMicro,
+                microEvaluacionCompleta);
+
         String resultadoGlobal;
         if (tipoAnalisis == null) {
             resultadoGlobal = "DESCONOCIDO";
@@ -196,6 +207,7 @@ public class EvaluacionCalidadMapper {
                 .tieneAdjuntosQuimicoMicro(tieneAdjuntosQuimicoMicro)
                 .evaluacionQuimicoMicroId(evaluacionQuimicoMicro.map(EvaluacionCalidad::getId).orElse(null))
                 .evaluacionFisicaId(evaluacionFisica.map(EvaluacionCalidad::getId).orElse(null))
+                .estadoEvaluacion(estadoEvaluacion)
                 .adjuntosQuimicoMicro(evaluacionQuimicoMicro
                         .map(this::mapearArchivos)
                         .orElse(java.util.List.of()))

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/EstadoEvaluacionCalidad.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/EstadoEvaluacionCalidad.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.calidad.model.enums;
+
+/**
+ * Estado consolidado de las evaluaciones de calidad de un lote.
+ */
+public enum EstadoEvaluacionCalidad {
+    EVALUADO,
+    PENDIENTE,
+    NO_REQUIERE
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import java.util.Optional;
 
@@ -60,6 +61,36 @@ public final class AnalisisCalidadHelper {
                 .faltaEvaluacionQuimica(requiereQuimico && !tieneEvaluacionQuimica)
                 .faltanResultadosMicro(requiereMicro && (!tieneEvaluacionQuimica || !tieneResultadosMicro))
                 .build();
+    }
+
+    /**
+     * Determina el estado consolidado de las evaluaciones de calidad de un lote.
+     * Reglas:
+     * - Si ninguna disciplina es requerida -> NO_REQUIERE
+     * - Si todas las disciplinas requeridas tienen evaluación registrada -> EVALUADO
+     * - En cualquier otro caso -> PENDIENTE
+     */
+    public static EstadoEvaluacionCalidad calcularEstadoEvaluacion(
+            boolean requiereFisico,
+            boolean fisicoTieneEvaluacion,
+            boolean requiereQuimico,
+            boolean quimicoTieneEvaluacion,
+            boolean requiereMicro,
+            boolean microTieneEvaluacion
+    ) {
+        if (!requiereFisico && !requiereQuimico && !requiereMicro) {
+            return EstadoEvaluacionCalidad.NO_REQUIERE;
+        }
+
+        boolean fisicoListo = !requiereFisico || fisicoTieneEvaluacion;
+        boolean quimicoListo = !requiereQuimico || quimicoTieneEvaluacion;
+        boolean microListo = !requiereMicro || microTieneEvaluacion;
+
+        if (fisicoListo && quimicoListo && microListo) {
+            return EstadoEvaluacionCalidad.EVALUADO;
+        }
+
+        return EstadoEvaluacionCalidad.PENDIENTE;
     }
 
     @lombok.Builder

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
@@ -94,4 +94,32 @@ class AnalisisCalidadHelperTest {
 
         assertThat(resultado.esValido()).isTrue();
     }
+
+    @Test
+    void calculaEstadoNoRequiere() {
+        var estado = AnalisisCalidadHelper.calcularEstadoEvaluacion(false, false, false, false, false, false);
+
+        assertThat(estado.name()).isEqualTo("NO_REQUIERE");
+    }
+
+    @Test
+    void calculaEstadoEvaluadoCuandoTodoCompleto() {
+        var estado = AnalisisCalidadHelper.calcularEstadoEvaluacion(true, true, true, true, true, true);
+
+        assertThat(estado.name()).isEqualTo("EVALUADO");
+    }
+
+    @Test
+    void calculaEstadoPendienteCuandoFaltaUnaDisciplina() {
+        var estado = AnalisisCalidadHelper.calcularEstadoEvaluacion(true, false, true, true, true, true);
+
+        assertThat(estado.name()).isEqualTo("PENDIENTE");
+    }
+
+    @Test
+    void calculaEstadoPendienteSoloMicroRequeridoSinResultados() {
+        var estado = AnalisisCalidadHelper.calcularEstadoEvaluacion(false, false, false, false, true, false);
+
+        assertThat(estado.name()).isEqualTo("PENDIENTE");
+    }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -4,6 +4,8 @@ import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.mapper.EvaluacionCalidadMapper;
 import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.ResultadoAnalisisMicrobiologico;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
@@ -34,6 +36,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -91,9 +94,9 @@ class EvaluacionCalidadServiceImplTest {
         lote.setEstado(EstadoLote.EN_CUARENTENA);
         lote.setAlmacen(almacen);
 
-        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(evaluador);
-        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(5L);
-        when(loteRepository.findById(10L)).thenReturn(Optional.of(lote));
+        lenient().when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(evaluador);
+        lenient().when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(5L);
+        lenient().when(loteRepository.findById(10L)).thenReturn(Optional.of(lote));
     }
 
     @Test
@@ -156,5 +159,45 @@ class EvaluacionCalidadServiceImplTest {
         assertThat(existente.getArchivosAdjuntos())
                 .extracting(ArchivoEvaluacion::getNombreVisible)
                 .contains("Químico");
+    }
+
+    @Test
+    void obtieneEstadoEvaluacionConsolidado() {
+        lote.getProducto().setRequiereAnalisisFisico(true);
+
+        EvaluacionCalidad evalFisico = EvaluacionCalidad.builder()
+                .id(70L)
+                .tipoEvaluacion(TipoEvaluacion.FISICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .usuarioEvaluador(evaluador)
+                .loteProducto(lote)
+                .fechaEvaluacion(LocalDateTime.now())
+                .build();
+
+        EvaluacionCalidad evalQuimicoMicro = EvaluacionCalidad.builder()
+                .id(71L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .usuarioEvaluador(evaluador)
+                .loteProducto(lote)
+                .fechaEvaluacion(LocalDateTime.now())
+                .build();
+
+        when(repository.findAllWithinFechaEvaluacion(any(), any()))
+                .thenReturn(List.of(evalFisico, evalQuimicoMicro));
+
+        ResultadoAnalisisMicrobiologico resultadoMicro = ResultadoAnalisisMicrobiologico.builder()
+                .id(200L)
+                .evaluacion(evalQuimicoMicro)
+                .build();
+
+        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(any()))
+                .thenReturn(List.of(resultadoMicro));
+
+        var consolidados = service.obtenerEvaluacionesConsolidadas(evalFisico.getFechaEvaluacion().toLocalDate(),
+                evalFisico.getFechaEvaluacion().toLocalDate());
+
+        assertThat(consolidados).hasSize(1);
+        assertThat(consolidados.get(0).getEstadoEvaluacion()).isEqualTo(EstadoEvaluacionCalidad.EVALUADO);
     }
 }


### PR DESCRIPTION
## Summary
- add EstadoEvaluacionCalidad enum and helper to compute consolidated evaluation state
- expose the new estadoEvaluacion field on the consolidated response DTO and mapper
- extend unit tests for helper and consolidated service response

## Testing
- mvn -q -Dtest=AnalisisCalidadHelperTest,EvaluacionCalidadServiceImplTest,EvaluacionCalidadControllerTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c38af57b483339f45d06c693c5994)