### PR TITLE
Ajustar validación de transferencias y manejo de errores

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -227,6 +227,9 @@ public class MovimientoInventarioController {
             log.info("[INVENTARIO] movimiento registrado correctamente: {}", creado.getId());
             return ResponseEntity.status(HttpStatus.CREATED).body(creado);
 
+        } catch (ResponseStatusException e) {
+            log.warn("[INVENTARIO] error funcional al registrar movimiento: {}", e.getReason());
+            throw e;
         } catch (NoSuchElementException e) {
             log.warn("[INVENTARIO] entidad no encontrada: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.NOT_FOUND)

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -1945,12 +1945,18 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                                 detalleContexto != null ? detalleContexto.getId() : null,
                                 loteOrigen.getId(), stockDisponibleEfectivoContextual, stockReservadoTotal,
                                 reservaAjena, reservadoPropio, cantidadSolicitadaContextual, producto.getId());
-                        throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE");
+                        throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                                tipo == TipoMovimiento.TRANSFERENCIA
+                                        ? "LOTE_NO_DISPONIBLE_TRANSFERIR"
+                                        : "LOTE_STOCK_INSUFICIENTE");
                     }
                 } else if (stockDisponibleEfectivo.compareTo(cantidad) < 0) {
                     log.warn("Stock insuficiente en lote (SIN_SOLICITUD): loteId={} disponible={} reservaPendiente={} solicitado={} productoId={}",
                             loteOrigen.getId(), stockDisponibleEfectivo, reservaPendiente, cantidad, producto.getId());
-                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE");
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                            tipo == TipoMovimiento.TRANSFERENCIA
+                                    ? "LOTE_NO_DISPONIBLE_TRANSFERIR"
+                                    : "LOTE_STOCK_INSUFICIENTE");
                 }
             }
         }
@@ -1992,14 +1998,34 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                 LoteProducto loteRespuesta = loteProcesadoOp != null ? loteProcesadoOp : loteOrigen;
                 return List.of(new MovimientoLoteDetalle(loteRespuesta, cantidad));
             }
-            if (loteOrigen.getEstado() != EstadoLote.DISPONIBLE) {
+            // Se rechaza la transferencia solo si el lote está agotado/sin disponible, en otro almacén de origen
+            // o su estado no es transferible (calidad ya se valida en LoteCalidadValidator).
+            Long almacenActualId = loteOrigen.getAlmacen() != null
+                    ? loteOrigen.getAlmacen().getId().longValue()
+                    : null;
+            Long almacenOrigenSolicitudId = almacenOrigen != null
+                    ? almacenOrigen.getId().longValue()
+                    : (dto.almacenOrigenId() != null ? dto.almacenOrigenId().longValue() : null);
+            boolean almacenesCoinciden = almacenOrigenSolicitudId == null
+                    || Objects.equals(almacenActualId, almacenOrigenSolicitudId);
+
+            BigDecimal disponibleTransferencia = calcularDisponibleLote(loteOrigen);
+            boolean sinDisponible = loteOrigen.isAgotado()
+                    || disponibleTransferencia.compareTo(cantidad) < 0;
+
+            EnumSet<EstadoLote> estadosTransferibles = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
+            boolean estadoNoTransferible = loteOrigen.getEstado() == null
+                    || !estadosTransferibles.contains(loteOrigen.getEstado());
+
+            // BUG: antes se rechazaba incluso con estado LIBERADO en almacén de origen con stock suficiente.
+            if (sinDisponible || !almacenesCoinciden || estadoNoTransferible) {
                 log.warn(
-                        "Transferencia con lote no disponible: loteId={} estado={} origenId={} destinoId={} productoId={} cantidad={}",
-                        loteOrigen.getId(), loteOrigen.getEstado(),
-                        origen != null ? origen.getId() : null,
-                        destino != null ? destino.getId() : null,
-                        producto.getId(), cantidad);
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_DISPONIBLE_TRANSFERIR");
+                        "Transferencia con lote no disponible (almacen/stock/estado inválido): loteId={} estado={} agotado={} disponible={} solicitado={} almacenActualId={} almacenOrigenSolicitudId={} destinoId={} productoId={}",
+                        loteOrigen.getId(), loteOrigen.getEstado(), loteOrigen.isAgotado(), disponibleTransferencia,
+                        cantidad, almacenActualId, almacenOrigenSolicitudId, destino != null ? destino.getId() : null,
+                        producto.getId());
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "LOTE_NO_DISPONIBLE_TRANSFERIR");
             }
 
             if (!requiereAutoSplit) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerErrorHandlingTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerErrorHandlingTest.java
