### PR TITLE
Add PUT endpoint for conteos cíclicos and align schema

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -60,6 +60,14 @@ public class ConteoCiclicoController {
         return ResponseEntity.ok(respuesta);
     }
 
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
+    public ResponseEntity<ConteoCiclicoResponseDTO> actualizar(@PathVariable Long id,
+                                                               @Valid @RequestBody List<ConteoCiclicoDetalleRequestDTO> detalles) {
+        ConteoCiclicoResponseDTO respuesta = conteoCiclicoService.actualizarConteo(id, detalles);
+        return ResponseEntity.ok(respuesta);
+    }
+
     @PostMapping("/{id}/en-conteo")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
     public ResponseEntity<ConteoCiclicoResponseDTO> marcarEnConteo(@PathVariable Long id) {

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -105,6 +105,33 @@ public class ConteoCiclicoService {
     }
 
     @Transactional
+    public ConteoCiclicoResponseDTO actualizarConteo(Long conteoId, List<ConteoCiclicoDetalleRequestDTO> detallesRequest) {
+        if (CollectionUtils.isEmpty(detallesRequest)) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "Debe enviar al menos un detalle");
+        }
+
+        ConteoCiclico conteo = conteoRepository.findByIdWithDetallesForUpdate(conteoId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Conteo no encontrado"));
+
+        if (conteo.getEstado() == EstadoConteoCiclico.CERRADO || conteo.getEstado() == EstadoConteoCiclico.APLICADO) {
+            throw new CustomBusinessException(ApiErrorCode.CONTEO_ESTADO_INVALIDO,
+                    "No se pueden modificar detalles en el estado actual");
+        }
+
+        conteo.getDetalles().clear();
+
+        Integer almacenId = conteo.getAlmacen() != null ? conteo.getAlmacen().getId() : null;
+        for (ConteoCiclicoDetalleRequestDTO req : detallesRequest) {
+            ConteoCiclicoDetalle detalle = construirDetalle(conteo, req, almacenId);
+            conteo.getDetalles().add(detalle);
+        }
+
+        ConteoCiclico actualizado = conteoRepository.save(conteo);
+        return mapper.toResponse(actualizado);
+    }
+
+    @Transactional
     public ConteoCiclicoResponseDTO marcarEnConteo(Long conteoId) {
         ConteoCiclico conteo = cambiarEstado(conteoId, EstadoConteoCiclico.EN_CONTEO);
         return mapper.toResponse(conteo);

--- a/src/main/resources/db/migration/V20251217__ajuste_tipo_producto_conteo.sql
+++ b/src/main/resources/db/migration/V20251217__ajuste_tipo_producto_conteo.sql
@@ -1,0 +1,3 @@
+-- Ajusta el tipo de dato para alinearlo con productos.id y evitar error 3780 en la FK
+ALTER TABLE conteos_ciclicos_detalle
+    MODIFY producto_id INT NOT NULL;

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
 import com.willyes.clemenintegra.inventario.service.ConteoCiclicoService;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleRequestDTO;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,12 +21,15 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.math.BigDecimal;
+
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -144,5 +148,61 @@ class ConteoCiclicoControllerTest {
                         .param("estado", "INVALIDO"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(ApiErrorCode.SOLICITUD_INVALIDA.name()));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void actualizarConteoDevuelve200() throws Exception {
+        ConteoCiclicoResponseDTO response = ConteoCiclicoResponseDTO.builder()
+                .id(4L)
+                .almacenId(3)
+                .estado(EstadoConteoCiclico.BORRADOR)
+                .build();
+        when(conteoCiclicoService.actualizarConteo(eq(4L), ArgumentMatchers.anyList())).thenReturn(response);
+
+        ConteoCiclicoDetalleRequestDTO detalle = new ConteoCiclicoDetalleRequestDTO();
+        detalle.setProductoId(11L);
+        detalle.setConteoFisico(new BigDecimal("2.00"));
+
+        mockMvc.perform(put("/api/inventario/conteos/4")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.List.of(detalle))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(4))
+                .andExpect(jsonPath("$.estado").value("BORRADOR"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void actualizarConteoNoEncontradoDevuelve404() throws Exception {
+        when(conteoCiclicoService.actualizarConteo(eq(9L), ArgumentMatchers.anyList()))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "Conteo no encontrado"));
+
+        ConteoCiclicoDetalleRequestDTO detalle = new ConteoCiclicoDetalleRequestDTO();
+        detalle.setProductoId(9L);
+        detalle.setConteoFisico(BigDecimal.ONE);
+
+        mockMvc.perform(put("/api/inventario/conteos/9")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.List.of(detalle))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ApiErrorCode.RECURSO_NO_ENCONTRADO.name()));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void actualizarConteoEstadoInvalidoDevuelve409() throws Exception {
+        when(conteoCiclicoService.actualizarConteo(eq(12L), ArgumentMatchers.anyList()))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.CONTEO_ESTADO_INVALIDO, "Estado no permite edición"));
+
+        ConteoCiclicoDetalleRequestDTO detalle = new ConteoCiclicoDetalleRequestDTO();
+        detalle.setProductoId(1L);
+        detalle.setConteoFisico(BigDecimal.ONE);
+
+        mockMvc.perform(put("/api/inventario/conteos/12")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.List.of(detalle))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(ApiErrorCode.CONTEO_ESTADO_INVALIDO.name()));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
@@ -197,4 +197,73 @@ class ConteoCiclicoServiceTest {
                 .isInstanceOfSatisfying(CustomBusinessException.class, ex ->
                         assertThat(ex.getCode()).isEqualTo(ApiErrorCode.SOLICITUD_INVALIDA));
     }
