### PR TITLE
Add Windows MySQL backup and restore verification runbooks

### DIFF
--- a/ops/backups/README.md
+++ b/ops/backups/README.md
@@ -1,0 +1,60 @@
+# Backups MySQL (Ops)
+
+Solución operativa para respaldos diarios y verificación semanal de restauración de la base de datos MySQL usada por el backend Spring Boot. Todo está pensado para ejecutarse en servidores/PC Windows con PowerShell y clientes MySQL 8 instalados.
+
+## Alcance
+- Protege la base de datos principal (por defecto `clemen_integra_erp`).
+- Genera respaldos diarios comprimidos en ZIP con hash SHA256 y rotación.
+- Verifica semanalmente que el último respaldo pueda restaurarse en una base temporal y que existan datos en tablas clave.
+- No almacena credenciales en el repositorio. Usa `mysql_config_editor` (`login-path`) o un `defaults-extra-file` ubicado fuera del repo.
+
+## Estructura
+```
+ops/backups/
+├─ README.md                   <- este archivo
+└─ mysql/
+   └─ windows/
+      ├─ backup_mysql.ps1
+      ├─ verify_restore_mysql.ps1
+      ├─ README.md            <- guía paso a paso en Windows
+      └─ task-scheduler/      <- plantillas XML de tareas programadas
+```
+
+## Parámetros principales
+- **Directorio de destino**: `ops/backups/mysql/windows/data` (configurable en cada script).
+- **Retención**: 30 días por defecto.
+- **Programación sugerida**:
+  - Backup diario a las 02:00 AM (`backup_mysql.ps1`).
+  - Verificación de restauración cada domingo 03:00 AM (`verify_restore_mysql.ps1`).
+- **Salida de cada ejecución**:
+  - `NOMBREDB_YYYYMMDD_HHMM.zip` + `NOMBREDB_YYYYMMDD_HHMM.zip.sha256`
+  - `backup_YYYYMMDD.log` o `verify_restore_YYYYMMDD.log`
+
+## Restauración manual rápida
+1. Ubicar el ZIP más reciente en la carpeta de backups y validar su hash:
+   ```powershell
+   Get-FileHash .\clemen_integra_erp_YYYYMMDD_HHMM.zip -Algorithm SHA256
+   Get-Content .\clemen_integra_erp_YYYYMMDD_HHMM.zip.sha256
+   ```
+2. Descomprimir el ZIP para obtener el `.sql`.
+3. Restaurar con el login-path configurado:
+   ```powershell
+   mysql --login-path=clemen_backup -e "DROP DATABASE IF EXISTS clemen_integra_erp;"
+   mysql --login-path=clemen_backup -e "CREATE DATABASE clemen_integra_erp CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+   mysql --login-path=clemen_backup clemen_integra_erp < clemen_integra_erp_YYYYMMDD_HHMM.sql
+   ```
+   > Alternativa: usar `--defaults-extra-file` apuntando a un archivo de credenciales **fuera** del repositorio.
+
+## Validación manual
+- Ejecutar `verify_restore_mysql.ps1` para validar restauración y consultas de salud sobre tablas clave (`productos`, `lotes_productos`, `movimientos_inventario`).
+- Revisar el log generado en la carpeta de backups para confirmar `INFO Verificación de restauración completada exitosamente`.
+
+## Monitoreo y logs
+- Cada script genera un log por día en la carpeta de backups (`backup_YYYYMMDD.log` y `verify_restore_YYYYMMDD.log`).
+- Buscar líneas con `[ERROR]` o códigos de salida distintos de `0` en el Programador de tareas.
+
+## Recomendación offsite
+Copiar periódicamente la carpeta de backups (ZIP + logs) a almacenamiento externo o carpeta de red segura para protegerse contra fallas locales. El proceso puede ser manual o automatizado fuera del alcance de estos scripts.
+
+## Más detalles
+Consulta `ops/backups/mysql/windows/README.md` para pasos exactos de configuración, ejemplos y plantillas del Programador de tareas.

