### PR TITLE
Add lote selection support for conteo

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.controller;
 
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoUpdateRequestDTO;
@@ -43,6 +44,18 @@ public class ConteoCiclicoController {
     @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
     public ResponseEntity<ConteoCiclicoResponseDTO> obtenerPorId(@PathVariable Long id) {
         ConteoCiclicoResponseDTO respuesta = conteoCiclicoService.obtenerPorId(id);
+        return ResponseEntity.ok(respuesta);
+    }
+
+    @GetMapping("/{id}/lotes")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
+    public ResponseEntity<List<ConteoCiclicoLoteResponseDTO>> listarLotes(
+            @PathVariable Long id,
+            @RequestParam Long productoId,
+            @RequestParam(required = false) Long ubicacionFisicaId,
+            @RequestParam(required = false, name = "q") String texto) {
+        List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
+                .listarLotesParaConteo(id, productoId, ubicacionFisicaId, texto);
         return ResponseEntity.ok(respuesta);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoLoteResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoLoteResponseDTO.java
@@ -1,0 +1,18 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Value
+@Builder
+public class ConteoCiclicoLoteResponseDTO {
+    Long id;
+    String codigoLote;
+    BigDecimal stockLote;
+    LocalDateTime fechaVencimiento;
+    Long ubicacionFisicaId;
+    String ubicacionCodigo;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -185,4 +185,22 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     BigDecimal sumarStockPorProductoYAlmacen(@Param("productoId") Long productoId,
                                              @Param("almacenId") Integer almacenId,
                                              @Param("ubicacionId") Long ubicacionId);
+
+    @Query("""
+        select lp
+        from LoteProducto lp
+        left join lp.ubicacionFisica uf
+        where lp.producto.id = :productoId
+          and lp.almacen.id = :almacenId
+          and lp.estado in :estados
+          and (lp.agotado = false or lp.agotado is null)
+          and (:ubicacionId is null or uf.id = :ubicacionId)
+          and (:texto is null or :texto = '' or upper(lp.codigoLote) like concat('%', upper(:texto), '%'))
+        order by lp.fechaVencimiento asc nulls last, lp.codigoLote asc
+    """)
+    List<LoteProducto> buscarParaConteo(@Param("productoId") Long productoId,
+                                        @Param("almacenId") Integer almacenId,
+                                        @Param("ubicacionId") Long ubicacionId,
+                                        @Param("texto") String texto,
+                                        @Param("estados") Collection<EstadoLote> estados);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
@@ -60,6 +61,59 @@ public class ConteoCiclicoService {
                 .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
                         "Conteo no encontrado"));
         return mapper.toResponse(conteo);
+    }
+
+    public List<ConteoCiclicoLoteResponseDTO> listarLotesParaConteo(Long conteoId,
+                                                                   Long productoId,
+                                                                   Long ubicacionFisicaId,
+                                                                   String texto) {
+        if (productoId == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "Debe especificar el producto a contar");
+        }
+
+        ConteoCiclico conteo = conteoRepository.findById(conteoId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Conteo no encontrado"));
+
+        Producto producto = productoRepository.findById(productoId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Producto no encontrado"));
+
+        Integer almacenId = conteo.getAlmacen() != null ? conteo.getAlmacen().getId() : null;
+        if (almacenId == null) {
+            throw new CustomBusinessException(ApiErrorCode.ERROR_INTERNO, "El conteo no tiene almacén asociado");
+        }
+
+        UbicacionFisica ubicacion = null;
+        if (ubicacionFisicaId != null) {
+            ubicacion = ubicacionFisicaRepository.findByIdAndActivoTrue(ubicacionFisicaId)
+                    .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.UBICACION_NO_ENCONTRADA,
+                            "Ubicación no encontrada"));
+            if (ubicacion.getAlmacen() == null || !Objects.equals(ubicacion.getAlmacen().getId(), almacenId)) {
+                throw new CustomBusinessException(ApiErrorCode.UBICACION_NO_PERTENECE_ALMACEN,
+                        "La ubicación no pertenece al almacén del conteo");
+            }
+        }
+
+        String filtroTexto = StringUtils.hasText(texto) ? texto.trim() : null;
+
+        List<LoteProducto> lotes = loteProductoRepository.buscarParaConteo(
+                producto.getId().longValue(),
+                almacenId,
+                ubicacion != null ? ubicacion.getId() : null,
+                filtroTexto,
+                LOTES_OPERABLES);
+
+        return lotes.stream()
+                .map(lp -> ConteoCiclicoLoteResponseDTO.builder()
+                        .id(lp.getId())
+                        .codigoLote(lp.getCodigoLote())
+                        .stockLote(Optional.ofNullable(lp.getStockLote()).orElse(BigDecimal.ZERO))
+                        .fechaVencimiento(lp.getFechaVencimiento())
+                        .ubicacionFisicaId(lp.getUbicacionFisica() != null ? lp.getUbicacionFisica().getId() : null)
+                        .ubicacionCodigo(lp.getUbicacionFisica() != null ? lp.getUbicacionFisica().getCodigo() : null)
+                        .build())
+                .toList();
     }
 
     @Transactional
