### PR TITLE
Corregir estado microbiológico en consolidado de evaluaciones

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.DisciplinaEstado;
 
 import java.util.List;
 
@@ -36,6 +37,7 @@ public class EvaluacionConsolidadaResponseDTO {
     private boolean tienePdfQuimico;
     private boolean tieneAdjuntosFisico;
     private boolean tieneAdjuntosQuimicoMicro;
+    private DisciplinaEstado estadoMicro;
     private String codigoAnalisis;
     private Long evaluacionQuimicoMicroId;
     private Long evaluacionFisicaId;

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.calcularCodigoAnalisis;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.calcularEstadoEvaluacion;
+import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.calcularEstadoMicro;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereFisico;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereMicro;
 import static com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper.requiereQuimico;
@@ -114,7 +115,8 @@ public class EvaluacionCalidadMapper {
         TipoAnalisisCalidad tipoAnalisis = lote.getProducto().getTipoAnalisisCalidad();
         boolean requiereFisico = requiereFisico(lote.getProducto());
         boolean requiereQuimico = requiereQuimico(lote.getProducto());
-        boolean requiereMicro = requiereMicro(lote.getProducto());
+        var estadoMicro = calcularEstadoMicro(lote.getProducto(), evals, evaluacionesConResultadosMicro);
+        boolean requiereMicro = estadoMicro.requiereMicro();
         boolean requiereQuimicoOMicro = requiereQuimico || requiereMicro;
 
         Boolean fisicoConforme = requiereFisico
@@ -124,17 +126,14 @@ public class EvaluacionCalidadMapper {
                 ? evaluacionQuimicoMicro.map(EvaluacionCalidad::getResultado).map(this::mapResultado).orElse(null)
                 : null;
 
-        boolean tieneResultadosMicro = evaluacionQuimicoMicro
-                .map(EvaluacionCalidad::getId)
-                .map(id -> evaluacionesConResultadosMicro != null && evaluacionesConResultadosMicro.contains(id))
-                .orElse(false);
+        boolean tieneResultadosMicro = estadoMicro.tieneResultadosMicro();
         Boolean microConforme = (requiereMicro && tieneResultadosMicro)
                 ? evaluacionQuimicoMicro.map(EvaluacionCalidad::getResultado).map(this::mapResultado).orElse(null)
                 : null;
 
         boolean tieneAdjuntosFisico = fisicos.stream()
                 .anyMatch(e -> e.getArchivosAdjuntos() != null && !e.getArchivosAdjuntos().isEmpty());
-        boolean tienePdfMicro = evaluacionQuimicoMicro.map(this::tienePdfMicro).orElse(false);
+        boolean tienePdfMicro = estadoMicro.tienePdfMicro();
         boolean tieneAdjuntosQuimicoMicro = tienePdfMicro;
         boolean tienePdfQuimico = evaluacionQuimicoMicro.map(this::tienePdfQuimico).orElse(false);
 
@@ -204,6 +203,7 @@ public class EvaluacionCalidadMapper {
                 .tienePdfQuimico(tienePdfQuimico)
                 .tieneAdjuntosFisico(tieneAdjuntosFisico)
                 .tieneAdjuntosQuimicoMicro(tieneAdjuntosQuimicoMicro)
+                .estadoMicro(estadoMicro.estado())
                 .codigoAnalisis(codigoAnalisis)
                 .evaluacionQuimicoMicroId(evaluacionQuimicoMicro.map(EvaluacionCalidad::getId).orElse(null))
                 .evaluacionFisicaId(evaluacionFisica.map(EvaluacionCalidad::getId).orElse(null))

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/DisciplinaEstado.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/DisciplinaEstado.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.calidad.model.enums;
+
+public enum DisciplinaEstado {
+    NO_REQUERIDO,
+    PENDIENTE,
+    EVALUADO
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
@@ -2,11 +2,14 @@ package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.DisciplinaEstado;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import java.util.Optional;
+import java.util.Comparator;
+import java.time.LocalDateTime;
 
 import static com.willyes.clemenintegra.calidad.service.ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO;
 
@@ -75,6 +78,36 @@ public final class AnalisisCalidadHelper {
                 .faltanResultadosMicro(requiereMicro && (!tieneEvaluacionQuimica || !evaluacionMicroConResultados))
                 .faltaPdfMicro(faltaPdfMicro)
                 .build();
+    }
+
+    public static EstadoDisciplinaMicro calcularEstadoMicro(
+            Producto producto,
+            java.util.List<EvaluacionCalidad> evaluaciones,
+            java.util.Set<Long> evaluacionesConResultadosMicro
+    ) {
+        boolean requiereMicro = requiereMicro(producto);
+        java.util.List<EvaluacionCalidad> evals = evaluaciones == null ? java.util.List.of() : evaluaciones;
+
+        Optional<EvaluacionCalidad> evaluacionMicro = evals.stream()
+                .filter(e -> e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .max(Comparator.comparing(EvaluacionCalidad::getFechaEvaluacion, Comparator.nullsLast(LocalDateTime::compareTo)));
+
+        boolean tieneResultadosMicro = evaluacionMicro
+                .map(EvaluacionCalidad::getId)
+                .map(id -> evaluacionesConResultadosMicro != null && evaluacionesConResultadosMicro.contains(id))
+                .orElse(false);
+        boolean tienePdfMicro = evaluacionMicro.map(AnalisisCalidadHelper::tienePdfMicro).orElse(false);
+
+        DisciplinaEstado estado;
+        if (!requiereMicro) {
+            estado = DisciplinaEstado.NO_REQUERIDO;
+        } else if (tieneResultadosMicro) {
+            estado = DisciplinaEstado.EVALUADO;
+        } else {
+            estado = DisciplinaEstado.PENDIENTE;
+        }
+
+        return new EstadoDisciplinaMicro(requiereMicro, tieneResultadosMicro, tienePdfMicro, estado);
     }
 
     private static boolean esEvaluacionAprobada(ResultadoEvaluacion resultado) {
@@ -175,5 +208,13 @@ public final class AnalisisCalidadHelper {
             }
             return null;
         }
+    }
+
+    public record EstadoDisciplinaMicro(
+            boolean requiereMicro,
+            boolean tieneResultadosMicro,
+            boolean tienePdfMicro,
+            DisciplinaEstado estado
+    ) {
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelperTest.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.calidad.service;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.DisciplinaEstado;
 import com.willyes.clemenintegra.calidad.service.ArchivoEvaluacionConstants;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
@@ -10,6 +11,7 @@ import com.willyes.clemenintegra.inventario.model.Producto;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -187,5 +189,53 @@ class AnalisisCalidadHelperTest {
         assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(false, true, false)).isEqualTo("Q");
         assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(false, false, true)).isEqualTo("M");
         assertThat(AnalisisCalidadHelper.calcularCodigoAnalisis(false, false, false)).isEqualTo("—");
+    }
+
+    @Test
+    void calculaEstadoMicroNoRequerido() {
+        Producto producto = new Producto();
+
+        var estado = AnalisisCalidadHelper.calcularEstadoMicro(producto, List.of(), Set.of());
+
+        assertThat(estado.estado()).isEqualTo(DisciplinaEstado.NO_REQUERIDO);
+        assertThat(estado.tieneResultadosMicro()).isFalse();
+        assertThat(estado.tienePdfMicro()).isFalse();
+    }
+
+    @Test
+    void calculaEstadoMicroPendienteSinResultados() {
+        Producto producto = new Producto();
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        EvaluacionCalidad evalMicro = EvaluacionCalidad.builder()
+                .id(1L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .build();
+
+        var estado = AnalisisCalidadHelper.calcularEstadoMicro(producto, List.of(evalMicro), Set.of());
+
+        assertThat(estado.estado()).isEqualTo(DisciplinaEstado.PENDIENTE);
+        assertThat(estado.tieneResultadosMicro()).isFalse();
+        assertThat(estado.tienePdfMicro()).isFalse();
+    }
+
+    @Test
+    void calculaEstadoMicroEvaluadoConResultadosYPdf() {
+        Producto producto = new Producto();
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        EvaluacionCalidad evalMicro = EvaluacionCalidad.builder()
+                .id(2L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreVisible(ArchivoEvaluacionConstants.NOMBRE_VISIBLE_MICRO)
+                        .build()))
+                .build();
+
+        var estado = AnalisisCalidadHelper.calcularEstadoMicro(producto, List.of(evalMicro), Set.of(2L));
+
+        assertThat(estado.estado()).isEqualTo(DisciplinaEstado.EVALUADO);
+        assertThat(estado.tieneResultadosMicro()).isTrue();
+        assertThat(estado.tienePdfMicro()).isTrue();
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.ResultadoAnalisisMicrobiologico;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.DisciplinaEstado;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
@@ -218,6 +219,7 @@ class EvaluacionCalidadServiceImplTest {
         assertThat(dto.getMicroConforme()).isTrue();
         assertThat(dto.isTieneResultadosMicro()).isTrue();
         assertThat(dto.isTienePdfMicro()).isTrue();
+        assertThat(dto.getEstadoMicro()).isEqualTo(DisciplinaEstado.EVALUADO);
         assertThat(dto.getEstadoEvaluacion()).isEqualTo(EstadoEvaluacionCalidad.EVALUADO);
     }
 
@@ -252,6 +254,38 @@ class EvaluacionCalidadServiceImplTest {
         var dto = consolidados.get(0);
         assertThat(dto.isTieneResultadosMicro()).isFalse();
         assertThat(dto.getMicroConforme()).isNull();
+        assertThat(dto.getEstadoMicro()).isEqualTo(DisciplinaEstado.PENDIENTE);
         assertThat(dto.getEstadoEvaluacion()).isEqualTo(EstadoEvaluacionCalidad.PENDIENTE);
+    }
+
+    @Test
+    void consolidaMicroNoRequerido() {
+        Producto productoSinMicro = new Producto();
+        productoSinMicro.setId(3);
+        productoSinMicro.setRequiereAnalisisMicrobiologico(false);
+        LoteProducto loteSinMicro = new LoteProducto();
+        loteSinMicro.setId(40L);
+        loteSinMicro.setProducto(productoSinMicro);
+        loteSinMicro.setEstado(EstadoLote.EN_CUARENTENA);
+
+        EvaluacionCalidad evalFisico = EvaluacionCalidad.builder()
+                .id(90L)
+                .tipoEvaluacion(TipoEvaluacion.FISICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .usuarioEvaluador(evaluador)
+                .loteProducto(loteSinMicro)
+                .fechaEvaluacion(LocalDateTime.now())
+                .build();
+
+        when(repository.findAllWithinFechaEvaluacion(any(), any()))
+                .thenReturn(List.of(evalFisico));
+
+        var consolidados = service.obtenerEvaluacionesConsolidadas(evalFisico.getFechaEvaluacion().toLocalDate(),
+                evalFisico.getFechaEvaluacion().toLocalDate());
+
+        assertThat(consolidados).hasSize(1);
+        var dto = consolidados.get(0);
+        assertThat(dto.getEstadoMicro()).isEqualTo(DisciplinaEstado.NO_REQUERIDO);
+        assertThat(dto.isTieneResultadosMicro()).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
- centralize microbiological discipline state with a helper and new `DisciplinaEstado` enum
- expose `estadoMicro` plus coherent microbiology flags in the consolidated evaluation DTO
- cover non-required, pending and evaluated microbiology scenarios with updated service/helper tests

## Testing
- mvn -Dtest=AnalisisCalidadHelperTest,EvaluacionCalidadServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c6e6e9b948333a475b2ef05144c96)