### PR TITLE
Add calidad lote audit endpoints and Excel export

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/CalidadAuditoriaController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/CalidadAuditoriaController.java
@@ -1,0 +1,59 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.service.AuditoriaLotePdfService;
+import com.willyes.clemenintegra.calidad.service.AuditoriaLoteService;
+import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/calidad")
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_SUPER_ADMIN')")
+public class CalidadAuditoriaController {
+
+    private final AuditoriaLoteService auditoriaLoteService;
+    private final AuditoriaLotePdfService auditoriaLotePdfService;
+    private final EvaluacionCalidadService evaluacionCalidadService;
+
+    @GetMapping("/auditoria-lote/{loteId}")
+    public ResponseEntity<AuditoriaLoteResponseDTO> obtenerAuditoriaLote(@PathVariable Long loteId) {
+        return ResponseEntity.ok(auditoriaLoteService.obtenerAuditoriaDeLote(loteId));
+    }
+
+    @GetMapping(path = "/auditoria-lote/{loteId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    public ResponseEntity<byte[]> descargarPdfAuditoria(@PathVariable Long loteId) {
+        AuditoriaLoteResponseDTO auditoria = auditoriaLoteService.obtenerAuditoriaDeLote(loteId);
+        byte[] pdf = auditoriaLotePdfService.generarPdf(auditoria);
+        String nombreArchivo = "AuditoriaLote_" + (auditoria.getCodigoLote() != null ? auditoria.getCodigoLote() : loteId) + ".pdf";
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
+                .body(pdf);
+    }
+
+    @GetMapping(path = "/reportes/evaluaciones/excel", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    public ResponseEntity<byte[]> exportarEvaluacionesExcel(@RequestParam(required = false) LocalDate fechaInicio,
+                                                            @RequestParam(required = false) LocalDate fechaFin,
+                                                            @RequestParam(required = false) ResultadoEvaluacion resultado) {
+        byte[] excel = evaluacionCalidadService.generarReporteEvaluacionesExcel(fechaInicio, fechaFin, resultado);
+        String nombreArchivo = "EvaluacionesCalidad_" + java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmm")) + ".xlsx";
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
+                .body(excel);
+    }
+}
+

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/AuditoriaLoteResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/AuditoriaLoteResponseDTO.java
@@ -1,0 +1,98 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.TipoCondicionUso;
+import com.willyes.clemenintegra.calidad.model.enums.TipoIncidente;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditoriaLoteResponseDTO {
+
+    private Long loteId;
+    private String codigoLote;
+    private String nombreProducto;
+    private String categoriaProducto;
+    private String tipoAnalisisCalidad;
+    private String estadoLote;
+    private LocalDateTime fechaFabricacion;
+    private LocalDateTime fechaVencimiento;
+    private BigDecimal stockLote;
+    private String nombreAlmacenActual;
+    private String ubicacionAlmacenActual;
+
+    private EstadoCalidadLoteResponseDTO estadoCalidad;
+
+    private List<IncidenteDTO> incidentes;
+    private List<RetencionDTO> retenciones;
+    private CondicionUsoDTO condicionUsoActiva;
+    private List<MovimientoDTO> movimientos;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class IncidenteDTO {
+        private Long id;
+        private String codigo;
+        private TipoIncidente tipoIncidente;
+        private SeveridadNoConformidad severidad;
+        private EstadoNoConformidad estado;
+        private LocalDateTime fechaApertura;
+        private LocalDateTime fechaCierre;
+        private boolean tieneCapa;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RetencionDTO {
+        private Long id;
+        private MotivoRetencion motivo;
+        private String descripcion;
+        private String estado;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CondicionUsoDTO {
+        private Long id;
+        private TipoCondicionUso tipo;
+        private LocalDateTime parametroFecha;
+        private String descripcion;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MovimientoDTO {
+        private Long id;
+        private LocalDateTime fechaMovimiento;
+        private TipoMovimiento tipoMovimiento;
+        private ClasificacionMovimientoInventario clasificacion;
+        private BigDecimal cantidad;
+        private String almacenOrigenNombre;
+        private String almacenDestinoNombre;
+        private String motivoMovimientoNombre;
+        private String registradoPorNombre;
+        private String ordenProduccionCodigo;
+    }
+}
+

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/CapaRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/CapaRepository.java
@@ -14,4 +14,6 @@ public interface CapaRepository extends JpaRepository<Capa, Long> {
 
     Page<Capa> findByNoConformidad_SeveridadAndEstado(SeveridadNoConformidad severidad,
                                                       EstadoCapa estado, Pageable pageable);
+
+    boolean existsByNoConformidad_Id(Long noConformidadId);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
@@ -44,4 +44,6 @@ public interface NoConformidadRepository extends JpaRepository<NoConformidad, Lo
     Optional<NoConformidad> findFirstByLote_IdAndEvaluacion_IdAndEstado(Long loteId,
                                                                         Long evaluacionId,
                                                                         EstadoNoConformidad estado);
+
+    java.util.List<NoConformidad> findByLote_Id(Long loteId);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLotePdfService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLotePdfService.java
@@ -1,0 +1,119 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StreamUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class AuditoriaLotePdfService {
+
+    private static final DateTimeFormatter FECHA_FORMATO = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+    public byte[] generarPdf(AuditoriaLoteResponseDTO auditoria) {
+        String template = loadTemplate("templates/calidad/auditoria-lote.ftl");
+
+        template = template.replace("${fechaGeneracion}", FECHA_FORMATO.format(LocalDateTime.now()));
+        template = template.replace("${codigoLote}", esc(auditoria.getCodigoLote()));
+        template = template.replace("${producto}", esc(auditoria.getNombreProducto()));
+        template = template.replace("${categoria}", esc(auditoria.getCategoriaProducto()));
+        template = template.replace("${tipoAnalisis}", esc(auditoria.getTipoAnalisisCalidad()));
+        template = template.replace("${estadoLote}", esc(auditoria.getEstadoLote()));
+        template = template.replace("${fechaFabricacion}", formatDate(auditoria.getFechaFabricacion()));
+        template = template.replace("${fechaVencimiento}", formatDate(auditoria.getFechaVencimiento()));
+        template = template.replace("${stockLote}", auditoria.getStockLote() != null ? auditoria.getStockLote().toString() : "");
+        template = template.replace("${almacen}", esc(auditoria.getNombreAlmacenActual()));
+        template = template.replace("${ubicacion}", esc(auditoria.getUbicacionAlmacenActual()));
+
+        template = template.replace("${estadoCalidad}", auditoria.getEstadoCalidad() != null
+                ? esc(auditoria.getEstadoCalidad().getEstadoLote()) : "");
+        template = template.replace("${retencionActiva}", auditoria.getEstadoCalidad() != null && auditoria.getEstadoCalidad().isRetencionActiva() ? "SI" : "NO");
+        template = template.replace("${motivoRetencion}", auditoria.getEstadoCalidad() != null && auditoria.getEstadoCalidad().getMotivoRetencion() != null
+                ? esc(auditoria.getEstadoCalidad().getMotivoRetencion().name()) : "");
+
+        template = template.replace("${tablaIncidentes}", buildIncidentes(auditoria));
+        template = template.replace("${tablaMovimientos}", buildMovimientos(auditoria));
+
+        return renderPdf(template);
+    }
+
+    private String buildIncidentes(AuditoriaLoteResponseDTO auditoria) {
+        if (auditoria.getIncidentes() == null || auditoria.getIncidentes().isEmpty()) {
+            return "<tr><td colspan='7'>Sin incidentes asociados</td></tr>";
+        }
+        StringBuilder sb = new StringBuilder();
+        auditoria.getIncidentes().forEach(nc -> sb.append("<tr>")
+                .append("<td>").append(esc(nc.getCodigo())).append("</td>")
+                .append("<td>").append(nc.getTipoIncidente() != null ? nc.getTipoIncidente().name() : "").append("</td>")
+                .append("<td>").append(nc.getSeveridad() != null ? nc.getSeveridad().name() : "").append("</td>")
+                .append("<td>").append(nc.getEstado() != null ? nc.getEstado().name() : "").append("</td>")
+                .append("<td>").append(formatDate(nc.getFechaApertura())).append("</td>")
+                .append("<td>").append(formatDate(nc.getFechaCierre())).append("</td>")
+                .append("<td>").append(nc.isTieneCapa() ? "SI" : "NO").append("</td>")
+                .append("</tr>"));
+        return sb.toString();
+    }
+
+    private String buildMovimientos(AuditoriaLoteResponseDTO auditoria) {
+        if (auditoria.getMovimientos() == null || auditoria.getMovimientos().isEmpty()) {
+            return "<tr><td colspan='9'>Sin movimientos registrados</td></tr>";
+        }
+        StringBuilder sb = new StringBuilder();
+        auditoria.getMovimientos().forEach(mov -> sb.append("<tr>")
+                .append("<td>").append(formatDate(mov.getFechaMovimiento())).append("</td>")
+                .append("<td>").append(mov.getTipoMovimiento() != null ? mov.getTipoMovimiento().name() : "").append("</td>")
+                .append("<td>").append(mov.getClasificacion() != null ? mov.getClasificacion().name() : "").append("</td>")
+                .append("<td>").append(mov.getCantidad() != null ? mov.getCantidad() : "").append("</td>")
+                .append("<td>").append(esc(mov.getAlmacenOrigenNombre())).append("</td>")
+                .append("<td>").append(esc(mov.getAlmacenDestinoNombre())).append("</td>")
+                .append("<td>").append(esc(mov.getMotivoMovimientoNombre())).append("</td>")
+                .append("<td>").append(esc(mov.getRegistradoPorNombre())).append("</td>")
+                .append("<td>").append(esc(mov.getOrdenProduccionCodigo())).append("</td>")
+                .append("</tr>"));
+        return sb.toString();
+    }
+
+    private byte[] renderPdf(String html) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PdfRendererBuilder builder = new PdfRendererBuilder();
+            builder.useFastMode();
+            builder.withHtmlContent(html, null);
+            builder.toStream(out);
+            builder.run();
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("No se pudo generar el PDF de auditoría de lote", e);
+        }
+    }
+
+    private String loadTemplate(String path) {
+        try {
+            var resource = new ClassPathResource(path);
+            try (var in = resource.getInputStream()) {
+                String html = StreamUtils.copyToString(in, StandardCharsets.UTF_8);
+                int index = html.indexOf('<');
+                return index > 0 ? html.substring(index) : html;
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("No se pudo cargar la plantilla de auditoría de lote", e);
+        }
+    }
+
+    private String esc(String val) {
+        return val == null ? "" : val
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+    }
+
+    private String formatDate(LocalDateTime fecha) {
+        return fecha == null ? "" : fecha.format(FECHA_FORMATO);
+    }
+}
+

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteService.java
@@ -1,0 +1,9 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+
+public interface AuditoriaLoteService {
+
+    AuditoriaLoteResponseDTO obtenerAuditoriaDeLote(Long loteId);
+}
+

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImpl.java
@@ -1,0 +1,129 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.model.NoConformidad;
+import com.willyes.clemenintegra.calidad.model.RetencionLote;
+import com.willyes.clemenintegra.calidad.repository.CapaRepository;
+import com.willyes.clemenintegra.calidad.repository.NoConformidadRepository;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuditoriaLoteServiceImpl implements AuditoriaLoteService {
+
+    private final LoteProductoRepository loteProductoRepository;
+    private final LoteProductoService loteProductoService;
+    private final NoConformidadRepository noConformidadRepository;
+    private final CapaRepository capaRepository;
+    private final RetencionLoteService retencionLoteService;
+    private final CondicionUsoService condicionUsoService;
+    private final MovimientoInventarioRepository movimientoInventarioRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AuditoriaLoteResponseDTO obtenerAuditoriaDeLote(Long loteId) {
+        LoteProducto lote = loteProductoRepository.findById(loteId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "LOTE_NO_ENCONTRADO"));
+
+        EstadoCalidadLoteResponseDTO estadoCalidad = loteProductoService.obtenerEstadoCalidad(loteId);
+
+        List<AuditoriaLoteResponseDTO.IncidenteDTO> incidentes = noConformidadRepository.findByLote_Id(loteId).stream()
+                .sorted(Comparator.comparing(NoConformidad::getFechaRegistro, Comparator.nullsLast(java.time.LocalDateTime::compareTo)))
+                .map(nc -> AuditoriaLoteResponseDTO.IncidenteDTO.builder()
+                        .id(nc.getId())
+                        .codigo(nc.getCodigo())
+                        .tipoIncidente(nc.getTipoIncidente())
+                        .severidad(nc.getSeveridad())
+                        .estado(nc.getEstado())
+                        .fechaApertura(nc.getFechaRegistro())
+                        .fechaCierre(nc.getFechaCierre())
+                        .tieneCapa(capaRepository.existsByNoConformidad_Id(nc.getId()))
+                        .build())
+                .toList();
+
+        List<AuditoriaLoteResponseDTO.RetencionDTO> retenciones = retencionLoteService.obtenerRetencionesActivas(loteId).stream()
+                .map(this::mapRetencion)
+                .toList();
+
+        CondicionUsoResponseDTO condicionUso = condicionUsoService.getActivasByLote(loteId).stream()
+                .findFirst()
+                .orElse(null);
+
+        List<AuditoriaLoteResponseDTO.MovimientoDTO> movimientos = movimientoInventarioRepository.findByLote_IdOrderByFechaIngresoDesc(loteId)
+                .stream()
+                .map(this::mapMovimiento)
+                .toList();
+
+        return AuditoriaLoteResponseDTO.builder()
+                .loteId(lote.getId())
+                .codigoLote(lote.getCodigoLote())
+                .nombreProducto(lote.getProducto() != null ? lote.getProducto().getNombre() : null)
+                .categoriaProducto(lote.getProducto() != null && lote.getProducto().getCategoriaProducto() != null
+                        ? lote.getProducto().getCategoriaProducto().getNombre() : null)
+                .tipoAnalisisCalidad(lote.getProducto() != null && lote.getProducto().getTipoAnalisisCalidad() != null
+                        ? lote.getProducto().getTipoAnalisisCalidad().name() : null)
+                .estadoLote(lote.getEstado() != null ? lote.getEstado().name() : null)
+                .fechaFabricacion(lote.getFechaFabricacion())
+                .fechaVencimiento(lote.getFechaVencimiento())
+                .stockLote(lote.getStockLote())
+                .nombreAlmacenActual(lote.getAlmacen() != null ? lote.getAlmacen().getNombre() : null)
+                .ubicacionAlmacenActual(lote.getAlmacen() != null ? lote.getAlmacen().getUbicacion() : null)
+                .estadoCalidad(estadoCalidad)
+                .incidentes(incidentes)
+                .retenciones(retenciones)
+                .condicionUsoActiva(mapCondicion(condicionUso))
+                .movimientos(movimientos)
+                .build();
+    }
+
+    private AuditoriaLoteResponseDTO.RetencionDTO mapRetencion(RetencionLote retencion) {
+        return AuditoriaLoteResponseDTO.RetencionDTO.builder()
+                .id(retencion.getId())
+                .motivo(retencion.getMotivo())
+                .descripcion(retencion.getCausa())
+                .estado(retencion.getEstado() != null ? retencion.getEstado().name() : null)
+                .build();
+    }
+
+    private AuditoriaLoteResponseDTO.CondicionUsoDTO mapCondicion(CondicionUsoResponseDTO condicionUso) {
+        if (condicionUso == null) {
+            return null;
+        }
+        return AuditoriaLoteResponseDTO.CondicionUsoDTO.builder()
+                .id(condicionUso.getId())
+                .tipo(condicionUso.getTipo())
+                .parametroFecha(condicionUso.getParametroFecha())
+                .descripcion(condicionUso.getDescripcion())
+                .build();
+    }
+
+    private AuditoriaLoteResponseDTO.MovimientoDTO mapMovimiento(MovimientoInventario mov) {
+        return AuditoriaLoteResponseDTO.MovimientoDTO.builder()
+                .id(mov.getId())
+                .fechaMovimiento(mov.getFechaIngreso())
+                .tipoMovimiento(mov.getTipoMovimiento())
+                .clasificacion(mov.getClasificacion())
+                .cantidad(mov.getCantidad())
+                .almacenOrigenNombre(mov.getAlmacenOrigen() != null ? mov.getAlmacenOrigen().getNombre() : null)
+                .almacenDestinoNombre(mov.getAlmacenDestino() != null ? mov.getAlmacenDestino().getNombre() : null)
+                .motivoMovimientoNombre(mov.getMotivoMovimiento() != null ? mov.getMotivoMovimiento().getDescripcion() : null)
+                .registradoPorNombre(mov.getRegistradoPor() != null ? mov.getRegistradoPor().getNombreCompleto() : null)
+                .ordenProduccionCodigo(mov.getOrdenProduccion() != null ? mov.getOrdenProduccion().getCodigoOrden() : null)
+                .build();
+    }
+}
+

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
@@ -20,4 +20,6 @@ public interface EvaluacionCalidadService {
     java.util.List<EvaluacionCalidadResponseDTO> listarPorLote(Long loteId);
     java.util.List<EvaluacionConsolidadaResponseDTO> obtenerEvaluacionesConsolidadas(LocalDate fechaInicio, LocalDate fechaFin);
     void eliminar(Long id);
+
+    byte[] generarReporteEvaluacionesExcel(LocalDate fechaInicio, LocalDate fechaFin, ResultadoEvaluacion resultado);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -33,14 +33,19 @@ import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -419,6 +424,75 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
             }
             default -> {
             }
+        }
+    }
+
+    @Override
+    public byte[] generarReporteEvaluacionesExcel(LocalDate fechaInicio, LocalDate fechaFin, ResultadoEvaluacion resultado) {
+        LocalDateTime inicio = fechaInicio != null ? fechaInicio.atStartOfDay() : null;
+        LocalDateTime fin = fechaFin != null ? fechaFin.atTime(LocalTime.MAX) : null;
+
+        java.util.List<EvaluacionCalidad> evaluaciones = repository.findAllWithRelations();
+
+        java.util.stream.Stream<EvaluacionCalidad> stream = evaluaciones.stream();
+        if (inicio != null) {
+            stream = stream.filter(e -> e.getFechaEvaluacion() != null && !e.getFechaEvaluacion().isBefore(inicio));
+        }
+        if (fin != null) {
+            stream = stream.filter(e -> e.getFechaEvaluacion() != null && !e.getFechaEvaluacion().isAfter(fin));
+        }
+        if (resultado != null) {
+            stream = stream.filter(e -> e.getResultado() == resultado);
+        }
+
+        java.util.List<EvaluacionCalidad> filtradas = stream.toList();
+
+        Workbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("Evaluaciones Calidad");
+
+        String[] headers = {
+                "Fecha evaluación", "Código Lote", "Producto", "Tipo análisis requerido", "Tipo de evaluación",
+                "Resultado evaluación", "Resultado global del lote", "Estado lote", "Analista/Evaluador", "Tiene adjuntos", "Código NC asociada"
+        };
+        Row header = sheet.createRow(0);
+        for (int i = 0; i < headers.length; i++) {
+            header.createCell(i).setCellValue(headers[i]);
+        }
+
+        int rowIdx = 1;
+        for (EvaluacionCalidad eval : filtradas) {
+            Row row = sheet.createRow(rowIdx++);
+            row.createCell(0).setCellValue(eval.getFechaEvaluacion() != null ? eval.getFechaEvaluacion().toString() : "");
+            row.createCell(1).setCellValue(eval.getLoteProducto() != null ? eval.getLoteProducto().getCodigoLote() : "");
+            row.createCell(2).setCellValue(eval.getLoteProducto() != null && eval.getLoteProducto().getProducto() != null
+                    ? eval.getLoteProducto().getProducto().getNombre() : "");
+            row.createCell(3).setCellValue(eval.getLoteProducto() != null && eval.getLoteProducto().getProducto() != null
+                    && eval.getLoteProducto().getProducto().getTipoAnalisisCalidad() != null
+                    ? eval.getLoteProducto().getProducto().getTipoAnalisisCalidad().name() : "");
+            row.createCell(4).setCellValue(eval.getTipoEvaluacion() != null ? eval.getTipoEvaluacion().name() : "");
+            row.createCell(5).setCellValue(eval.getResultado() != null ? eval.getResultado().name() : "");
+            row.createCell(6).setCellValue(eval.getResultado() != null ? eval.getResultado().name() : "");
+            row.createCell(7).setCellValue(eval.getLoteProducto() != null && eval.getLoteProducto().getEstado() != null
+                    ? eval.getLoteProducto().getEstado().name() : "");
+            row.createCell(8).setCellValue(eval.getUsuarioEvaluador() != null ? eval.getUsuarioEvaluador().getNombreCompleto() : "");
+            boolean tieneAdjuntos = eval.getArchivosAdjuntos() != null && !eval.getArchivosAdjuntos().isEmpty();
+            row.createCell(9).setCellValue(tieneAdjuntos ? "SI" : "NO");
+            String codigoNc = noConformidadService.obtenerActivaPorLoteYEvaluacion(
+                    eval.getLoteProducto() != null ? eval.getLoteProducto().getId() : null,
+                    eval.getId()).map(com.willyes.clemenintegra.calidad.model.NoConformidad::getCodigo).orElse("");
+            row.createCell(10).setCellValue(codigoNc);
+        }
+
+        for (int i = 0; i < headers.length; i++) {
+            sheet.autoSizeColumn(i);
+        }
+
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            workbook.write(out);
+            workbook.close();
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("No se pudo generar el Excel de evaluaciones", e);
         }
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -169,6 +169,15 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
     })
     List<MovimientoInventario> findAllByRecepcionOcIdOrderByFechaIngresoAsc(Long recepcionOcId);
 
