### PR TITLE
Add production order alistamiento view and filtering

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
@@ -46,6 +46,7 @@ public class SolicitudMovimientoController {
             @RequestParam(required = false) String busqueda,
             @RequestParam(required = false) Long almacenOrigenId,
             @RequestParam(required = false) Long almacenDestinoId,
+            @RequestParam(required = false) Long ordenProduccionId,
             @RequestParam(required = false) String fechaDesde,
             @RequestParam(required = false) String fechaHasta
     ) {
@@ -63,7 +64,15 @@ public class SolicitudMovimientoController {
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "fechaDesde no puede ser mayor a fechaHasta");
                 }
             }
-            Page<SolicitudMovimientoListadoDTO> page = service.listarSolicitudes(estado, busqueda, almacenOrigenId, almacenDestinoId, inicio, fin, sanitized);
+            Page<SolicitudMovimientoListadoDTO> page = service.listarSolicitudes(
+                    estado,
+                    busqueda,
+                    almacenOrigenId,
+                    almacenDestinoId,
+                    ordenProduccionId,
+                    inicio,
+                    fin,
+                    sanitized);
             return ResponseEntity.ok(page);
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoService.java
@@ -16,6 +16,7 @@ public interface SolicitudMovimientoService {
                                                           String busqueda,
                                                           Long almacenOrigenId,
                                                           Long almacenDestinoId,
+                                                          Long ordenProduccionId,
                                                           LocalDateTime inicio,
                                                           LocalDateTime fin,
                                                           Pageable pageable);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -187,6 +187,7 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                                                                  String busqueda,
                                                                  Long almacenOrigenId,
                                                                  Long almacenDestinoId,
