### PR TITLE
Add production consumption reporting and batch exports

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -100,6 +100,9 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
                                                                 Integer almacenId,
                                                                 Collection<EstadoLote> estados);
 
+    @EntityGraph(attributePaths = {"producto", "almacen"})
+    List<LoteProducto> findByOrdenProduccionId(Long ordenProduccionId);
+
     @Query("""
       select l
       from LoteProducto l

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/KardexServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/KardexServiceImpl.java
@@ -136,8 +136,7 @@ public class KardexServiceImpl implements KardexService {
         TipoMovimiento tipoMovimiento = movimiento.getTipoMovimiento();
 
         if (CLASIFICACIONES_TRANSFERENCIA.contains(clasificacion) || tipoMovimiento == TipoMovimiento.TRANSFERENCIA) {
-            if (almacenId != null && movimiento.getAlmacenDestino() != null
-                    && Objects.equals(movimiento.getAlmacenDestino().getId(), almacenId)) {
+            if (mismoAlmacen(movimiento.getAlmacenDestino() != null ? movimiento.getAlmacenDestino().getId() : null, almacenId)) {
                 return obtenerCantidad(movimiento);
             }
             return BigDecimal.ZERO;
@@ -161,8 +160,7 @@ public class KardexServiceImpl implements KardexService {
         TipoMovimiento tipoMovimiento = movimiento.getTipoMovimiento();
 
         if (CLASIFICACIONES_TRANSFERENCIA.contains(clasificacion) || tipoMovimiento == TipoMovimiento.TRANSFERENCIA) {
-            if (almacenId != null && movimiento.getAlmacenOrigen() != null
-                    && Objects.equals(movimiento.getAlmacenOrigen().getId(), almacenId)) {
+            if (mismoAlmacen(movimiento.getAlmacenOrigen() != null ? movimiento.getAlmacenOrigen().getId() : null, almacenId)) {
                 return obtenerCantidad(movimiento);
             }
             return BigDecimal.ZERO;
@@ -177,6 +175,13 @@ public class KardexServiceImpl implements KardexService {
         }
 
         return BigDecimal.ZERO;
+    }
+
+    private boolean mismoAlmacen(Number almacenMovimientoId, Long almacenFiltroId) {
+        if (almacenMovimientoId == null || almacenFiltroId == null) {
+            return false;
+        }
+        return Objects.equals(almacenMovimientoId.longValue(), almacenFiltroId);
     }
 
     private BigDecimal obtenerCantidad(MovimientoInventario movimientoInventario) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/ProduccionReportesController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/ProduccionReportesController.java
@@ -1,0 +1,51 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.dto.ConsumoTeoricoRealResponseDTO;
+import com.willyes.clemenintegra.produccion.service.ConsumoTeoricoRealService;
+import com.willyes.clemenintegra.produccion.service.ReportesProduccionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/produccion/ordenes")
+@RequiredArgsConstructor
+public class ProduccionReportesController {
+
+    private final ConsumoTeoricoRealService consumoTeoricoRealService;
+    private final ReportesProduccionService reportesProduccionService;
+
+    @GetMapping("/{id}/consumo-real-vs-teorico")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ConsumoTeoricoRealResponseDTO> consumoRealVsTeorico(@PathVariable Long id) {
+        return ResponseEntity.ok(consumoTeoricoRealService.obtenerConsumo(id));
+    }
+
+    @GetMapping(value = "/{id}/batch-record/excel", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<byte[]> descargarBatchRecordExcel(@PathVariable Long id) {
+        byte[] excel = reportesProduccionService.generarBatchRecordExcel(id);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=batch-record-" + id + ".xlsx");
+        headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+        return new ResponseEntity<>(excel, headers, HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/{id}/batch-record/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<byte[]> descargarBatchRecordPdf(@PathVariable Long id) {
+        byte[] pdf = reportesProduccionService.generarBatchRecordPdf(id);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=batch-record-" + id + ".pdf");
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        return new ResponseEntity<>(pdf, headers, HttpStatus.OK);
+    }
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ConsumoTeoricoRealItemDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ConsumoTeoricoRealItemDTO.java
@@ -1,0 +1,22 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class ConsumoTeoricoRealItemDTO {
+
+    private Long productoId;
+    private String codigoSku;
+    private String nombreProducto;
+    private String unidad;
+
+    private BigDecimal cantidadTeorica;
+    private BigDecimal cantidadReal;
+    private BigDecimal diferencia;
+    private BigDecimal porcentajeDesviacion;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ConsumoTeoricoRealResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ConsumoTeoricoRealResponseDTO.java
@@ -1,0 +1,23 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@Builder
+public class ConsumoTeoricoRealResponseDTO {
+
+    private Long ordenId;
+    private String codigoOrden;
+    private String productoTerminadoSku;
+    private String productoTerminadoNombre;
+    private BigDecimal cantidadProgramada;
+    private BigDecimal cantidadProducida;
+
+    private List<ConsumoTeoricoRealItemDTO> items;
+    private List<LoteTerminadoResumenDTO> lotesTerminados;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/LoteTerminadoResumenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/LoteTerminadoResumenDTO.java
@@ -1,0 +1,18 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class LoteTerminadoResumenDTO {
+    private Long idLote;
+    private String codigoLote;
+    private String estadoLote;
+    private String almacenNombre;
+    private LocalDateTime fechaVencimiento;
+    private java.math.BigDecimal stockLote;
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ConsumoTeoricoRealService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ConsumoTeoricoRealService.java
@@ -1,0 +1,9 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.ConsumoTeoricoRealResponseDTO;
+
+public interface ConsumoTeoricoRealService {
+
+    ConsumoTeoricoRealResponseDTO obtenerConsumo(Long ordenProduccionId);
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ConsumoTeoricoRealServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ConsumoTeoricoRealServiceImpl.java
@@ -1,0 +1,246 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.produccion.dto.ConsumoTeoricoRealItemDTO;
+import com.willyes.clemenintegra.produccion.dto.ConsumoTeoricoRealResponseDTO;
+import com.willyes.clemenintegra.produccion.dto.LoteTerminadoResumenDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class ConsumoTeoricoRealServiceImpl implements ConsumoTeoricoRealService {
+
+    private final OrdenProduccionRepository ordenProduccionRepository;
+    private final FormulaProductoRepository formulaProductoRepository;
+    private final MovimientoInventarioRepository movimientoInventarioRepository;
+    private final LoteProductoRepository loteProductoRepository;
+
+    @Override
+    public ConsumoTeoricoRealResponseDTO obtenerConsumo(Long ordenProduccionId) {
+        OrdenProduccion ordenProduccion = ordenProduccionRepository.findById(ordenProduccionId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "ORDEN_NO_ENCONTRADA"));
+
+        FormulaProducto formula = obtenerFormulaProducto(ordenProduccion.getProducto());
+        if (formula == null || formula.getDetalles() == null || formula.getDetalles().isEmpty()) {
+            throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA, "FORMULA_NO_ASOCIADA");
+        }
+
+        Map<Long, ConsumoTeoricoRealItemDTO.ConsumoTeoricoRealItemDTOBuilder> items = new HashMap<>();
+
+        BigDecimal cantidadProgramada = ordenProduccion.getCantidadProgramada();
+        construirTeorico(formula, cantidadProgramada, items);
+        construirReal(ordenProduccionId, items);
+
+        List<ConsumoTeoricoRealItemDTO> resultItems = items.values().stream()
+                .map(builder -> {
+                    ConsumoTeoricoRealItemDTO dto = builder.build();
+                    BigDecimal teorica = defaultZero(dto.getCantidadTeorica());
+                    BigDecimal real = defaultZero(dto.getCantidadReal());
+                    BigDecimal diferencia = real.subtract(teorica);
+                    dto.setDiferencia(diferencia);
+                    if (teorica.compareTo(BigDecimal.ZERO) == 0) {
+                        dto.setPorcentajeDesviacion(null);
+                    } else {
+                        dto.setPorcentajeDesviacion(diferencia
+                                .divide(teorica, 6, RoundingMode.HALF_UP)
+                                .multiply(BigDecimal.valueOf(100)));
+                    }
+                    return dto;
+                })
+                .toList();
+
+        List<LoteTerminadoResumenDTO> lotesTerminados = obtenerLotesTerminados(ordenProduccionId);
+
+        return ConsumoTeoricoRealResponseDTO.builder()
+                .ordenId(ordenProduccion.getId())
+                .codigoOrden(ordenProduccion.getCodigoOrden())
+                .productoTerminadoSku(ordenProduccion.getProducto() != null
+                        ? ordenProduccion.getProducto().getCodigoSku()
+                        : null)
+                .productoTerminadoNombre(ordenProduccion.getProducto() != null
+                        ? ordenProduccion.getProducto().getNombre()
+                        : null)
+                .cantidadProgramada(ordenProduccion.getCantidadProgramada())
+                .cantidadProducida(ordenProduccion.getCantidadProducida())
+                .items(resultItems)
+                .lotesTerminados(lotesTerminados)
+                .build();
+    }
+
+    private void construirTeorico(FormulaProducto formula,
+                                  BigDecimal cantidadProgramada,
+                                  Map<Long, ConsumoTeoricoRealItemDTO.ConsumoTeoricoRealItemDTOBuilder> items) {
+        for (DetalleFormula detalle : formula.getDetalles()) {
+            if (esProductoSemiElaborado(detalle)) {
+                expandirProductoSemiElaborado(detalle, cantidadProgramada, items);
+                continue;
+            }
+            agregarCantidadTeorica(detalle.getInsumo(), detalle.getUnidadMedida() != null
+                    ? detalle.getUnidadMedida().getNombre()
+                    : null,
+                    calcularCantidadTeoricaPt(detalle.getCantidadNecesaria(), cantidadProgramada),
+                    items);
+        }
+    }
+
+    private void construirReal(Long ordenProduccionId,
+                               Map<Long, ConsumoTeoricoRealItemDTO.ConsumoTeoricoRealItemDTOBuilder> items) {
+        List<MovimientoInventario> movimientos = movimientoInventarioRepository
+                .findByOrdenProduccionIdAndClasificacion(
+                        ordenProduccionId,
+                        ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                        Pageable.unpaged())
+                .getContent();
+
+        for (MovimientoInventario movimiento : movimientos) {
+            if (movimiento.getTipoMovimiento() == null
+                    || !(movimiento.getTipoMovimiento() == TipoMovimiento.SALIDA
+                    || movimiento.getTipoMovimiento() == TipoMovimiento.TRANSFERENCIA
+                    || movimiento.getTipoMovimiento() == TipoMovimiento.AJUSTE)) {
+                continue;
+            }
+            Producto producto = movimiento.getProducto();
+            if (producto == null || producto.getId() == null) {
+                continue;
+            }
+            ConsumoTeoricoRealItemDTO.ConsumoTeoricoRealItemDTOBuilder builder =
+                    items.computeIfAbsent(producto.getId().longValue(),
+                            id -> ConsumoTeoricoRealItemDTO.builder()
+                                    .productoId(id)
+                                    .codigoSku(producto.getCodigoSku())
+                                    .nombreProducto(producto.getNombre())
+                                    .unidad(producto.getUnidadMedida() != null
+                                            ? producto.getUnidadMedida().getNombre()
+                                            : null)
+                                    .cantidadTeorica(BigDecimal.ZERO)
+                                    .cantidadReal(BigDecimal.ZERO));
+            builder.cantidadReal(defaultZero(builder.build().getCantidadReal())
+                    .add(defaultZero(movimiento.getCantidad())));
+        }
+    }
+
+    private void agregarCantidadTeorica(Producto insumo,
+                                        String unidad,
+                                        BigDecimal cantidad,
+                                        Map<Long, ConsumoTeoricoRealItemDTO.ConsumoTeoricoRealItemDTOBuilder> items) {
+        if (insumo == null || insumo.getId() == null || cantidad == null) {
+            return;
+        }
+        ConsumoTeoricoRealItemDTO.ConsumoTeoricoRealItemDTOBuilder builder = items
+                .computeIfAbsent(insumo.getId().longValue(),
+                        id -> ConsumoTeoricoRealItemDTO.builder()
+                                .productoId(id)
+                                .codigoSku(insumo.getCodigoSku())
+                                .nombreProducto(insumo.getNombre())
+                                .unidad(unidad)
+                                .cantidadTeorica(BigDecimal.ZERO)
+                                .cantidadReal(BigDecimal.ZERO));
+        builder.cantidadTeorica(defaultZero(builder.build().getCantidadTeorica()).add(cantidad));
+    }
+
+    private void expandirProductoSemiElaborado(DetalleFormula detallePs,
+                                               BigDecimal cantidadProgramada,
+                                               Map<Long, ConsumoTeoricoRealItemDTO.ConsumoTeoricoRealItemDTOBuilder> items) {
+        FormulaProducto formulaPs = obtenerFormulaProducto(detallePs.getInsumo());
+        if (formulaPs == null || formulaPs.getDetalles() == null || formulaPs.getDetalles().isEmpty()) {
+            log.warn("No se encontró fórmula activa para el producto semi elaborado {}", detallePs.getInsumo());
+            agregarCantidadTeorica(detallePs.getInsumo(),
+                    detallePs.getUnidadMedida() != null ? detallePs.getUnidadMedida().getNombre() : null,
+                    calcularCantidadTeoricaPt(detallePs.getCantidadNecesaria(), cantidadProgramada),
+                    items);
+            return;
+        }
+        for (DetalleFormula detalleMp : formulaPs.getDetalles()) {
+            BigDecimal cantidadTeorica = calcularCantidadTeoricaPs(detalleMp.getCantidadNecesaria(),
+                    detallePs.getCantidadNecesaria(), cantidadProgramada);
+            agregarCantidadTeorica(detalleMp.getInsumo(),
+                    detalleMp.getUnidadMedida() != null ? detalleMp.getUnidadMedida().getNombre() : null,
+                    cantidadTeorica,
+                    items);
+        }
+    }
+
+    private FormulaProducto obtenerFormulaProducto(Producto producto) {
+        if (producto == null || producto.getId() == null) {
+            return null;
+        }
+        return formulaProductoRepository
+                .findByProductoIdAndEstadoAndActivoTrue(producto.getId().longValue(), EstadoFormula.APROBADA)
+                .orElseGet(() -> formulaProductoRepository.findByProductoId(producto.getId().longValue()).orElse(null));
+    }
+
+    private boolean esProductoSemiElaborado(DetalleFormula detalle) {
+        return detalle != null
+                && detalle.getInsumo() != null
+                && detalle.getInsumo().getCategoriaProducto() != null
+                && detalle.getInsumo().getCategoriaProducto().getTipo() == TipoCategoria.PRODUCTO_SEMI_ELABORADO;
+    }
+
+    private BigDecimal calcularCantidadTeoricaPs(BigDecimal cantidadMpPorPs,
+                                                 BigDecimal cantidadPsPorPt,
+                                                 BigDecimal cantidadProgramadaPt) {
+        if (cantidadMpPorPs == null) {
+            return null;
+        }
+        BigDecimal psPorPt = cantidadPsPorPt != null ? cantidadPsPorPt : BigDecimal.ZERO;
+        BigDecimal cantidadPt = cantidadProgramadaPt != null ? cantidadProgramadaPt : BigDecimal.ONE;
+        return cantidadMpPorPs.multiply(psPorPt).multiply(cantidadPt);
+    }
+
+    private BigDecimal calcularCantidadTeoricaPt(BigDecimal cantidadNecesariaPorUnidad, BigDecimal cantidadProgramadaPt) {
+        if (cantidadNecesariaPorUnidad == null) {
+            return null;
+        }
+        BigDecimal cantidadPt = cantidadProgramadaPt != null ? cantidadProgramadaPt : BigDecimal.ONE;
+        return cantidadNecesariaPorUnidad.multiply(cantidadPt);
+    }
+
+    private BigDecimal defaultZero(BigDecimal value) {
+        return value != null ? value : BigDecimal.ZERO;
+    }
+
+    private List<LoteTerminadoResumenDTO> obtenerLotesTerminados(Long ordenProduccionId) {
+        List<LoteProducto> lotes = loteProductoRepository.findByOrdenProduccionId(ordenProduccionId);
+        List<LoteTerminadoResumenDTO> respuesta = new ArrayList<>();
+        for (LoteProducto lote : lotes) {
+            respuesta.add(LoteTerminadoResumenDTO.builder()
+                    .idLote(lote.getId())
+                    .codigoLote(lote.getCodigoLote())
+                    .estadoLote(lote.getEstado() != null ? lote.getEstado().name() : null)
+                    .almacenNombre(lote.getAlmacen() != null ? lote.getAlmacen().getNombre() : null)
+                    .fechaVencimiento(lote.getFechaVencimiento())
+                    .stockLote(lote.getStockLote())
+                    .build());
+        }
+        return respuesta;
+    }
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReportesProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReportesProduccionService.java
@@ -1,0 +1,9 @@
+package com.willyes.clemenintegra.produccion.service;
+
+public interface ReportesProduccionService {
+
+    byte[] generarBatchRecordExcel(Long ordenProduccionId);
+
+    byte[] generarBatchRecordPdf(Long ordenProduccionId);
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReportesProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReportesProduccionServiceImpl.java
@@ -1,0 +1,108 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.ConsumoTeoricoRealResponseDTO;
+import com.willyes.clemenintegra.produccion.dto.LoteTerminadoResumenDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReportesProduccionServiceImpl implements ReportesProduccionService {
+
+    private final ConsumoTeoricoRealService consumoTeoricoRealService;
+    private final ReporteBatchRecordService reporteBatchRecordService;
+
+    @Override
+    public byte[] generarBatchRecordExcel(Long ordenProduccionId) {
+        ConsumoTeoricoRealResponseDTO resumen = consumoTeoricoRealService.obtenerConsumo(ordenProduccionId);
+        try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            construirHojaConsumos(workbook, resumen);
+            construirHojaLotes(workbook, resumen);
+            workbook.write(bos);
+            return bos.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando Excel de batch record para OP {}", ordenProduccionId, e);
+            throw new RuntimeException("No fue posible generar el Excel de batch record", e);
+        }
+    }
+
+    @Override
+    public byte[] generarBatchRecordPdf(Long ordenProduccionId) {
+        return reporteBatchRecordService.generarPdfBatchRecord(ordenProduccionId);
+    }
+
+    private void construirHojaConsumos(Workbook workbook, ConsumoTeoricoRealResponseDTO resumen) {
+        Sheet sheet = workbook.createSheet("Consumos");
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("Producto");
+        header.createCell(1).setCellValue("SKU");
+        header.createCell(2).setCellValue("Unidad");
+        header.createCell(3).setCellValue("Cantidad teórica");
+        header.createCell(4).setCellValue("Cantidad real");
+        header.createCell(5).setCellValue("Diferencia");
+        header.createCell(6).setCellValue("% Desviación");
+
+        int rowIdx = 1;
+        for (var item : resumen.getItems()) {
+            Row row = sheet.createRow(rowIdx++);
+            crearCelda(row, 0, item.getNombreProducto());
+            crearCelda(row, 1, item.getCodigoSku());
+            crearCelda(row, 2, item.getUnidad());
+            crearCelda(row, 3, item.getCantidadTeorica());
+            crearCelda(row, 4, item.getCantidadReal());
+            crearCelda(row, 5, item.getDiferencia());
+            crearCelda(row, 6, item.getPorcentajeDesviacion());
+        }
+        for (int i = 0; i <= 6; i++) {
+            sheet.autoSizeColumn(i);
+        }
+    }
+
+    private void construirHojaLotes(Workbook workbook, ConsumoTeoricoRealResponseDTO resumen) {
+        Sheet sheet = workbook.createSheet("Lotes terminados");
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("ID Lote");
+        header.createCell(1).setCellValue("Código Lote");
+        header.createCell(2).setCellValue("Estado");
+        header.createCell(3).setCellValue("Almacén");
+        header.createCell(4).setCellValue("Stock");
+        header.createCell(5).setCellValue("Vencimiento");
+
+        int rowIdx = 1;
+        for (LoteTerminadoResumenDTO lote : resumen.getLotesTerminados()) {
+            Row row = sheet.createRow(rowIdx++);
+            crearCelda(row, 0, lote.getIdLote());
+            crearCelda(row, 1, lote.getCodigoLote());
+            crearCelda(row, 2, lote.getEstadoLote());
+            crearCelda(row, 3, lote.getAlmacenNombre());
+            crearCelda(row, 4, lote.getStockLote());
+            crearCelda(row, 5, lote.getFechaVencimiento());
+        }
+        for (int i = 0; i <= 5; i++) {
+            sheet.autoSizeColumn(i);
+        }
+    }
+
+    private void crearCelda(Row row, int idx, Object value) {
+        Cell cell = row.createCell(idx);
+        if (value == null) {
+            cell.setBlank();
+            return;
+        }
+        if (value instanceof Number number) {
+            cell.setCellValue(number.doubleValue());
+        } else {
+            cell.setCellValue(value.toString());
+        }
+    }
+}
+

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/ConsumoTeoricoRealServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/ConsumoTeoricoRealServiceImplTest.java
@@ -1,0 +1,147 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.produccion.dto.ConsumoTeoricoRealResponseDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumoTeoricoRealServiceImplTest {
+
+    @Mock
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock
+    private FormulaProductoRepository formulaProductoRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+
+    @InjectMocks
+    private ConsumoTeoricoRealServiceImpl service;
+
+    @Test
+    @DisplayName("calcula diferencias en cero cuando real=teorico")
+    void calcularConsumoRealIgualTeorico() {
+        OrdenProduccion orden = ordenProduccion();
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+        Producto insumo = insumoPrincipal();
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(anyLong(), any()))
+                .thenReturn(Optional.of(formulaSimple(BigDecimal.ONE, insumo)));
+        MovimientoInventario movimiento = movimiento(insumo, new BigDecimal("10"));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(anyLong(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(movimiento)));
+        when(loteProductoRepository.findByOrdenProduccionId(1L)).thenReturn(List.of());
+
+        ConsumoTeoricoRealResponseDTO response = service.obtenerConsumo(1L);
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getDiferencia()).isZero();
+        assertThat(response.getItems().get(0).getPorcentajeDesviacion()).isZero();
+    }
+
+    @Test
+    @DisplayName("maneja porcentaje nulo cuando cantidad teórica es cero")
+    void manejarTeoricoCero() {
+        OrdenProduccion orden = ordenProduccion();
+        when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
+        Producto insumo = insumoPrincipal();
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(anyLong(), any()))
+                .thenReturn(Optional.of(formulaSimple(BigDecimal.ZERO, insumo)));
+        MovimientoInventario movimiento = movimiento(insumo, new BigDecimal("5"));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(anyLong(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(movimiento)));
+        LoteProducto lote = new LoteProducto();
+        lote.setId(5L);
+        when(loteProductoRepository.findByOrdenProduccionId(1L)).thenReturn(List.of(lote));
+
+        ConsumoTeoricoRealResponseDTO response = service.obtenerConsumo(1L);
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getPorcentajeDesviacion()).isNull();
+        assertThat(response.getLotesTerminados()).hasSize(1);
+    }
+
+    private OrdenProduccion ordenProduccion() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(1L);
+        orden.setCantidadProgramada(new BigDecimal("10"));
+        Producto producto = new Producto();
+        producto.setId(2);
+        producto.setCodigoSku("PT-01");
+        producto.setNombre("Producto terminado");
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setNombre("UND");
+        producto.setUnidadMedida(unidad);
+        CategoriaProducto categoria = new CategoriaProducto();
+        categoria.setTipo(TipoCategoria.PRODUCTO_TERMINADO);
+        producto.setCategoriaProducto(categoria);
+        orden.setProducto(producto);
+        return orden;
+    }
+
+    private FormulaProducto formulaSimple(BigDecimal cantidadNecesaria, Producto insumo) {
+        FormulaProducto formula = new FormulaProducto();
+        formula.setEstado(EstadoFormula.APROBADA);
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setCantidadNecesaria(cantidadNecesaria);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setNombre("KG");
+        insumo.setUnidadMedida(unidad);
+        detalle.setInsumo(insumo);
+        detalle.setUnidadMedida(unidad);
+        formula.setDetalles(List.of(detalle));
+        return formula;
+    }
+
+    private Producto insumoPrincipal() {
+        Producto insumo = new Producto();
+        insumo.setId(10);
+        insumo.setCodigoSku("INS-1");
+        insumo.setNombre("Insumo principal");
+        CategoriaProducto categoria = new CategoriaProducto();
+        categoria.setTipo(TipoCategoria.MATERIA_PRIMA);
+        insumo.setCategoriaProducto(categoria);
+        return insumo;
+    }
+
+    private MovimientoInventario movimiento(Producto producto, BigDecimal cantidad) {
+        MovimientoInventario movimiento = new MovimientoInventario();
+        movimiento.setProducto(producto);
+        movimiento.setCantidad(cantidad);
+        movimiento.setTipoMovimiento(TipoMovimiento.SALIDA);
+        movimiento.setClasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+        return movimiento;
+    }
+}
+

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/ReportesProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/ReportesProduccionServiceImplTest.java
@@ -1,0 +1,66 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.ConsumoTeoricoRealItemDTO;
+import com.willyes.clemenintegra.produccion.dto.ConsumoTeoricoRealResponseDTO;
+import com.willyes.clemenintegra.produccion.dto.LoteTerminadoResumenDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReportesProduccionServiceImplTest {
+
+    @Mock
+    private ConsumoTeoricoRealService consumoTeoricoRealService;
+    @Mock
+    private ReporteBatchRecordService reporteBatchRecordService;
+
+    @InjectMocks
+    private ReportesProduccionServiceImpl service;
+
+    @Test
+    @DisplayName("genera excel con datos de consumos y lotes")
+    void generarExcel() {
+        ConsumoTeoricoRealResponseDTO resumen = ConsumoTeoricoRealResponseDTO.builder()
+                .items(List.of(ConsumoTeoricoRealItemDTO.builder()
+                        .nombreProducto("Insumo 1")
+                        .codigoSku("INS-1")
+                        .unidad("KG")
+                        .cantidadTeorica(BigDecimal.ONE)
+                        .cantidadReal(BigDecimal.ONE)
+                        .diferencia(BigDecimal.ZERO)
+                        .porcentajeDesviacion(BigDecimal.ZERO)
+                        .build()))
+                .lotesTerminados(List.of(LoteTerminadoResumenDTO.builder()
+                        .idLote(1L)
+                        .codigoLote("L-01")
+                        .estadoLote("DISPONIBLE")
+                        .build()))
+                .build();
+        when(consumoTeoricoRealService.obtenerConsumo(5L)).thenReturn(resumen);
+
+        byte[] bytes = service.generarBatchRecordExcel(5L);
+
+        assertThat(bytes).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("delegar pdf a servicio existente")
+    void generarPdf() {
+        when(reporteBatchRecordService.generarPdfBatchRecord(7L)).thenReturn(new byte[]{1, 2, 3});
+
+        byte[] bytes = service.generarBatchRecordPdf(7L);
+
+        assertThat(bytes).containsExactly(1, 2, 3);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add consumption real vs theoretical aggregation service, DTOs, and controller endpoint for production orders
- expose batch record PDF/Excel downloads reusing existing batch record generator
- include finished product lot summaries and align kardex transfer handling for destination warehouses

## Testing
- mvn -q -DskipITs test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eb74b3ac88333be981ff1fae9667a)