### PR TITLE
Document Windows operations and enable actuator health

### DIFF
--- a/ops/HealthWatchdog.ps1
+++ b/ops/HealthWatchdog.ps1
@@ -1,0 +1,36 @@
+param(
+    [string]$ServiceName = "ClemenERP-Backend",
+    [string]$HealthUrl = "http://localhost:8080/actuator/health",
+    [int]$TimeoutSeconds = 10,
+    [string]$LogFile = "C:\\ClemenERP\\logs\\health-watchdog.log"
+)
+
+$timestamp = (Get-Date).ToString("s")
+$logPrefix = "[$timestamp]"
+
+function Write-Log($message) {
+    "$logPrefix $message" | Out-File -FilePath $LogFile -Append -Encoding utf8
+}
+
+try {
+    $response = Invoke-RestMethod -Method Get -Uri $HealthUrl -TimeoutSec $TimeoutSeconds
+    if ($response.status -eq "UP" -or $response.status -eq "up") {
+        Write-Log "Health OK ($HealthUrl)."
+        exit 0
+    }
+    Write-Log "Health en estado inesperado: $($response | ConvertTo-Json -Compress). Reiniciando $ServiceName"
+}
+catch {
+    Write-Log "Error al consultar health: $($_.Exception.Message). Reiniciando $ServiceName"
+}
+
+# Si llegó aquí, reinicia el servicio
+try {
+    Write-Log "Reiniciando servicio $ServiceName"
+    Restart-Service -Name $ServiceName -Force -ErrorAction Stop
+    Write-Log "Servicio $ServiceName reiniciado"
+}
+catch {
+    Write-Log "Fallo al reiniciar $ServiceName: $($_.Exception.Message)"
+    exit 1
+}

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,8 +1,89 @@
 # Operación y despliegue
 
-El backend de Clemen Integra ERP se publica detrás de un reverse proxy/Tunnel (p. ej. Cloudflare) que termina HTTPS.
+## Publicación detrás de túnel/Reverse Proxy
+El backend se publica detrás de un túnel HTTPS (Cloudflared) que termina TLS públicamente y reenvía al backend por `http://localhost:8080` dentro del servidor.
 
-- **Encabezados reenviados**: la aplicación debe respetar los encabezados `X-Forwarded-*`/`Forwarded` para que las URLs generadas conserven el esquema seguro (`https`). Configura el perfil que uses con `server.forward-headers-strategy=framework` (ya definido en los perfiles principales).
-- **CORS**: define el dominio real del frontend vía `CORS_ALLOWED_ORIGINS` o ajustando `app.cors.allowed-origins` en el perfil correspondiente. En producción el valor por defecto es `https://erp.clemenlab.com`.
+- **Encabezados reenviados**: `server.forward-headers-strategy=framework` ya está activo en los perfiles principales para respetar `X-Forwarded-*`/`Forwarded` y conservar el esquema seguro (`https`).
+- **CORS**: define el dominio real del frontend vía `CORS_ALLOWED_ORIGINS` o ajusta `app.cors.allowed-origins` en el perfil correspondiente. En producción el valor por defecto es `https://erp.clemenlab.com`.
+- **Objetivo**: HTTPS público extremo a extremo. Cloudflared termina TLS y reenvía al backend local en 8080; el frontend consume únicamente la URL pública.
 
