### PR TITLE
Add date-based repository and controller tests

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerFechaWebMvcTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerFechaWebMvcTest.java
@@ -1,0 +1,129 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import com.willyes.clemenintegra.inventario.service.StockQueryService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = MovimientoInventarioController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class),
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class
+        })
+@AutoConfigureMockMvc(addFilters = false)
+class MovimientoInventarioControllerFechaWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MovimientoInventarioService movimientoInventarioService;
+    @MockBean
+    private ProductoRepository productoRepository;
+    @MockBean
+    private LoteProductoRepository loteProductoRepository;
+    @MockBean
+    private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    @MockBean
+    private StockQueryService stockQueryService;
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    @DisplayName("/filtrar parsea fechas y devuelve resultados ordenados por fechaIngreso desc")
+    void filtrarDebeRetornarOrdenDescPorFechaIngreso() throws Exception {
+        MovimientoInventarioResponseDTO masReciente = MovimientoInventarioResponseDTO.builder()
+                .id(1L)
+                .fechaIngreso(LocalDateTime.of(2025, 12, 16, 10, 15))
+                .tipoMovimiento(TipoMovimiento.RECEPCION)
+                .clasificacion(ClasificacionMovimientoInventario.RECEPCION_COMPRA.name())
+                .cantidad(BigDecimal.TEN)
+                .build();
+
+        MovimientoInventarioResponseDTO masAntiguo = MovimientoInventarioResponseDTO.builder()
+                .id(2L)
+                .fechaIngreso(LocalDateTime.of(2025, 12, 8, 9, 0))
+                .tipoMovimiento(TipoMovimiento.RECEPCION)
+                .clasificacion(ClasificacionMovimientoInventario.RECEPCION_COMPRA.name())
+                .cantidad(BigDecimal.ONE)
+                .build();
+
+        Page<MovimientoInventarioResponseDTO> page = new PageImpl<>(
+                List.of(masReciente, masAntiguo),
+                PageRequest.of(0, 20),
+                2
+        );
+
+        given(movimientoInventarioService.filtrar(any(), any(), any(), any(), any(), any(), any(Pageable.class)))
+                .willReturn(page);
+
+        mockMvc.perform(get("/api/movimientos/filtrar")
+                        .param("fechaInicio", "2025-12-08")
+                        .param("fechaFin", "2025-12-16")
+                        .param("page", "0")
+                        .param("size", "20")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].fechaIngreso").value("2025-12-16T10:15:00"))
+                .andExpect(jsonPath("$.content[1].fechaIngreso").value("2025-12-08T09:00:00"));
+
+        ArgumentCaptor<LocalDateTime> inicioCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> finCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+
+        verify(movimientoInventarioService).filtrar(
+                inicioCaptor.capture(),
+                finCaptor.capture(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                any(Pageable.class)
+        );
+
+        assertThat(inicioCaptor.getValue()).isEqualTo(LocalDateTime.of(2025, 12, 8, 0, 0));
+        assertThat(finCaptor.getValue()).isEqualTo(LocalDateTime.of(2025, 12, 16, 23, 59, 59));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepositoryFechaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepositoryFechaTest.java
@@ -1,0 +1,175 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.*;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.TestPropertySource;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop",
+        "spring.flyway.enabled=false",
+        "DB_SECURPASS=dummy",
+        "DB_SECURNAME=dummy"
+})
+class MovimientoInventarioRepositoryFechaTest {
+
+    @Autowired
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Usuario usuario;
+    private Producto producto;
+    private LoteProducto lote;
+    private MotivoMovimiento motivoMovimiento;
+    private TipoMovimientoDetalle tipoMovimientoDetalle;
+    private Almacen almacen;
+
+    @BeforeEach
+    void setUp() {
+        usuario = entityManager.persist(Usuario.builder()
+                .nombreUsuario("tester")
+                .clave("clave")
+                .nombreCompleto("Usuario Test")
+                .correo("tester@example.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = entityManager.persist(UnidadMedida.builder()
+                .nombre("Unidad")
+                .nombrePlural("Unidades")
+                .simbolo("U")
+                .codigo("U01")
+                .simboloImpresion("U")
+                .build());
+
+        CategoriaProducto categoria = entityManager.persist(CategoriaProducto.builder()
+                .nombre("MP")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        producto = entityManager.persist(Producto.builder()
+                .codigoSku("SKU-1")
+                .nombre("Producto de prueba")
+                .stockMinimo(BigDecimal.ONE)
+                .stockMinimoProveedor(BigDecimal.ZERO)
+                .leadTimeCompraDias(1)
+                .leadTimeProduccionDias(1)
+                .stockSeguridad(BigDecimal.ZERO)
+                .stockMaximoPlaneacion(BigDecimal.ZERO)
+                .rendimientoUnidad(BigDecimal.ONE)
+                .activo(true)
+                .fechaCreacion(LocalDateTime.now())
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+
+        almacen = entityManager.persist(Almacen.builder()
+                .nombre("Principal")
+                .ubicacion("Bodega")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        lote = entityManager.persist(LoteProducto.builder()
+                .codigoLote("L-001")
+                .fechaFabricacion(LocalDateTime.of(2025, 12, 1, 10, 0))
+                .fechaVencimiento(LocalDateTime.of(2026, 1, 1, 10, 0))
+                .stockLote(BigDecimal.TEN)
+                .agotado(false)
+                .stockReservado(BigDecimal.ZERO)
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(producto)
+                .almacen(almacen)
+                .build());
+
+        motivoMovimiento = entityManager.persist(MotivoMovimiento.builder()
+                .descripcion("Compra")
+                .motivo(ClasificacionMovimientoInventario.RECEPCION_COMPRA)
+                .build());
+
+        tipoMovimientoDetalle = entityManager.persist(TipoMovimientoDetalle.builder()
+                .descripcion("Detalle")
+                .build());
+    }
+
+    @Test
+    @DisplayName("filtrar por fechaIngreso respeta rango y orden descendente")
+    void filtrarPorRangoYOrden() {
+        MovimientoInventario movimientoAntiguo = crearMovimiento(
+                LocalDateTime.of(2025, 12, 10, 9, 0),
+                BigDecimal.valueOf(5)
+        );
+        MovimientoInventario movimientoReciente = crearMovimiento(
+                LocalDateTime.of(2025, 12, 15, 15, 30),
+                BigDecimal.valueOf(8)
+        );
+        // Fuera de rango
+        crearMovimiento(LocalDateTime.of(2025, 12, 20, 8, 0), BigDecimal.valueOf(12));
+
+        LocalDateTime inicio = LocalDateTime.of(2025, 12, 9, 0, 0);
+        LocalDateTime fin = LocalDateTime.of(2025, 12, 16, 23, 59, 59);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("fechaIngreso").descending());
+
+        Page<MovimientoInventario> page = movimientoInventarioRepository.filtrar(
+                inicio, fin, null, null, null, null, pageable
+        );
+
+        List<MovimientoInventario> resultados = page.getContent();
+        assertThat(resultados)
+                .hasSize(2)
+                .extracting(MovimientoInventario::getId)
+                .containsExactly(movimientoReciente.getId(), movimientoAntiguo.getId());
+        assertThat(resultados.get(0).getFechaIngreso()).isAfterOrEqualTo(resultados.get(1).getFechaIngreso());
+    }
+
+    private MovimientoInventario crearMovimiento(LocalDateTime fechaIngreso, BigDecimal cantidad) {
+        MovimientoInventario movimiento = MovimientoInventario.builder()
+                .cantidad(cantidad)
+                .tipoMovimiento(TipoMovimiento.RECEPCION)
+                .clasificacion(ClasificacionMovimientoInventario.RECEPCION_COMPRA)
+                .fechaIngreso(fechaIngreso)
+                .docReferencia("OC-123")
+                .registradoPor(usuario)
+                .producto(producto)
+                .lote(lote)
+                .almacenOrigen(almacen)
+                .almacenDestino(null)
+                .motivoMovimiento(motivoMovimiento)
+                .tipoMovimientoDetalle(tipoMovimientoDetalle)
+                .build();
+
+        movimientoInventarioRepository.save(movimiento);
+        entityManager.flush();
+        entityManager.clear();
+        return movimiento;
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated @DataJpaTest for MovimientoInventarioRepository to verify fechaIngreso range filtering and descending order
- replace the controller integration test with a lightweight WebMvcTest mocking service and security dependencies to assert date parsing and ordering
- ensure movement API slice test uses mocked provider/filter to avoid full security context

## Testing
- mvn -Dtest=MovimientoInventarioRepositoryFechaTest,MovimientoInventarioControllerFechaWebMvcTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694042bd80888333adc8cd4b258941ab)