--- a/ops/backups/mysql/windows/README.md
+++ b/ops/backups/mysql/windows/README.md
@@ -1,0 +1,130 @@
+# Backups MySQL en Windows
+
+Scripts operativos para crear backups diarios y verificar restauración semanal en MySQL 8, sin exponer credenciales en el repositorio.
+
+## Prerrequisitos
+- Windows con PowerShell 5+.
+- Cliente MySQL 8 (`mysqldump.exe` y `mysql.exe`) en el PATH.
+- Permisos para crear bases de datos y ejecutar `mysql_config_editor`.
+- Carpeta de destino accesible para escribir backups (por defecto `ops/backups/mysql/windows/data`).
+
+## Configurar credenciales seguras
+### Opción A (recomendada): `mysql_config_editor`
+1. Abrir PowerShell en el servidor.
+2. Registrar el login-path (ejemplo con usuario `backup_user`):
+   ```powershell
+   mysql_config_editor set --login-path=clemen_backup --host=localhost --user=backup_user --password
+   ```
+   Se solicitará la contraseña y quedará cifrada en `%APPDATA%\MySQL\.mylogin.cnf`.
+3. Probar conexión:
+   ```powershell
+   mysql --login-path=clemen_backup -e "SELECT NOW();"
+   ```
+
+### Opción B: `--defaults-extra-file`
+1. Crear un archivo fuera del repositorio, por ejemplo `C:\secure\mysql-backup.cnf`:
+   ```
+   [client]
+   user=backup_user
+   password=********
+   host=localhost
+   ```
+2. Probar conexión:
+   ```powershell
+   mysql --defaults-extra-file=C:\secure\mysql-backup.cnf -e "SELECT NOW();"
+   ```
+3. Pasar la ruta del archivo al parámetro `-DefaultsExtraFile` de cada script.
+
+> No guardes usuario/clave dentro del repositorio.
+
+## Script: `backup_mysql.ps1`
+- Hora sugerida: todos los días 02:00 AM.
+- Genera: `NOMBREDB_YYYYMMDD_HHMM.zip`, `NOMBREDB_YYYYMMDD_HHMM.zip.sha256` y `backup_YYYYMMDD.log`.
+- Flags usados: `--single-transaction --routines --triggers --events --hex-blob --default-character-set=utf8mb4`.
+
+### Uso manual
+```powershell
+cd ops\backups\mysql\windows
+./backup_mysql.ps1 -DatabaseName "clemen_integra_erp" -BackupDirectory "D:\backups\mysql" -RetentionDays 30 -LoginPath "clemen_backup"
+# o usando defaults-extra-file
+./backup_mysql.ps1 -DefaultsExtraFile "C:\\secure\\mysql-backup.cnf"
+```
+
+### Comprobación del resultado
+```powershell
+Get-ChildItem D:\backups\mysql
+Get-Content D:\backups\mysql\backup_YYYYMMDD.log
+Get-Content D:\backups\mysql\clemen_integra_erp_YYYYMMDD_HHMM.zip.sha256
+Get-FileHash D:\backups\mysql\clemen_integra_erp_YYYYMMDD_HHMM.zip -Algorithm SHA256
+```
+
+## Script: `verify_restore_mysql.ps1`
+- Hora sugerida: domingos 03:00 AM.
+- Busca el último ZIP, valida SHA256, restaura en `<db>_restorecheck`, ejecuta consultas y elimina la base temporal.
+- Log: `verify_restore_YYYYMMDD.log`.
+
+### Uso manual
+```powershell
+cd ops\backups\mysql\windows
+./verify_restore_mysql.ps1 -DatabaseName "clemen_integra_erp" -BackupDirectory "D:\backups\mysql" -LoginPath "clemen_backup"
+# o usando defaults-extra-file
+./verify_restore_mysql.ps1 -DefaultsExtraFile "C:\\secure\\mysql-backup.cnf"
+```
+
+### Qué valida
+- Integridad del ZIP (coincidencia SHA256).
+- Restauración en base temporal `clemen_integra_erp_restorecheck`.
+- Consultas de salud:
+  - `SELECT COUNT(*) FROM productos;`
+  - `SELECT COUNT(*) FROM lotes_productos;`
+  - `SELECT COUNT(*) FROM movimientos_inventario;`
+
+Si cualquier paso falla, el script sale con código diferente de `0` y registra `[ERROR]` en el log.
+
+## Programar tareas en Windows (Task Scheduler)
+### Importar plantillas
+1. Abrir **Task Scheduler** > **Import Task...**.
+2. Seleccionar la plantilla desde `ops\backups\mysql\windows\task-scheduler`:
+   - `mysql_backup_daily.xml` para el backup diario 02:00 AM.
+   - `mysql_verify_restore_weekly.xml` para la verificación semanal domingo 03:00 AM.
+3. Ajustar:
+   - Usuario que ejecuta la tarea (con permisos de MySQL y escritura de backups).
+   - Ruta absoluta de `Program/Arguments` hacia `powershell.exe` y el script.
+   - Ruta de `Start in` hacia la carpeta que contiene los scripts.
+
+### Crear manualmente (alternativa)
+```powershell
+# Backup diario
+schtasks /Create /SC DAILY /TN "MySQL Backup" /TR "powershell -ExecutionPolicy Bypass -File C:\ops\backups\mysql\windows\backup_mysql.ps1" /ST 02:00
+
+# Verificación semanal
+schtasks /Create /SC WEEKLY /D SUN /TN "MySQL Verify Restore" /TR "powershell -ExecutionPolicy Bypass -File C:\ops\backups\mysql\windows\verify_restore_mysql.ps1" /ST 03:00
+```
+> Ajusta las rutas y parámetros (por ejemplo `-BackupDirectory` y `-DefaultsExtraFile`).
+
+## Restauración manual a producción
+1. Validar hash del ZIP.
+2. Detener la aplicación que use la BD.
+3. `DROP DATABASE` y `CREATE DATABASE` de la base objetivo con `utf8mb4`.
+4. Importar el `.sql` con `mysql --login-path=clemen_backup <archivo>`.
+5. Arrancar la aplicación y revisar.
+
+## Dónde revisar logs y qué hacer si falla
+- Carpeta de backups: revisar los archivos `backup_YYYYMMDD.log` y `verify_restore_YYYYMMDD.log`.
+- Task Scheduler: revisar History / Last Run Result (0x0 indica éxito).
+- Acciones sugeridas ante fallas:
+  - Validar conectividad MySQL con `mysql --login-path=clemen_backup -e "SELECT 1;"`.
+  - Revisar espacio en disco y permisos de escritura en la carpeta de backups.
+  - Reconfigurar credenciales con `mysql_config_editor set --login-path=clemen_backup ...`.
+  - Reejecutar el script manualmente para confirmar.
+
+## Ejemplo de ejecución local (sin credenciales reales)
+```powershell
+# Simular con parámetros mínimos en una máquina con MySQL local y login-path configurado
+cd ops\backups\mysql\windows
+./backup_mysql.ps1 -BackupDirectory "C:\\temp\\mysql-backups"
+./verify_restore_mysql.ps1 -BackupDirectory "C:\\temp\\mysql-backups"
+```
+
+## Nota offsite
+Recomienda copiar la carpeta de backups (ZIP + logs) a un medio externo o carpeta de red segura después de cada respaldo. Esto no está automatizado en estos scripts.

