### PR TITLE
Ajusta PUT de conteos con DTO tolerante y mensajes de error claros

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.inventario.controller;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoUpdateRequestDTO;
 import com.willyes.clemenintegra.inventario.service.ConteoCiclicoService;
 import com.willyes.clemenintegra.shared.util.PaginationUtil;
 import jakarta.validation.Valid;
@@ -63,8 +64,8 @@ public class ConteoCiclicoController {
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
     public ResponseEntity<ConteoCiclicoResponseDTO> actualizar(@PathVariable Long id,
-                                                               @Valid @RequestBody List<ConteoCiclicoDetalleRequestDTO> detalles) {
-        ConteoCiclicoResponseDTO respuesta = conteoCiclicoService.actualizarConteo(id, detalles);
+                                                               @Valid @RequestBody ConteoCiclicoUpdateRequestDTO request) {
+        ConteoCiclicoResponseDTO respuesta = conteoCiclicoService.actualizarConteo(id, request != null ? request.getDetalles() : null);
         return ResponseEntity.ok(respuesta);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoDetalleRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoDetalleRequestDTO.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -7,11 +9,13 @@ import lombok.Data;
 import java.math.BigDecimal;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ConteoCiclicoDetalleRequestDTO {
 
     @NotNull
     private Long productoId;
     private Long loteProductoId;
+    @JsonAlias("ubicacionId")
     private Long ubicacionFisicaId;
 
     private BigDecimal stockSistema;

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoUpdateRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoUpdateRequestDTO.java
@@ -1,0 +1,17 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConteoCiclicoUpdateRequestDTO {
+
+    @Valid
+    @NotEmpty(message = "Debe enviar al menos un detalle")
+    private List<ConteoCiclicoDetalleRequestDTO> detalles;
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.shared.exception;
 import com.willyes.clemenintegra.shared.dto.ErrorResponseDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -38,10 +39,35 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler({HttpMessageNotReadableException.class, DateTimeParseException.class})
-    public ResponseEntity<ErrorResponseDTO> handleInvalidDateFormat(Exception ex) {
+    public ResponseEntity<ErrorResponseDTO> handleUnreadableMessage(Exception ex) {
+        Throwable root = ex instanceof HttpMessageNotReadableException hmre
+                ? hmre.getMostSpecificCause()
+                : ex;
+
+        if (root instanceof DateTimeParseException) {
+            return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Formato de fecha inválido",
+                    "Use 'YYYY-MM-DDTHH:mm:ss' (ISO-8601). Si el campo no aplica, envíelo nulo u omítalo.");
+        }
+
+        if (root instanceof InvalidFormatException ife) {
+            String path = ife.getPath().stream()
+                    .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "[" + ref.getIndex() + "]")
+                    .reduce("", (acc, curr) -> acc.isEmpty() ? curr : acc + "." + curr);
+
+            Map<String, Object> details = Map.of(
+                    "field", path,
+                    "rejectedValue", ife.getValue()
+            );
+
+            return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Valor inválido para el campo '" + path + "'",
+                    details);
+        }
+
         return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA,
-                "Formato de fecha inválido",
-                "Use 'YYYY-MM-DDTHH:mm:ss' (ISO-8601). Si el campo no aplica, envíelo nulo u omítalo.");
+                "Solicitud inválida",
+                root != null ? root.getMessage() : ex.getMessage());
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
@@ -7,7 +7,6 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
 import com.willyes.clemenintegra.inventario.service.ConteoCiclicoService;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
-import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleRequestDTO;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +21,10 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,7 +65,7 @@ class ConteoCiclicoControllerTest {
                 .almacenId(1)
                 .estado(EstadoConteoCiclico.BORRADOR)
                 .build();
-        Page<ConteoCiclicoResponseDTO> page = new PageImpl<>(java.util.List.of(response));
+        Page<ConteoCiclicoResponseDTO> page = new PageImpl<>(List.of(response));
         when(conteoCiclicoService.listar(ArgumentMatchers.isNull(), ArgumentMatchers.isNull(), ArgumentMatchers.any(Pageable.class)))
                 .thenReturn(page);
 
@@ -160,13 +162,15 @@ class ConteoCiclicoControllerTest {
                 .build();
         when(conteoCiclicoService.actualizarConteo(eq(4L), ArgumentMatchers.anyList())).thenReturn(response);
 
-        ConteoCiclicoDetalleRequestDTO detalle = new ConteoCiclicoDetalleRequestDTO();
-        detalle.setProductoId(11L);
-        detalle.setConteoFisico(new BigDecimal("2.00"));
+        String body = objectMapper.writeValueAsString(Map.of(
+                "detalles", List.of(Map.of(
+                        "productoId", 11,
+                        "conteoFisico", new BigDecimal("2.00")
+                ))));
 
         mockMvc.perform(put("/api/inventario/conteos/4")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(java.util.List.of(detalle))))
+                        .content(body))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(4))
                 .andExpect(jsonPath("$.estado").value("BORRADOR"));
