### PR TITLE
Fix: actualizar tests Movimientos a firma con Idempotency-Key y evitar NPE en controller

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -226,6 +226,10 @@ public class MovimientoInventarioController {
 
             // 2) Registrar movimiento
             MovimientoInventarioResponseDTO creado = service.registrarMovimiento(dto, idempotencyKey);
+            if (creado == null) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                        "El servicio de movimientos no devolvió respuesta");
+            }
             log.info("[INVENTARIO] movimiento registrado correctamente: {}", creado.getId());
             return ResponseEntity.status(HttpStatus.CREATED).body(creado);
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerErrorHandlingTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerErrorHandlingTest.java
@@ -18,7 +18,10 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.UUID;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -67,7 +70,7 @@ class MovimientoInventarioControllerErrorHandlingTest {
     @Test
     @WithMockUser(username = "analista", authorities = "ROL_ALMACENISTA")
     void cuandoServicioLanzaResponseStatusExceptionSePropaga() throws Exception {
-        when(movimientoInventarioService.registrarMovimiento(any()))
+        when(movimientoInventarioService.registrarMovimiento(any(), anyString()))
                 .thenThrow(new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                         "LOTE_NO_DISPONIBLE_TRANSFERIR"));
 
@@ -85,6 +88,7 @@ class MovimientoInventarioControllerErrorHandlingTest {
 
         mockMvc.perform(post("/api/movimientos")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header("Idempotency-Key", "test-" + UUID.randomUUID())
                         .content(payload))
                 .andExpect(status().isUnprocessableEntity());
     }
@@ -92,7 +96,7 @@ class MovimientoInventarioControllerErrorHandlingTest {
     @Test
     @WithMockUser(username = "analista", authorities = "ROL_ALMACENISTA")
     void cuandoLoteNoLiberadoRetorna422ConCodigo() throws Exception {
-        when(movimientoInventarioService.registrarMovimiento(any()))
+        when(movimientoInventarioService.registrarMovimiento(any(), anyString()))
                 .thenThrow(new CustomBusinessException(ApiErrorCode.CALIDAD_LOTE_NO_LIBERADO,
                         "El lote aún no está liberado por Calidad y no puede utilizarse en esta operación."));
 
@@ -109,6 +113,7 @@ class MovimientoInventarioControllerErrorHandlingTest {
 
         mockMvc.perform(post("/api/movimientos")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header("Idempotency-Key", "test-" + UUID.randomUUID())
                         .content(payload))
                 .andExpect(status().isUnprocessableEntity())
                 .andExpect(jsonPath("$.code").value(ApiErrorCode.CALIDAD_LOTE_NO_LIBERADO.getCode()))
@@ -118,7 +123,7 @@ class MovimientoInventarioControllerErrorHandlingTest {
     @Test
     @WithMockUser(username = "analista", authorities = "ROL_ALMACENISTA")
     void transferenciaLiberadaDevuelveCreated() throws Exception {
-        when(movimientoInventarioService.registrarMovimiento(any()))
+        when(movimientoInventarioService.registrarMovimiento(any(), anyString()))
                 .thenReturn(com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO.builder()
                         .id(42L)
                         .build());
@@ -136,6 +141,7 @@ class MovimientoInventarioControllerErrorHandlingTest {
 
         mockMvc.perform(post("/api/movimientos")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header("Idempotency-Key", "test-" + UUID.randomUUID())
                         .content(payload))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(42));

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerSalidaPtTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerSalidaPtTest.java
@@ -21,10 +21,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -85,7 +87,7 @@ class MovimientoInventarioControllerSalidaPtTest {
                 .clasificacion(ClasificacionMovimientoInventario.SALIDA_CLIENTE.name())
                 .cantidad(BigDecimal.valueOf(50))
                 .build();
-        when(movimientoInventarioService.registrarMovimiento(any(MovimientoInventarioDTO.class)))
+        when(movimientoInventarioService.registrarMovimiento(any(MovimientoInventarioDTO.class), anyString()))
                 .thenReturn(response);
 
         String payload = """
@@ -105,12 +107,13 @@ class MovimientoInventarioControllerSalidaPtTest {
 
         mockMvc.perform(post("/api/movimientos")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header("Idempotency-Key", "test-" + UUID.randomUUID())
                         .content(payload))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(1));
 
         ArgumentCaptor<MovimientoInventarioDTO> captor = ArgumentCaptor.forClass(MovimientoInventarioDTO.class);
-        verify(movimientoInventarioService).registrarMovimiento(captor.capture());
+        verify(movimientoInventarioService).registrarMovimiento(captor.capture(), anyString());
         assertThat(captor.getValue().fechaVencimiento()).as("fechaVencimiento debe ser opcional para salida PT")
                 .isNull();
     }

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/MovimientoInventarioControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/MovimientoInventarioControllerSmokeTest.java
@@ -31,8 +31,10 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -93,10 +95,11 @@ class MovimientoInventarioControllerSmokeTest {
                 .fechaIngreso(LocalDateTime.now())
                 .build();
 
-        when(movimientoInventarioService.registrarMovimiento(any())).thenReturn(response);
+        when(movimientoInventarioService.registrarMovimiento(any(), anyString())).thenReturn(response);
 
         mockMvc.perform(post("/api/movimientos")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header("Idempotency-Key", "test-" + UUID.randomUUID())
                         .content(objectMapper.writeValueAsString(payload)))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
## Summary
- Update MovimientoInventario controller tests to stub the new service signature and send Idempotency-Key headers
- Add a defensive null check in registrar to avoid NPE when the service returns no response

## Testing
- mvn -Dtest=MovimientoInventarioControllerSmokeTest test
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694074bfbf10833397cedaedc6eb4726)