### PR TITLE
prod: bind localhost y watchdog robusto

### DIFF
--- a/ops/HealthWatchdog.ps1
+++ b/ops/HealthWatchdog.ps1
@@ -5,6 +5,11 @@ param(
     [string]$LogFile = "C:\\ClemenERP\\logs\\health-watchdog.log"
 )
 
+$logDirectory = Split-Path -Path $LogFile -Parent
+if (-not (Test-Path -Path $logDirectory)) {
+    New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+}
+
 $timestamp = (Get-Date).ToString("s")
 $logPrefix = "[$timestamp]"
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -3,6 +3,10 @@
 ## Publicación detrás de túnel/Reverse Proxy
 El backend se publica detrás de un túnel HTTPS (Cloudflared) que termina TLS públicamente y reenvía al backend por `http://localhost:8080` dentro del servidor.
 
+- **Escucha local en PROD**: el perfil `prod` de Spring Boot queda ligado a `127.0.0.1:8080` (`server.address` + `server.port`).
+- **Cloudflared interno**: el túnel debe apuntar a `http://localhost:8080` (no exponer el puerto directamente).
+- **Acceso externo**: solo se atiende por `https://<DOMINIO>` publicado en Cloudflare; no se debe acceder directamente al puerto local.
+
 - **Encabezados reenviados**: `server.forward-headers-strategy=framework` ya está activo en los perfiles principales para respetar `X-Forwarded-*`/`Forwarded` y conservar el esquema seguro (`https`).
 - **CORS**: define el dominio real del frontend vía `CORS_ALLOWED_ORIGINS` o ajusta `app.cors.allowed-origins` en el perfil correspondiente. En producción el valor por defecto es `https://erp.clemenlab.com`.
 - **Objetivo**: HTTPS público extremo a extremo. Cloudflared termina TLS y reenvía al backend local en 8080; el frontend consume únicamente la URL pública.

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -7,6 +7,7 @@ spring.application.name=clemen-integra-erp
 # --- Puerto de la app en el servidor ---
 # Expuesto solo en localhost para el túnel; ajustar con SERVER_PORT si se necesita otro
 server.port=8080
+server.address=127.0.0.1
 server.forward-headers-strategy=framework
 app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:https://erp.clemenlab.com}
 


### PR DESCRIPTION
## Summary
- Force Spring Boot prod profile to bind on 127.0.0.1 for Cloudflared-only exposure
- Ensure HealthWatchdog.ps1 creates the log directory before writing
- Document the tunnel setup: localhost binding, Cloudflared target, and external HTTPS entrypoint

## Testing
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694084f6d1448333ae06c76e6604d825)