### PR TITLE
Expose per-discipline quality statuses in consolidated evaluations

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
@@ -26,11 +26,17 @@ public class EvaluacionConsolidadaResponseDTO {
     private boolean requiereAnalisisFisico;
     private boolean requiereAnalisisQuimico;
     private boolean requiereAnalisisMicrobiologico;
+    private Boolean fisicoConforme;
+    private Boolean quimicoConforme;
+    private Boolean microConforme;
     private boolean tieneEvaluacionFisica;
     private boolean tieneEvaluacionQuimicaMicro;
     private boolean tieneResultadosMicro;
+    private boolean tienePdfMicro;
+    private boolean tienePdfQuimico;
     private boolean tieneAdjuntosFisico;
     private boolean tieneAdjuntosQuimicoMicro;
+    private String codigoAnalisis;
     private Long evaluacionQuimicoMicroId;
     private Long evaluacionFisicaId;
     private EstadoEvaluacionCalidad estadoEvaluacion;

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
@@ -22,10 +22,11 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.Optional;
 
+import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.calcularCodigoAnalisis;
+import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.calcularEstadoEvaluacion;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereFisico;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereMicro;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereQuimico;
-import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.calcularEstadoEvaluacion;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.validarDisciplinasCompletas;
 import static com.willyes.clemenintegra.calidad.service.ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO;
 
@@ -110,60 +111,50 @@ public class EvaluacionCalidadMapper {
         boolean fisicoCargado = evaluacionFisica.isPresent();
         boolean microCargado = evaluacionQuimicoMicro.isPresent();
 
-        boolean fisicoConforme = evaluacionFisica
-                .map(EvaluacionCalidad::getResultado)
-                .map(r -> r == ResultadoEvaluacion.CONFORME)
-                .orElse(false);
-        boolean microConforme = evaluacionQuimicoMicro
-                .map(EvaluacionCalidad::getResultado)
-                .map(r -> r == ResultadoEvaluacion.CONFORME)
-                .orElse(false);
+        TipoAnalisisCalidad tipoAnalisis = lote.getProducto().getTipoAnalisisCalidad();
+        boolean requiereFisico = requiereFisico(lote.getProducto());
+        boolean requiereQuimico = requiereQuimico(lote.getProducto());
+        boolean requiereMicro = requiereMicro(lote.getProducto());
+        boolean requiereQuimicoOMicro = requiereQuimico || requiereMicro;
 
-        boolean fisicoAnyOk = evaluacionFisica
-                .map(EvaluacionCalidad::getResultado)
-                .map(r -> r == ResultadoEvaluacion.CONFORME || r == ResultadoEvaluacion.CONDICIONADO)
-                .orElse(false);
-
-        boolean microAnyOk = evaluacionQuimicoMicro
-                .map(EvaluacionCalidad::getResultado)
-                .map(r -> r == ResultadoEvaluacion.CONFORME || r == ResultadoEvaluacion.CONDICIONADO)
-                .orElse(false);
+        Boolean fisicoConforme = requiereFisico
+                ? evaluacionFisica.map(EvaluacionCalidad::getResultado).map(this::mapResultado).orElse(null)
+                : null;
+        Boolean quimicoConforme = requiereQuimico
+                ? evaluacionQuimicoMicro.map(EvaluacionCalidad::getResultado).map(this::mapResultado).orElse(null)
+                : null;
 
         boolean tieneResultadosMicro = evaluacionQuimicoMicro
                 .map(EvaluacionCalidad::getId)
                 .map(id -> evaluacionesConResultadosMicro != null && evaluacionesConResultadosMicro.contains(id))
                 .orElse(false);
+        Boolean microConforme = (requiereMicro && tieneResultadosMicro)
+                ? evaluacionQuimicoMicro.map(EvaluacionCalidad::getResultado).map(this::mapResultado).orElse(null)
+                : null;
 
         boolean tieneAdjuntosFisico = fisicos.stream()
                 .anyMatch(e -> e.getArchivosAdjuntos() != null && !e.getArchivosAdjuntos().isEmpty());
-        boolean tieneAdjuntosQuimicoMicro = evaluacionQuimicoMicro
-                .map(this::tienePdfMicro)
-                .orElse(false);
+        boolean tienePdfMicro = evaluacionQuimicoMicro.map(this::tienePdfMicro).orElse(false);
+        boolean tieneAdjuntosQuimicoMicro = tienePdfMicro;
+        boolean tienePdfQuimico = evaluacionQuimicoMicro.map(this::tienePdfQuimico).orElse(false);
 
         boolean algunNoConforme = evals.stream().anyMatch(e -> e.getResultado() == ResultadoEvaluacion.NO_CONFORME);
-
-        TipoAnalisisCalidad tipoAnalisis = lote.getProducto().getTipoAnalisisCalidad();
-        boolean requiereFisico = requiereFisico(lote.getProducto());
-        boolean requiereQuimico = requiereQuimico(lote.getProducto());
-        boolean requiereMicro = requiereMicro(lote.getProducto());
-
-        boolean requiereQuimicoOMicro = requiereQuimico || requiereMicro;
 
         var validacion = validarDisciplinasCompletas(lote, evals,
                 id -> evaluacionesConResultadosMicro != null && evaluacionesConResultadosMicro.contains(id));
 
         boolean disciplinasCompletas = validacion.esValido();
 
-        boolean evaluacionesCompletas = (!requiereFisico || fisicoAnyOk)
-                && (!requiereQuimicoOMicro || microAnyOk)
+        boolean evaluacionesCompletas = (!requiereFisico || fisicoConforme != null)
+                && (!requiereQuimicoOMicro || quimicoConforme != null)
                 && (!requiereMicro || tieneResultadosMicro);
 
-        boolean microEvaluacionCompleta = microCargado && (!requiereMicro || tieneResultadosMicro);
+        boolean microEvaluacionCompleta = !requiereMicro || tieneResultadosMicro;
         EstadoEvaluacionCalidad estadoEvaluacion = calcularEstadoEvaluacion(
                 requiereFisico,
-                fisicoCargado,
+                fisicoConforme != null,
                 requiereQuimico,
-                microCargado,
+                quimicoConforme != null,
                 requiereMicro,
                 microEvaluacionCompleta);
 
@@ -174,8 +165,9 @@ public class EvaluacionCalidadMapper {
             resultadoGlobal = "NO_REQUERIDO";
         } else if (algunNoConforme) {
             resultadoGlobal = ResultadoEvaluacion.NO_CONFORME.name();
-        } else if ((!requiereFisico || fisicoConforme)
-                && (!requiereQuimicoOMicro || (microConforme && (!requiereMicro || tieneResultadosMicro)))) {
+        } else if ((!requiereFisico || Boolean.TRUE.equals(fisicoConforme))
+                && (!requiereQuimicoOMicro || Boolean.TRUE.equals(quimicoConforme))
+                && (!requiereMicro || (tieneResultadosMicro && (microConforme == null || Boolean.TRUE.equals(microConforme))))) {
             resultadoGlobal = ResultadoEvaluacion.CONFORME.name();
         } else if (evaluacionesCompletas) {
             resultadoGlobal = ResultadoEvaluacion.CONDICIONADO.name();
@@ -185,6 +177,8 @@ public class EvaluacionCalidadMapper {
                     || (requiereMicro && tieneResultadosMicro);
             resultadoGlobal = avances ? "EN_PROCESO" : "PENDIENTE";
         }
+
+        String codigoAnalisis = calcularCodigoAnalisis(requiereFisico, requiereQuimico, requiereMicro);
 
         return EvaluacionConsolidadaResponseDTO.builder()
                 .id(lote.getId())
@@ -200,11 +194,17 @@ public class EvaluacionCalidadMapper {
                 .requiereAnalisisFisico(requiereFisico)
                 .requiereAnalisisQuimico(requiereQuimico)
                 .requiereAnalisisMicrobiologico(requiereMicro)
+                .fisicoConforme(fisicoConforme)
+                .quimicoConforme(quimicoConforme)
+                .microConforme(microConforme)
                 .tieneEvaluacionFisica(fisicoCargado)
                 .tieneEvaluacionQuimicaMicro(microCargado)
                 .tieneResultadosMicro(tieneResultadosMicro)
+                .tienePdfMicro(tienePdfMicro)
+                .tienePdfQuimico(tienePdfQuimico)
                 .tieneAdjuntosFisico(tieneAdjuntosFisico)
                 .tieneAdjuntosQuimicoMicro(tieneAdjuntosQuimicoMicro)
+                .codigoAnalisis(codigoAnalisis)
                 .evaluacionQuimicoMicroId(evaluacionQuimicoMicro.map(EvaluacionCalidad::getId).orElse(null))
                 .evaluacionFisicaId(evaluacionFisica.map(EvaluacionCalidad::getId).orElse(null))
                 .estadoEvaluacion(estadoEvaluacion)
@@ -289,5 +289,21 @@ public class EvaluacionCalidadMapper {
         return evaluacionCalidad.getArchivosAdjuntos() != null
                 && evaluacionCalidad.getArchivosAdjuntos().stream()
                 .anyMatch(a -> NOMBRE_VISIBLE_MICRO.equalsIgnoreCase(a.getNombreVisible()));
+    }
+
+    private boolean tienePdfQuimico(EvaluacionCalidad evaluacionCalidad) {
+        return evaluacionCalidad.getArchivosAdjuntos() != null
+                && evaluacionCalidad.getArchivosAdjuntos().stream()
+                .anyMatch(a -> a.getNombreVisible() != null && !NOMBRE_VISIBLE_MICRO.equalsIgnoreCase(a.getNombreVisible()));
+    }
+
+    private Boolean mapResultado(ResultadoEvaluacion resultado) {
+        if (resultado == null) {
+            return null;
+        }
+        return switch (resultado) {
+            case CONFORME, CONDICIONADO -> true;
+            case NO_CONFORME -> false;
+        };
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
@@ -93,6 +93,31 @@ public final class AnalisisCalidadHelper {
                 .anyMatch(nombre -> nombre.equalsIgnoreCase(NOMBRE_VISIBLE_MICRO));
     }
 
+    public static String calcularCodigoAnalisis(boolean requiereFisico, boolean requiereQuimico, boolean requiereMicro) {
+        if (requiereFisico && requiereQuimico && requiereMicro) {
+            return "FQM";
+        }
+        if (!requiereFisico && requiereQuimico && requiereMicro) {
+            return "QM";
+        }
+        if (requiereFisico && !requiereQuimico && requiereMicro) {
+            return "FM";
+        }
+        if (requiereFisico && requiereQuimico && !requiereMicro) {
+            return "FQ";
+        }
+        if (requiereFisico && !requiereQuimico && !requiereMicro) {
+            return "F";
+        }
+        if (!requiereFisico && requiereQuimico && !requiereMicro) {
+            return "Q";
+        }
+        if (!requiereFisico && !requiereQuimico && requiereMicro) {
+            return "M";
+        }
+        return "—";
+    }
+
     /**
      * Determina el estado consolidado de las evaluaciones de calidad de un lote.
      * Reglas:
@@ -102,19 +127,19 @@ public final class AnalisisCalidadHelper {
      */
     public static EstadoEvaluacionCalidad calcularEstadoEvaluacion(
             boolean requiereFisico,
-            boolean fisicoTieneEvaluacion,
+            boolean fisicoCompleto,
             boolean requiereQuimico,
-            boolean quimicoTieneEvaluacion,
+            boolean quimicoCompleto,
             boolean requiereMicro,
-            boolean microTieneEvaluacion
+            boolean microCompleto
     ) {
         if (!requiereFisico && !requiereQuimico && !requiereMicro) {
             return EstadoEvaluacionCalidad.NO_REQUIERE;
         }
 
-        boolean fisicoListo = !requiereFisico || fisicoTieneEvaluacion;
-        boolean quimicoListo = !requiereQuimico || quimicoTieneEvaluacion;
-        boolean microListo = !requiereMicro || microTieneEvaluacion;
+        boolean fisicoListo = !requiereFisico || fisicoCompleto;
+        boolean quimicoListo = !requiereQuimico || quimicoCompleto;
+        boolean microListo = !requiereMicro || microCompleto;
 
         if (fisicoListo && quimicoListo && microListo) {
             return EstadoEvaluacionCalidad.EVALUADO;

--- a/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
@@ -109,6 +109,12 @@ class EvaluacionCalidadMapperTest {
                 .containsExactly("Químico", "Microbiológico");
         assertThat(dto.isTieneResultadosMicro()).isTrue();
         assertThat(dto.isTieneAdjuntosQuimicoMicro()).isTrue();
+        assertThat(dto.isTienePdfMicro()).isTrue();
+        assertThat(dto.isTienePdfQuimico()).isTrue();
+        assertThat(dto.getCodigoAnalisis()).isEqualTo("QM");
+        assertThat(dto.getQuimicoConforme()).isTrue();
+        assertThat(dto.getMicroConforme()).isTrue();
+        assertThat(dto.getFisicoConforme()).isNull();
     }
 
     @Test
@@ -144,5 +150,8 @@ class EvaluacionCalidadMapperTest {
 
         assertThat(dto.isTieneResultadosMicro()).isTrue();
         assertThat(dto.isTieneAdjuntosQuimicoMicro()).isFalse();
+        assertThat(dto.isTienePdfMicro()).isFalse();
+        assertThat(dto.isTienePdfQuimico()).isTrue();
+        assertThat(dto.getMicroConforme()).isTrue();
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
@@ -176,4 +176,16 @@ class AnalisisCalidadHelperTest {
 
         assertThat(estado.name()).isEqualTo("PENDIENTE");
     }
+
+    @Test
+    void calculaCodigoAnalisisParaTodasLasCombinaciones() {
+        assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(true, true, true)).isEqualTo("FQM");
+        assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(false, true, true)).isEqualTo("QM");
+        assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(true, false, true)).isEqualTo("FM");
+        assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(true, true, false)).isEqualTo("FQ");
+        assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(true, false, false)).isEqualTo("F");
+        assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(false, true, false)).isEqualTo("Q");
+        assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(false, false, true)).isEqualTo("M");
+        assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(false, false, false)).isEqualTo("—");
+    }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -162,7 +162,7 @@ class EvaluacionCalidadServiceImplTest {
     }
 
     @Test
