### PR TITLE
Make q optional when listing lots for cycle counts

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -53,9 +53,9 @@ public class ConteoCiclicoController {
             @PathVariable Long id,
             @RequestParam Long productoId,
             @RequestParam(required = false) Long ubicacionFisicaId,
-            @RequestParam(required = false, name = "q") String texto) {
+            @RequestParam(name = "q", required = false) String q) {
         List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
-                .listarLotesParaConteo(id, productoId, ubicacionFisicaId, texto);
+                .listarLotesParaConteo(id, productoId, ubicacionFisicaId, q);
         return ResponseEntity.ok(respuesta);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -194,12 +194,12 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
           and lp.almacen.id = :almacenId
           and lp.estado in :estados
           and (:ubicacionId is null or uf.id = :ubicacionId)
-          and (:texto is null or :texto = '' or upper(lp.codigoLote) like concat('%', upper(:texto), '%'))
+          and (:q is null or lower(lp.codigoLote) like lower(concat('%', :q, '%')))
         order by lp.fechaVencimiento asc nulls last, lp.codigoLote asc
     """)
     List<LoteProducto> buscarParaConteo(@Param("productoId") Long productoId,
                                         @Param("almacenId") Integer almacenId,
                                         @Param("ubicacionId") Long ubicacionId,
-                                        @Param("texto") String texto,
+                                        @Param("q") String q,
                                         @Param("estados") Collection<EstadoLote> estados);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -69,7 +69,7 @@ public class ConteoCiclicoService {
     public List<ConteoCiclicoLoteResponseDTO> listarLotesParaConteo(Long conteoId,
                                                                    Long productoId,
                                                                    Long ubicacionFisicaId,
-                                                                   String texto) {
+                                                                   String q) {
         if (productoId == null) {
             throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "Debe especificar el producto a contar");
         }
@@ -98,7 +98,7 @@ public class ConteoCiclicoService {
             }
         }
 
-        String filtroTexto = StringUtils.hasText(texto) ? texto.trim() : null;
+        String filtroTexto = (q == null || q.isBlank()) ? null : q.trim();
 
         log.debug("[ConteoCiclico] listarLotes conteoId={}, almacenId={}, productoId={}, ubicacionFisicaId={}, search={}",
                 conteoId, almacenId, producto.getId(), ubicacion != null ? ubicacion.getId() : null, filtroTexto);

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
@@ -95,22 +95,40 @@ class ConteoCiclicoControllerTest {
 
     @Test
     @WithMockUser(authorities = "ROL_ALMACENISTA")
-    void listarLotesParaConteoDevuelve200() throws Exception {
+    void listarLotesParaConteoSinQDevuelveListado() throws Exception {
+        ConteoCiclicoLoteResponseDTO lote = ConteoCiclicoLoteResponseDTO.builder()
+                .id(11L)
+                .codigoLote("FAFAFSAF")
+                .stockLote(new BigDecimal("3.00"))
+                .build();
+        when(conteoCiclicoService.listarLotesParaConteo(8L, 3L, null, null))
+                .thenReturn(List.of(lote));
+
+        mockMvc.perform(get("/api/inventario/conteos/8/lotes")
+                        .param("productoId", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(11))
+                .andExpect(jsonPath("$[0].codigoLote").value("FAFAFSAF"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    void listarLotesParaConteoConQParcialDevuelve200() throws Exception {
         ConteoCiclicoLoteResponseDTO lote = ConteoCiclicoLoteResponseDTO.builder()
                 .id(9L)
-                .codigoLote("L-001")
+                .codigoLote("L20251003-01")
                 .stockLote(new BigDecimal("5.00"))
                 .build();
-        when(conteoCiclicoService.listarLotesParaConteo(8L, 3L, 2L, "AB"))
+        when(conteoCiclicoService.listarLotesParaConteo(8L, 3L, 2L, "2025"))
                 .thenReturn(List.of(lote));
 
         mockMvc.perform(get("/api/inventario/conteos/8/lotes")
                         .param("productoId", "3")
                         .param("ubicacionFisicaId", "2")
-                        .param("q", "AB"))
+                        .param("q", "2025"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(9))
-                .andExpect(jsonPath("$[0].codigoLote").value("L-001"));
+                .andExpect(jsonPath("$[0].codigoLote").value("L20251003-01"));
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.ConteoCiclicoMapper;
@@ -342,5 +343,70 @@ class ConteoCiclicoServiceTest {
 
         verify(loteProductoRepository).buscarParaConteo(eq(3L), eq(7), isNull(), isNull(), estadosCaptor.capture());
         assertThat(estadosCaptor.getValue()).containsExactlyInAnyOrder(EstadoLote.values());
+    }
+
+    @Test
+    void listarLotesParaConteoSinBuscarTextoNoFiltraPorCodigo() {
+        ConteoCiclico conteo = ConteoCiclico.builder()
+                .id(12L)
+                .almacen(new Almacen(5))
+                .build();
+        Producto producto = new Producto();
+        producto.setId(8);
+
+        LoteProducto lote = LoteProducto.builder()
+                .id(99L)
+                .producto(producto)
+                .almacen(conteo.getAlmacen())
+                .codigoLote("FAFAFSAF")
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(BigDecimal.ONE)
+                .build();
+
+        when(conteoCiclicoRepository.findById(12L)).thenReturn(Optional.of(conteo));
+        when(productoRepository.findById(8L)).thenReturn(Optional.of(producto));
+        when(loteProductoRepository.buscarParaConteo(eq(8L), eq(5), isNull(), isNull(), anyCollection()))
+                .thenReturn(List.of(lote));
+
+        List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
+                .listarLotesParaConteo(12L, 8L, null, null);
+
+        assertThat(respuesta).hasSize(1);
+        assertThat(respuesta.getFirst().getCodigoLote()).isEqualTo("FAFAFSAF");
+    }
+
+    @Test
+    void listarLotesParaConteoConTextoAplicaFiltro() {
+        ConteoCiclico conteo = ConteoCiclico.builder()
+                .id(13L)
+                .almacen(new Almacen(6))
+                .build();
+        Producto producto = new Producto();
+        producto.setId(9);
+
+        LoteProducto lote = LoteProducto.builder()
+                .id(101L)
+                .producto(producto)
+                .almacen(conteo.getAlmacen())
+                .codigoLote("L20251003-01")
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(BigDecimal.TEN)
+                .build();
+
+        when(conteoCiclicoRepository.findById(13L)).thenReturn(Optional.of(conteo));
+        when(productoRepository.findById(9L)).thenReturn(Optional.of(producto));
+        when(loteProductoRepository.buscarParaConteo(eq(9L), eq(6), isNull(), anyString(), anyCollection()))
+                .thenReturn(List.of(lote));
+
+        ArgumentCaptor<String> qCaptor = ArgumentCaptor.forClass(String.class);
+
+        List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
+                .listarLotesParaConteo(13L, 9L, null, " 20251003 ");
+
+        assertThat(respuesta).hasSize(1);
+        assertThat(respuesta.getFirst().getCodigoLote()).isEqualTo("L20251003-01");
+
+        verify(loteProductoRepository).buscarParaConteo(eq(9L), eq(6), isNull(), qCaptor.capture(), anyCollection());
+        assertThat(qCaptor.getValue()).isEqualTo("20251003");
     }
 }


### PR DESCRIPTION
## Summary
- treat the `q` search parameter as optional when listing lots for cycle counts and normalize whitespace in the service
- update repository query to skip the code filter when `q` is null while keeping existing filters intact
- add controller and service tests covering calls with and without `q`

## Testing
- mvn -Dtest=ConteoCiclicoServiceTest,ConteoCiclicoControllerTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941f5ee14e88333b88475e8d56576b4)