### PR TITLE
Agregar indicadores y alertas para programa de producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/IndicadoresProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/IndicadoresProduccionController.java
@@ -1,0 +1,39 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.dto.AlertaOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
+import com.willyes.clemenintegra.produccion.service.ProduccionIndicadoresService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/produccion")
+@RequiredArgsConstructor
+public class IndicadoresProduccionController {
+
+    private final ProduccionIndicadoresService produccionIndicadoresService;
+
+    @GetMapping("/indicadores")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<IndicadoresProduccionResponseDTO> obtenerIndicadores(
+            @RequestParam LocalDate fechaInicio,
+            @RequestParam LocalDate fechaFin) {
+        return ResponseEntity.ok(produccionIndicadoresService.calcularIndicadores(fechaInicio, fechaFin));
+    }
+
+    @GetMapping("/ordenes/alertas")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<List<AlertaOrdenProduccionDTO>> obtenerAlertas(
+            @RequestParam(required = false) LocalDate fechaReferencia,
+            @RequestParam(required = false, defaultValue = "3") Integer diasVentana) {
+        return ResponseEntity.ok(produccionIndicadoresService.obtenerOrdenesConAlertas(fechaReferencia, diasVentana));
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/AlertaOrdenProduccionDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/AlertaOrdenProduccionDTO.java
@@ -1,0 +1,18 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class AlertaOrdenProduccionDTO {
+
+    private Long ordenId;
+    private String codigoOrden;
+    private String productoPrincipal;
+    private LocalDate fechaCompromiso;
+    private String estado;
+    private String tipoAlerta;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/IndicadoresProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/IndicadoresProduccionResponseDTO.java
@@ -1,0 +1,19 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class IndicadoresProduccionResponseDTO {
+
+    private long totalOrdenesPeriodo;
+    private long ordenesEnTiempo;
+    private long ordenesRetrasadas;
+    private double porcentajeCumplimiento;
+    private BigDecimal cantidadTotalPlanificada;
+    private BigDecimal cantidadTotalProducida;
+    private long ordenesAbiertasConVencimientoVencido;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.produccion.repository;
 
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
@@ -9,7 +10,10 @@ import org.springframework.data.repository.query.Param;
 
 import jakarta.persistence.LockModeType;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.List;
 
 public interface OrdenProduccionRepository extends JpaRepository<OrdenProduccion, Long>, JpaSpecificationExecutor<OrdenProduccion> {
 
@@ -22,5 +26,11 @@ public interface OrdenProduccionRepository extends JpaRepository<OrdenProduccion
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select o from OrdenProduccion o where o.id = :id")
     Optional<OrdenProduccion> findByIdForUpdate(@Param("id") Long id);
+
+    List<OrdenProduccion> findByFechaFinBetween(LocalDateTime inicio, LocalDateTime fin);
+
+    List<OrdenProduccion> findByEstadoNotInAndFechaFinBetween(Collection<EstadoProduccion> estados, LocalDateTime inicio, LocalDateTime fin);
+
+    List<OrdenProduccion> findByEstadoNotInAndFechaFinBefore(Collection<EstadoProduccion> estados, LocalDateTime limite);
 
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresService.java
@@ -1,0 +1,14 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.AlertaOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ProduccionIndicadoresService {
+
+    IndicadoresProduccionResponseDTO calcularIndicadores(LocalDate fechaInicio, LocalDate fechaFin);
+
+    List<AlertaOrdenProduccionDTO> obtenerOrdenesConAlertas(LocalDate fechaReferencia, int diasVentana);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresServiceImpl.java
@@ -1,0 +1,144 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.AlertaOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class ProduccionIndicadoresServiceImpl implements ProduccionIndicadoresService {
+
+    private static final BigDecimal ZERO = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+
+    private final OrdenProduccionRepository ordenProduccionRepository;
+
+    @Override
+    public IndicadoresProduccionResponseDTO calcularIndicadores(LocalDate fechaInicio, LocalDate fechaFin) {
+        LocalDateTime desde = fechaInicio.atStartOfDay();
+        LocalDateTime hasta = fechaFin.atTime(LocalTime.MAX);
+        List<OrdenProduccion> ordenes = ordenProduccionRepository.findByFechaFinBetween(desde, hasta);
+
+        long ordenesEnTiempo = 0;
+        long ordenesRetrasadas = 0;
+        long ordenesAbiertasVencidas = 0;
+        BigDecimal cantidadPlanificada = ZERO;
+        BigDecimal cantidadProducida = ZERO;
+        LocalDateTime hoy = LocalDateTime.now();
+
+        for (OrdenProduccion orden : ordenes) {
+            cantidadPlanificada = cantidadPlanificada.add(valorNoNulo(orden.getCantidadProgramada()));
+            cantidadProducida = cantidadProducida.add(obtenerCantidadProducida(orden));
+
+            boolean tieneFechaFin = orden.getFechaFin() != null;
+            boolean esCerrada = esOrdenCerrada(orden);
+            boolean esRetrasadaAbierta = !esCerrada && tieneFechaFin && orden.getFechaFin().isBefore(hoy);
+            boolean esRetrasadaCerrada = esCerrada && tieneFechaFin && orden.getFechaCierre() != null
+                    && orden.getFechaCierre().isAfter(orden.getFechaFin());
+
+            if (esCerrada && tieneFechaFin && orden.getFechaCierre() != null
+                    && !orden.getFechaCierre().isAfter(orden.getFechaFin())) {
+                ordenesEnTiempo++;
+            } else if (esRetrasadaCerrada || esRetrasadaAbierta) {
+                ordenesRetrasadas++;
+            }
+
+            if (esRetrasadaAbierta) {
+                ordenesAbiertasVencidas++;
+            }
+        }
+
+        long totalOrdenes = ordenes.size();
+        long denominador = ordenesEnTiempo + ordenesRetrasadas;
+        double porcentajeCumplimiento = denominador == 0
+                ? 0
+                : (ordenesEnTiempo * 100.0) / denominador;
+
+        return IndicadoresProduccionResponseDTO.builder()
+                .totalOrdenesPeriodo(totalOrdenes)
+                .ordenesEnTiempo(ordenesEnTiempo)
+                .ordenesRetrasadas(ordenesRetrasadas)
+                .porcentajeCumplimiento(porcentajeCumplimiento)
+                .cantidadTotalPlanificada(cantidadPlanificada)
+                .cantidadTotalProducida(cantidadProducida)
+                .ordenesAbiertasConVencimientoVencido(ordenesAbiertasVencidas)
+                .build();
+    }
+
+    @Override
+    public List<AlertaOrdenProduccionDTO> obtenerOrdenesConAlertas(LocalDate fechaReferencia, int diasVentana) {
+        LocalDate fechaBase = fechaReferencia != null ? fechaReferencia : LocalDate.now();
+        int ventana = diasVentana > 0 ? diasVentana : 3;
+        LocalDateTime inicioVentana = fechaBase.atStartOfDay();
+        LocalDateTime finVentana = fechaBase.plusDays(ventana).atTime(LocalTime.MAX);
+
+        List<EstadoProduccion> estadosCerrados = List.of(
+                EstadoProduccion.FINALIZADA,
+                EstadoProduccion.CERRADA_INCOMPLETA,
+                EstadoProduccion.CANCELADA);
+
+        List<AlertaOrdenProduccionDTO> alertas = new ArrayList<>();
+        List<OrdenProduccion> proximas = ordenProduccionRepository
+                .findByEstadoNotInAndFechaFinBetween(estadosCerrados, inicioVentana, finVentana);
+        proximas.stream()
+                .map(op -> crearAlerta(op, "PROXIMA_VENCER"))
+                .filter(Objects::nonNull)
+                .forEach(alertas::add);
+
+        List<OrdenProduccion> retrasadas = ordenProduccionRepository
+                .findByEstadoNotInAndFechaFinBefore(estadosCerrados, inicioVentana);
+        retrasadas.stream()
+                .map(op -> crearAlerta(op, "RETRASADA"))
+                .filter(Objects::nonNull)
+                .forEach(alertas::add);
+
+        return alertas;
+    }
+
+    private boolean esOrdenCerrada(OrdenProduccion orden) {
+        EstadoProduccion estado = orden.getEstado();
+        return estado == EstadoProduccion.FINALIZADA
+                || estado == EstadoProduccion.CERRADA_INCOMPLETA
+                || estado == EstadoProduccion.CANCELADA;
+    }
+
+    private BigDecimal valorNoNulo(BigDecimal valor) {
+        return valor != null ? valor : ZERO;
+    }
+
+    private BigDecimal obtenerCantidadProducida(OrdenProduccion orden) {
+        if (orden.getCantidadProducidaAcumulada() != null) {
+            return orden.getCantidadProducidaAcumulada();
+        }
+        if (orden.getCantidadProducida() != null) {
+            return orden.getCantidadProducida();
+        }
+        return ZERO;
+    }
+
+    private AlertaOrdenProduccionDTO crearAlerta(OrdenProduccion orden, String tipoAlerta) {
+        if (orden.getFechaFin() == null) {
+            return null;
+        }
+        return AlertaOrdenProduccionDTO.builder()
+                .ordenId(orden.getId())
+                .codigoOrden(orden.getCodigoOrden())
+                .productoPrincipal(orden.getProducto() != null ? orden.getProducto().getNombre() : null)
+                .fechaCompromiso(orden.getFechaFin().toLocalDate())
+                .estado(orden.getEstado() != null ? orden.getEstado().name() : null)
+                .tipoAlerta(tipoAlerta)
+                .build();
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresServiceImplTest.java
@@ -1,0 +1,131 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.AlertaOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProduccionIndicadoresServiceImplTest {
+
+    @Mock
+    private OrdenProduccionRepository ordenProduccionRepository;
+
+    @InjectMocks
+    private ProduccionIndicadoresServiceImpl service;
+
+    private LocalDateTime ahora;
+
+    @BeforeEach
+    void setUp() {
+        ahora = LocalDateTime.now();
+    }
+
+    @Test
+    @DisplayName("calcularIndicadores resume ordenes en tiempo y retrasadas con cantidades")
+    void calcularIndicadores_calculaKPIs() {
+        OrdenProduccion enTiempo = OrdenProduccion.builder()
+                .id(1L)
+                .codigoOrden("OP1")
+                .fechaFin(ahora.plusHours(1))
+                .fechaCierre(ahora)
+                .estado(EstadoProduccion.FINALIZADA)
+                .cantidadProgramada(new BigDecimal("10"))
+                .cantidadProducidaAcumulada(new BigDecimal("12"))
+                .build();
+
+        OrdenProduccion cerradaRetrasada = OrdenProduccion.builder()
+                .id(2L)
+                .codigoOrden("OP2")
+                .fechaFin(ahora.minusDays(1))
+                .fechaCierre(ahora)
+                .estado(EstadoProduccion.FINALIZADA)
+                .cantidadProgramada(new BigDecimal("5"))
+                .cantidadProducida(new BigDecimal("4"))
+                .build();
+
+        OrdenProduccion abiertaRetrasada = OrdenProduccion.builder()
+                .id(3L)
+                .codigoOrden("OP3")
+                .fechaFin(ahora.minusDays(2))
+                .estado(EstadoProduccion.EN_PROCESO)
+                .cantidadProgramada(new BigDecimal("8"))
+                .build();
+
+        when(ordenProduccionRepository.findByFechaFinBetween(any(), any()))
+                .thenReturn(List.of(enTiempo, cerradaRetrasada, abiertaRetrasada));
+
+        IndicadoresProduccionResponseDTO resultado = service.calcularIndicadores(
+                LocalDate.now().minusDays(3), LocalDate.now());
+
+        assertThat(resultado.getTotalOrdenesPeriodo()).isEqualTo(3);
+        assertThat(resultado.getOrdenesEnTiempo()).isEqualTo(1);
+        assertThat(resultado.getOrdenesRetrasadas()).isEqualTo(2);
+        assertThat(resultado.getOrdenesAbiertasConVencimientoVencido()).isEqualTo(1);
+        assertThat(resultado.getCantidadTotalPlanificada()).isEqualByComparingTo("23.00");
+        assertThat(resultado.getCantidadTotalProducida()).isEqualByComparingTo("16.00");
+        assertThat(resultado.getPorcentajeCumplimiento()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("calcularIndicadores retorna cero cuando no hay ordenes")
+    void calcularIndicadores_sinOrdenes() {
+        when(ordenProduccionRepository.findByFechaFinBetween(any(), any())).thenReturn(List.of());
+
+        IndicadoresProduccionResponseDTO resultado = service.calcularIndicadores(
+                LocalDate.now().minusDays(1), LocalDate.now());
+
+        assertThat(resultado.getTotalOrdenesPeriodo()).isZero();
+        assertThat(resultado.getPorcentajeCumplimiento()).isZero();
+        assertThat(resultado.getCantidadTotalPlanificada()).isEqualByComparingTo("0.00");
+        assertThat(resultado.getCantidadTotalProducida()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    @DisplayName("obtenerOrdenesConAlertas identifica proximas y retrasadas")
+    void obtenerOrdenesConAlertas_devuelveLista() {
+        LocalDate referencia = LocalDate.now();
+        OrdenProduccion proxima = OrdenProduccion.builder()
+                .id(10L)
+                .codigoOrden("OP-PROX")
+                .estado(EstadoProduccion.EN_PROCESO)
+                .fechaFin(referencia.plusDays(2).atStartOfDay())
+                .build();
+
+        OrdenProduccion retrasada = OrdenProduccion.builder()
+                .id(11L)
+                .codigoOrden("OP-RET")
+                .estado(EstadoProduccion.EN_PROCESO)
+                .fechaFin(referencia.minusDays(1).atStartOfDay())
+                .build();
+
+        when(ordenProduccionRepository.findByEstadoNotInAndFechaFinBetween(any(), any(), any()))
+                .thenReturn(List.of(proxima));
+        when(ordenProduccionRepository.findByEstadoNotInAndFechaFinBefore(any(), any()))
+                .thenReturn(List.of(retrasada));
+
+        List<AlertaOrdenProduccionDTO> alertas = service.obtenerOrdenesConAlertas(referencia, 3);
+
+        assertThat(alertas).hasSize(2);
+        assertThat(alertas)
+                .extracting(AlertaOrdenProduccionDTO::getTipoAlerta)
+                .containsExactlyInAnyOrder("PROXIMA_VENCER", "RETRASADA");
+    }
+}


### PR DESCRIPTION
## Summary
- Add KPI service and DTOs to calcular cumplimiento del programa y sumar cantidades producidas
- Expose secured endpoints para indicadores y alertas de órdenes próximas o retrasadas
- Incorporate repository filters y pruebas unitarias para escenarios de cumplimiento y alertas

## Testing
- mvn -Dtest=ProduccionIndicadoresServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ebecf890083339ecc0d70d748d226)