--- a/ops/backups/mysql/windows/backup_mysql.ps1
+++ b/ops/backups/mysql/windows/backup_mysql.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+    Realiza un backup diario de MySQL con rotación y hash SHA256.
+.DESCRIPTION
+    - Usa mysql_config_editor (login-path) o un archivo defaults-extra-file externo al repositorio.
+    - Genera un archivo .sql, lo comprime en ZIP y crea un archivo .sha256.
+    - Elimina respaldos más antiguos que el número de días definido en $RetentionDays.
+    - Registra la ejecución en un archivo de log por día.
+#>
+
+param(
+    [string]$DatabaseName = "clemen_integra_erp",
+    [string]$BackupDirectory = (Join-Path $PSScriptRoot "data"),
+    [int]$RetentionDays = 30,
+    [string]$LoginPath = "clemen_backup",
+    [string]$MysqlDumpPath = "mysqldump",
+    [string]$DefaultsExtraFile = ""
+)
+
+$ErrorActionPreference = "Stop"
+$timestamp = Get-Date -Format "yyyyMMdd_HHmm"
+$today = Get-Date -Format "yyyyMMdd"
+$logDirectory = $BackupDirectory
+$logFile = Join-Path $logDirectory "backup_${today}.log"
+
+function Write-Log {
+    param(
+        [string]$Message,
+        [ValidateSet("INFO","WARN","ERROR")]
+        [string]$Level = "INFO"
+    )
+    $line = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [$Level] $Message"
+    Write-Output $line
+    Add-Content -Path $logFile -Value $line
+}
+
+try {
+    if (-not (Test-Path -Path $BackupDirectory)) {
+        Write-Log "Creando directorio de backups en '$BackupDirectory'" "INFO"
+        New-Item -Path $BackupDirectory -ItemType Directory -Force | Out-Null
+    }
+
+    $dumpFile = Join-Path $BackupDirectory "${DatabaseName}_${timestamp}.sql"
+    $zipFile = Join-Path $BackupDirectory "${DatabaseName}_${timestamp}.zip"
+    $hashFile = "$zipFile.sha256"
+
+    $dumpArgs = @("--single-transaction","--routines","--triggers","--events","--hex-blob","--default-character-set=utf8mb4")
+
+    if ([string]::IsNullOrWhiteSpace($DefaultsExtraFile)) {
+        $dumpArgs += "--login-path=$LoginPath"
+    }
+    else {
+        $dumpArgs += "--defaults-extra-file=$DefaultsExtraFile"
+    }
+
+    $dumpArgs += $DatabaseName
+
+    Write-Log "Iniciando backup de base de datos '$DatabaseName'" "INFO"
+    $dumpArgs += @("--result-file=$dumpFile")
+
+    & $MysqlDumpPath @($dumpArgs) 2>&1 | ForEach-Object { Write-Log $_ "INFO" }
+
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $dumpFile)) {
+        throw "mysqldump falló con código $LASTEXITCODE"
+    }
+
+    Write-Log "Compresion ZIP -> '$zipFile'" "INFO"
+    Compress-Archive -Path $dumpFile -DestinationPath $zipFile -Force
+
+    if (-not (Test-Path $zipFile)) {
+        throw "No se generó el archivo ZIP"
+    }
+
+    Remove-Item -Path $dumpFile -Force
+
+    $fileHash = Get-FileHash -Algorithm SHA256 -Path $zipFile
+    "${fileHash.Hash} $(Split-Path -Leaf $zipFile)" | Set-Content -Path $hashFile -Encoding ASCII
+    Write-Log "Hash SHA256 generado en '$hashFile'" "INFO"
+
+    Write-Log "Iniciando rotación de backups (retención: $RetentionDays días)" "INFO"
+    $threshold = (Get-Date).AddDays(-$RetentionDays)
+    $oldBackups = Get-ChildItem -Path $BackupDirectory -File | Where-Object { $_.LastWriteTime -lt $threshold -and ($_.Extension -in '.zip','.sha256','.log') }
+    foreach ($item in $oldBackups) {
+        Write-Log "Eliminando backup antiguo '${item.FullName}'" "WARN"
+        Remove-Item -Path $item.FullName -Force
+    }
+
+    Write-Log "Backup finalizado exitosamente" "INFO"
+    exit 0
+}
+catch {
+    Write-Log $_.Exception.Message "ERROR"
+    exit 1
+}

