### PR TITLE
Fix microbiological validation for lot release

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
@@ -1,10 +1,14 @@
 package com.willyes.clemenintegra.calidad.service;
 
+import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import java.util.Optional;
+
+import static com.willyes.clemenintegra.calidad.service.ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO;
 
 /**
  * Utilidades para determinar los análisis de calidad requeridos por producto.
@@ -45,22 +49,48 @@ public final class AnalisisCalidadHelper {
         boolean requiereMicro = requiereMicro(producto);
 
         boolean tieneEvaluacionFisica = evals.stream().anyMatch(e -> e.getTipoEvaluacion() == TipoEvaluacion.FISICO);
-        java.util.Optional<EvaluacionCalidad> evaluacionQuimicaMicro = evals.stream()
+        java.util.List<EvaluacionCalidad> evaluacionesQuimicoMicro = evals.stream()
                 .filter(e -> e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
-                .findFirst();
+                .toList();
 
-        boolean tieneEvaluacionQuimica = evaluacionQuimicaMicro.isPresent();
-        boolean tieneResultadosMicro = evaluacionQuimicaMicro
-                .map(EvaluacionCalidad::getId)
-                .filter(id -> existeResultadoMicro != null)
-                .map(existeResultadoMicro::test)
-                .orElse(false);
+        boolean tieneEvaluacionQuimica = !evaluacionesQuimicoMicro.isEmpty();
+
+        boolean evaluacionMicroConResultados = evaluacionesQuimicoMicro.stream()
+                .filter(e -> e.getId() != null)
+                .filter(e -> esEvaluacionAprobada(e.getResultado()))
+                .anyMatch(e -> existeResultadoMicro != null && existeResultadoMicro.test(e.getId()));
+
+        boolean faltaPdfMicro = false;
+        if (requiereMicro && evaluacionMicroConResultados) {
+            faltaPdfMicro = evaluacionesQuimicoMicro.stream()
+                    .filter(e -> e.getId() != null)
+                    .filter(e -> esEvaluacionAprobada(e.getResultado()))
+                    .filter(e -> existeResultadoMicro != null && existeResultadoMicro.test(e.getId()))
+                    .noneMatch(AnalisisCalidadHelper::tienePdfMicro);
+        }
 
         return builder
                 .faltaEvaluacionFisica(requiereFisico && !tieneEvaluacionFisica)
                 .faltaEvaluacionQuimica(requiereQuimico && !tieneEvaluacionQuimica)
-                .faltanResultadosMicro(requiereMicro && (!tieneEvaluacionQuimica || !tieneResultadosMicro))
+                .faltanResultadosMicro(requiereMicro && (!tieneEvaluacionQuimica || !evaluacionMicroConResultados))
+                .faltaPdfMicro(faltaPdfMicro)
                 .build();
+    }
+
+    private static boolean esEvaluacionAprobada(ResultadoEvaluacion resultado) {
+        return resultado == null
+                || resultado == ResultadoEvaluacion.CONFORME
+                || resultado == ResultadoEvaluacion.CONDICIONADO;
+    }
+
+    private static boolean tienePdfMicro(EvaluacionCalidad evaluacion) {
+        if (evaluacion == null || evaluacion.getArchivosAdjuntos() == null) {
+            return false;
+        }
+        return evaluacion.getArchivosAdjuntos().stream()
+                .map(ArchivoEvaluacion::getNombreVisible)
+                .filter(java.util.Objects::nonNull)
+                .anyMatch(nombre -> nombre.equalsIgnoreCase(NOMBRE_VISIBLE_MICRO));
     }
 
     /**
@@ -99,9 +129,10 @@ public final class AnalisisCalidadHelper {
         boolean faltaEvaluacionFisica;
         boolean faltaEvaluacionQuimica;
         boolean faltanResultadosMicro;
+        boolean faltaPdfMicro;
 
         public boolean esValido() {
-            return !faltaEvaluacionFisica && !faltaEvaluacionQuimica && !faltanResultadosMicro;
+            return !faltaEvaluacionFisica && !faltaEvaluacionQuimica && !faltanResultadosMicro && !faltaPdfMicro;
         }
 
         public String getPrimerMensaje() {
@@ -113,6 +144,9 @@ public final class AnalisisCalidadHelper {
             }
             if (faltanResultadosMicro) {
                 return "Faltan resultados microbiológicos";
+            }
+            if (faltaPdfMicro) {
+                return "Falta PDF microbiológico";
             }
             return null;
         }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -593,8 +593,9 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         }
 
         List<EvaluacionCalidad> evaluaciones = evaluacionRepository.findByLoteProductoId(loteId);
+        java.util.Set<Long> evaluacionesConResultadosMicro = obtenerEvaluacionesConResultadosMicro(evaluaciones);
         var validacion = validarDisciplinasCompletas(lote, evaluaciones,
-                resultadoAnalisisMicrobiologicoRepository::existsByEvaluacionId);
+                evaluacionId -> evaluacionesConResultadosMicro.contains(evaluacionId));
         if (!validacion.esValido()) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, validacion.getPrimerMensaje());
         }
@@ -633,6 +634,24 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         movimientoInventarioRepository.save(mov);
 
         return loteProductoMapper.toResponseDTO(lote);
+    }
+
+    private java.util.Set<Long> obtenerEvaluacionesConResultadosMicro(List<EvaluacionCalidad> evaluaciones) {
+        if (evaluaciones == null || evaluaciones.isEmpty()) {
+            return java.util.Collections.emptySet();
+        }
+        List<Long> ids = evaluaciones.stream()
+                .filter(e -> e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .map(EvaluacionCalidad::getId)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        if (ids.isEmpty()) {
+            return java.util.Collections.emptySet();
+        }
+        return resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(ids).stream()
+                .map(r -> r.getEvaluacion() != null ? r.getEvaluacion().getId() : null)
+                .filter(java.util.Objects::nonNull)
+                .collect(java.util.stream.Collectors.toSet());
     }
 
     private void registrarBitacoraReapertura(LoteProducto lote,

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
@@ -1,6 +1,9 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.service.ArchivoEvaluacionConstants;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
@@ -44,6 +47,10 @@ class AnalisisCalidadHelperTest {
         EvaluacionCalidad evaluacionQuimica = EvaluacionCalidad.builder()
                 .id(3L)
                 .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreVisible(ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO)
+                        .build()))
                 .build();
 
         AnalisisCalidadHelper.ResultadoValidacionDisciplinas resultado = AnalisisCalidadHelper
@@ -87,12 +94,59 @@ class AnalisisCalidadHelperTest {
         EvaluacionCalidad evalMicro = EvaluacionCalidad.builder()
                 .id(15L)
                 .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONDICIONADO)
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreVisible(ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO)
+                        .build()))
                 .build();
 
         AnalisisCalidadHelper.ResultadoValidacionDisciplinas resultado = AnalisisCalidadHelper
                 .validarDisciplinasCompletas(lote, List.of(evalFisico, evalMicro), id -> id == 15L);
 
         assertThat(resultado.esValido()).isTrue();
+    }
+
+    @Test
+    void validaMicroSinResultadosBloqueaLiberacion() {
+        Producto producto = new Producto();
+        producto.setRequiereAnalisisMicrobiologico(true);
+        LoteProducto lote = new LoteProducto();
+        lote.setProducto(producto);
+
+        EvaluacionCalidad evalMicro = EvaluacionCalidad.builder()
+                .id(99L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreVisible(ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO)
+                        .build()))
+                .build();
+
+        AnalisisCalidadHelper.ResultadoValidacionDisciplinas resultado = AnalisisCalidadHelper
+                .validarDisciplinasCompletas(lote, List.of(evalMicro), id -> false);
+
+        assertThat(resultado.esValido()).isFalse();
+        assertThat(resultado.getPrimerMensaje()).isEqualTo("Faltan resultados microbiológicos");
+    }
+
+    @Test
+    void validaMicroSinPdfDevuelveMensajeCorrecto() {
+        Producto producto = new Producto();
+        producto.setRequiereAnalisisMicrobiologico(true);
+        LoteProducto lote = new LoteProducto();
+        lote.setProducto(producto);
+
+        EvaluacionCalidad evalMicro = EvaluacionCalidad.builder()
+                .id(100L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .build();
+
+        AnalisisCalidadHelper.ResultadoValidacionDisciplinas resultado = AnalisisCalidadHelper
+                .validarDisciplinasCompletas(lote, List.of(evalMicro), id -> id == 100L);
+
+        assertThat(resultado.esValido()).isFalse();
+        assertThat(resultado.getPrimerMensaje()).isEqualTo("Falta PDF microbiológico");
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImplTest.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.calidad.repository.CondicionUsoRepository;
 import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import com.willyes.clemenintegra.calidad.repository.ResultadoAnalisisMicrobiologicoRepository;
 import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
 import com.willyes.clemenintegra.calidad.service.NoConformidadService;
 import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
@@ -42,6 +43,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -76,6 +79,7 @@ class LoteProductoServiceImplTest {
     @Mock private CondicionUsoRepository condicionUsoRepository;
     @Mock private CondicionUsoMapper condicionUsoMapper;
     @Mock private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
+    @Mock private ResultadoAnalisisMicrobiologicoRepository resultadoAnalisisMicrobiologicoRepository;
 
     @InjectMocks
     private LoteProductoServiceImpl service;
@@ -223,6 +227,65 @@ class LoteProductoServiceImplTest {
         assertThat(liberado.getEstado()).isEqualTo(EstadoLote.LIBERADO);
     }
 
+    @Test
+    @DisplayName("Libera lote cuando existen resultados micro y PDF requeridos")
+    void liberarLoteConMicroCompleto() {
+        Usuario jefeCalidad = usuarioConRol(RolUsuario.ROL_JEFE_CALIDAD);
+        Producto producto = productoConCategoria(TipoCategoria.PRODUCTO_TERMINADO);
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        LoteProducto lote = loteEnCuarentena(30L, producto, 7, BigDecimal.ONE);
+        lote.setStockReservado(BigDecimal.ZERO);
+
+        EvaluacionCalidad evaluacionMicro = evaluacionMicroCompleta(300L, lote);
+
+        mockCatalogosBasicos(13L, 12L);
+        when(catalogResolver.resolveAlmacenPrincipal(producto)).thenReturn(2L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(loteProductoRepository.findByIdForUpdate(30L)).thenReturn(Optional.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(30L)).thenReturn(List.of(evaluacionMicro));
+        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(any()))
+                .thenReturn(List.of(com.willyes.clemenintegra.calidad.model.ResultadoAnalisisMicrobiologico.builder()
+                        .id(1L)
+                        .evaluacion(evaluacionMicro)
+                        .build()));
+        when(almacenRepo.findById(2L)).thenReturn(Optional.of(almacenConId(2)));
+
+        service.liberarLotePorCalidad(30L, jefeCalidad);
+
+        assertThat(lote.getEstado()).isEqualTo(EstadoLote.LIBERADO);
+        assertThat(lote.getAlmacen().getId()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("Bloquea liberación si falta resultados microbiológicos")
+    void bloqueaLiberacionSinResultadosMicro() {
+        Usuario jefeCalidad = usuarioConRol(RolUsuario.ROL_JEFE_CALIDAD);
+        Producto producto = productoConCategoria(TipoCategoria.PRODUCTO_TERMINADO);
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        LoteProducto lote = loteEnCuarentena(31L, producto, 7, BigDecimal.ONE);
+        lote.setStockReservado(BigDecimal.ZERO);
+
+        EvaluacionCalidad evaluacionMicro = evaluacionMicroCompleta(301L, lote);
+
+        mockCatalogosBasicos(13L, 12L);
+        when(catalogResolver.resolveAlmacenPrincipal(producto)).thenReturn(2L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(7L);
+        when(loteProductoRepository.findByIdForUpdate(31L)).thenReturn(Optional.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(31L)).thenReturn(List.of(evaluacionMicro));
+        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(any()))
+                .thenReturn(Collections.emptyList());
+
+        ResponseStatusException ex = org.junit.jupiter.api.Assertions.assertThrows(ResponseStatusException.class,
+                () -> service.liberarLotePorCalidad(31L, jefeCalidad));
+
+        assertThat(ex.getStatusCode().value()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(ex.getReason()).isEqualTo("Faltan resultados microbiológicos");
+    }
+
     private void mockCatalogosBasicos(Long motivoId, Long tipoDetalleId) {
         MotivoMovimiento motivo = new MotivoMovimiento();
         motivo.setId(motivoId);
@@ -285,6 +348,20 @@ class LoteProductoServiceImplTest {
         Almacen almacen = new Almacen();
         almacen.setId(id);
         return almacen;
+    }
+
+    private EvaluacionCalidad evaluacionMicroCompleta(Long id, LoteProducto lote) {
+        return EvaluacionCalidad.builder()
+                .id(id)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .observaciones("ok")
+                .loteProducto(lote)
+                .archivosAdjuntos(List.of(com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion.builder()
+                        .nombreVisible(com.willyes.clemenintegra.calidad.service.ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO)
+                        .nombreArchivo("micro.pdf")
+                        .build()))
+                .build();
     }
 }
 


### PR DESCRIPTION
## Summary
- refine microbiological validation to require approved QM evaluations with recorded results and ensure the microbiological PDF is present
- use consolidated microbiological result detection when releasing lots instead of relying on a single evaluation
- add coverage for helper and lot release workflows when microbiological data is present or missing

## Testing
- mvn -Dtest=AnalisisCalidadHelperTest,EvaluacionCalidadServiceImplTest,ResultadoAnalisisMicroServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c60d3ae948333a02fb23332fbade1)