+
+    @Test
+    void actualizarConteoReemplazaDetallesYRecalcula() {
+        Almacen almacen = new Almacen(1);
+        ConteoCiclico conteo = ConteoCiclico.builder()
+                .id(10L)
+                .almacen(almacen)
+                .estado(EstadoConteoCiclico.BORRADOR)
+                .detalles(new java.util.ArrayList<>(List.of(ConteoCiclicoDetalle.builder().id(99L).build())))
+                .build();
+
+        Producto productoUno = new Producto();
+        productoUno.setId(3);
+        Producto productoDos = new Producto();
+        productoDos.setId(4);
+
+        ConteoCiclicoDetalleRequestDTO detalleUno = new ConteoCiclicoDetalleRequestDTO();
+        detalleUno.setProductoId(3L);
+        detalleUno.setStockSistema(new BigDecimal("10.00"));
+        detalleUno.setConteoFisico(new BigDecimal("12.00"));
+
+        ConteoCiclicoDetalleRequestDTO detalleDos = new ConteoCiclicoDetalleRequestDTO();
+        detalleDos.setProductoId(4L);
+        detalleDos.setConteoFisico(new BigDecimal("5.00"));
+
+        when(conteoCiclicoRepository.findByIdWithDetallesForUpdate(10L)).thenReturn(Optional.of(conteo));
+        when(productoRepository.findById(3L)).thenReturn(Optional.of(productoUno));
+        when(productoRepository.findById(4L)).thenReturn(Optional.of(productoDos));
+        when(loteProductoRepository.sumarStockPorProductoYAlmacen(4L, almacen.getId(), null))
+                .thenReturn(new BigDecimal("2.00"));
+        when(conteoCiclicoRepository.save(any(ConteoCiclico.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ConteoCiclicoResponseDTO respuesta = conteoCiclicoService.actualizarConteo(10L, List.of(detalleUno, detalleDos));
+
+        assertThat(conteo.getDetalles())
+                .hasSize(2)
+                .allSatisfy(det -> assertThat(det.getDiferencia()).isNotNull());
+        assertThat(conteo.getDetalles())
+                .anySatisfy(det -> {
+                    assertThat(det.getProducto().getId()).isEqualTo(3);
+                    assertThat(det.getDiferencia()).isEqualByComparingTo(new BigDecimal("2.00"));
+                })
+                .anySatisfy(det -> {
+                    assertThat(det.getProducto().getId()).isEqualTo(4);
+                    assertThat(det.getDiferencia()).isEqualByComparingTo(new BigDecimal("3.00"));
+                });
+        assertThat(conteo.getDetalles().stream().noneMatch(det -> Long.valueOf(99L).equals(det.getId()))).isTrue();
+        assertThat(respuesta.getDetalles()).hasSize(2);
+    }
+
+    @Test
+    void actualizarConteoRechazaCuandoEstadoEsCerrado() {
+        ConteoCiclico conteo = ConteoCiclico.builder()
+                .id(11L)
+                .estado(EstadoConteoCiclico.CERRADO)
+                .build();
+        when(conteoCiclicoRepository.findByIdWithDetallesForUpdate(11L)).thenReturn(Optional.of(conteo));
+
+        ConteoCiclicoDetalleRequestDTO detalle = new ConteoCiclicoDetalleRequestDTO();
+        detalle.setProductoId(1L);
+        detalle.setConteoFisico(BigDecimal.ONE);
+
+        assertThatThrownBy(() -> conteoCiclicoService.actualizarConteo(11L, List.of(detalle)))
+                .isInstanceOfSatisfying(CustomBusinessException.class, ex ->
+                        assertThat(ex.getCode()).isEqualTo(ApiErrorCode.CONTEO_ESTADO_INVALIDO));
+
+        verify(conteoCiclicoRepository, never()).save(any());
+    }
 }


### PR DESCRIPTION
## Summary
- add PUT /api/inventario/conteos/{id} with role guards and controlled responses when updating conteos
- update service logic to replace detalles, recalculate diferencias/stock, and extend controller/service tests for happy path and error cases
- add migration to enforce conteos_ciclicos_detalle.producto_id as INT to match productos

## Testing
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694182b6bc1083339f543dccd0d08b94)