--- a/ops/backups/mysql/windows/task-scheduler/mysql_backup_daily.xml
+++ b/ops/backups/mysql/windows/task-scheduler/mysql_backup_daily.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Backup MySQL diario con rotación y hash SHA256.</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <CalendarTrigger>
+      <StartBoundary>2024-01-01T02:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+      <ScheduleByDay>
+        <DaysInterval>1</DaysInterval>
+      </ScheduleByDay>
+    </CalendarTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>DOMAIN\\USER</UserId>
+      <RunLevel>HighestAvailable</RunLevel>
+      <LogonType>Password</LogonType>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT2H</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>-ExecutionPolicy Bypass -File "C:\\ops\\backups\\mysql\\windows\\backup_mysql.ps1" -BackupDirectory "C:\\backups\\mysql" -LoginPath "clemen_backup"</Arguments>
+      <WorkingDirectory>C:\\ops\\backups\\mysql\\windows</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>

--- a/ops/backups/mysql/windows/task-scheduler/mysql_verify_restore_weekly.xml
+++ b/ops/backups/mysql/windows/task-scheduler/mysql_verify_restore_weekly.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Verificación semanal de restauración de backup MySQL.</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <CalendarTrigger>
+      <StartBoundary>2024-01-07T03:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+      <ScheduleByWeek>
+        <DaysOfWeek>
+          <Sunday/>
+        </DaysOfWeek>
+        <WeeksInterval>1</WeeksInterval>
+      </ScheduleByWeek>
+    </CalendarTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>DOMAIN\\USER</UserId>
+      <RunLevel>HighestAvailable</RunLevel>
+      <LogonType>Password</LogonType>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT3H</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>-ExecutionPolicy Bypass -File "C:\\ops\\backups\\mysql\\windows\\verify_restore_mysql.ps1" -BackupDirectory "C:\\backups\\mysql" -LoginPath "clemen_backup"</Arguments>
+      <WorkingDirectory>C:\\ops\\backups\\mysql\\windows</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>

