### PR TITLE
Configure forwarded headers and CORS for proxy deployments

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,8 @@
+# Operación y despliegue
+
+El backend de Clemen Integra ERP se publica detrás de un reverse proxy/Tunnel (p. ej. Cloudflare) que termina HTTPS.
+
+- **Encabezados reenviados**: la aplicación debe respetar los encabezados `X-Forwarded-*`/`Forwarded` para que las URLs generadas conserven el esquema seguro (`https`). Configura el perfil que uses con `server.forward-headers-strategy=framework` (ya definido en los perfiles principales).
+- **CORS**: define el dominio real del frontend vía `CORS_ALLOWED_ORIGINS` o ajustando `app.cors.allowed-origins` en el perfil correspondiente. En producción el valor por defecto es `https://erp.clemenlab.com`.
+
+Al publicar detrás del túnel, asegúrate de que el proxy reenvíe `X-Forwarded-Proto=https` y `X-Forwarded-Host` para que Spring detecte correctamente el origen seguro.

--- a/src/main/resources/application-demo.properties
+++ b/src/main/resources/application-demo.properties
@@ -1,6 +1,7 @@
 # Puerto y binding en IPv4 (evita el ::1)
 server.port=8080
 server.address=127.0.0.1
+server.forward-headers-strategy=framework
 # Or\u00EDgenes para demo (Vercel + Tunnel)
 app.cors.allowed-origins=https://clemen-integra-demo-front.vercel.app,https://*.trycloudflare.com
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -7,8 +7,8 @@ spring.application.name=clemen-integra-erp
 # --- Puerto de la app en el servidor ---
 # Puedes cambiar SERVER_PORT en el servidor, por defecto 8080
 server.port=8081
-app.cors.allowed-origins=http://localhost:4173
-# --- app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:https://erp.clemenlab.com}
+server.forward-headers-strategy=framework
+app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:https://erp.clemenlab.com}
 
 # --- Datasource MySQL (PRODUCCIÓN) ---
 # URL de BD, por defecto apunta a localhost y a la base clemen_integra_erp

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,7 @@ spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=INFO
 
 server.port=8081
+server.forward-headers-strategy=framework
 app.cors.allowed-origins=http://localhost:5173,http://127.0.0.1:5173
 #springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html

--- a/src/test/java/com/willyes/clemenintegra/shared/security/ForwardHeadersIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/ForwardHeadersIntegrationTest.java
@@ -1,0 +1,73 @@
+package com.willyes.clemenintegra.shared.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ForwardHeadersIntegrationTest.ForwardedSchemeController.class)
+@TestPropertySource(properties = {
+        "server.forward-headers-strategy=framework"
+})
+@Import({ForwardHeadersIntegrationTest.ForwardedSchemeController.class, ForwardHeadersIntegrationTest.TestSecurityConfig.class})
+class ForwardHeadersIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser
+    void respectsForwardedProtoHttps() throws Exception {
+        mockMvc.perform(get("/test/forwarded-scheme")
+                        .header("X-Forwarded-Proto", "https")
+                        .header("X-Forwarded-Host", "example.com")
+                        .header("X-Forwarded-Port", "443"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(startsWith("https://example.com/test/forwarded-scheme")));
+    }
+
+    @RestController
+    public static class ForwardedSchemeController {
+
+        @GetMapping("/test/forwarded-scheme")
+        public String currentRequestUri(HttpServletRequest request) {
+            return ServletUriComponentsBuilder.fromCurrentRequest()
+                    .build()
+                    .toUriString();
+        }
+    }
+
+    @Configuration
+    static class TestSecurityConfig {
+
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+            return http.build();
+        }
+
+        @Bean
+        ForwardedHeaderFilter forwardedHeaderFilter() {
+            return new ForwardedHeaderFilter();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable forward header processing in main, demo, and prod profiles to honor HTTPS behind tunnels
- update production CORS origins to default to the public HTTPS domain and document proxy expectations under ops/README
- add a WebMvc test confirming requests respect X-Forwarded-Proto when building URLs

## Testing
- mvn -q -Dtest=ForwardHeadersIntegrationTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69406428538c8333a268404046b1da01)