@@ -1,0 +1,88 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import com.willyes.clemenintegra.inventario.service.StockQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MovimientoInventarioController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MovimientoInventarioControllerErrorHandlingTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MovimientoInventarioService movimientoInventarioService;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private StockQueryService stockQueryService;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.repository.ProductoRepository productoRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.repository.LoteProductoRepository loteProductoRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository solicitudMovimientoRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @BeforeEach
+    void setUpMocks() {
+        Mockito.reset(movimientoInventarioService, inventoryCatalogResolver, stockQueryService,
+                productoRepository, loteProductoRepository, solicitudMovimientoRepository);
+    }
+
+    @Test
+    @WithMockUser(username = "analista", authorities = "ROL_ALMACENISTA")
+    void cuandoServicioLanzaResponseStatusExceptionSePropaga() throws Exception {
+        when(movimientoInventarioService.registrarMovimiento(any()))
+                .thenThrow(new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "LOTE_NO_DISPONIBLE_TRANSFERIR"));
+
+        String payload = """
+                {
+                  \"tipoMovimiento\": \"TRANSFERENCIA\",
+                  \"clasificacionMovimientoInventario\": \"TRANSFERENCIA_GENERAL\",
+                  \"productoId\": 8,
+                  \"cantidad\": 1000,
+                  \"almacenOrigenId\": 1,
+                  \"almacenDestinoId\": 6,
+                  \"tipoMovimientoDetalleId\": 5
+                }
+                """;
+
+        mockMvc.perform(post("/api/movimientos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isUnprocessableEntity());
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -673,7 +673,7 @@ class MovimientoInventarioServiceSolicitudOpTest {
 
         assertThatThrownBy(() -> service.registrarMovimiento(dto))
                 .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("LOTE_STOCK_INSUFICIENTE");
+                .hasMessageContaining("LOTE_NO_DISPONIBLE_TRANSFERIR");
     }
 
     @Test
@@ -760,7 +760,7 @@ class MovimientoInventarioServiceSolicitudOpTest {
 
         assertThatThrownBy(() -> service.registrarMovimiento(dto))
                 .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("LOTE_STOCK_INSUFICIENTE");
+                .hasMessageContaining("LOTE_NO_DISPONIBLE_TRANSFERIR");
 
         verify(solicitudMovimientoRepository, never()).findByIdWithLock(anyLong());
     }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
@@ -1,0 +1,242 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.TipoMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MovimientoInventarioServiceTransferenciaTest {
+
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private ProveedorRepository proveedorRepository;
+    @Mock
+    private OrdenCompraRepository ordenCompraRepository;
+    @Mock
+    private OrdenCompraService ordenCompraService;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private MovimientoInventarioMapper mapper;
+    @Mock
+    private UsuarioService usuarioService;
+    @Mock
+    private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock
+    private InventoryCatalogResolver catalogResolver;
+    @Mock
+    private ReservaLoteService reservaLoteService;
+    @Mock
+    private ReservaLoteRepository reservaLoteRepository;
+    @Mock
+    private RecepcionOCService recepcionOCService;
+    @Mock
+    private LoteCalidadValidator loteCalidadValidator;
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private MovimientoInventarioServiceImpl service;
+
+    @BeforeEach
+    void setupSecurity() {
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("tester", "secret");
+        authentication.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        lenient().when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(null);
+    }
+
+    @Test
+    void transferenciaConLoteLiberadoEnOrigenSeAcepta() {
+        Producto producto = crearProducto(8, 2);
+        LoteProducto lote = crearLote(30L, producto, 1, EstadoLote.LIBERADO,
+                new BigDecimal("4000"), BigDecimal.ZERO, false);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("1000"),
+                TipoMovimiento.TRANSFERENCIA,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_GENERAL,
+                null,
+                null,
+                producto.getId(),
+                lote.getId(),
+                1,
+                6,
+                null,
+                null,
+                null,
+                5L,
+                null,
+                null,
+                null,
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                null
+        );
+
+        configurarMocksBasicos(producto, lote);
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(dto.tipoMovimiento());
+        movimientoEntidad.setClasificacion(dto.clasificacionMovimientoInventario());
+        movimientoEntidad.setCantidad(dto.cantidad());
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(200L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willReturn(MovimientoInventarioResponseDTO.builder().id(200L).build());
+
+        MovimientoInventarioResponseDTO respuesta = service.registrarMovimiento(dto);
+
+        assertThat(respuesta).isNotNull();
+        assertThat(respuesta.getId()).isEqualTo(200L);
+        assertThat(lote.getStockLote()).isEqualByComparingTo(new BigDecimal("3000.00"));
+    }
+
+    @Test
+    void transferenciaConStockInsuficienteDisparaError() {
+        Producto producto = crearProducto(9, 2);
+        LoteProducto lote = crearLote(31L, producto, 1, EstadoLote.LIBERADO,
+                new BigDecimal("500"), BigDecimal.ZERO, false);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("1000"),
+                TipoMovimiento.TRANSFERENCIA,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_GENERAL,
+                null,
+                null,
+                producto.getId(),
+                lote.getId(),
+                1,
+                6,
+                null,
+                null,
+                null,
+                5L,
+                null,
+                null,
+                null,
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                null
+        );
+
+        configurarMocksBasicos(producto, lote);
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setTipoMovimiento(dto.tipoMovimiento());
+        movimientoEntidad.setClasificacion(dto.clasificacionMovimientoInventario());
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+
+        assertThatThrownBy(() -> service.registrarMovimiento(dto))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("LOTE_NO_DISPONIBLE_TRANSFERIR");
+    }
+
+    private void configurarMocksBasicos(Producto producto, LoteProducto lote) {
+        given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
+        given(tipoMovimientoDetalleRepository.findById(5L)).willReturn(Optional.of(new TipoMovimientoDetalle()));
+        given(loteProductoRepository.findByIdForUpdate(lote.getId())).willReturn(Optional.of(lote));
+        lenient().when(loteProductoRepository.findByCodigoLoteAndProductoIdAndAlmacenId(
+                lote.getCodigoLote(), producto.getId(), 6)).thenReturn(Optional.empty());
+        lenient().when(loteProductoRepository.save(any(LoteProducto.class))).thenAnswer(invocation -> {
+            LoteProducto loteArgument = invocation.getArgument(0);
+            if (loteArgument.getId() == null) {
+                loteArgument.setId(900L);
+            }
+            return loteArgument;
+        });
+        lenient().when(entityManager.getReference(eq(Almacen.class), any()))
+                .thenAnswer(invocation -> {
+                    Object id = invocation.getArgument(1);
+                    return new Almacen(id instanceof Integer ? (Integer) id : ((Long) id).intValue());
+                });
+        lenient().when(catalogResolver.decimals(any())).thenReturn(2);
+    }
+
+    private Producto crearProducto(Integer id, int escala) {
+        Producto producto = new Producto();
+        producto.setId(id);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(100L);
+        producto.setUnidadMedida(unidad);
+        lenient().when(catalogResolver.decimals(unidad)).thenReturn(escala);
+        return producto;
+    }
+
+    private LoteProducto crearLote(Long id,
+                                   Producto producto,
+                                   Integer almacenId,
+                                   EstadoLote estado,
+                                   BigDecimal stock,
+                                   BigDecimal reservado,
+                                   boolean agotado) {
+        LoteProducto lote = new LoteProducto();
+        lote.setId(id);
+        lote.setCodigoLote("L-" + id);
+        lote.setProducto(producto);
+        lote.setAlmacen(new Almacen(almacenId));
+        lote.setEstado(estado);
+        lote.setStockLote(stock);
+        lote.setStockReservado(reservado);
+        lote.setAgotado(agotado);
+        return lote;
+    }
+}


### PR DESCRIPTION
## Summary
- Refined transferencia validations to allow liberar stock while blocking agotado/estado/almacén inconsistencies and reused quality checks
- Propagated ResponseStatusException statuses from el controlador to avoid masking 4xx errores
- Added unit and controller tests for transferencias disponibles/no disponibles y propagación de 422

## Testing
- mvn -Dtest=MovimientoInventarioService*,MovimientoInventarioController* test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694032e7c30483338e873548d79a0f43)