@@ -241,16 +295,21 @@ public class ConteoCiclicoService {
                 throw new CustomBusinessException(ApiErrorCode.UBICACION_NO_PERTENECE_ALMACEN,
                         "La ubicación no pertenece al almacén del conteo");
             }
-            if (lote != null && lote.getUbicacionFisica() != null
-                    && !Objects.equals(lote.getUbicacionFisica().getId(), ubicacion.getId())) {
+            if (lote != null && (lote.getUbicacionFisica() == null
+                    || !Objects.equals(lote.getUbicacionFisica().getId(), ubicacion.getId()))) {
                 throw new CustomBusinessException(ApiErrorCode.CONTEO_DETALLE_INVALIDO,
                         "La ubicación del lote difiere de la del detalle");
             }
         }
 
-        BigDecimal stockSistema = req.getStockSistema() != null
-                ? req.getStockSistema()
-                : obtenerStockSnapshot(producto.getId().longValue(), lote, almacenId, ubicacion);
+        BigDecimal stockSistema;
+        if (lote != null) {
+            stockSistema = obtenerStockSnapshot(producto.getId().longValue(), lote, almacenId, ubicacion);
+        } else {
+            stockSistema = req.getStockSistema() != null
+                    ? req.getStockSistema()
+                    : obtenerStockSnapshot(producto.getId().longValue(), null, almacenId, ubicacion);
+        }
 
         BigDecimal conteoFisico = req.getConteoFisico().setScale(2, RoundingMode.HALF_UP);
         BigDecimal diferencia = conteoFisico.subtract(stockSistema).setScale(2, RoundingMode.HALF_UP);

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.inventario.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
 import com.willyes.clemenintegra.inventario.service.ConteoCiclicoService;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
@@ -90,6 +91,26 @@ class ConteoCiclicoControllerTest {
         mockMvc.perform(get("/api/inventario/conteos/15"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.estado").value("EN_CONTEO"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    void listarLotesParaConteoDevuelve200() throws Exception {
+        ConteoCiclicoLoteResponseDTO lote = ConteoCiclicoLoteResponseDTO.builder()
+                .id(9L)
+                .codigoLote("L-001")
+                .stockLote(new BigDecimal("5.00"))
+                .build();
+        when(conteoCiclicoService.listarLotesParaConteo(8L, 3L, 2L, "AB"))
+                .thenReturn(List.of(lote));
+
+        mockMvc.perform(get("/api/inventario/conteos/8/lotes")
+                        .param("productoId", "3")
+                        .param("ubicacionFisicaId", "2")
+                        .param("q", "AB"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(9))
+                .andExpect(jsonPath("$[0].codigoLote").value("L-001"));
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
@@ -266,4 +266,44 @@ class ConteoCiclicoServiceTest {
 
         verify(conteoCiclicoRepository, never()).save(any());
     }
+
+    @Test
+    void actualizarConteoConLoteUsaStockDelLote() {
+        Almacen almacen = new Almacen(5);
+        ConteoCiclico conteo = ConteoCiclico.builder()
+                .id(31L)
+                .almacen(almacen)
+                .estado(EstadoConteoCiclico.BORRADOR)
+                .detalles(new java.util.ArrayList<>())
+                .build();
+
+        Producto producto = new Producto();
+        producto.setId(22);
+
+        LoteProducto lote = LoteProducto.builder()
+                .id(77L)
+                .producto(producto)
+                .almacen(almacen)
+                .stockLote(new BigDecimal("15.50"))
+                .build();
+
+        ConteoCiclicoDetalleRequestDTO detalleRequest = new ConteoCiclicoDetalleRequestDTO();
+        detalleRequest.setProductoId(22L);
+        detalleRequest.setLoteProductoId(77L);
+        detalleRequest.setStockSistema(new BigDecimal("99.99"));
+        detalleRequest.setConteoFisico(new BigDecimal("10.00"));
+
+        when(conteoCiclicoRepository.findByIdWithDetallesForUpdate(31L)).thenReturn(Optional.of(conteo));
+        when(productoRepository.findById(22L)).thenReturn(Optional.of(producto));
+        when(loteProductoRepository.findById(77L)).thenReturn(Optional.of(lote));
+        when(conteoCiclicoRepository.save(any(ConteoCiclico.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        conteoCiclicoService.actualizarConteo(31L, List.of(detalleRequest));
+
+        assertThat(conteo.getDetalles()).hasSize(1);
+        ConteoCiclicoDetalle guardado = conteo.getDetalles().get(0);
+        assertThat(guardado.getStockSistema()).isEqualByComparingTo(new BigDecimal("15.50"));
+        assertThat(guardado.getDiferencia()).isEqualByComparingTo(new BigDecimal("-5.50"));
+    }
 }


### PR DESCRIPTION
## Summary
- add endpoint to listar lotes elegibles por conteo usando almacen del conteo y filtros de producto/ubicación
- validar lotes al construir detalles y recalcular stock de sistema desde el lote seleccionado
- cubrir la API y la lógica de stock con nuevas pruebas de controlador y servicio

## Testing
- mvn test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941dd7ddf248333a5d5a61bd7e6b6f4)