### PR TITLE
Add unified microbiological PDF download endpoint

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
@@ -163,9 +163,9 @@ public class EvaluacionCalidadController {
         return ResponseEntity.ok(resultadoAnalisisMicroService.obtenerPorEvaluacion(evaluacionId));
     }
 
-    @GetMapping(path = "/{evaluacionId}/micro-pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    @GetMapping(path = "/{evaluacionId}/micro/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
     @PreAuthorize("hasAnyAuthority('ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public ResponseEntity<byte[]> descargarPdfMicroConNombre(@PathVariable Long evaluacionId) {
+    public ResponseEntity<byte[]> descargarPdfMicro(@PathVariable Long evaluacionId) {
         byte[] pdf = resultadoAnalisisMicroService.obtenerPdfMicro(evaluacionId);
         String nombreArchivo = "MICRO_" + evaluacionId + ".pdf";
         try {
@@ -180,16 +180,6 @@ public class EvaluacionCalidadController {
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_PDF)
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + nombreArchivo)
-                .body(pdf);
-    }
-
-    @GetMapping(path = "/{evaluacionId}/microbiologico/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
-    @PreAuthorize("hasAnyAuthority('ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public ResponseEntity<byte[]> descargarPdfMicro(@PathVariable Long evaluacionId) {
-        byte[] pdf = resultadoAnalisisMicroService.obtenerPdfMicro(evaluacionId);
-        return ResponseEntity.ok()
-                .contentType(MediaType.APPLICATION_PDF)
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=analisis_micro_" + evaluacionId + ".pdf")
                 .body(pdf);
     }
 

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerTest.java
@@ -80,10 +80,12 @@ class EvaluacionCalidadControllerTest {
     void descargaPdfMicroExistente() throws Exception {
         when(resultadoAnalisisMicroService.obtenerPdfMicro(5L)).thenReturn("pdf".getBytes());
 
-        mockMvc.perform(get("/api/calidad/evaluaciones/5/microbiologico/pdf")
+        mockMvc.perform(get("/api/calidad/evaluaciones/5/micro/pdf")
                         .accept(MediaType.APPLICATION_PDF))
                 .andExpect(status().isOk())
-                .andExpect(result -> assertThat(result.getResponse().getContentAsByteArray()).isNotEmpty());
+                .andExpect(result -> assertThat(result.getResponse().getContentAsByteArray()).isEqualTo("pdf".getBytes()))
+                .andExpect(result -> assertThat(result.getResponse().getHeader("Content-Disposition")).contains("attachment"))
+                .andExpect(result -> assertThat(result.getResponse().getContentType()).isEqualTo(MediaType.APPLICATION_PDF_VALUE));
 
         verify(resultadoAnalisisMicroService).obtenerPdfMicro(5L);
     }
@@ -92,11 +94,21 @@ class EvaluacionCalidadControllerTest {
     void generaPdfMicroCuandoNoExisteAdjunto() throws Exception {
         when(resultadoAnalisisMicroService.obtenerPdfMicro(7L)).thenReturn("nuevo".getBytes());
 
-        mockMvc.perform(get("/api/calidad/evaluaciones/7/micro-pdf")
+        mockMvc.perform(get("/api/calidad/evaluaciones/7/micro/pdf")
                         .accept(MediaType.APPLICATION_PDF))
                 .andExpect(status().isOk())
                 .andExpect(result -> assertThat(result.getResponse().getContentAsByteArray()).isEqualTo("nuevo".getBytes()));
 
         verify(resultadoAnalisisMicroService).obtenerPdfMicro(7L);
+    }
+
+    @Test
+    void devuelve404CuandoNoHayResultadosMicro() throws Exception {
+        when(resultadoAnalisisMicroService.obtenerPdfMicro(10L))
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "No hay resultados microbiológicos para generar el informe"));
+
+        mockMvc.perform(get("/api/calidad/evaluaciones/10/micro/pdf")
+                        .accept(MediaType.ALL))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/ResultadoAnalisisMicroServiceImplTest.java
@@ -21,9 +21,11 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -220,9 +222,27 @@ class ResultadoAnalisisMicroServiceImplTest {
 
         assertThat(resultadoPdf).isEqualTo("nuevoPdf".getBytes());
         verify(analisisMicroPdfService).generarPdf(40L);
+        verify(evaluacionRepository, times(1)).save(any(EvaluacionCalidad.class));
+        verify(resultadoRepository, times(1)).findByEvaluacionId(40L);
         assertThat(evaluacion.getArchivosAdjuntos())
                 .filteredOn(a -> "Microbiológico".equalsIgnoreCase(a.getNombreVisible()))
                 .hasSize(1);
+    }
+
+    @Test
+    void lanzaNotFoundCuandoNoHayResultadosMicro() {
+        EvaluacionCalidad evaluacion = EvaluacionCalidad.builder()
+                .id(55L)
+                .build();
+
+        when(evaluacionRepository.findById(55L)).thenReturn(Optional.of(evaluacion));
+        when(resultadoRepository.findByEvaluacionId(55L)).thenReturn(List.of());
+
+        org.junit.jupiter.api.Assertions.assertThrows(org.springframework.web.server.ResponseStatusException.class,
+                () -> service.obtenerPdfMicro(55L));
+
+        verify(analisisMicroPdfService, never()).generarPdf(anyLong());
+        verify(evaluacionRepository, never()).save(any(EvaluacionCalidad.class));
     }
 }
 


### PR DESCRIPTION
## Summary
- unify the microbiological PDF download route under `/api/calidad/evaluaciones/{evaluacionId}/micro/pdf` while preserving filename resolution
- expand controller coverage for existing PDFs, generated fallbacks, and missing-result errors
- reinforce service tests to assert regeneration flows persist attachments and raise 404 when no results exist

## Testing
- mvn -q -Dtest=EvaluacionCalidadControllerTest,EvaluacionCalidadServiceImplTest,ResultadoAnalisisMicroServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4b91194c833397893b2288921433)