### PR TITLE
Add debug logging for conteo lot listing

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -111,6 +111,15 @@ public class ConteoCiclicoService {
                 LOTES_VISIBLES_EN_CONTEO);
 
         log.debug("[ConteoCiclico] lotes encontrados antes de mapear: {}", lotes.size());
+        lotes.stream()
+                .limit(3)
+                .forEach(lp -> log.debug(
+                        "[ConteoCiclico] lote id={} codigo={} ubicacionId={} estado={} stockLote={}",
+                        lp.getId(),
+                        lp.getCodigoLote(),
+                        lp.getUbicacionFisica() != null ? lp.getUbicacionFisica().getId() : null,
+                        lp.getEstado(),
+                        lp.getStockLote()));
 
         return lotes.stream()
                 .map(lp -> ConteoCiclicoLoteResponseDTO.builder()


### PR DESCRIPTION
## Summary
- add extra debug information when listing lotes for conteos to aid diagnostics

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941f21bc3f4833398694695c6b88782)