-Al publicar detrás del túnel, asegúrate de que el proxy reenvíe `X-Forwarded-Proto=https` y `X-Forwarded-Host` para que Spring detecte correctamente el origen seguro.
+## Carpeta recomendada en Windows
+```
+C:\ClemenERP\
+├─ backend\           (JAR y config Spring Boot)
+├─ cloudflared\       (config.yml, credenciales del túnel)
+├─ logs\              (stdout/stderr de servicios, logs de app)
+├─ config\            (vars/env, archivos .env opcionales)
+├─ ops\               (scripts operativos, p. ej. HealthWatchdog.ps1)
+└─ backups\           (respaldos BD/config)
+```
+
+## Servicios Windows (NSSM)
+Nombres estándar de servicios:
+- **ClemenERP-Backend**: ejecuta `java -jar clemen-integra-erp.jar --spring.profiles.active=prod`
+- **ClemenERP-Tunnel**: ejecuta el túnel Cloudflared apuntando al backend local.
+
+### Backend (ClemenERP-Backend)
+1. Copia el JAR a `C:\ClemenERP\backend\clemen-integra-erp.jar`.
+2. Instala con NSSM (ejecutar en PowerShell/Administrador):
+   ```powershell
+   nssm install ClemenERP-Backend "C:\Program Files\Java\jdk-21\bin\java.exe" \
+       -jar "C:\ClemenERP\backend\clemen-integra-erp.jar" --spring.profiles.active=prod
+   ```
+3. En **I/O** de NSSM define:
+   - `stdout`: `C:\ClemenERP\logs\backend-stdout.log`
+   - `stderr`: `C:\ClemenERP\logs\backend-stderr.log`
+   - Habilita rotación por tamaño (p. ej. 10 MB, conservar 7 archivos).
+4. En **Environment** agrega variables requeridas (`DB_URL`, `DB_USERNAME`, `DB_PASS`, `CORS_ALLOWED_ORIGINS`, `SERVER_PORT` si deseas diferente a 8080, etc.).
+5. En **Shutdown** usa `Graceful` para permitir cierre limpio.
+6. Habilita reinicio automático ante fallos:
+   ```powershell
+   sc.exe failure ClemenERP-Backend reset= 0 actions= restart/5000/restart/5000/restart/5000
+   ```
+7. Inicia y verifica:
+   ```powershell
+   nssm start ClemenERP-Backend
+   ```
+
+### Cloudflared Tunnel (ClemenERP-Tunnel)
+1. Instala Cloudflared y coloca `config.yml` en `C:\ClemenERP\cloudflared\config.yml`.
+2. Plantilla mínima de `config.yml` (reemplaza `<DOMINIO>` y `tunnel:` por el ID creado en Cloudflare):
+   ```yaml
+   tunnel: <ID_DEL_TUNEL>
+   credentials-file: C:\ClemenERP\cloudflared\<ID_DEL_TUNEL>.json
+   ingress:
+     - hostname: api.<DOMINIO>
+       service: http://localhost:8080
+     - service: http_status:404
+   originRequest:
+     connectTimeout: 10s
+   ```
+3. Instala el servicio NSSM:
+   ```powershell
+   nssm install ClemenERP-Tunnel "C:\Program Files\cloudflared\cloudflared.exe" tunnel run
+   ```
+   - Directorio de inicio: `C:\ClemenERP\cloudflared`
+   - `stdout`/`stderr`: `C:\ClemenERP\logs\cloudflared-stdout.log` y `cloudflared-stderr.log` (con rotación).
+4. Configura reinicio automático:
+   ```powershell
+   sc.exe failure ClemenERP-Tunnel reset= 0 actions= restart/5000/restart/5000/restart/5000
+   ```
+5. Inicia y valida que el túnel publique `https://api.<DOMINIO>`.
+
+## Healthcheck operativo (/actuator/health)
+- El backend expone `/actuator/health` y `/actuator/info` (sin información sensible). Usar el perfil `prod` y puerto local 8080 salvo que se sobrescriba `SERVER_PORT`.
+- Pruebas:
+  - **Local**: `curl http://localhost:8080/actuator/health`
+  - **Público**: `curl https://api.<DOMINIO>/actuator/health` (debe devolver `X-Forwarded-Proto: https` desde Cloudflared).
+
+## Checklist de verificación (24/7)
+1. **Servicio Backend**: `nssm status ClemenERP-Backend`; revisar `backend-stdout.log`/`stderr`.
+2. **Servicio Túnel**: `nssm status ClemenERP-Tunnel`; revisar logs de cloudflared.
+3. **Health local**: `curl http://localhost:8080/actuator/health` devuelve `UP`.
+4. **Health público**: `curl https://api.<DOMINIO>/actuator/health` devuelve `UP` con encabezado `X-Forwarded-Proto: https`.
+5. **CORS**: el frontend carga sin errores CORS. Ajustar `CORS_ALLOWED_ORIGINS` si aparece `CORS policy error`.
+6. **Contenido mixto**: la consola del navegador no debe mostrar `Mixed Content`; el backend debe ser consumido siempre por `https://api.<DOMINIO>`.
+7. **TLS extremo a extremo**: validar el certificado público en el navegador y que Cloudflared apunte a `http://localhost:8080` únicamente dentro del servidor.
+
+## Watchdog opcional
+`ops/HealthWatchdog.ps1` permite reiniciar el servicio si falla el health local. Se recomienda programarlo en el Programador de tareas cada 5 minutos con privilegios de Administrador. No es obligatorio para compilar.

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -54,6 +54,9 @@ public class SecurityConfig {
                     auth.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
 
                     auth.requestMatchers(
+                            "/actuator/health",
+                            "/actuator/health/**",
+                            "/actuator/info",
                             "/auth/login",
                             "/api/auth/**",
                             "/v3/api-docs/**",

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,14 +1,19 @@
-git add .# =========================
+## =========================
 # Perfil PROD - Clemen
-# =========================
+## =========================
 
 spring.application.name=clemen-integra-erp
 
 # --- Puerto de la app en el servidor ---
-# Puedes cambiar SERVER_PORT en el servidor, por defecto 8080
-server.port=8081
+# Expuesto solo en localhost para el túnel; ajustar con SERVER_PORT si se necesita otro
+server.port=8080
 server.forward-headers-strategy=framework
 app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:https://erp.clemenlab.com}
+
+# --- Endpoints de observabilidad mínimos ---
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.probes.enabled=true
+management.endpoint.health.show-details=never
 
 # --- Datasource MySQL (PRODUCCIÓN) ---
 # URL de BD, por defecto apunta a localhost y a la base clemen_integra_erp

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,10 @@ logging.level.org.hibernate.SQL=INFO
 server.port=8081
 server.forward-headers-strategy=framework
 app.cors.allowed-origins=http://localhost:5173,http://127.0.0.1:5173
+# Observabilidad básica (solo health/info)
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.probes.enabled=true
+management.endpoint.health.show-details=never
 #springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 


### PR DESCRIPTION
## Summary
- Add Windows on-prem operations guide covering Cloudflared tunnel, NSSM services, health verification, and restart policies
- Enable actuator health/info exposure and permit public health endpoints with secure defaults
- Include optional PowerShell watchdog script for automatic service restarts when health fails

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407e4cc5c88333bc73228cc8bf22eb)