### PR TITLE
Add GET support for conteos cíclicos listing and details

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -4,8 +4,13 @@ import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
 import com.willyes.clemenintegra.inventario.service.ConteoCiclicoService;
+import com.willyes.clemenintegra.shared.util.PaginationUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +23,27 @@ import java.util.List;
 public class ConteoCiclicoController {
 
     private final ConteoCiclicoService conteoCiclicoService;
+
+    @GetMapping
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
+    public ResponseEntity<Page<ConteoCiclicoResponseDTO>> listar(
+            @RequestParam(required = false) Integer almacenId,
+            @RequestParam(required = false) String estado,
+            @PageableDefault(size = 10, sort = "fechaCreacion", direction = Sort.Direction.DESC) Pageable pageable) {
+        if (pageable.getPageNumber() < 0 || pageable.getPageSize() < 1 || pageable.getPageSize() > 100) {
+            return ResponseEntity.badRequest().build();
+        }
+        Pageable sanitized = PaginationUtil.sanitize(pageable, List.of("fechaCreacion", "id"), "fechaCreacion");
+        Page<ConteoCiclicoResponseDTO> respuesta = conteoCiclicoService.listar(almacenId, estado, sanitized);
+        return ResponseEntity.ok(respuesta);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
+    public ResponseEntity<ConteoCiclicoResponseDTO> obtenerPorId(@PathVariable Long id) {
+        ConteoCiclicoResponseDTO respuesta = conteoCiclicoService.obtenerPorId(id);
+        return ResponseEntity.ok(respuesta);
+    }
 
     @PostMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ConteoCiclicoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ConteoCiclicoRepository.java
@@ -1,7 +1,10 @@
 package com.willyes.clemenintegra.inventario.repository;
 
 import com.willyes.clemenintegra.inventario.model.ConteoCiclico;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -11,6 +14,16 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface ConteoCiclicoRepository extends JpaRepository<ConteoCiclico, Long> {
+
+    @EntityGraph(attributePaths = {
+            "almacen",
+            "detalles",
+            "detalles.producto",
+            "detalles.loteProducto",
+            "detalles.ubicacionFisica"
+    })
+    @Query("select distinct c from ConteoCiclico c left join c.detalles d where c.id = :id")
+    Optional<ConteoCiclico> findByIdWithDetalles(@Param("id") Long id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @EntityGraph(attributePaths = {
@@ -22,4 +35,10 @@ public interface ConteoCiclicoRepository extends JpaRepository<ConteoCiclico, Lo
     })
     @Query("select distinct c from ConteoCiclico c left join c.detalles d where c.id = :id")
     Optional<ConteoCiclico> findByIdWithDetallesForUpdate(@Param("id") Long id);
+
+    @Query("select c from ConteoCiclico c where (:almacenId is null or c.almacen.id = :almacenId) " +
+            "and (:estado is null or c.estado = :estado)")
+    Page<ConteoCiclico> buscar(@Param("almacenId") Integer almacenId,
+                               @Param("estado") EstadoConteoCiclico estado,
+                               Pageable pageable);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -15,6 +15,8 @@ import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -46,6 +48,19 @@ public class ConteoCiclicoService {
     private final MovimientoInventarioService movimientoInventarioService;
     private final UsuarioService usuarioService;
     private final ConteoCiclicoMapper mapper;
+
+    public Page<ConteoCiclicoResponseDTO> listar(Integer almacenId, String estado, Pageable pageable) {
+        EstadoConteoCiclico estadoEnum = parseEstado(estado);
+        Page<ConteoCiclico> conteos = conteoRepository.buscar(almacenId, estadoEnum, pageable);
+        return conteos.map(mapper::toResponse);
+    }
+
+    public ConteoCiclicoResponseDTO obtenerPorId(Long conteoId) {
+        ConteoCiclico conteo = conteoRepository.findByIdWithDetalles(conteoId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Conteo no encontrado"));
+        return mapper.toResponse(conteo);
+    }
 
     @Transactional
     public ConteoCiclicoResponseDTO crearConteo(ConteoCiclicoRequestDTO request) {
@@ -331,6 +346,17 @@ public class ConteoCiclicoService {
             movimientoKey = movimientoKey + "-" + idempotencyKey;
         }
         movimientoInventarioService.registrarMovimiento(dto, movimientoKey);
+    }
+
+    private EstadoConteoCiclico parseEstado(String estado) {
+        if (!StringUtils.hasText(estado)) {
+            return null;
+        }
+        try {
+            return EstadoConteoCiclico.valueOf(estado.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "Estado de conteo inválido");
+        }
     }
 
     private Long resolverMotivo(ClasificacionMovimientoInventario clasificacion) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
@@ -5,19 +5,26 @@ import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
 import com.willyes.clemenintegra.inventario.service.ConteoCiclicoService;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -43,6 +50,51 @@ class ConteoCiclicoControllerTest {
 
     @MockBean
     private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    void listarConteosDevuelve200() throws Exception {
+        ConteoCiclicoResponseDTO response = ConteoCiclicoResponseDTO.builder()
+                .id(5L)
+                .almacenId(1)
+                .estado(EstadoConteoCiclico.BORRADOR)
+                .build();
+        Page<ConteoCiclicoResponseDTO> page = new PageImpl<>(java.util.List.of(response));
+        when(conteoCiclicoService.listar(ArgumentMatchers.isNull(), ArgumentMatchers.isNull(), ArgumentMatchers.any(Pageable.class)))
+                .thenReturn(page);
+
+        mockMvc.perform(get("/api/inventario/conteos")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(5));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_CONTADOR")
+    void obtenerPorIdDevuelve200() throws Exception {
+        ConteoCiclicoResponseDTO response = ConteoCiclicoResponseDTO.builder()
+                .id(15L)
+                .almacenId(2)
+                .estado(EstadoConteoCiclico.EN_CONTEO)
+                .build();
+        when(conteoCiclicoService.obtenerPorId(15L)).thenReturn(response);
+
+        mockMvc.perform(get("/api/inventario/conteos/15"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.estado").value("EN_CONTEO"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_CONTADOR")
+    void obtenerPorIdNoEncontradoDevuelve404() throws Exception {
+        when(conteoCiclicoService.obtenerPorId(99L))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "Conteo no encontrado"));
+
+        mockMvc.perform(get("/api/inventario/conteos/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ApiErrorCode.RECURSO_NO_ENCONTRADO.name()));
+    }
 
     @Test
     @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
@@ -80,5 +132,17 @@ class ConteoCiclicoControllerTest {
                         .header("Idempotency-Key", "k1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.estado").value("APLICADO"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    void listarConEstadoInvalidoDevuelve400() throws Exception {
+        when(conteoCiclicoService.listar(ArgumentMatchers.isNull(), anyString(), ArgumentMatchers.any(Pageable.class)))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "Estado de conteo inválido"));
+
+        mockMvc.perform(get("/api/inventario/conteos")
+                        .param("estado", "INVALIDO"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ApiErrorCode.SOLICITUD_INVALIDA.name()));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
@@ -10,6 +10,7 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -187,5 +189,12 @@ class ConteoCiclicoServiceTest {
 
         assertThatThrownBy(() -> conteoCiclicoService.aplicar(99L, null))
                 .isInstanceOf(CustomBusinessException.class);
+    }
+
+    @Test
+    void listarConEstadoInvalidoLanzaExcepcion() {
+        assertThatThrownBy(() -> conteoCiclicoService.listar(null, "INVALIDO", PageRequest.of(0, 10)))
+                .isInstanceOfSatisfying(CustomBusinessException.class, ex ->
+                        assertThat(ex.getCode()).isEqualTo(ApiErrorCode.SOLICITUD_INVALIDA));
     }
 }


### PR DESCRIPTION
## Summary
- add list and detail GET endpoints for conteos cíclicos with pagination and role checks
- implement repository/service support for filtering by almacén and estado, returning 404 on missing conteos
- extend controller and service tests to cover new endpoints and invalid estado handling

## Testing
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941786de13083339e602d4e92fe94ad)