### PR TITLE
Permitir listar lotes de cualquier estado en conteos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -193,7 +193,6 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
         where lp.producto.id = :productoId
           and lp.almacen.id = :almacenId
           and lp.estado in :estados
-          and (lp.agotado = false or lp.agotado is null)
           and (:ubicacionId is null or uf.id = :ubicacionId)
           and (:texto is null or :texto = '' or upper(lp.codigoLote) like concat('%', upper(:texto), '%'))
         order by lp.fechaVencimiento asc nulls last, lp.codigoLote asc

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -34,9 +35,11 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ConteoCiclicoService {
 
     private static final EnumSet<EstadoLote> LOTES_OPERABLES = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
+    private static final EnumSet<EstadoLote> LOTES_VISIBLES_EN_CONTEO = EnumSet.allOf(EstadoLote.class);
 
     private final ConteoCiclicoRepository conteoRepository;
     private final ConteoCiclicoDetalleRepository detalleRepository;
@@ -97,12 +100,17 @@ public class ConteoCiclicoService {
 
         String filtroTexto = StringUtils.hasText(texto) ? texto.trim() : null;
 
+        log.debug("[ConteoCiclico] listarLotes conteoId={}, almacenId={}, productoId={}, ubicacionFisicaId={}, search={}",
+                conteoId, almacenId, producto.getId(), ubicacion != null ? ubicacion.getId() : null, filtroTexto);
+
         List<LoteProducto> lotes = loteProductoRepository.buscarParaConteo(
                 producto.getId().longValue(),
                 almacenId,
                 ubicacion != null ? ubicacion.getId() : null,
                 filtroTexto,
-                LOTES_OPERABLES);
+                LOTES_VISIBLES_EN_CONTEO);
+
+        log.debug("[ConteoCiclico] lotes encontrados antes de mapear: {}", lotes.size());
 
         return lotes.stream()
                 .map(lp -> ConteoCiclicoLoteResponseDTO.builder()

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.PageRequest;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -305,5 +307,40 @@ class ConteoCiclicoServiceTest {
         ConteoCiclicoDetalle guardado = conteo.getDetalles().get(0);
         assertThat(guardado.getStockSistema()).isEqualByComparingTo(new BigDecimal("15.50"));
         assertThat(guardado.getDiferencia()).isEqualByComparingTo(new BigDecimal("-5.50"));
+    }
+
+    @Test
+    void listarLotesIncluyeEstadosNoOperables() {
+        ConteoCiclico conteo = ConteoCiclico.builder()
+                .id(2L)
+                .almacen(new Almacen(7))
+                .build();
+        Producto producto = new Producto();
+        producto.setId(3);
+
+        LoteProducto loteRetenido = LoteProducto.builder()
+                .id(15L)
+                .producto(producto)
+                .almacen(conteo.getAlmacen())
+                .codigoLote("RET-001")
+                .estado(EstadoLote.RETENIDO)
+                .stockLote(BigDecimal.ZERO)
+                .build();
+
+        when(conteoCiclicoRepository.findById(2L)).thenReturn(Optional.of(conteo));
+        when(productoRepository.findById(3L)).thenReturn(Optional.of(producto));
+        when(loteProductoRepository.buscarParaConteo(eq(3L), eq(7), isNull(), isNull(), anyCollection()))
+                .thenReturn(List.of(loteRetenido));
+
+        ArgumentCaptor<Collection<EstadoLote>> estadosCaptor = ArgumentCaptor.forClass(Collection.class);
+
+        List<com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
+                .listarLotesParaConteo(2L, 3L, null, null);
+
+        assertThat(respuesta).hasSize(1);
+        assertThat(respuesta.getFirst().getId()).isEqualTo(15L);
+
+        verify(loteProductoRepository).buscarParaConteo(eq(3L), eq(7), isNull(), isNull(), estadosCaptor.capture());
+        assertThat(estadosCaptor.getValue()).containsExactlyInAnyOrder(EstadoLote.values());
     }
 }


### PR DESCRIPTION
## Summary
- Amplío el servicio de lotes de conteos para registrar parámetros en logs y usar todos los estados de lote al consultar
- Ajusto la consulta a base de datos para no excluir lotes agotados y respetar únicamente filtros de producto, almacén, ubicación y búsqueda
- Agrego una prueba de servicio que cubre el caso de lotes en estado no operable

## Testing
- mvn -Dtest=ConteoCiclicoServiceTest,ConteoCiclicoControllerTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941e4c9c5f48333aa147b2b2cf59374)