-    void obtieneEstadoEvaluacionConsolidado() {
+    void consolidaFqmConDisciplinasConformes() {
         lote.getProducto().setRequiereAnalisisFisico(true);
 
         EvaluacionCalidad evalFisico = EvaluacionCalidad.builder()
@@ -172,6 +172,10 @@ class EvaluacionCalidadServiceImplTest {
                 .usuarioEvaluador(evaluador)
                 .loteProducto(lote)
                 .fechaEvaluacion(LocalDateTime.now())
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreVisible("Fisico")
+                        .nombreArchivo("fisico.pdf")
+                        .build()))
                 .build();
 
         EvaluacionCalidad evalQuimicoMicro = EvaluacionCalidad.builder()
@@ -181,6 +185,15 @@ class EvaluacionCalidadServiceImplTest {
                 .usuarioEvaluador(evaluador)
                 .loteProducto(lote)
                 .fechaEvaluacion(LocalDateTime.now())
+                .archivosAdjuntos(List.of(
+                        ArchivoEvaluacion.builder()
+                                .nombreVisible("Químico")
+                                .nombreArchivo("quim.pdf")
+                                .build(),
+                        ArchivoEvaluacion.builder()
+                                .nombreVisible(com.willyes.clemenintegra.calidad.service.ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO)
+                                .nombreArchivo("micro.pdf")
+                                .build()))
                 .build();
 
         when(repository.findAllWithinFechaEvaluacion(any(), any()))
@@ -198,6 +211,47 @@ class EvaluacionCalidadServiceImplTest {
                 evalFisico.getFechaEvaluacion().toLocalDate());
 
         assertThat(consolidados).hasSize(1);
-        assertThat(consolidados.get(0).getEstadoEvaluacion()).isEqualTo(EstadoEvaluacionCalidad.EVALUADO);
+        var dto = consolidados.get(0);
+        assertThat(dto.getCodigoAnalisis()).isEqualTo("FQM");
+        assertThat(dto.getFisicoConforme()).isTrue();
+        assertThat(dto.getQuimicoConforme()).isTrue();
+        assertThat(dto.getMicroConforme()).isTrue();
+        assertThat(dto.isTieneResultadosMicro()).isTrue();
+        assertThat(dto.isTienePdfMicro()).isTrue();
+        assertThat(dto.getEstadoEvaluacion()).isEqualTo(EstadoEvaluacionCalidad.EVALUADO);
+    }
+
+    @Test
+    void consolidaMicroPendienteCuandoNoHayResultados() {
+        Producto productoSoloMicro = new Producto();
+        productoSoloMicro.setId(2);
+        productoSoloMicro.setRequiereAnalisisMicrobiologico(true);
+        LoteProducto loteSoloMicro = new LoteProducto();
+        loteSoloMicro.setId(30L);
+        loteSoloMicro.setProducto(productoSoloMicro);
+        loteSoloMicro.setEstado(EstadoLote.EN_CUARENTENA);
+
+        EvaluacionCalidad evalMicro = EvaluacionCalidad.builder()
+                .id(80L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .usuarioEvaluador(evaluador)
+                .loteProducto(loteSoloMicro)
+                .fechaEvaluacion(LocalDateTime.now())
+                .build();
+
+        when(repository.findAllWithinFechaEvaluacion(any(), any()))
+                .thenReturn(List.of(evalMicro));
+        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(any()))
+                .thenReturn(List.of());
+
+        var consolidados = service.obtenerEvaluacionesConsolidadas(evalMicro.getFechaEvaluacion().toLocalDate(),
+                evalMicro.getFechaEvaluacion().toLocalDate());
+
+        assertThat(consolidados).hasSize(1);
+        var dto = consolidados.get(0);
+        assertThat(dto.isTieneResultadosMicro()).isFalse();
+        assertThat(dto.getMicroConforme()).isNull();
+        assertThat(dto.getEstadoEvaluacion()).isEqualTo(EstadoEvaluacionCalidad.PENDIENTE);
     }
 }


### PR DESCRIPTION
## Summary
- add explicit per-discipline requirement, conformity, and attachment flags to consolidated quality responses
- calculate analysis code/state through updated helper and mapper logic driven by product discipline requirements and micro results
- extend helper, mapper, and service tests to cover new DTO fields and consolidated scenarios for FQM and pending micro cases

## Testing
- mvn -Dtest=AnalisisCalidadHelperTest,EvaluacionCalidadMapperTest,EvaluacionCalidadServiceImplTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c68af66308333b8d0dc5c4540a67b)