+                                                                 Long ordenProduccionId,
                                                                  LocalDateTime desde,
                                                                  LocalDateTime hasta,
                                                                  Pageable pageable) {
@@ -208,6 +209,11 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
         if (almacenDestinoId != null) {
             Specification<SolicitudMovimiento> filtro = (root, query, cb) ->
                     cb.equal(root.join("almacenDestino", jakarta.persistence.criteria.JoinType.LEFT).get("id"), almacenDestinoId);
+            spec = spec == null ? Specification.where(filtro) : spec.and(filtro);
+        }
+        if (ordenProduccionId != null) {
+            Specification<SolicitudMovimiento> filtro = (root, query, cb) ->
+                    cb.equal(root.join("ordenProduccion", jakarta.persistence.criteria.JoinType.LEFT).get("id"), ordenProduccionId);
             spec = spec == null ? Specification.where(filtro) : spec.and(filtro);
         }
         LocalDateTime inicio = desde;

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/AlistamientoProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/AlistamientoProduccionController.java
@@ -1,0 +1,25 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.dto.AlistamientoOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.service.ProduccionAlistamientoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/produccion/ordenes")
+@RequiredArgsConstructor
+public class AlistamientoProduccionController {
+
+    private final ProduccionAlistamientoService alistamientoService;
+
+    @GetMapping("/{id}/alistamiento")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<AlistamientoOrdenProduccionDTO> obtenerAlistamiento(@PathVariable Long id) {
+        return ResponseEntity.ok(alistamientoService.obtenerAlistamientoPorOrden(id));
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/AlistamientoOrdenProduccionDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/AlistamientoOrdenProduccionDTO.java
@@ -1,0 +1,16 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Builder
+@Data
+public class AlistamientoOrdenProduccionDTO {
+    private Long ordenId;
+    private String codigoOrden;
+    private String estadoOrden;
+    private String estadoAlistamiento;
+    private List<SolicitudAlistamientoResumenDTO> solicitudes;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/SolicitudAlistamientoResumenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/SolicitudAlistamientoResumenDTO.java
@@ -1,0 +1,18 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Data
+public class SolicitudAlistamientoResumenDTO {
+    private Long solicitudId;
+    private String codigoSolicitud;
+    private String estado;
+    private LocalDateTime fechaCreacion;
+    private String almacenOrigenNombre;
+    private String almacenDestinoNombre;
+    private Integer totalLineas;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionAlistamientoService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionAlistamientoService.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.AlistamientoOrdenProduccionDTO;
+
+public interface ProduccionAlistamientoService {
+    AlistamientoOrdenProduccionDTO obtenerAlistamientoPorOrden(Long ordenId);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionAlistamientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionAlistamientoServiceImpl.java
@@ -1,0 +1,91 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
+import com.willyes.clemenintegra.produccion.dto.AlistamientoOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.dto.SolicitudAlistamientoResumenDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ProduccionAlistamientoServiceImpl implements ProduccionAlistamientoService {
+
+    private static final Set<EstadoSolicitudMovimiento> ESTADOS_LISTO =
+            EnumSet.of(EstadoSolicitudMovimiento.ATENDIDA, EstadoSolicitudMovimiento.CERRADA);
+    private static final List<EstadoProduccion> ESTADOS_OP_CERRADAS = List.of(
+            EstadoProduccion.FINALIZADA,
+            EstadoProduccion.CANCELADA,
+            EstadoProduccion.CERRADA_INCOMPLETA
+    );
+
+    private final OrdenProduccionRepository ordenProduccionRepository;
+    private final SolicitudMovimientoRepository solicitudMovimientoRepository;
+
+    @Override
+    public AlistamientoOrdenProduccionDTO obtenerAlistamientoPorOrden(Long ordenId) {
+        OrdenProduccion orden = ordenProduccionRepository.findById(ordenId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Orden de producción no encontrada"));
+
+        List<SolicitudMovimiento> solicitudes = solicitudMovimientoRepository.findWithDetalles(
+                ordenId,
+                null,
+                null,
+                null,
+                false,
+                ESTADOS_OP_CERRADAS
+        );
+
+        List<SolicitudAlistamientoResumenDTO> resumenes = solicitudes.stream()
+                .map(this::toResumen)
+                .toList();
+
+        String estadoAlistamiento = determinarEstadoAlistamiento(solicitudes);
+
+        return AlistamientoOrdenProduccionDTO.builder()
+                .ordenId(orden.getId())
+                .codigoOrden(orden.getCodigoOrden())
+                .estadoOrden(orden.getEstado() != null ? orden.getEstado().name() : null)
+                .estadoAlistamiento(estadoAlistamiento)
+                .solicitudes(resumenes)
+                .build();
+    }
+
+    private String determinarEstadoAlistamiento(List<SolicitudMovimiento> solicitudes) {
+        if (solicitudes == null || solicitudes.isEmpty()) {
+            return "SIN_SOLICITUD";
+        }
+        boolean todasListas = solicitudes.stream()
+                .map(SolicitudMovimiento::getEstado)
+                .filter(Objects::nonNull)
+                .allMatch(ESTADOS_LISTO::contains);
+        if (todasListas) {
+            return "LISTO";
+        }
+        return "EN_PROCESO";
+    }
+
+    private SolicitudAlistamientoResumenDTO toResumen(SolicitudMovimiento solicitud) {
+        return SolicitudAlistamientoResumenDTO.builder()
+                .solicitudId(solicitud.getId())
+                .codigoSolicitud(solicitud.getId() != null ? solicitud.getId().toString() : null)
+                .estado(solicitud.getEstado() != null ? solicitud.getEstado().name() : null)
+                .fechaCreacion(solicitud.getFechaSolicitud())
+                .almacenOrigenNombre(solicitud.getAlmacenOrigen() != null ? solicitud.getAlmacenOrigen().getNombre() : null)
+                .almacenDestinoNombre(solicitud.getAlmacenDestino() != null ? solicitud.getAlmacenDestino().getNombre() : null)
+                .totalLineas(solicitud.getDetalles() != null ? solicitud.getDetalles().size() : null)
+                .build();
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceOrdenProduccionFiltroTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceOrdenProduccionFiltroTest.java
@@ -1,0 +1,104 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SolicitudMovimientoServiceOrdenProduccionFiltroTest {
+
+    @Mock
+    private SolicitudMovimientoRepository repository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private LoteProductoRepository loteRepository;
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private ReservaLoteService reservaLoteService;
+
+    @InjectMocks
+    private SolicitudMovimientoServiceImpl service;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(repository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+    }
+
+    @Test
+    void listarSolicitudes_aplicaFiltroPorOrdenProduccion() {
+        Page<?> resultado = service.listarSolicitudes(null, null, null, null, 15L, null, null, Pageable.unpaged());
+
+        ArgumentCaptor<Specification<SolicitudMovimiento>> captor = ArgumentCaptor.forClass(Specification.class);
+        verify(repository).findAll(captor.capture(), eq(Pageable.unpaged()));
+
+        Specification<SolicitudMovimiento> specification = captor.getValue();
+
+        Root<SolicitudMovimiento> root = mock(Root.class);
+        @SuppressWarnings("unchecked")
+        Join<Object, Object> join = mock(Join.class);
+        @SuppressWarnings("unchecked")
+        Path<Object> path = mock(Path.class);
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+        CriteriaBuilder cb = mock(CriteriaBuilder.class);
+        Predicate predicate = mock(Predicate.class);
+
+        when(root.join("ordenProduccion", JoinType.LEFT)).thenReturn(join);
+        when(join.get("id")).thenReturn(path);
+        when(cb.equal(path, 15L)).thenReturn(predicate);
+
+        specification.toPredicate(root, query, cb);
+
+        verify(cb).equal(path, 15L);
+        verify(root).join("ordenProduccion", JoinType.LEFT);
+        verify(join).get("id");
+        verify(cb).equal(path, 15L);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/AlistamientoProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/AlistamientoProduccionControllerTest.java
@@ -1,0 +1,80 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.dto.AlistamientoOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.dto.SolicitudAlistamientoResumenDTO;
+import com.willyes.clemenintegra.produccion.service.ProduccionAlistamientoService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AlistamientoProduccionController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+@ImportAutoConfiguration(exclude = {
+        SecurityAutoConfiguration.class,
+        SecurityFilterAutoConfiguration.class,
+        UserDetailsServiceAutoConfiguration.class
+})
+@TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
+@EnableMethodSecurity
+class AlistamientoProduccionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProduccionAlistamientoService alistamientoService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void obtenerAlistamientoRetornaDto() throws Exception {
+        AlistamientoOrdenProduccionDTO dto = AlistamientoOrdenProduccionDTO.builder()
+                .ordenId(1L)
+                .codigoOrden("OP-123")
+                .estadoOrden("EN_PROCESO")
+                .estadoAlistamiento("EN_PROCESO")
+                .solicitudes(List.of(
+                        SolicitudAlistamientoResumenDTO.builder()
+                                .solicitudId(5L)
+                                .estado("PENDIENTE")
+                                .fechaCreacion(LocalDateTime.of(2024, 1, 1, 10, 0))
+                                .build()
+                ))
+                .build();
+
+        when(alistamientoService.obtenerAlistamientoPorOrden(eq(1L))).thenReturn(dto);
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}/alistamiento", 1L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.codigoOrden").value("OP-123"))
+                .andExpect(jsonPath("$.estadoAlistamiento").value("EN_PROCESO"))
+                .andExpect(jsonPath("$.solicitudes[0].solicitudId").value(5L));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/ProduccionAlistamientoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/ProduccionAlistamientoServiceImplTest.java
@@ -1,0 +1,118 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
+import com.willyes.clemenintegra.produccion.dto.AlistamientoOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProduccionAlistamientoServiceImplTest {
+
+    @Mock
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock
+    private SolicitudMovimientoRepository solicitudMovimientoRepository;
+
+    @InjectMocks
+    private ProduccionAlistamientoServiceImpl service;
+
+    @Test
+    void obtenerAlistamiento_sinSolicitudesDevuelveSinSolicitud() {
+        OrdenProduccion orden = crearOrden();
+        when(ordenProduccionRepository.findById(orden.getId())).thenReturn(Optional.of(orden));
+        when(solicitudMovimientoRepository.findWithDetalles(eq(orden.getId()), any(), any(), any(), eq(false), any()))
+                .thenReturn(List.of());
+
+        AlistamientoOrdenProduccionDTO dto = service.obtenerAlistamientoPorOrden(orden.getId());
+
+        assertThat(dto.getEstadoAlistamiento()).isEqualTo("SIN_SOLICITUD");
+        assertThat(dto.getSolicitudes()).isEmpty();
+    }
+
+    @Test
+    void obtenerAlistamiento_enProcesoCuandoHayPendientes() {
+        OrdenProduccion orden = crearOrden();
+        when(ordenProduccionRepository.findById(orden.getId())).thenReturn(Optional.of(orden));
+        when(solicitudMovimientoRepository.findWithDetalles(eq(orden.getId()), any(), any(), any(), eq(false), any()))
+                .thenReturn(List.of(
+                        crearSolicitud(1L, EstadoSolicitudMovimiento.PENDIENTE),
+                        crearSolicitud(2L, EstadoSolicitudMovimiento.AUTORIZADA)
+                ));
+
+        AlistamientoOrdenProduccionDTO dto = service.obtenerAlistamientoPorOrden(orden.getId());
+
+        assertThat(dto.getEstadoAlistamiento()).isEqualTo("EN_PROCESO");
+        assertThat(dto.getSolicitudes()).hasSize(2);
+    }
+
+    @Test
+    void obtenerAlistamiento_listoCuandoTodasAtendidasOCerradas() {
+        OrdenProduccion orden = crearOrden();
+        when(ordenProduccionRepository.findById(orden.getId())).thenReturn(Optional.of(orden));
+        when(solicitudMovimientoRepository.findWithDetalles(eq(orden.getId()), any(), any(), any(), eq(false), any()))
+                .thenReturn(List.of(
+                        crearSolicitud(10L, EstadoSolicitudMovimiento.ATENDIDA),
+                        crearSolicitud(11L, EstadoSolicitudMovimiento.CERRADA)
+                ));
+
+        AlistamientoOrdenProduccionDTO dto = service.obtenerAlistamientoPorOrden(orden.getId());
+
+        assertThat(dto.getEstadoAlistamiento()).isEqualTo("LISTO");
+    }
+
+    @Test
+    void obtenerAlistamiento_lanza404CuandoNoExisteOrden() {
+        when(ordenProduccionRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.obtenerAlistamientoPorOrden(99L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Orden de producción no encontrada");
+    }
+
+    private OrdenProduccion crearOrden() {
+        return OrdenProduccion.builder()
+                .id(5L)
+                .codigoOrden("OP-01")
+                .estado(EstadoProduccion.EN_PROCESO)
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(java.math.BigDecimal.ONE)
+                .cantidadProducida(java.math.BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(java.math.BigDecimal.ZERO)
+                .build();
+    }
+
+    private SolicitudMovimiento crearSolicitud(Long id, EstadoSolicitudMovimiento estado) {
+        Almacen almacenOrigen = new Almacen();
+        almacenOrigen.setNombre("Origen");
+        Almacen almacenDestino = new Almacen();
+        almacenDestino.setNombre("Destino");
+
+        return SolicitudMovimiento.builder()
+                .id(id)
+                .estado(estado)
+                .fechaSolicitud(LocalDateTime.now())
+                .almacenOrigen(almacenOrigen)
+                .almacenDestino(almacenDestino)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- add optional `ordenProduccionId` filter to inventory movement request listing
- introduce production alistamiento DTOs, service, and controller endpoint for aggregated readiness per order
- add unit and controller tests for the new filter and alistamiento logic

## Testing
- mvn -q -DskipITs test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ec8a9a58c8333915ea87fa7619641)