### PR TITLE
Add conteo state transition endpoints

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -69,6 +69,13 @@ public class ConteoCiclicoController {
         return ResponseEntity.ok(respuesta);
     }
 
+    @PostMapping("/{id}/iniciar")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
+    public ResponseEntity<ConteoCiclicoResponseDTO> iniciar(@PathVariable Long id) {
+        ConteoCiclicoResponseDTO respuesta = conteoCiclicoService.marcarEnConteo(id);
+        return ResponseEntity.ok(respuesta);
+    }
+
     @PostMapping("/{id}/en-conteo")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
     public ResponseEntity<ConteoCiclicoResponseDTO> marcarEnConteo(@PathVariable Long id) {

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -206,11 +206,9 @@ public class ConteoCiclicoService {
         if (estadoActual == destino) {
             return conteo;
         }
-        if (estadoActual == EstadoConteoCiclico.BORRADOR && destino == EstadoConteoCiclico.EN_CONTEO) {
+        if (destino == EstadoConteoCiclico.EN_CONTEO && estadoActual == EstadoConteoCiclico.BORRADOR) {
             conteo.setEstado(destino);
-        } else if (estadoActual == EstadoConteoCiclico.EN_CONTEO && destino == EstadoConteoCiclico.CERRADO) {
-            conteo.setEstado(destino);
-        } else if (estadoActual == EstadoConteoCiclico.BORRADOR && destino == EstadoConteoCiclico.CERRADO) {
+        } else if (destino == EstadoConteoCiclico.CERRADO && estadoActual == EstadoConteoCiclico.EN_CONTEO) {
             conteo.setEstado(destino);
         } else {
             throw new CustomBusinessException(ApiErrorCode.CONTEO_ESTADO_INVALIDO,

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -131,13 +132,67 @@ class ConteoCiclicoControllerTest {
                 .id(7L)
                 .almacenId(2)
                 .estado(EstadoConteoCiclico.APLICADO)
+                .aplicadoEn(LocalDateTime.now())
                 .build();
         when(conteoCiclicoService.aplicar(anyLong(), eq("k1"))).thenReturn(response);
 
         mockMvc.perform(post("/api/inventario/conteos/7/aplicar")
                         .header("Idempotency-Key", "k1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.estado").value("APLICADO"));
+                .andExpect(jsonPath("$.estado").value("APLICADO"))
+                .andExpect(jsonPath("$.aplicadoEn").exists());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void iniciarConteoDevuelve200() throws Exception {
+        ConteoCiclicoResponseDTO response = ConteoCiclicoResponseDTO.builder()
+                .id(3L)
+                .almacenId(1)
+                .estado(EstadoConteoCiclico.EN_CONTEO)
+                .build();
+        when(conteoCiclicoService.marcarEnConteo(3L)).thenReturn(response);
+
+        mockMvc.perform(post("/api/inventario/conteos/3/iniciar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.estado").value("EN_CONTEO"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void cerrarConteoDevuelve200() throws Exception {
+        ConteoCiclicoResponseDTO response = ConteoCiclicoResponseDTO.builder()
+                .id(4L)
+                .almacenId(2)
+                .estado(EstadoConteoCiclico.CERRADO)
+                .build();
+        when(conteoCiclicoService.cerrar(4L)).thenReturn(response);
+
+        mockMvc.perform(post("/api/inventario/conteos/4/cerrar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.estado").value("CERRADO"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void transicionInvalidaDevuelve409() throws Exception {
+        when(conteoCiclicoService.cerrar(21L))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.CONTEO_ESTADO_INVALIDO, "Transición de estado no permitida"));
+
+        mockMvc.perform(post("/api/inventario/conteos/21/cerrar"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(ApiErrorCode.CONTEO_ESTADO_INVALIDO.name()));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void iniciarConteoNoEncontradoDevuelve404() throws Exception {
+        when(conteoCiclicoService.marcarEnConteo(30L))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "Conteo no encontrado"));
+
+        mockMvc.perform(post("/api/inventario/conteos/30/iniciar"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ApiErrorCode.RECURSO_NO_ENCONTRADO.name()));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add POST /api/inventario/conteos/{id}/iniciar endpoint as alias to start counts
- restrict conteo state transitions to the valid workflow before closing and applying
- extend controller tests to cover iniciar, cerrar, aplicar and error cases

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941d0160b6483339b21c2e9ae587eac)