### PR TITLE
Ensure microbiological PDFs are persisted and regenerated

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
@@ -8,7 +8,6 @@ import com.willyes.clemenintegra.calidad.dto.PlantillaAnalisisMicroDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
-import com.willyes.clemenintegra.calidad.service.AnalisisMicroPdfService;
 import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
 import com.willyes.clemenintegra.calidad.service.ResultadoAnalisisMicroService;
 import com.willyes.clemenintegra.calidad.service.PlantillaAnalisisMicroService;
@@ -43,7 +42,6 @@ public class EvaluacionCalidadController {
 
     private final EvaluacionCalidadService service;
     private final ResultadoAnalisisMicroService resultadoAnalisisMicroService;
-    private final AnalisisMicroPdfService analisisMicroPdfService;
     private final PlantillaAnalisisMicroService plantillaAnalisisMicroService;
 
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_SUPER_ADMIN')")
@@ -168,7 +166,7 @@ public class EvaluacionCalidadController {
     @GetMapping(path = "/{evaluacionId}/micro-pdf", produces = MediaType.APPLICATION_PDF_VALUE)
     @PreAuthorize("hasAnyAuthority('ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> descargarPdfMicroConNombre(@PathVariable Long evaluacionId) {
-        byte[] pdf = analisisMicroPdfService.generarPdf(evaluacionId);
+        byte[] pdf = resultadoAnalisisMicroService.obtenerPdfMicro(evaluacionId);
         String nombreArchivo = "MICRO_" + evaluacionId + ".pdf";
         try {
             EvaluacionCalidadResponseDTO dto = service.obtenerPorId(evaluacionId);
@@ -188,7 +186,7 @@ public class EvaluacionCalidadController {
     @GetMapping(path = "/{evaluacionId}/microbiologico/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
     @PreAuthorize("hasAnyAuthority('ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> descargarPdfMicro(@PathVariable Long evaluacionId) {
-        byte[] pdf = analisisMicroPdfService.generarPdf(evaluacionId);
+        byte[] pdf = resultadoAnalisisMicroService.obtenerPdfMicro(evaluacionId);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_PDF)
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=analisis_micro_" + evaluacionId + ".pdf")

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
@@ -27,6 +27,7 @@ import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.re
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereQuimico;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.calcularEstadoEvaluacion;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.validarDisciplinasCompletas;
+import static com.willyes.clemenintegra.calidad.service.ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO;
 
 @Component
 public class EvaluacionCalidadMapper {
@@ -136,8 +137,7 @@ public class EvaluacionCalidadMapper {
         boolean tieneAdjuntosFisico = fisicos.stream()
                 .anyMatch(e -> e.getArchivosAdjuntos() != null && !e.getArchivosAdjuntos().isEmpty());
         boolean tieneAdjuntosQuimicoMicro = evaluacionQuimicoMicro
-                .map(EvaluacionCalidad::getArchivosAdjuntos)
-                .map(lista -> lista != null && !lista.isEmpty())
+                .map(this::tienePdfMicro)
                 .orElse(false);
 
         boolean algunNoConforme = evals.stream().anyMatch(e -> e.getResultado() == ResultadoEvaluacion.NO_CONFORME);
@@ -283,5 +283,11 @@ public class EvaluacionCalidadMapper {
                                 .nombreVisible(a.getNombreVisible())
                                 .build())
                         .toList();
+    }
+
+    private boolean tienePdfMicro(EvaluacionCalidad evaluacionCalidad) {
+        return evaluacionCalidad.getArchivosAdjuntos() != null
+                && evaluacionCalidad.getArchivosAdjuntos().stream()
+                .anyMatch(a -> NOMBRE_VISIBLE_MICRO.equalsIgnoreCase(a.getNombreVisible()));
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/ArchivoEvaluacionConstants.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/ArchivoEvaluacionConstants.java
@@ -1,0 +1,12 @@
+package com.willyes.clemenintegra.calidad.service;
+
+/**
+ * Constantes reutilizables para el manejo de adjuntos de evaluaciones.
+ */
+public final class ArchivoEvaluacionConstants {
+
+    private ArchivoEvaluacionConstants() {
+    }
+
+    public static final String NOMBRE_VISIBLE_MICRO = "Microbiológico";
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroService.java
@@ -9,5 +9,7 @@ public interface ResultadoAnalisisMicroService {
     List<ResultadoAnalisisMicroResponseDTO> guardarResultados(Long evaluacionId, List<ResultadoAnalisisMicroRequestDTO> payload);
 
     List<ResultadoAnalisisMicroResponseDTO> obtenerPorEvaluacion(Long evaluacionId);
+
+    byte[] obtenerPdfMicro(Long evaluacionId);
 }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImpl.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
+import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.ParametroAnalisisMicrobiologico;
 import com.willyes.clemenintegra.calidad.model.PlantillaAnalisisMicrobiologico;
@@ -14,11 +15,16 @@ import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
+
+import static com.willyes.clemenintegra.calidad.service.ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO;
 
 @Service
 @RequiredArgsConstructor
@@ -74,7 +80,8 @@ public class ResultadoAnalisisMicroServiceImpl implements ResultadoAnalisisMicro
         }
 
         List<ResultadoAnalisisMicrobiologico> guardados = resultadoRepository.saveAll(aGuardar);
-        registrarPdfMicrobiologico(evaluacion);
+        byte[] pdf = analisisMicroPdfService.generarPdf(evaluacion.getId());
+        registrarPdfMicrobiologico(evaluacion, pdf);
         return mapear(guardados);
     }
 
@@ -82,6 +89,31 @@ public class ResultadoAnalisisMicroServiceImpl implements ResultadoAnalisisMicro
     @Transactional(readOnly = true)
     public List<ResultadoAnalisisMicroResponseDTO> obtenerPorEvaluacion(Long evaluacionId) {
         return mapear(resultadoRepository.findByEvaluacionId(evaluacionId));
+    }
+
+    @Override
+    @Transactional
+    public byte[] obtenerPdfMicro(Long evaluacionId) {
+        EvaluacionCalidad evaluacion = evaluacionRepository.findById(evaluacionId)
+                .orElseThrow(() -> new NoSuchElementException("Evaluación no encontrada con ID: " + evaluacionId));
+
+        Optional<ArchivoEvaluacion> adjuntoMicro = buscarAdjuntoMicro(evaluacion);
+        if (adjuntoMicro.isPresent()) {
+            byte[] contenido = leerArchivoSiExiste(adjuntoMicro.get());
+            if (contenido != null) {
+                return contenido;
+            }
+        }
+
+        List<ResultadoAnalisisMicrobiologico> resultados = resultadoRepository.findByEvaluacionId(evaluacionId);
+        if (resultados.isEmpty()) {
+            throw new ResponseStatusException(org.springframework.http.HttpStatus.NOT_FOUND,
+                    "No hay resultados microbiológicos para generar informe");
+        }
+
+        byte[] pdf = analisisMicroPdfService.generarPdf(evaluacionId);
+        registrarPdfMicrobiologico(evaluacion, pdf);
+        return pdf;
     }
 
     private List<ResultadoAnalisisMicroResponseDTO> mapear(List<ResultadoAnalisisMicrobiologico> entidades) {
@@ -102,31 +134,88 @@ public class ResultadoAnalisisMicroServiceImpl implements ResultadoAnalisisMicro
                 .toList();
     }
 
-    private void registrarPdfMicrobiologico(EvaluacionCalidad evaluacion) {
-        byte[] pdf = analisisMicroPdfService.generarPdf(evaluacion.getId());
-        String nombreArchivo = System.currentTimeMillis() + "_MICRO_" + evaluacion.getId() + ".pdf";
+    private void registrarPdfMicrobiologico(EvaluacionCalidad evaluacion, byte[] pdf) {
+        String nombreArchivo = construirNombreArchivo(evaluacion);
 
         try {
-            Path uploadRoot = Paths.get(System.getProperty("user.dir"), "uploads", "evaluaciones");
+            Path uploadRoot = obtenerUploadRoot();
             Files.createDirectories(uploadRoot);
             Files.write(uploadRoot.resolve(nombreArchivo), pdf);
         } catch (Exception e) {
             throw new IllegalStateException("No se pudo almacenar el PDF microbiológico", e);
         }
 
-        java.util.List<com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion> adjuntos = evaluacion.getArchivosAdjuntos();
+        java.util.List<ArchivoEvaluacion> adjuntos = evaluacion.getArchivosAdjuntos();
         if (adjuntos == null) {
             adjuntos = new ArrayList<>();
         } else {
             adjuntos = new ArrayList<>(adjuntos);
         }
-        adjuntos.removeIf(a -> "Microbiológico".equalsIgnoreCase(a.getNombreVisible()));
-        adjuntos.add(com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion.builder()
+
+        java.util.List<String> archivosRemovidos = new ArrayList<>();
+        Iterator<ArchivoEvaluacion> iterator = adjuntos.iterator();
+        while (iterator.hasNext()) {
+            ArchivoEvaluacion adjunto = iterator.next();
+            if (NOMBRE_VISIBLE_MICRO.equalsIgnoreCase(adjunto.getNombreVisible())) {
+                archivosRemovidos.add(adjunto.getNombreArchivo());
+                iterator.remove();
+            }
+        }
+
+        archivosRemovidos.forEach(this::eliminarArchivoSiExiste);
+
+        adjuntos.add(ArchivoEvaluacion.builder()
                 .nombreArchivo(nombreArchivo)
-                .nombreVisible("Microbiológico")
+                .nombreVisible(NOMBRE_VISIBLE_MICRO)
                 .build());
         evaluacion.setArchivosAdjuntos(adjuntos);
         evaluacionRepository.save(evaluacion);
+    }
+
+    private Optional<ArchivoEvaluacion> buscarAdjuntoMicro(EvaluacionCalidad evaluacion) {
+        return Optional.ofNullable(evaluacion.getArchivosAdjuntos())
+                .orElseGet(Collections::emptyList)
+                .stream()
+                .filter(a -> NOMBRE_VISIBLE_MICRO.equalsIgnoreCase(a.getNombreVisible()))
+                .findFirst();
+    }
+
+    private Path obtenerUploadRoot() {
+        return Paths.get(System.getProperty("user.dir"), "uploads", "evaluaciones");
+    }
+
+    private byte[] leerArchivoSiExiste(ArchivoEvaluacion adjunto) {
+        if (adjunto == null || adjunto.getNombreArchivo() == null) {
+            return null;
+        }
+        try {
+            Path archivo = obtenerUploadRoot().resolve(adjunto.getNombreArchivo());
+            if (!Files.exists(archivo)) {
+                return null;
+            }
+            return Files.readAllBytes(archivo);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void eliminarArchivoSiExiste(String nombreArchivo) {
+        if (nombreArchivo == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(obtenerUploadRoot().resolve(nombreArchivo));
+        } catch (Exception ignored) {
+        }
+    }
+
+    private String construirNombreArchivo(EvaluacionCalidad evaluacion) {
+        String codigoLote = Optional.ofNullable(evaluacion.getLoteProducto())
+                .map(l -> l.getCodigoLote())
+                .orElse("EVAL_" + evaluacion.getId());
+        String codigoSanitizado = codigoLote.replaceAll("[^a-zA-Z0-9._-]", "_");
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        return codigoSanitizado + "_MICRO_" + timestamp + ".pdf";
     }
 }
 

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerTest.java
@@ -1,7 +1,6 @@
 package com.willyes.clemenintegra.calidad.controller;
 
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO;
-import com.willyes.clemenintegra.calidad.service.AnalisisMicroPdfService;
 import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
 import com.willyes.clemenintegra.calidad.service.ResultadoAnalisisMicroService;
 import com.willyes.clemenintegra.calidad.service.PlantillaAnalisisMicroService;
@@ -20,7 +19,9 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.LocalDateTime;
 import java.util.Collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -37,8 +38,6 @@ class EvaluacionCalidadControllerTest {
     private EvaluacionCalidadService evaluacionCalidadService;
     @MockBean
     private ResultadoAnalisisMicroService resultadoAnalisisMicroService;
-    @MockBean
-    private AnalisisMicroPdfService analisisMicroPdfService;
     @MockBean
     private PlantillaAnalisisMicroService plantillaAnalisisMicroService;
     @MockBean
@@ -75,5 +74,29 @@ class EvaluacionCalidadControllerTest {
 
         mockMvc.perform(get("/api/calidad/evaluaciones/999/detalle"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void descargaPdfMicroExistente() throws Exception {
+        when(resultadoAnalisisMicroService.obtenerPdfMicro(5L)).thenReturn("pdf".getBytes());
+
+        mockMvc.perform(get("/api/calidad/evaluaciones/5/microbiologico/pdf")
+                        .accept(MediaType.APPLICATION_PDF))
+                .andExpect(status().isOk())
+                .andExpect(result -> assertThat(result.getResponse().getContentAsByteArray()).isNotEmpty());
+
+        verify(resultadoAnalisisMicroService).obtenerPdfMicro(5L);
+    }
+
+    @Test
+    void generaPdfMicroCuandoNoExisteAdjunto() throws Exception {
+        when(resultadoAnalisisMicroService.obtenerPdfMicro(7L)).thenReturn("nuevo".getBytes());
+
+        mockMvc.perform(get("/api/calidad/evaluaciones/7/micro-pdf")
+                        .accept(MediaType.APPLICATION_PDF))
+                .andExpect(status().isOk())
+                .andExpect(result -> assertThat(result.getResponse().getContentAsByteArray()).isEqualTo("nuevo".getBytes()));
+
+        verify(resultadoAnalisisMicroService).obtenerPdfMicro(7L);
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
@@ -90,10 +90,15 @@ class EvaluacionCalidadMapperTest {
                 .resultado(ResultadoEvaluacion.CONFORME)
                 .usuarioEvaluador(usuario)
                 .fechaEvaluacion(LocalDateTime.now())
-                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
-                        .nombreArchivo("quim.pdf")
-                        .nombreVisible("Químico")
-                        .build()))
+                .archivosAdjuntos(List.of(
+                        ArchivoEvaluacion.builder()
+                                .nombreArchivo("quim.pdf")
+                                .nombreVisible("Químico")
+                                .build(),
+                        ArchivoEvaluacion.builder()
+                                .nombreArchivo("micro.pdf")
+                                .nombreVisible("Microbiológico")
+                                .build()))
                 .build();
 
         var dto = mapper.toConsolidadoDTO(lote, List.of(evalQuimicoMicro), java.util.Set.of(30L));
@@ -101,7 +106,43 @@ class EvaluacionCalidadMapperTest {
         assertThat(dto.getEvaluacionQuimicoMicroId()).isEqualTo(30L);
         assertThat(dto.isEvaluacionesRequeridasCompletas()).isTrue();
         assertThat(dto.getAdjuntosQuimicoMicro()).extracting(ArchivoEvaluacionDTO::getNombreVisible)
-                .containsExactly("Químico");
+                .containsExactly("Químico", "Microbiológico");
         assertThat(dto.isTieneResultadosMicro()).isTrue();
+        assertThat(dto.isTieneAdjuntosQuimicoMicro()).isTrue();
+    }
+
+    @Test
+    void consolidaResultadosMicroSinPdfMicro() {
+        Producto producto = new Producto();
+        producto.setNombre("Producto C");
+        producto.setRequiereAnalisisFisico(false);
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(25L);
+        lote.setCodigoLote("L003");
+        lote.setProducto(producto);
+        lote.setEstado(com.willyes.clemenintegra.inventario.model.enums.EstadoLote.EN_CUARENTENA);
+
+        var usuario = new com.willyes.clemenintegra.shared.model.Usuario();
+        usuario.setNombreCompleto("Micro");
+
+        EvaluacionCalidad evalQuimicoMicro = EvaluacionCalidad.builder()
+                .id(31L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .usuarioEvaluador(usuario)
+                .fechaEvaluacion(LocalDateTime.now())
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreArchivo("quim.pdf")
+                        .nombreVisible("Químico")
+                        .build()))
+                .build();
+
+        var dto = mapper.toConsolidadoDTO(lote, List.of(evalQuimicoMicro), java.util.Set.of(31L));
+
+        assertThat(dto.isTieneResultadosMicro()).isTrue();
+        assertThat(dto.isTieneAdjuntosQuimicoMicro()).isFalse();
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImplTest.java
@@ -13,6 +13,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +23,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -66,6 +72,7 @@ class ResultadoAnalisisMicroServiceImplTest {
         when(resultadoRepository.findByEvaluacionId(3L)).thenReturn(List.of());
         when(resultadoRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(analisisMicroPdfService.generarPdf(3L)).thenReturn("pdf".getBytes());
+        when(evaluacionRepository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         var payload = List.of(ResultadoAnalisisMicroRequestDTO.builder()
                 .parametroId(5L)
@@ -122,6 +129,100 @@ class ResultadoAnalisisMicroServiceImplTest {
         assertThat(evaluacion.getArchivosAdjuntos())
                 .extracting(ArchivoEvaluacion::getNombreVisible)
                 .contains("Químico", "Microbiológico");
+    }
+
+    @Test
+    void generaPdfMicroCuandoNoExisteAdjuntoPrevio() {
+        PlantillaAnalisisMicrobiologico plantilla = PlantillaAnalisisMicrobiologico.builder()
+                .id(20L)
+                .build();
+        ParametroAnalisisMicrobiologico parametro = ParametroAnalisisMicrobiologico.builder()
+                .id(15L)
+                .plantilla(plantilla)
+                .nombreEnsayo("Aerobios")
+                .tipoResultado(TipoResultadoAnalisis.TEXTO)
+                .orden(1)
+                .build();
+        plantilla.setParametros(List.of(parametro));
+
+        Producto producto = Producto.builder().id(5).nombre("Prod C").plantillaAnalisisMicrobiologico(plantilla).build();
+        LoteProducto lote = LoteProducto.builder().id(9L).producto(producto).codigoLote("L-3").build();
+        EvaluacionCalidad evaluacion = EvaluacionCalidad.builder()
+                .id(12L)
+                .loteProducto(lote)
+                .tipoEvaluacion(com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .archivosAdjuntos(new java.util.ArrayList<>())
+                .fechaEvaluacion(LocalDateTime.now())
+                .build();
+
+        when(evaluacionRepository.findById(12L)).thenReturn(Optional.of(evaluacion));
+        when(resultadoRepository.findByEvaluacionId(12L)).thenReturn(List.of());
+        when(resultadoRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(analisisMicroPdfService.generarPdf(12L)).thenReturn("pdf".getBytes());
+        when(evaluacionRepository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var payload = List.of(ResultadoAnalisisMicroRequestDTO.builder()
+                .parametroId(15L)
+                .resultado("Ok")
+                .cumple(true)
+                .build());
+
+        service.guardarResultados(12L, payload);
+
+        assertThat(evaluacion.getArchivosAdjuntos())
+                .filteredOn(a -> "Microbiológico".equalsIgnoreCase(a.getNombreVisible()))
+                .hasSize(1);
+    }
+
+    @Test
+    void devuelveAdjuntoMicroExistenteSinRegenerar() throws Exception {
+        String nombreArchivo = "L-4_MICRO_prueba.pdf";
+        Path uploadRoot = Paths.get(System.getProperty("user.dir"), "uploads", "evaluaciones");
+        Files.createDirectories(uploadRoot);
+        Files.writeString(uploadRoot.resolve(nombreArchivo), "contenido");
+
+        EvaluacionCalidad evaluacion = EvaluacionCalidad.builder()
+                .id(30L)
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreArchivo(nombreArchivo)
+                        .nombreVisible("Microbiológico")
+                        .build()))
+                .build();
+
+        when(evaluacionRepository.findById(30L)).thenReturn(Optional.of(evaluacion));
+
+        byte[] pdf = service.obtenerPdfMicro(30L);
+
+        assertThat(new String(pdf)).isEqualTo("contenido");
+        verifyNoInteractions(analisisMicroPdfService);
+    }
+
+    @Test
+    void regeneraAdjuntoMicroCuandoNoExisteArchivoPeroHayResultados() {
+        EvaluacionCalidad evaluacion = EvaluacionCalidad.builder()
+                .id(40L)
+                .archivosAdjuntos(new java.util.ArrayList<>())
+                .tipoEvaluacion(com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .loteProducto(LoteProducto.builder().codigoLote("L-5").producto(new Producto()).build())
+                .build();
+
+        ResultadoAnalisisMicrobiologico resultado = ResultadoAnalisisMicrobiologico.builder()
+                .id(100L)
+                .evaluacion(evaluacion)
+                .build();
+
+        when(evaluacionRepository.findById(40L)).thenReturn(Optional.of(evaluacion));
+        when(resultadoRepository.findByEvaluacionId(40L)).thenReturn(List.of(resultado));
+        when(analisisMicroPdfService.generarPdf(40L)).thenReturn("nuevoPdf".getBytes());
+        when(evaluacionRepository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        byte[] resultadoPdf = service.obtenerPdfMicro(40L);
+
+        assertThat(resultadoPdf).isEqualTo("nuevoPdf".getBytes());
+        verify(analisisMicroPdfService).generarPdf(40L);
+        assertThat(evaluacion.getArchivosAdjuntos())
+                .filteredOn(a -> "Microbiológico".equalsIgnoreCase(a.getNombreVisible()))
+                .hasSize(1);
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure microbiological results always produce an attached PDF using a shared constant and replacement of stale attachments
- add fallback download flow that regenerates and persists missing microbiology PDFs before returning them
- tighten consolidated flags to look for microbiology PDFs specifically and extend controller/service/mapper coverage tests

## Testing
- mvn -q -Dtest=ResultadoAnalisisMicroServiceImplTest,AnalisisMicroPdfServiceTest,EvaluacionCalidadMapperTest,EvaluacionCalidadServiceImplTest,EvaluacionCalidadControllerTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3da9693083339df96f3f4c8c3dca)