--- a/ops/backups/mysql/windows/verify_restore_mysql.ps1
+++ b/ops/backups/mysql/windows/verify_restore_mysql.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+    Verifica semanalmente que el backup más reciente puede restaurarse en una base temporal.
+.DESCRIPTION
+    - Valida integridad del ZIP usando el archivo .sha256 generado por el backup.
+    - Restaura en <DatabaseName>_restorecheck, ejecuta consultas de salud y elimina la base temporal.
+    - Usa login-path de mysql_config_editor o defaults-extra-file externo.
+#>
+
+param(
+    [string]$DatabaseName = "clemen_integra_erp",
+    [string]$BackupDirectory = (Join-Path $PSScriptRoot "data"),
+    [string]$LoginPath = "clemen_backup",
+    [string]$MysqlClientPath = "mysql",
+    [string]$DefaultsExtraFile = ""
+)
+
+$ErrorActionPreference = "Stop"
+$today = Get-Date -Format "yyyyMMdd"
+$logFile = Join-Path $BackupDirectory "verify_restore_${today}.log"
+$tempDbName = "${DatabaseName}_restorecheck"
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "mysql_restorecheck"
+
+function Write-Log {
+    param(
+        [string]$Message,
+        [ValidateSet("INFO","WARN","ERROR")]
+        [string]$Level = "INFO"
+    )
+    $line = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [$Level] $Message"
+    Write-Output $line
+    Add-Content -Path $logFile -Value $line
+}
+
+function Invoke-MysqlCommand {
+    param(
+        [string]$Command,
+        [string]$Database
+    )
+    $args = @()
+    if ([string]::IsNullOrWhiteSpace($DefaultsExtraFile)) {
+        $args += "--login-path=$LoginPath"
+    }
+    else {
+        $args += "--defaults-extra-file=$DefaultsExtraFile"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Database)) {
+        $args += "--database=$Database"
+    }
+
+    $args += "-e"
+    $args += $Command
+
+    & $MysqlClientPath @($args)
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "mysql falló con código $LASTEXITCODE al ejecutar: $Command"
+    }
+}
+
+try {
+    if (-not (Test-Path -Path $BackupDirectory)) {
+        throw "Directorio de backups no encontrado: $BackupDirectory"
+    }
+
+    $latestBackup = Get-ChildItem -Path $BackupDirectory -Filter "${DatabaseName}_*.zip" -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if (-not $latestBackup) {
+        throw "No hay backups ZIP disponibles para restaurar"
+    }
+
+    $hashFile = "$($latestBackup.FullName).sha256"
+    if (-not (Test-Path $hashFile)) {
+        Write-Log "No se encontró el archivo de hash para validar integridad ($hashFile)." "WARN"
+    }
+    else {
+        $expected = (Get-Content -Path $hashFile -ErrorAction Stop).Split(" ")[0]
+        $actual = (Get-FileHash -Algorithm SHA256 -Path $latestBackup.FullName).Hash
+        if ($expected -ne $actual) {
+            throw "Hash SHA256 no coincide para ${latestBackup.Name}"
+        }
+        Write-Log "Integridad del backup verificada mediante SHA256." "INFO"
+    }
+
+    if (Test-Path $tempDir) { Remove-Item -Path $tempDir -Recurse -Force }
+    New-Item -Path $tempDir -ItemType Directory | Out-Null
+
+    Write-Log "Descomprimiendo ${latestBackup.Name} en $tempDir" "INFO"
+    Expand-Archive -Path $latestBackup.FullName -DestinationPath $tempDir -Force
+
+    $sqlFile = Get-ChildItem -Path $tempDir -Filter "*.sql" -File | Select-Object -First 1
+    if (-not $sqlFile) { throw "No se encontró archivo SQL dentro del ZIP" }
+
+    Write-Log "Recreando base temporal '$tempDbName'" "INFO"
+    Invoke-MysqlCommand -Command "DROP DATABASE IF EXISTS \`$tempDbName\`;" -Database ""
+    Invoke-MysqlCommand -Command "CREATE DATABASE \`$tempDbName\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" -Database ""
+
+    Write-Log "Restaurando desde ${sqlFile.FullName}" "INFO"
+    $mysqlArgs = @()
+    if ([string]::IsNullOrWhiteSpace($DefaultsExtraFile)) {
+        $mysqlArgs += "--login-path=$LoginPath"
+    }
+    else {
+        $mysqlArgs += "--defaults-extra-file=$DefaultsExtraFile"
+    }
+    $mysqlArgs += "--database=$tempDbName"
+
+    $restoreCmd = "\"$MysqlClientPath\" ${($mysqlArgs -join ' ')} < \"$($sqlFile.FullName)\""
+    cmd.exe /c $restoreCmd
+    if ($LASTEXITCODE -ne 0) {
+        throw "Restauración falló con código $LASTEXITCODE"
+    }
+
+    $healthQueries = @(
+        @{ Description = "Conteo de productos"; Query = "SELECT COUNT(*) AS total_productos FROM productos;" },
+        @{ Description = "Conteo de lotes"; Query = "SELECT COUNT(*) AS total_lotes FROM lotes_productos;" },
+        @{ Description = "Conteo de movimientos"; Query = "SELECT COUNT(*) AS total_movimientos FROM movimientos_inventario;" }
+    )
+
+    foreach ($check in $healthQueries) {
+        Write-Log "Ejecutando chequeo: $($check.Description)" "INFO"
+        $result = & $MysqlClientPath @($mysqlArgs) "-e" $check.Query
+        if ($LASTEXITCODE -ne 0) {
+            throw "Consulta de salud falló: $($check.Description)"
+        }
+        $result | ForEach-Object { Write-Log $_ "INFO" }
+    }
+
+    Write-Log "Verificación de restauración completada exitosamente" "INFO"
+}
+catch {
+    Write-Log $_.Exception.Message "ERROR"
+    exit 1
+}
+finally {
+    try {
+        Write-Log "Eliminando base temporal '$tempDbName'" "INFO"
+        Invoke-MysqlCommand -Command "DROP DATABASE IF EXISTS \`$tempDbName\`;" -Database ""
+    }
+    catch {
+        Write-Log "No se pudo limpiar la base temporal: $($_.Exception.Message)" "WARN"
+    }
+
+    if (Test-Path $tempDir) { Remove-Item -Path $tempDir -Recurse -Force }
+}


### PR DESCRIPTION
## Summary
- add PowerShell scripts for daily MySQL backups with zip compression, SHA256 hash, and retention
- add weekly restore verification script with health checks and cleanup
- document setup, scheduling, and manual recovery in new ops backup guides and Task Scheduler templates

## Testing
- not run (documentation and scripts only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404921c0248333b31ae4b103112202)