### PR TITLE
Add kardex reporting and lote internal location metadata

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/KardexController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/KardexController.java
@@ -1,0 +1,74 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.KardexFiltro;
+import com.willyes.clemenintegra.inventario.dto.KardexItemDTO;
+import com.willyes.clemenintegra.inventario.service.KardexService;
+import com.willyes.clemenintegra.shared.util.DateParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/inventario/kardex")
+@RequiredArgsConstructor
+public class KardexController {
+
+    private final KardexService kardexService;
+
+    @GetMapping
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<List<KardexItemDTO>> obtenerKardex(
+            @RequestParam(required = false) Long productoId,
+            @RequestParam(required = false) String codigoSku,
+            @RequestParam(required = false) Long loteId,
+            @RequestParam(required = false) String codigoLote,
+            @RequestParam(required = false) String fechaDesde,
+            @RequestParam(required = false) String fechaHasta,
+            @RequestParam(required = false) Long almacenId
+    ) {
+        if (productoId == null && !StringUtils.hasText(codigoSku)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Se requiere productoId o codigoSku");
+        }
+
+        LocalDateTime inicio = parseFecha(fechaDesde, true);
+        LocalDateTime fin = parseFecha(fechaHasta, false);
+
+        KardexFiltro filtro = KardexFiltro.builder()
+                .productoId(productoId)
+                .codigoSku(codigoSku)
+                .loteId(loteId)
+                .codigoLote(codigoLote)
+                .fechaDesde(inicio)
+                .fechaHasta(fin)
+                .almacenId(almacenId)
+                .build();
+
+        try {
+            List<KardexItemDTO> resultado = kardexService.obtenerKardex(filtro);
+            return ResponseEntity.ok(resultado);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+    }
+
+    private LocalDateTime parseFecha(String fechaTexto, boolean isInicio) {
+        if (!StringUtils.hasText(fechaTexto)) {
+            return null;
+        }
+        try {
+            return isInicio ? DateParser.parseStart(fechaTexto) : DateParser.parseEnd(fechaTexto);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/KardexFiltro.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/KardexFiltro.java
@@ -1,0 +1,22 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KardexFiltro {
+    private Long productoId;
+    private String codigoSku;
+    private Long loteId;
+    private String codigoLote;
+    private LocalDateTime fechaDesde;
+    private LocalDateTime fechaHasta;
+    private Long almacenId;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/KardexItemDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/KardexItemDTO.java
@@ -1,0 +1,30 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KardexItemDTO {
+
+    private LocalDateTime fechaMovimiento;
+    private String tipoMovimiento;
+    private String clasificacion;
+    private String referencia;
+    private String almacenOrigen;
+    private String almacenDestino;
+    private String codigoLote;
+    private String codigoSku;
+    private String nombreProducto;
+    private BigDecimal cantidadEntrada;
+    private BigDecimal cantidadSalida;
+    private BigDecimal saldo;
+    private String usuario;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoRequestDTO.java
@@ -36,5 +36,7 @@ public class LoteProductoRequestDTO {
     private Long usuario_liberador_id;
     private Long orden_produccion_id;
     private Long produccion_id;
+    private String codigoUbicacionInterna;
+    private String descripcionUbicacionInterna;
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoResponseDTO.java
@@ -36,6 +36,8 @@ public class LoteProductoResponseDTO {
     private Long lotePsOrigenId;
     private String codigoLotePsOrigen;
     private String alerta;
+    private String codigoUbicacionInterna;
+    private String descripcionUbicacionInterna;
 
     public String getNombreProducto() {
         return nombreProducto;}

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/LoteProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/LoteProducto.java
@@ -63,6 +63,12 @@ public class LoteProducto {
     @Column(name = "temperatura_almacenamiento")
     private Double temperaturaAlmacenamiento;
 
+    @Column(name = "codigo_ubicacion_interna", length = 50)
+    private String codigoUbicacionInterna;
+
+    @Column(name = "descripcion_ubicacion_interna", length = 255)
+    private String descripcionUbicacionInterna;
+
     @Column(name = "fecha_liberacion")
     private LocalDateTime fechaLiberacion;
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -197,5 +197,30 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
                                                                        LocalDateTime fechaInicio,
                                                                        LocalDateTime fechaFin);
 
+    @EntityGraph(attributePaths = {
+            "producto",
+            "lote",
+            "almacenOrigen",
+            "almacenDestino",
+            "registradoPor",
+            "motivoMovimiento",
+            "ordenProduccion"
+    })
+    @Query("""
+        select m
+          from MovimientoInventario m
+         where (:productoId is null or m.producto.id = :productoId)
+           and (:loteId is null or m.lote.id = :loteId)
+           and (:inicio is null or m.fechaIngreso >= :inicio)
+           and (:fin is null or m.fechaIngreso <= :fin)
+           and (:almacenId is null or m.almacenOrigen.id = :almacenId or m.almacenDestino.id = :almacenId)
+         order by m.fechaIngreso asc, m.id asc
+    """)
+    List<MovimientoInventario> buscarParaKardex(@Param("inicio") LocalDateTime inicio,
+                                                @Param("fin") LocalDateTime fin,
+                                                @Param("productoId") Long productoId,
+                                                @Param("loteId") Long loteId,
+                                                @Param("almacenId") Long almacenId);
+
 }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/KardexService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/KardexService.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.KardexFiltro;
+import com.willyes.clemenintegra.inventario.dto.KardexItemDTO;
+
+import java.util.List;
+
+public interface KardexService {
+    List<KardexItemDTO> obtenerKardex(KardexFiltro filtro);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/KardexServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/KardexServiceImpl.java
@@ -1,0 +1,185 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.KardexFiltro;
+import com.willyes.clemenintegra.inventario.dto.KardexItemDTO;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class KardexServiceImpl implements KardexService {
+
+    private static final EnumSet<ClasificacionMovimientoInventario> CLASIFICACIONES_ENTRADA = EnumSet.of(
+            ClasificacionMovimientoInventario.AJUSTE_POSITIVO,
+            ClasificacionMovimientoInventario.DEVOLUCION_DESDE_PRODUCCION,
+            ClasificacionMovimientoInventario.DEVOLUCION_DE_PROVEEDOR,
+            ClasificacionMovimientoInventario.ENTRADA_PRODUCTO_TERMINADO,
+            ClasificacionMovimientoInventario.ENTRADA_REPROCESO,
+            ClasificacionMovimientoInventario.RECEPCION_COMPRA,
+            ClasificacionMovimientoInventario.RECEPCION_DEVOLUCION_CLIENTE,
+            ClasificacionMovimientoInventario.LIBERACION_CALIDAD
+    );
+
+    private static final EnumSet<ClasificacionMovimientoInventario> CLASIFICACIONES_SALIDA = EnumSet.of(
+            ClasificacionMovimientoInventario.AJUSTE_NEGATIVO,
+            ClasificacionMovimientoInventario.DEVOLUCION_A_PROVEEDOR,
+            ClasificacionMovimientoInventario.SALIDA_MUESTRA_CALIDAD,
+            ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+            ClasificacionMovimientoInventario.SALIDA_CLIENTE,
+            ClasificacionMovimientoInventario.RECHAZO_CALIDAD
+    );
+
+    private static final EnumSet<ClasificacionMovimientoInventario> CLASIFICACIONES_TRANSFERENCIA = EnumSet.of(
+            ClasificacionMovimientoInventario.TRANSFERENCIA_GENERAL,
+            ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION
+    );
+
+    private final ProductoRepository productoRepository;
+    private final LoteProductoRepository loteProductoRepository;
+    private final MovimientoInventarioRepository movimientoInventarioRepository;
+
+    @Override
+    public List<KardexItemDTO> obtenerKardex(KardexFiltro filtro) {
+        if ((filtro.getProductoId() == null) && !StringUtils.hasText(filtro.getCodigoSku())) {
+            throw new IllegalArgumentException("Se requiere productoId o codigoSku");
+        }
+
+        Producto producto = resolverProducto(filtro.getProductoId(), filtro.getCodigoSku());
+        Long productoId = producto.getId() != null ? producto.getId().longValue() : null;
+        LoteProducto lote = resolverLote(filtro.getLoteId(), filtro.getCodigoLote(), productoId);
+
+        List<MovimientoInventario> movimientos = movimientoInventarioRepository.buscarParaKardex(
+                filtro.getFechaDesde(),
+                filtro.getFechaHasta(),
+                productoId,
+                lote != null ? lote.getId() : null,
+                filtro.getAlmacenId()
+        );
+
+        return calcularSaldo(movimientos, producto, lote, filtro.getAlmacenId());
+    }
+
+    private Producto resolverProducto(Long productoId, String codigoSku) {
+        if (productoId != null) {
+            return productoRepository.findById(productoId)
+                    .orElseThrow(() -> new IllegalArgumentException("Producto no encontrado"));
+        }
+        return productoRepository.findByCodigoSku(codigoSku)
+                .orElseThrow(() -> new IllegalArgumentException("Producto no encontrado"));
+    }
+
+    private LoteProducto resolverLote(Long loteId, String codigoLote, Long productoId) {
+        if (loteId != null) {
+            Optional<LoteProducto> lote = loteProductoRepository.findById(loteId);
+            return lote.filter(lp -> Objects.equals(lp.getProducto() != null ? lp.getProducto().getId().longValue() : null, productoId))
+                    .orElseThrow(() -> new IllegalArgumentException("Lote no pertenece al producto"));
+        }
+        if (StringUtils.hasText(codigoLote)) {
+            return loteProductoRepository.findByCodigoLoteAndProductoId(codigoLote, productoId)
+                    .orElseThrow(() -> new IllegalArgumentException("Lote no encontrado"));
+        }
+        return null;
+    }
+
+    private List<KardexItemDTO> calcularSaldo(List<MovimientoInventario> movimientos,
+                                              Producto producto,
+                                              LoteProducto lote,
+                                              Long almacenId) {
+        BigDecimal saldo = BigDecimal.ZERO;
+        List<MovimientoConTotales> items = movimientos.stream()
+                .map(mov -> new MovimientoConTotales(mov, calcularEntrada(mov, almacenId), calcularSalida(mov, almacenId)))
+                .collect(Collectors.toList());
+
+        List<KardexItemDTO> resultado = new java.util.ArrayList<>(items.size());
+        for (MovimientoConTotales item : items) {
+            saldo = saldo.add(item.entrada()).subtract(item.salida());
+            MovimientoInventario mov = item.movimiento();
+            resultado.add(KardexItemDTO.builder()
+                    .fechaMovimiento(mov.getFechaIngreso())
+                    .tipoMovimiento(mov.getTipoMovimiento() != null ? mov.getTipoMovimiento().name() : null)
+                    .clasificacion(mov.getClasificacion() != null ? mov.getClasificacion().name() : null)
+                    .referencia(mov.getDocReferencia())
+                    .almacenOrigen(mov.getAlmacenOrigen() != null ? mov.getAlmacenOrigen().getNombre() : null)
+                    .almacenDestino(mov.getAlmacenDestino() != null ? mov.getAlmacenDestino().getNombre() : null)
+                    .codigoLote(mov.getLote() != null ? mov.getLote().getCodigoLote() : (lote != null ? lote.getCodigoLote() : null))
+                    .codigoSku(producto.getCodigoSku())
+                    .nombreProducto(producto.getNombre())
+                    .cantidadEntrada(item.entrada())
+                    .cantidadSalida(item.salida())
+                    .saldo(saldo)
+                    .usuario(mov.getRegistradoPor() != null ? mov.getRegistradoPor().getNombreCompleto() : null)
+                    .build());
+        }
+        return resultado;
+    }
+
+    private record MovimientoConTotales(MovimientoInventario movimiento, BigDecimal entrada, BigDecimal salida) {}
+
+    private BigDecimal calcularEntrada(MovimientoInventario movimiento, Long almacenId) {
+        ClasificacionMovimientoInventario clasificacion = movimiento.getClasificacion();
+        TipoMovimiento tipoMovimiento = movimiento.getTipoMovimiento();
+
+        if (CLASIFICACIONES_TRANSFERENCIA.contains(clasificacion) || tipoMovimiento == TipoMovimiento.TRANSFERENCIA) {
+            if (almacenId != null && movimiento.getAlmacenDestino() != null
+                    && Objects.equals(movimiento.getAlmacenDestino().getId(), almacenId)) {
+                return obtenerCantidad(movimiento);
+            }
+            return BigDecimal.ZERO;
+        }
+
+        if (CLASIFICACIONES_ENTRADA.contains(clasificacion)) {
+            return obtenerCantidad(movimiento);
+        }
+
+        if (clasificacion == null && (tipoMovimiento == TipoMovimiento.ENTRADA
+                || tipoMovimiento == TipoMovimiento.RECEPCION
+                || tipoMovimiento == TipoMovimiento.DEVOLUCION)) {
+            return obtenerCantidad(movimiento);
+        }
+
+        return BigDecimal.ZERO;
+    }
+
+    private BigDecimal calcularSalida(MovimientoInventario movimiento, Long almacenId) {
+        ClasificacionMovimientoInventario clasificacion = movimiento.getClasificacion();
+        TipoMovimiento tipoMovimiento = movimiento.getTipoMovimiento();
+
+        if (CLASIFICACIONES_TRANSFERENCIA.contains(clasificacion) || tipoMovimiento == TipoMovimiento.TRANSFERENCIA) {
+            if (almacenId != null && movimiento.getAlmacenOrigen() != null
+                    && Objects.equals(movimiento.getAlmacenOrigen().getId(), almacenId)) {
+                return obtenerCantidad(movimiento);
+            }
+            return BigDecimal.ZERO;
+        }
+
+        if (CLASIFICACIONES_SALIDA.contains(clasificacion)) {
+            return obtenerCantidad(movimiento);
+        }
+
+        if (clasificacion == null && tipoMovimiento == TipoMovimiento.SALIDA) {
+            return obtenerCantidad(movimiento);
+        }
+
+        return BigDecimal.ZERO;
+    }
+
+    private BigDecimal obtenerCantidad(MovimientoInventario movimientoInventario) {
+        return Optional.ofNullable(movimientoInventario.getCantidad()).orElse(BigDecimal.ZERO);
+    }
+}

--- a/src/main/resources/db/migration/V20251213__inventario_ubicacion_interna_lote.sql
+++ b/src/main/resources/db/migration/V20251213__inventario_ubicacion_interna_lote.sql
@@ -1,0 +1,3 @@
+ALTER TABLE lotes_productos
+    ADD COLUMN codigo_ubicacion_interna VARCHAR(50) NULL,
+    ADD COLUMN descripcion_ubicacion_interna VARCHAR(255) NULL;

--- a/src/test/java/com/willyes/clemenintegra/inventario/mapper/LoteProductoMapperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/mapper/LoteProductoMapperTest.java
@@ -1,0 +1,34 @@
+package com.willyes.clemenintegra.inventario.mapper;
+
+import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoteProductoMapperTest {
+
+    private final LoteProductoMapper mapper = Mappers.getMapper(LoteProductoMapper.class);
+
+    @Test
+    void incluyeAlertaYUbicacionInternaEnRespuesta() {
+        LoteProducto lote = new LoteProducto();
+        lote.setCodigoLote("LOT-01");
+        lote.setEstado(EstadoLote.EN_CUARENTENA);
+        lote.setFechaVencimiento(LocalDateTime.now().minusDays(1));
+        lote.setCodigoUbicacionInterna("A-01-02");
+        lote.setDescripcionUbicacionInterna("Pasillo A, nivel 1");
+        lote.setAlmacen(new Almacen(10));
+
+        LoteProductoResponseDTO dto = mapper.toDto(lote);
+
+        assertThat(dto.getAlerta()).isEqualTo("VENCIDO");
+        assertThat(dto.getCodigoUbicacionInterna()).isEqualTo("A-01-02");
+        assertThat(dto.getDescripcionUbicacionInterna()).isEqualTo("Pasillo A, nivel 1");
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/KardexServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/KardexServiceImplTest.java
@@ -1,0 +1,139 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.KardexFiltro;
+import com.willyes.clemenintegra.inventario.dto.KardexItemDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KardexServiceImplTest {
+
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+
+    @InjectMocks
+    private KardexServiceImpl kardexService;
+
+    @Test
+    void calculaSaldoConEntradasYSalidas() {
+        Producto producto = crearProducto(1, "SKU-01", "Producto A");
+        when(productoRepository.findById(1L)).thenReturn(Optional.of(producto));
+
+        MovimientoInventario entrada = movimiento(LocalDateTime.now().minusDays(2), new BigDecimal("10"),
+                TipoMovimiento.RECEPCION, ClasificacionMovimientoInventario.RECEPCION_COMPRA);
+        MovimientoInventario salida = movimiento(LocalDateTime.now().minusDays(1), new BigDecimal("3"),
+                TipoMovimiento.SALIDA, ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+
+        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(1L), any(), any()))
+                .thenReturn(List.of(entrada, salida));
+
+        KardexFiltro filtro = KardexFiltro.builder().productoId(1L).build();
+        List<KardexItemDTO> resultado = kardexService.obtenerKardex(filtro);
+
+        assertThat(resultado).hasSize(2);
+        assertThat(resultado.get(0).getSaldo()).isEqualByComparingTo("10");
+        assertThat(resultado.get(1).getSaldo()).isEqualByComparingTo("7");
+        assertThat(resultado.get(0).getCantidadEntrada()).isEqualByComparingTo("10");
+        assertThat(resultado.get(1).getCantidadSalida()).isEqualByComparingTo("3");
+    }
+
+    @Test
+    void respetaFiltroPorLote() {
+        Producto producto = crearProducto(5, "SKU-05", "Producto F");
+        LoteProducto lote = new LoteProducto();
+        lote.setId(9L);
+        lote.setProducto(producto);
+        when(productoRepository.findByCodigoSku("SKU-05")).thenReturn(Optional.of(producto));
+        when(loteProductoRepository.findByCodigoLoteAndProductoId("L-001", 5L)).thenReturn(Optional.of(lote));
+
+        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(5L), eq(9L), any()))
+                .thenReturn(List.of());
+
+        KardexFiltro filtro = KardexFiltro.builder()
+                .codigoSku("SKU-05")
+                .codigoLote("L-001")
+                .build();
+
+        List<KardexItemDTO> resultado = kardexService.obtenerKardex(filtro);
+
+        assertThat(resultado).isEmpty();
+        verify(movimientoInventarioRepository).buscarParaKardex(null, null, 5L, 9L, null);
+    }
+
+    @Test
+    void calculaTransferenciaPorAlmacenDestino() {
+        Producto producto = crearProducto(2, "SKU-02", "Producto B");
+        when(productoRepository.findById(2L)).thenReturn(Optional.of(producto));
+
+        Almacen origen = new Almacen(1);
+        origen.setNombre("Origen");
+        Almacen destino = new Almacen(2);
+        destino.setNombre("Destino");
+
+        MovimientoInventario transferencia = movimiento(LocalDateTime.now(), new BigDecimal("5"),
+                TipoMovimiento.TRANSFERENCIA, ClasificacionMovimientoInventario.TRANSFERENCIA_GENERAL);
+        transferencia.setAlmacenOrigen(origen);
+        transferencia.setAlmacenDestino(destino);
+
+        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(2L), any(), eq(2L)))
+                .thenReturn(List.of(transferencia));
+
+        KardexFiltro filtro = KardexFiltro.builder()
+                .productoId(2L)
+                .almacenId(2L)
+                .build();
+
+        List<KardexItemDTO> resultado = kardexService.obtenerKardex(filtro);
+
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getCantidadEntrada()).isEqualByComparingTo("5");
+        assertThat(resultado.get(0).getSaldo()).isEqualByComparingTo("5");
+    }
+
+    private Producto crearProducto(Integer id, String sku, String nombre) {
+        Producto producto = new Producto();
+        producto.setId(id);
+        producto.setCodigoSku(sku);
+        producto.setNombre(nombre);
+        return producto;
+    }
+
+    private MovimientoInventario movimiento(LocalDateTime fecha, BigDecimal cantidad,
+                                           TipoMovimiento tipoMovimiento,
+                                           ClasificacionMovimientoInventario clasificacion) {
+        MovimientoInventario mov = new MovimientoInventario();
+        mov.setFechaIngreso(fecha);
+        mov.setCantidad(cantidad);
+        mov.setTipoMovimiento(tipoMovimiento);
+        mov.setClasificacion(clasificacion);
+        mov.setLote(new LoteProducto());
+        return mov;
+    }
+}


### PR DESCRIPTION
## Summary
- add Flyway migration and entity/DTO mapping for lote internal location fields
- implement kardex saldo-a-saldo service and endpoint with filtering by producto/lote/almacen
- cover alerta mapping and kardex saldo logic with new unit tests

## Testing
- mvn -q -Dtest=KardexServiceImplTest,LoteProductoMapperTest test *(fails: dependency download from Maven Central returned HTTP 500 for org.infinispan:infinispan-bom)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e3012776083339d5be601eb0654b7)