+    @EntityGraph(attributePaths = {
+            "almacenOrigen",
+            "almacenDestino",
+            "motivoMovimiento",
+            "registradoPor",
+            "ordenProduccion"
+    })
+    List<MovimientoInventario> findByLote_IdOrderByFechaIngresoDesc(Long loteId);
+
     @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m " +
             "where m.solicitudMovimiento.id = :solicitudId " +
             "and m.producto.id = :productoId " +

--- a/src/main/resources/templates/calidad/auditoria-lote.ftl
+++ b/src/main/resources/templates/calidad/auditoria-lote.ftl
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Auditoría de Lote</title>
+    <style>
+        body { font-family: Arial, sans-serif; font-size: 12px; }
+        h1 { text-align: center; }
+        table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+        th, td { border: 1px solid #ccc; padding: 6px; }
+        th { background: #f0f0f0; }
+    </style>
+</head>
+<body>
+<h1>AUDITORÍA DE LOTE</h1>
+<p>Fecha de generación: ${fechaGeneracion}</p>
+
+<h3>Datos del lote</h3>
+<table>
+    <tr><th>Código Lote</th><td>${codigoLote}</td><th>Producto</th><td>${producto}</td></tr>
+    <tr><th>Categoría</th><td>${categoria}</td><th>Tipo análisis</th><td>${tipoAnalisis}</td></tr>
+    <tr><th>Estado lote</th><td>${estadoLote}</td><th>Stock</th><td>${stockLote}</td></tr>
+    <tr><th>Fecha fabricación</th><td>${fechaFabricacion}</td><th>Fecha vencimiento</th><td>${fechaVencimiento}</td></tr>
+    <tr><th>Almacén</th><td>${almacen}</td><th>Ubicación</th><td>${ubicacion}</td></tr>
+</table>
+
+<h3>Estado de calidad</h3>
+<table>
+    <tr><th>Estado</th><td>${estadoCalidad}</td><th>Retención activa</th><td>${retencionActiva}</td></tr>
+    <tr><th>Motivo retención</th><td colspan="3">${motivoRetencion}</td></tr>
+</table>
+
+<h3>No conformidades / Desviaciones</h3>
+<table>
+    <thead>
+    <tr>
+        <th>Código</th>
+        <th>Tipo</th>
+        <th>Severidad</th>
+        <th>Estado</th>
+        <th>Fecha Apertura</th>
+        <th>Fecha Cierre</th>
+        <th>CAPA</th>
+    </tr>
+    </thead>
+    <tbody>
+    ${tablaIncidentes}
+    </tbody>
+</table>
+
+<h3>Movimientos de inventario</h3>
+<table>
+    <thead>
+    <tr>
+        <th>Fecha</th>
+        <th>Tipo</th>
+        <th>Clasificación</th>
+        <th>Cantidad</th>
+        <th>Almacén Origen</th>
+        <th>Almacén Destino</th>
+        <th>Motivo</th>
+        <th>Usuario</th>
+        <th>O.P.</th>
+    </tr>
+    </thead>
+    <tbody>
+    ${tablaMovimientos}
+    </tbody>
+</table>
+
+</body>
+</html>

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadAuditoriaControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadAuditoriaControllerTest.java
@@ -1,0 +1,85 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.service.AuditoriaLotePdfService;
+import com.willyes.clemenintegra.calidad.service.AuditoriaLoteService;
+import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CalidadAuditoriaController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CalidadAuditoriaControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuditoriaLoteService auditoriaLoteService;
+    @MockBean
+    private AuditoriaLotePdfService auditoriaLotePdfService;
+    @MockBean
+    private EvaluacionCalidadService evaluacionCalidadService;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    void devuelveAuditoriaLoteComoJson() throws Exception {
+        AuditoriaLoteResponseDTO dto = AuditoriaLoteResponseDTO.builder()
+                .loteId(1L)
+                .codigoLote("LOT-01")
+                .nombreProducto("Producto")
+                .build();
+
+        when(auditoriaLoteService.obtenerAuditoriaDeLote(1L)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/calidad/auditoria-lote/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.codigoLote").value("LOT-01"))
+                .andExpect(jsonPath("$.nombreProducto").value("Producto"));
+    }
+
+    @Test
+    void descargaPdfAuditoria() throws Exception {
+        AuditoriaLoteResponseDTO dto = AuditoriaLoteResponseDTO.builder()
+                .loteId(2L)
+                .codigoLote("LOT-02")
+                .build();
+        when(auditoriaLoteService.obtenerAuditoriaDeLote(2L)).thenReturn(dto);
+        when(auditoriaLotePdfService.generarPdf(any())).thenReturn("pdf".getBytes());
+
+        mockMvc.perform(get("/api/calidad/auditoria-lote/2/pdf"))
+                .andExpect(status().isOk())
+                .andExpect(result -> assertThat(result.getResponse().getContentAsByteArray()).isEqualTo("pdf".getBytes()))
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF));
+    }
+
+    @Test
+    void exportaExcelEvaluaciones() throws Exception {
+        when(evaluacionCalidadService.generarReporteEvaluacionesExcel(any(), any(), any())).thenReturn("excel".getBytes());
+
+        mockMvc.perform(get("/api/calidad/reportes/evaluaciones/excel"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .andExpect(result -> assertThat(result.getResponse().getContentAsByteArray()).isEqualTo("excel".getBytes()));
+    }
+}
+

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImplTest.java
@@ -1,0 +1,131 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.model.NoConformidad;
+import com.willyes.clemenintegra.calidad.model.RetencionLote;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
+import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.TipoIncidente;
+import com.willyes.clemenintegra.calidad.repository.CapaRepository;
+import com.willyes.clemenintegra.calidad.repository.NoConformidadRepository;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuditoriaLoteServiceImplTest {
+
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private LoteProductoService loteProductoService;
+    @Mock
+    private NoConformidadRepository noConformidadRepository;
+    @Mock
+    private CapaRepository capaRepository;
+    @Mock
+    private RetencionLoteService retencionLoteService;
+    @Mock
+    private CondicionUsoService condicionUsoService;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+
+    @InjectMocks
+    private AuditoriaLoteServiceImpl service;
+
+    @Test
+    void armaAuditoriaConDatosBasicos() {
+        LoteProducto lote = LoteProducto.builder()
+                .id(1L)
+                .codigoLote("LOT-01")
+                .estado(EstadoLote.EN_CUARENTENA)
+                .stockLote(BigDecimal.TEN)
+                .almacen(Almacen.builder().nombre("Principal").ubicacion("A1").build())
+                .build();
+
+        EstadoCalidadLoteResponseDTO estado = EstadoCalidadLoteResponseDTO.builder()
+                .loteId(1L)
+                .estadoLote("EN_CUARENTENA")
+                .build();
+
+        NoConformidad nc = NoConformidad.builder()
+                .id(5L)
+                .codigo("NC-001")
+                .tipoIncidente(TipoIncidente.NO_CONFORMIDAD)
+                .severidad(SeveridadNoConformidad.MAYOR)
+                .estado(EstadoNoConformidad.ABIERTA)
+                .fechaRegistro(LocalDateTime.now())
+                .build();
+
+        RetencionLote retencion = RetencionLote.builder()
+                .id(2L)
+                .motivo(MotivoRetencion.NO_CONFORMIDAD)
+                .causa("Retención de prueba")
+                .estado(EstadoRetencion.RETENIDO)
+                .build();
+
+        MovimientoInventario mov = MovimientoInventario.builder()
+                .id(3L)
+                .fechaIngreso(LocalDateTime.now())
+                .tipoMovimiento(TipoMovimiento.ENTRADA)
+                .clasificacion(ClasificacionMovimientoInventario.ENTRADA_PRODUCTO_TERMINADO)
+                .cantidad(BigDecimal.ONE)
+                .motivoMovimiento(com.willyes.clemenintegra.inventario.model.MotivoMovimiento.builder()
+                        .descripcion("Ingreso")
+                        .build())
+                .registradoPor(Usuario.builder().nombreCompleto("Analista").build())
+                .build();
+
+        when(loteProductoRepository.findById(1L)).thenReturn(Optional.of(lote));
+        when(loteProductoService.obtenerEstadoCalidad(1L)).thenReturn(estado);
+        when(noConformidadRepository.findByLote_Id(1L)).thenReturn(List.of(nc));
+        when(capaRepository.existsByNoConformidad_Id(5L)).thenReturn(true);
+        when(retencionLoteService.obtenerRetencionesActivas(1L)).thenReturn(List.of(retencion));
+        when(condicionUsoService.getActivasByLote(1L)).thenReturn(List.of(CondicionUsoResponseDTO.builder().id(7L).descripcion("Condición").build()));
+        when(movimientoInventarioRepository.findByLote_IdOrderByFechaIngresoDesc(1L)).thenReturn(List.of(mov));
+
+        AuditoriaLoteResponseDTO dto = service.obtenerAuditoriaDeLote(1L);
+
+        assertThat(dto.getCodigoLote()).isEqualTo("LOT-01");
+        assertThat(dto.getEstadoCalidad().getEstadoLote()).isEqualTo("EN_CUARENTENA");
+        assertThat(dto.getIncidentes()).hasSize(1);
+        assertThat(dto.getIncidentes().get(0).isTieneCapa()).isTrue();
+        assertThat(dto.getRetenciones()).hasSize(1);
+        assertThat(dto.getMovimientos()).hasSize(1);
+    }
+
+    @Test
+    void lanzaNotFoundCuandoNoExisteLote() {
+        when(loteProductoRepository.findById(9L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.obtenerAuditoriaDeLote(9L))
+                .isInstanceOf(ResponseStatusException.class);
+    }
+}
+

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -22,6 +22,7 @@ import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.ByteArrayInputStream;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -288,5 +290,43 @@ class EvaluacionCalidadServiceImplTest {
         var dto = consolidados.get(0);
         assertThat(dto.getEstadoMicro()).isEqualTo(DisciplinaEstado.NO_REQUERIDO);
         assertThat(dto.isTieneResultadosMicro()).isFalse();
+    }
+
+    @Test
+    void generaExcelEvaluacionesConFilaDeDatos() throws Exception {
+        Producto producto = new Producto();
+        producto.setId(8);
+        producto.setNombre("Producto Excel");
+        producto.setTipoAnalisisCalidad(com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.FISICO);
+
+        LoteProducto loteExcel = new LoteProducto();
+        loteExcel.setId(22L);
+        loteExcel.setCodigoLote("LOT-EXCEL");
+        loteExcel.setProducto(producto);
+        loteExcel.setEstado(EstadoLote.EN_CUARENTENA);
+
+        EvaluacionCalidad eval = new EvaluacionCalidad();
+        eval.setId(11L);
+        eval.setFechaEvaluacion(LocalDateTime.now());
+        eval.setResultado(ResultadoEvaluacion.CONFORME);
+        eval.setTipoEvaluacion(TipoEvaluacion.FISICO);
+        eval.setLoteProducto(loteExcel);
+        eval.setUsuarioEvaluador(evaluador);
+        eval.setArchivosAdjuntos(List.of(ArchivoEvaluacion.builder().nombreArchivo("a.pdf").build()));
+
+        when(repository.findAllWithRelations()).thenReturn(List.of(eval));
+        when(noConformidadService.obtenerActivaPorLoteYEvaluacion(any(), any())).thenReturn(Optional.empty());
+
+        byte[] excel = service.generarReporteEvaluacionesExcel(null, null, null);
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(excel))) {
+            var sheet = workbook.getSheetAt(0);
+            var header = sheet.getRow(0);
+            assertThat(header.getCell(0).getStringCellValue()).isEqualTo("Fecha evaluación");
+            var dataRow = sheet.getRow(1);
+            assertThat((Object) dataRow).isNotNull();
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("LOT-EXCEL");
+            assertThat(dataRow.getCell(9).getStringCellValue()).isEqualTo("SI");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a new auditoría de lote controller with JSON and PDF responses for calidad
- assemble lote audit details, movements, incidentes and render a PDF template
- generate Excel export for evaluaciones and cover new behaviors with tests

## Testing
- mvn test -DskipITs

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693deaa7b1708333929d0a3c6898c4f7)