### PR TITLE
Add consumption projections and criticality to MRP suggestions

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
@@ -160,6 +160,11 @@ public class MrpController {
                 .fechaNecesidad(sugerencia.getFechaNecesidad())
                 .fechaSugeridaLanzamiento(sugerencia.getFechaSugeridaLanzamiento())
                 .leadTimeDias(sugerencia.getLeadTimeDias())
+                .consumoTotalPeriodo(sugerencia.getConsumoTotalPeriodo())
+                .consumoSemanalPromedio(sugerencia.getConsumoSemanalPromedio())
+                .semanasCobertura(sugerencia.getSemanasCobertura())
+                .nivelCriticidad(sugerencia.getNivelCriticidad())
+                .esCritico(sugerencia.getEsCritico())
                 .estado(sugerencia.getEstado() != null ? sugerencia.getEstado().name() : null)
                 .build();
     }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/dto/CorridaMrpResponseDTO.java
@@ -67,6 +67,11 @@ public class CorridaMrpResponseDTO {
         private LocalDate fechaNecesidad;
         private LocalDate fechaSugeridaLanzamiento;
         private Integer leadTimeDias;
+        private BigDecimal consumoTotalPeriodo;
+        private BigDecimal consumoSemanalPromedio;
+        private BigDecimal semanasCobertura;
+        private String nivelCriticidad;
+        private Boolean esCritico;
         private String estado;
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/SugerenciaAbastecimiento.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/SugerenciaAbastecimiento.java
@@ -49,4 +49,19 @@ public class SugerenciaAbastecimiento {
 
     @Column(name = "orden_produccion_id")
     private Long ordenProduccionId;
+
+    @Transient
+    private BigDecimal consumoTotalPeriodo;
+
+    @Transient
+    private BigDecimal consumoSemanalPromedio;
+
+    @Transient
+    private BigDecimal semanasCobertura;
+
+    @Transient
+    private String nivelCriticidad;
+
+    @Transient
+    private Boolean esCritico;
 }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
@@ -26,8 +26,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 @Slf4j
@@ -180,6 +182,19 @@ public class MrpServiceImpl implements MrpService {
                     .leadTimeDias(leadTime)
                     .estado(EstadoSugerenciaAbastecimiento.PENDIENTE)
                     .build();
+            // Métricas de consumo y cobertura para exponer al frontend.
+            BigDecimal consumoTotal = Optional.ofNullable(detalle.getRequerimientoNeto()).orElse(BigDecimal.ZERO);
+            sugerencia.setConsumoTotalPeriodo(consumoTotal);
+
+            BigDecimal horizonteSemanas = calcularHorizonteSemanas(detalle.getCorrida());
+            BigDecimal consumoSemanalPromedio = calcularConsumoSemanalPromedio(consumoTotal, horizonteSemanas);
+            sugerencia.setConsumoSemanalPromedio(consumoSemanalPromedio);
+
+            BigDecimal semanasCobertura = calcularSemanasCobertura(detalle, consumoSemanalPromedio);
+            sugerencia.setSemanasCobertura(semanasCobertura);
+
+            // Determinar criticidad basada en la cobertura y lead time.
+            asignarCriticidad(sugerencia, leadTime);
             detalle.setSugerencia(sugerencia);
             sugerencias.add(sugerencia);
         }
@@ -263,5 +278,69 @@ public class MrpServiceImpl implements MrpService {
             return producto.getLeadTimeProduccionDias();
         }
         return producto.getLeadTimeCompraDias();
+    }
+
+    private BigDecimal calcularHorizonteSemanas(CorridaMrp corrida) {
+        if (corrida == null || corrida.getHorizonteInicio() == null || corrida.getHorizonteFin() == null) {
+            return null;
+        }
+        long dias = ChronoUnit.DAYS.between(corrida.getHorizonteInicio(), corrida.getHorizonteFin()) + 1;
+        if (dias <= 0) {
+            return null;
+        }
+        return BigDecimal.valueOf(dias)
+                .divide(BigDecimal.valueOf(7), 2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal calcularConsumoSemanalPromedio(BigDecimal consumoTotal, BigDecimal horizonteSemanas) {
+        if (horizonteSemanas == null || horizonteSemanas.compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        return consumoTotal.divide(horizonteSemanas, 2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal calcularSemanasCobertura(DetalleCorridaMrp detalle, BigDecimal consumoSemanalPromedio) {
+        if (consumoSemanalPromedio == null || consumoSemanalPromedio.compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        BigDecimal inventario = Optional.ofNullable(detalle.getInventarioDisponible()).orElse(BigDecimal.ZERO);
+        BigDecimal recepciones = Optional.ofNullable(detalle.getRecepcionesProgramadas()).orElse(BigDecimal.ZERO);
+        return inventario.add(recepciones)
+                .divide(consumoSemanalPromedio, 2, RoundingMode.HALF_UP);
+    }
+
+    private void asignarCriticidad(SugerenciaAbastecimiento sugerencia, Integer leadTimeDias) {
+        BigDecimal semanasCobertura = sugerencia.getSemanasCobertura();
+        if (semanasCobertura == null) {
+            sugerencia.setNivelCriticidad("ALTO");
+            sugerencia.setEsCritico(false);
+            return;
+        }
+
+        BigDecimal leadTimeSemanas = leadTimeDias != null && leadTimeDias > 0
+                ? BigDecimal.valueOf(leadTimeDias).divide(BigDecimal.valueOf(7), 2, RoundingMode.HALF_UP)
+                : null;
+
+        if (semanasCobertura.compareTo(BigDecimal.ONE) < 0
+                || (leadTimeSemanas != null && semanasCobertura.compareTo(leadTimeSemanas) < 0)) {
+            sugerencia.setNivelCriticidad("CRITICO");
+            sugerencia.setEsCritico(true);
+            return;
+        }
+
+        if (semanasCobertura.compareTo(BigDecimal.ONE) >= 0 && semanasCobertura.compareTo(BigDecimal.valueOf(3)) < 0) {
+            sugerencia.setNivelCriticidad("ALTO");
+            sugerencia.setEsCritico(true);
+            return;
+        }
+
+        if (semanasCobertura.compareTo(BigDecimal.valueOf(3)) >= 0 && semanasCobertura.compareTo(BigDecimal.valueOf(6)) < 0) {
+            sugerencia.setNivelCriticidad("MEDIO");
+            sugerencia.setEsCritico(false);
+            return;
+        }
+
+        sugerencia.setNivelCriticidad("BAJO");
+        sugerencia.setEsCritico(false);
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
@@ -18,6 +18,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -25,6 +26,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -124,5 +127,95 @@ class MrpServiceImplTest {
         assertEquals(TipoCambioMrp.AUMENTO, cambios.get(insumoAumenta));
         assertEquals(TipoCambioMrp.REDUCCION, cambios.get(insumoReduce));
         assertEquals(TipoCambioMrp.SIN_CAMBIO, cambios.get(insumoIgual));
+    }
+
+    @Test
+    void calculaProyeccionYCriticidadCritica() {
+        CorridaMrp corrida = CorridaMrp.builder()
+                .horizonteInicio(LocalDate.of(2024, 1, 1))
+                .horizonteFin(LocalDate.of(2024, 1, 7))
+                .build();
+        Producto producto = Producto.builder()
+                .id(1)
+                .leadTimeCompraDias(14)
+                .build();
+        DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
+                .corrida(corrida)
+                .producto(producto)
+                .requerimientoBruto(BigDecimal.valueOf(120))
+                .inventarioDisponible(BigDecimal.valueOf(40))
+                .recepcionesProgramadas(BigDecimal.ZERO)
+                .requerimientoNeto(BigDecimal.valueOf(100))
+                .nivelBom(1)
+                .build();
+
+        List<com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento> sugerencias = service.generarSugerencias(List.of(detalle));
+
+        assertEquals(1, sugerencias.size());
+        com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento sugerencia = sugerencias.get(0);
+        assertEquals(BigDecimal.valueOf(100), sugerencia.getConsumoTotalPeriodo());
+        assertEquals(BigDecimal.valueOf(100.00).setScale(2), sugerencia.getConsumoSemanalPromedio());
+        assertEquals(BigDecimal.valueOf(0.40).setScale(2), sugerencia.getSemanasCobertura());
+        assertEquals("CRITICO", sugerencia.getNivelCriticidad());
+        assertEquals(Boolean.TRUE, sugerencia.getEsCritico());
+    }
+
+    @Test
+    void calculaCriticidadBajaCuandoCoberturaAlta() {
+        CorridaMrp corrida = CorridaMrp.builder()
+                .horizonteInicio(LocalDate.of(2024, 1, 1))
+                .horizonteFin(LocalDate.of(2024, 1, 28))
+                .build();
+        Producto producto = Producto.builder()
+                .id(2)
+                .leadTimeCompraDias(7)
+                .build();
+        DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
+                .corrida(corrida)
+                .producto(producto)
+                .requerimientoBruto(BigDecimal.valueOf(10))
+                .inventarioDisponible(BigDecimal.valueOf(1000))
+                .recepcionesProgramadas(BigDecimal.ZERO)
+                .requerimientoNeto(BigDecimal.TEN)
+                .nivelBom(1)
+                .build();
+
+        List<com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento> sugerencias = service.generarSugerencias(List.of(detalle));
+
+        assertEquals(1, sugerencias.size());
+        com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento sugerencia = sugerencias.get(0);
+        assertEquals("BAJO", sugerencia.getNivelCriticidad());
+        assertEquals(Boolean.FALSE, sugerencia.getEsCritico());
+    }
+
+    @Test
+    void manejaHorizonteInvalidoSinDividirPorCero() {
+        CorridaMrp corrida = CorridaMrp.builder()
+                .horizonteInicio(null)
+                .horizonteFin(null)
+                .build();
+        Producto producto = Producto.builder()
+                .id(3)
+                .leadTimeCompraDias(7)
+                .build();
+        DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
+                .corrida(corrida)
+                .producto(producto)
+                .requerimientoBruto(BigDecimal.TEN)
+                .inventarioDisponible(BigDecimal.ZERO)
+                .recepcionesProgramadas(BigDecimal.ZERO)
+                .requerimientoNeto(BigDecimal.TEN)
+                .nivelBom(1)
+                .build();
+
+        List<com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento> sugerencias = service.generarSugerencias(List.of(detalle));
+
+        assertEquals(1, sugerencias.size());
+        com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento sugerencia = sugerencias.get(0);
+        assertNotNull(sugerencia.getConsumoTotalPeriodo());
+        assertNull(sugerencia.getConsumoSemanalPromedio());
+        assertNull(sugerencia.getSemanasCobertura());
+        assertEquals("ALTO", sugerencia.getNivelCriticidad());
+        assertEquals(Boolean.FALSE, sugerencia.getEsCritico());
     }
 }


### PR DESCRIPTION
## Summary
- Add consumption projection, coverage, and criticality fields to MRP suggestion DTOs for downstream purchase recommendations
- Calculate consumption horizons, weekly averages, coverage, and criticality levels in the MRP service using existing demand, stock, and lead time data, exposing them through the controller
- Extend MRP service tests to verify projection math, safe handling of missing horizons, and criticality thresholds

## Testing
- mvn -q -DskipITs test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e0eb5c0e48333b7103a2cd46f37f9)