@@ -178,13 +182,15 @@ class ConteoCiclicoControllerTest {
         when(conteoCiclicoService.actualizarConteo(eq(9L), ArgumentMatchers.anyList()))
                 .thenThrow(new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "Conteo no encontrado"));
 
-        ConteoCiclicoDetalleRequestDTO detalle = new ConteoCiclicoDetalleRequestDTO();
-        detalle.setProductoId(9L);
-        detalle.setConteoFisico(BigDecimal.ONE);
+        String body = objectMapper.writeValueAsString(Map.of(
+                "detalles", List.of(Map.of(
+                        "productoId", 9,
+                        "conteoFisico", BigDecimal.ONE
+                ))));
 
         mockMvc.perform(put("/api/inventario/conteos/9")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(java.util.List.of(detalle))))
+                        .content(body))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(ApiErrorCode.RECURSO_NO_ENCONTRADO.name()));
     }
@@ -195,14 +201,65 @@ class ConteoCiclicoControllerTest {
         when(conteoCiclicoService.actualizarConteo(eq(12L), ArgumentMatchers.anyList()))
                 .thenThrow(new CustomBusinessException(ApiErrorCode.CONTEO_ESTADO_INVALIDO, "Estado no permite edición"));
 
-        ConteoCiclicoDetalleRequestDTO detalle = new ConteoCiclicoDetalleRequestDTO();
-        detalle.setProductoId(1L);
-        detalle.setConteoFisico(BigDecimal.ONE);
+        String body = objectMapper.writeValueAsString(Map.of(
+                "detalles", List.of(Map.of(
+                        "productoId", 1,
+                        "conteoFisico", BigDecimal.ONE
+                ))));
 
         mockMvc.perform(put("/api/inventario/conteos/12")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(java.util.List.of(detalle))))
+                        .content(body))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value(ApiErrorCode.CONTEO_ESTADO_INVALIDO.name()));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void actualizarConteoToleraCamposExtras() throws Exception {
+        ConteoCiclicoResponseDTO response = ConteoCiclicoResponseDTO.builder()
+                .id(14L)
+                .almacenId(1)
+                .estado(EstadoConteoCiclico.BORRADOR)
+                .build();
+        when(conteoCiclicoService.actualizarConteo(eq(14L), ArgumentMatchers.anyList())).thenReturn(response);
+
+        Map<String, Object> detalle = new java.util.LinkedHashMap<>();
+        detalle.put("productoId", 36);
+        detalle.put("loteProductoId", null);
+        detalle.put("ubicacionFisicaId", null);
+        detalle.put("conteoFisico", new BigDecimal("10000"));
+        detalle.put("aplicadoEn", "2024-01-01T00:00:00");
+
+        Map<String, Object> request = new java.util.LinkedHashMap<>();
+        request.put("fechaCreacion", "2023-12-31");
+        request.put("detalles", List.of(detalle));
+
+        String body = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(put("/api/inventario/conteos/14")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(14))
+                .andExpect(jsonPath("$.estado").value("BORRADOR"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void actualizarConteoConDatoInvalidoDetallaCampo() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "detalles", List.of(Map.of(
+                        "productoId", 36,
+                        "conteoFisico", "no-numero"
+                ))));
+
+        mockMvc.perform(put("/api/inventario/conteos/20")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ApiErrorCode.SOLICITUD_INVALIDA.name()))
+                .andExpect(jsonPath("$.message").value(containsString("detalles.[0].conteoFisico")))
+                .andExpect(jsonPath("$.details.field").value("detalles.[0].conteoFisico"));
     }
 }


### PR DESCRIPTION
## Summary
- Add a minimal ConteoCiclicoUpdateRequestDTO with unknown-field tolerance and update the PUT /api/inventario/conteos/{id} contract to consume it.
- Make detail requests ignore unknown properties, support ubicacionId alias, and keep updates from touching date fields.
- Improve global HttpMessageNotReadableException handling to surface the offending field/value instead of always assuming date errors, and expand controller tests for the new body shape and invalid payloads.

## Testing
- mvn -Dtest=ConteoCiclicoControllerTest,ConteoCiclicoServiceTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941c332ab1083339f2019df3d3595f0)