### PR TITLE
Expose active inventory alerts with expiry thresholds

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/AlertaInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/AlertaInventarioController.java
@@ -17,26 +17,27 @@ public class AlertaInventarioController {
     private final AlertaInventarioService alertaService;
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION')")
-    public ResponseEntity<List<AlertaInventarioResponseDTO>> obtenerAlertas() {
-        return ResponseEntity.ok(alertaService.obtenerAlertasInventario());
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA')")
+    public ResponseEntity<List<AlertaInventarioResponseDTO>> obtenerAlertas(
+            @RequestParam(value = "diasVencimiento", required = false, defaultValue = "30") Integer diasVencimiento) {
+        return ResponseEntity.ok(alertaService.obtenerAlertasInventario(diasVencimiento));
     }
 
     @GetMapping("/stock-bajo")
-    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION')")
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA')")
     public ResponseEntity<List<ProductoAlertaResponseDTO>> obtenerProductosConStockBajo() {
         List<ProductoAlertaResponseDTO> alertas = alertaService.obtenerProductosConStockBajo();
         return ResponseEntity.ok(alertas);
     }
 
     @GetMapping("/productos-vencidos")
-    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION')")
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA')")
     public ResponseEntity<List<LoteAlertaResponseDTO>> obtenerProductosVencidos() {
         return ResponseEntity.ok(alertaService.obtenerLotesVencidos());
     }
 
     @GetMapping("/lotes-retenidos-prolongados")
-    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION', 'ROL_JEFE_CALIDAD')")
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA')")
     public ResponseEntity<List<LoteEstadoProlongadoResponseDTO>> obtenerLotesEnCuarentenaORetenidosProlongados() {
         return ResponseEntity.ok(alertaService.obtenerLotesRetenidosOCuarentenaProlongados());
     }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/AlertaInventarioResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/AlertaInventarioResponseDTO.java
@@ -1,6 +1,9 @@
 package com.willyes.clemenintegra.inventario.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -10,13 +13,17 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class AlertaInventarioResponseDTO {
-    private String tipo;
+    private AlertaInventarioTipo tipo;
+    private AlertaInventarioSeveridad severidad;
+    private Long productoId;
     private String nombreProducto;
+    private String codigoSku;
+    private Long almacenId;
     private String nombreAlmacen;
+    private Long loteProductoId;
     private String codigoLote;
     private LocalDateTime fechaVencimiento;
-    private BigDecimal stockDisponible;
-    private BigDecimal stockMinimo;
-    private String estado;
-    private String criticidad;
+    private BigDecimal stockActual;
+    private BigDecimal umbral;
+    private String mensaje;
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/AlertaInventarioSeveridad.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/AlertaInventarioSeveridad.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+public enum AlertaInventarioSeveridad {
+    CRITICA,
+    ADVERTENCIA,
+    INFORMACION
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/AlertaInventarioTipo.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/AlertaInventarioTipo.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+public enum AlertaInventarioTipo {
+    STOCK_MINIMO,
+    STOCK_MAXIMO,
+    LOTE_POR_VENCER,
+    LOTE_VENCIDO
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteAlertaActivaProjection.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteAlertaActivaProjection.java
@@ -1,0 +1,16 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public interface LoteAlertaActivaProjection {
+    Long getLoteProductoId();
+    String getCodigoLote();
+    LocalDateTime getFechaVencimiento();
+    Long getProductoId();
+    String getNombreProducto();
+    String getCodigoSku();
+    Long getAlmacenId();
+    String getNombreAlmacen();
+    BigDecimal getStockActual();
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/StockAlertaProjection.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/StockAlertaProjection.java
@@ -1,0 +1,14 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import java.math.BigDecimal;
+
+public interface StockAlertaProjection {
+    Long getProductoId();
+    String getNombreProducto();
+    String getCodigoSku();
+    Long getAlmacenId();
+    String getNombreAlmacen();
+    BigDecimal getStockMinimo();
+    BigDecimal getStockMaximoPlaneacion();
+    BigDecimal getStockActual();
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.inventario.repository;
 
+import com.willyes.clemenintegra.inventario.dto.LoteAlertaActivaProjection;
+import com.willyes.clemenintegra.inventario.dto.StockAlertaProjection;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
@@ -202,4 +204,43 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
                                         @Param("ubicacionId") Long ubicacionId,
                                         @Param("q") String q,
                                         @Param("estados") Collection<EstadoLote> estados);
+
+    @Query(value = """
+        SELECT lp.productos_id        AS productoId,
+               p.nombre               AS nombreProducto,
+               p.codigo_sku           AS codigoSku,
+               lp.almacenes_id        AS almacenId,
+               a.nombre               AS nombreAlmacen,
+               p.stock_minimo         AS stockMinimo,
+               p.stock_maximo_planeacion AS stockMaximoPlaneacion,
+               COALESCE(SUM(GREATEST(lp.stock_lote - COALESCE(lp.stock_reservado, 0), 0)), 0) AS stockActual
+        FROM lotes_productos lp
+                 JOIN productos p ON p.id = lp.productos_id
+                 JOIN almacenes a ON a.id = lp.almacenes_id
+        GROUP BY lp.productos_id,
+                 p.nombre,
+                 p.codigo_sku,
+                 lp.almacenes_id,
+                 a.nombre,
+                 p.stock_minimo,
+                 p.stock_maximo_planeacion
+        """, nativeQuery = true)
+    List<StockAlertaProjection> sumarStockParaAlertas();
+
+    @Query(value = """
+        SELECT lp.id                AS loteProductoId,
+               lp.codigo_lote       AS codigoLote,
+               lp.fecha_vencimiento AS fechaVencimiento,
+               lp.productos_id      AS productoId,
+               p.nombre             AS nombreProducto,
+               p.codigo_sku         AS codigoSku,
+               lp.almacenes_id      AS almacenId,
+               a.nombre             AS nombreAlmacen,
+               COALESCE(lp.stock_lote - COALESCE(lp.stock_reservado, 0), 0) AS stockActual
+        FROM lotes_productos lp
+                 JOIN productos p ON p.id = lp.productos_id
+                 JOIN almacenes a ON a.id = lp.almacenes_id
+        WHERE lp.fecha_vencimiento IS NOT NULL
+        """, nativeQuery = true)
+    List<LoteAlertaActivaProjection> listarLotesConVencimiento();
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioService.java
@@ -9,5 +9,5 @@ public interface AlertaInventarioService {
     List<ProductoAlertaResponseDTO> obtenerProductosConStockBajo();
     List<LoteAlertaResponseDTO> obtenerLotesVencidos();
     List<LoteEstadoProlongadoResponseDTO> obtenerLotesRetenidosOCuarentenaProlongados();
-    List<AlertaInventarioResponseDTO> obtenerAlertasInventario();
+    List<AlertaInventarioResponseDTO> obtenerAlertasInventario(Integer diasVencimiento);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioServiceImpl.java
@@ -1,6 +1,13 @@
 package com.willyes.clemenintegra.inventario.service;
 
-import com.willyes.clemenintegra.inventario.dto.*;
+import com.willyes.clemenintegra.inventario.dto.AlertaInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.AlertaInventarioSeveridad;
+import com.willyes.clemenintegra.inventario.dto.AlertaInventarioTipo;
+import com.willyes.clemenintegra.inventario.dto.LoteAlertaActivaProjection;
+import com.willyes.clemenintegra.inventario.dto.LoteAlertaResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.LoteEstadoProlongadoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ProductoAlertaResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.StockAlertaProjection;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
@@ -9,11 +16,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,6 +32,9 @@ public class AlertaInventarioServiceImpl implements AlertaInventarioService {
     private final ProductoRepository productoRepository;
     private final LoteProductoRepository loteProductoRepository;
     private final StockQueryService stockQueryService;
+    private Clock clock = Clock.systemDefaultZone();
+
+    private static final int DIAS_VENCIMIENTO_POR_DEFECTO = 30;
 
     public List<ProductoAlertaResponseDTO> obtenerProductosConStockBajo() {
         List<Producto> productos = productoRepository.findAll();
@@ -47,7 +59,7 @@ public class AlertaInventarioServiceImpl implements AlertaInventarioService {
     public List<LoteAlertaResponseDTO> obtenerLotesVencidos() {
         return loteProductoRepository.findAll().stream()
                 .filter(lote -> lote.getFechaVencimiento() != null
-                        && lote.getFechaVencimiento().isBefore(LocalDateTime.now()))
+                        && lote.getFechaVencimiento().isBefore(LocalDateTime.now(clock)))
                 .filter(lote -> lote.getProducto() != null)
                 .map(lote -> LoteAlertaResponseDTO.builder()
                         .loteId(lote.getId())
@@ -65,7 +77,7 @@ public class AlertaInventarioServiceImpl implements AlertaInventarioService {
                         lote.getEstado() != null &&
                                 (lote.getEstado().name().equals("EN_CUARENTENA") || lote.getEstado().name().equals("RETENIDO")) &&
                                 lote.getFechaFabricacion() != null &&
-                                lote.getFechaFabricacion().isBefore(LocalDate.now().minusDays(10).atStartOfDay())  // Cambia a 10 días para prolongados, campo para modificar la alerta
+                                lote.getFechaFabricacion().isBefore(LocalDate.now(clock).minusDays(10).atStartOfDay())  // Cambia a 10 días para prolongados, campo para modificar la alerta
                 )
                 .filter(lote -> lote.getProducto() != null)
                 .map(lote -> LoteEstadoProlongadoResponseDTO.builder()
@@ -73,82 +85,105 @@ public class AlertaInventarioServiceImpl implements AlertaInventarioService {
                         .codigoLote(lote.getCodigoLote())
                         .estado(lote.getEstado().name())
                         .fechaFabricacion(lote.getFechaFabricacion())
-                        .diasEnEstado((int) ChronoUnit.DAYS.between(lote.getFechaFabricacion(), LocalDate.now()))
+                        .diasEnEstado((int) ChronoUnit.DAYS.between(lote.getFechaFabricacion(), LocalDate.now(clock)))
                         .nombreProducto(lote.getProducto().getNombre())
                         .build())
                 .collect(Collectors.toList());
     }
 
-    public List<AlertaInventarioResponseDTO> obtenerAlertasInventario() {
+    public List<AlertaInventarioResponseDTO> obtenerAlertasInventario(Integer diasVencimiento) {
+        int diasUmbral = (diasVencimiento == null || diasVencimiento < 0) ? DIAS_VENCIMIENTO_POR_DEFECTO : diasVencimiento;
+        LocalDateTime ahora = LocalDateTime.now(clock);
+        LocalDateTime corteProximoVencer = ahora.plusDays(diasUmbral);
+
         List<AlertaInventarioResponseDTO> alertas = new java.util.ArrayList<>();
 
-        // Productos con stock bajo
-        List<Producto> productos = productoRepository.findAll();
-        Map<Long, BigDecimal> stockMap = stockQueryService.obtenerStockDisponible(
-                productos.stream().map(p -> p.getId().longValue()).toList());
-        productos.stream()
-                .filter(p -> stockMap.getOrDefault(p.getId().longValue(), BigDecimal.ZERO)
-                        .compareTo(p.getStockMinimo()) < 0)
-                .forEach(producto -> {
-                    BigDecimal stock = stockMap.getOrDefault(producto.getId().longValue(), BigDecimal.ZERO);
-                    alertas.add(AlertaInventarioResponseDTO.builder()
-                            .tipo("Stock bajo")
-                            .nombreProducto(producto.getNombre())
-                            .nombreAlmacen("")
-                            .codigoLote("")
-                            .fechaVencimiento(null)
-                            .stockDisponible(stock)
-                            .stockMinimo(producto.getStockMinimo())
-                            .estado("")
-                            .criticidad("stock")
-                            .build());
-                });
+        for (StockAlertaProjection stock : loteProductoRepository.sumarStockParaAlertas()) {
+            BigDecimal stockActual = defaultBigDecimal(stock.getStockActual());
+            BigDecimal stockMinimo = defaultBigDecimal(stock.getStockMinimo());
+            BigDecimal stockMaximo = stock.getStockMaximoPlaneacion();
 
-        // Lotes vencidos
-        loteProductoRepository.findAll().stream()
-                .filter(lote -> lote.getFechaVencimiento() != null && lote.getFechaVencimiento().isBefore(LocalDateTime.now()))
-                .filter(lote -> lote.getProducto() != null)
-                .forEach(lote -> {
-                    String nombreAlmacen = lote.getAlmacen() != null && lote.getAlmacen().getNombre() != null
-                            ? lote.getAlmacen().getNombre() : "";
-                    alertas.add(AlertaInventarioResponseDTO.builder()
-                            .tipo("Lote vencido")
-                            .nombreProducto(lote.getProducto().getNombre())
-                            .nombreAlmacen(nombreAlmacen)
-                            .codigoLote(lote.getCodigoLote())
-                            .fechaVencimiento(lote.getFechaVencimiento())
-                            .stockDisponible(lote.getStockLote().subtract(lote.getStockReservado()))
-                            .stockMinimo(null)
-                            .estado("")
-                            .criticidad("critica")
-                            .build());
-                });
+            if (stockActual.compareTo(stockMinimo) < 0) {
+                alertas.add(AlertaInventarioResponseDTO.builder()
+                        .tipo(AlertaInventarioTipo.STOCK_MINIMO)
+                        .severidad(AlertaInventarioSeveridad.ADVERTENCIA)
+                        .productoId(stock.getProductoId())
+                        .nombreProducto(stock.getNombreProducto())
+                        .codigoSku(stock.getCodigoSku())
+                        .almacenId(stock.getAlmacenId())
+                        .nombreAlmacen(stock.getNombreAlmacen())
+                        .stockActual(stockActual)
+                        .umbral(stockMinimo)
+                        .mensaje(String.format("Stock actual %s por debajo del mínimo %s", stockActual.toPlainString(), stockMinimo.toPlainString()))
+                        .build());
+            }
 
-        // Lotes en cuarentena o retenidos prolongados
-        loteProductoRepository.findAll().stream()
-                .filter(lote -> lote.getEstado() != null &&
-                        (lote.getEstado().name().equals("EN_CUARENTENA") || lote.getEstado().name().equals("RETENIDO")))
-                .filter(lote -> lote.getFechaFabricacion() != null &&
-                        lote.getFechaFabricacion().isBefore(LocalDateTime.now().minusDays(15)))
-                .filter(lote -> lote.getProducto() != null)
-                .forEach(lote -> {
-                    String nombreAlmacen = lote.getAlmacen() != null && lote.getAlmacen().getNombre() != null
-                            ? lote.getAlmacen().getNombre() : "";
-                    alertas.add(AlertaInventarioResponseDTO.builder()
-                            .tipo("Lote en cuarentena")
-                            .nombreProducto(lote.getProducto().getNombre())
-                            .nombreAlmacen(nombreAlmacen)
-                            .codigoLote(lote.getCodigoLote())
-                            .fechaVencimiento(lote.getFechaVencimiento())
-                            .stockDisponible(lote.getStockLote().subtract(lote.getStockReservado()))
-                            .stockMinimo(null)
-                            .estado(lote.getEstado().name())
-                            .criticidad("advertencia")
-                            .build());
-                });
+            if (stockMaximo != null && stockActual.compareTo(stockMaximo) > 0) {
+                alertas.add(AlertaInventarioResponseDTO.builder()
+                        .tipo(AlertaInventarioTipo.STOCK_MAXIMO)
+                        .severidad(AlertaInventarioSeveridad.ADVERTENCIA)
+                        .productoId(stock.getProductoId())
+                        .nombreProducto(stock.getNombreProducto())
+                        .codigoSku(stock.getCodigoSku())
+                        .almacenId(stock.getAlmacenId())
+                        .nombreAlmacen(stock.getNombreAlmacen())
+                        .stockActual(stockActual)
+                        .umbral(stockMaximo)
+                        .mensaje(String.format("Stock actual %s supera el máximo %s", stockActual.toPlainString(), stockMaximo.toPlainString()))
+                        .build());
+            }
+        }
+
+        for (LoteAlertaActivaProjection lote : loteProductoRepository.listarLotesConVencimiento()) {
+            LocalDateTime fechaVencimiento = lote.getFechaVencimiento();
+            if (fechaVencimiento == null) {
+                continue;
+            }
+
+            BigDecimal stockActual = defaultBigDecimal(lote.getStockActual());
+            if (fechaVencimiento.isBefore(ahora)) {
+                alertas.add(AlertaInventarioResponseDTO.builder()
+                        .tipo(AlertaInventarioTipo.LOTE_VENCIDO)
+                        .severidad(AlertaInventarioSeveridad.CRITICA)
+                        .productoId(lote.getProductoId())
+                        .nombreProducto(lote.getNombreProducto())
+                        .codigoSku(lote.getCodigoSku())
+                        .almacenId(lote.getAlmacenId())
+                        .nombreAlmacen(lote.getNombreAlmacen())
+                        .loteProductoId(lote.getLoteProductoId())
+                        .codigoLote(lote.getCodigoLote())
+                        .fechaVencimiento(fechaVencimiento)
+                        .stockActual(stockActual)
+                        .umbral(BigDecimal.ZERO)
+                        .mensaje("Lote vencido")
+                        .build());
+            } else if (!fechaVencimiento.isAfter(corteProximoVencer)) {
+                alertas.add(AlertaInventarioResponseDTO.builder()
+                        .tipo(AlertaInventarioTipo.LOTE_POR_VENCER)
+                        .severidad(AlertaInventarioSeveridad.ADVERTENCIA)
+                        .productoId(lote.getProductoId())
+                        .nombreProducto(lote.getNombreProducto())
+                        .codigoSku(lote.getCodigoSku())
+                        .almacenId(lote.getAlmacenId())
+                        .nombreAlmacen(lote.getNombreAlmacen())
+                        .loteProductoId(lote.getLoteProductoId())
+                        .codigoLote(lote.getCodigoLote())
+                        .fechaVencimiento(fechaVencimiento)
+                        .stockActual(stockActual)
+                        .umbral(BigDecimal.valueOf(diasUmbral))
+                        .mensaje(String.format("Lote próximo a vencer en %d días o menos", diasUmbral))
+                        .build());
+            }
+        }
 
         return alertas;
     }
 
-}
+    private BigDecimal defaultBigDecimal(BigDecimal value) {
+        return Objects.requireNonNullElse(value, BigDecimal.ZERO);
+    }
 
+    void setClock(Clock clock) {
+        this.clock = clock == null ? Clock.systemDefaultZone() : clock;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -107,8 +107,6 @@ public class SecurityConfig {
                             "/api/inventario/alertas/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_ALMACENES.name(),
                             RolUsuario.ROL_ALMACENISTA.name(),
-                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
-                            RolUsuario.ROL_JEFE_CALIDAD.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/AlertaInventarioControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/AlertaInventarioControllerTest.java
@@ -1,0 +1,78 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.AlertaInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.AlertaInventarioSeveridad;
+import com.willyes.clemenintegra.inventario.dto.AlertaInventarioTipo;
+import com.willyes.clemenintegra.inventario.service.AlertaInventarioService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AlertaInventarioController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AlertaInventarioControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AlertaInventarioService alertaInventarioService;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void devuelveAlertasActivasConUmbralPersonalizado() throws Exception {
+        AlertaInventarioResponseDTO dto = AlertaInventarioResponseDTO.builder()
+                .tipo(AlertaInventarioTipo.STOCK_MINIMO)
+                .severidad(AlertaInventarioSeveridad.ADVERTENCIA)
+                .productoId(1L)
+                .nombreProducto("Producto A")
+                .codigoSku("SKU-A")
+                .almacenId(10L)
+                .nombreAlmacen("Almacén 1")
+                .stockActual(BigDecimal.ONE)
+                .umbral(BigDecimal.TEN)
+                .fechaVencimiento(LocalDateTime.parse("2025-01-10T00:00:00"))
+                .mensaje("Stock actual 1 por debajo del mínimo 10")
+                .build();
+        when(alertaInventarioService.obtenerAlertasInventario(45)).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/inventario/alertas")
+                        .param("diasVencimiento", "45")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].tipo").value("STOCK_MINIMO"))
+                .andExpect(jsonPath("$[0].productoId").value(1))
+                .andExpect(jsonPath("$[0].almacenId").value(10))
+                .andExpect(jsonPath("$[0].umbral").value(10));
+
+        ArgumentCaptor<Integer> diasCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(alertaInventarioService).obtenerAlertasInventario(diasCaptor.capture());
+        assertThat(diasCaptor.getValue()).isEqualTo(45);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioServiceImplTest.java
@@ -1,0 +1,170 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.AlertaInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.AlertaInventarioSeveridad;
+import com.willyes.clemenintegra.inventario.dto.AlertaInventarioTipo;
+import com.willyes.clemenintegra.inventario.dto.LoteAlertaActivaProjection;
+import com.willyes.clemenintegra.inventario.dto.StockAlertaProjection;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AlertaInventarioServiceImplTest {
+
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private StockQueryService stockQueryService;
+
+    @InjectMocks
+    private AlertaInventarioServiceImpl service;
+
+    @BeforeEach
+    void setUpClock() {
+        service.setClock(Clock.fixed(Instant.parse("2025-01-15T10:00:00Z"), ZoneId.of("UTC")));
+    }
+
+    @Test
+    @DisplayName("Genera alertas por stock mínimo, stock máximo, lote por vencer y lote vencido sin filtrar por estado")
+    void generaAlertasActivasCompleta() {
+        when(loteProductoRepository.sumarStockParaAlertas()).thenReturn(List.of(
+                new StockRow(1L, "Producto A", "SKU-A", 10L, "Almacén 1",
+                        BigDecimal.valueOf(5), BigDecimal.valueOf(20), BigDecimal.valueOf(3)),
+                new StockRow(2L, "Producto B", "SKU-B", 11L, "Almacén 2",
+                        BigDecimal.valueOf(5), BigDecimal.valueOf(8), BigDecimal.valueOf(12))
+        ));
+
+        when(loteProductoRepository.listarLotesConVencimiento()).thenReturn(List.of(
+                new LoteRow(101L, "L-1", LocalDateTime.parse("2025-01-10T00:00:00"), 1L, "Producto A", "SKU-A",
+                        10L, "Almacén 1", BigDecimal.valueOf(1)),
+                new LoteRow(102L, "L-2", LocalDateTime.parse("2025-02-10T00:00:00"), 2L, "Producto B", "SKU-B",
+                        11L, "Almacén 2", BigDecimal.valueOf(2)),
+                new LoteRow(103L, "L-3", LocalDateTime.parse("2025-03-20T00:00:00"), 3L, "Producto C", "SKU-C",
+                        12L, "Almacén 3", BigDecimal.ONE)
+        ));
+
+        List<AlertaInventarioResponseDTO> alertas = service.obtenerAlertasInventario(30);
+
+        assertThat(alertas)
+                .hasSize(4)
+                .extracting(AlertaInventarioResponseDTO::getTipo)
+                .containsExactlyInAnyOrder(
+                        AlertaInventarioTipo.STOCK_MINIMO,
+                        AlertaInventarioTipo.STOCK_MAXIMO,
+                        AlertaInventarioTipo.LOTE_VENCIDO,
+                        AlertaInventarioTipo.LOTE_POR_VENCER
+                );
+
+        assertThat(alertas)
+                .filteredOn(a -> a.getTipo() == AlertaInventarioTipo.STOCK_MINIMO)
+                .first()
+                .satisfies(alerta -> {
+                    assertThat(alerta.getStockActual()).isEqualByComparingTo("3");
+                    assertThat(alerta.getUmbral()).isEqualByComparingTo("5");
+                    assertThat(alerta.getSeveridad()).isEqualTo(AlertaInventarioSeveridad.ADVERTENCIA);
+                });
+
+        assertThat(alertas)
+                .filteredOn(a -> a.getTipo() == AlertaInventarioTipo.STOCK_MAXIMO)
+                .first()
+                .satisfies(alerta -> {
+                    assertThat(alerta.getStockActual()).isEqualByComparingTo("12");
+                    assertThat(alerta.getUmbral()).isEqualByComparingTo("8");
+                });
+
+        assertThat(alertas)
+                .filteredOn(a -> a.getTipo() == AlertaInventarioTipo.LOTE_VENCIDO)
+                .first()
+                .satisfies(alerta -> {
+                    assertThat(alerta.getLoteProductoId()).isEqualTo(101L);
+                    assertThat(alerta.getSeveridad()).isEqualTo(AlertaInventarioSeveridad.CRITICA);
+                });
+
+        assertThat(alertas)
+                .filteredOn(a -> a.getTipo() == AlertaInventarioTipo.LOTE_POR_VENCER)
+                .first()
+                .satisfies(alerta -> {
+                    assertThat(alerta.getLoteProductoId()).isEqualTo(102L);
+                    assertThat(alerta.getUmbral()).isEqualByComparingTo("30");
+                });
+    }
+
+    private record StockRow(Long productoId, String nombreProducto, String codigoSku, Long almacenId, String nombreAlmacen,
+                            BigDecimal stockMinimo, BigDecimal stockMaximoPlaneacion, BigDecimal stockActual)
+            implements StockAlertaProjection {
+        @Override
+        public Long getProductoId() {return productoId;}
+
+        @Override
+        public String getNombreProducto() {return nombreProducto;}
+
+        @Override
+        public String getCodigoSku() {return codigoSku;}
+
+        @Override
+        public Long getAlmacenId() {return almacenId;}
+
+        @Override
+        public String getNombreAlmacen() {return nombreAlmacen;}
+
+        @Override
+        public BigDecimal getStockMinimo() {return stockMinimo;}
+
+        @Override
+        public BigDecimal getStockMaximoPlaneacion() {return stockMaximoPlaneacion;}
+
+        @Override
+        public BigDecimal getStockActual() {return stockActual;}
+    }
+
+    private record LoteRow(Long loteProductoId, String codigoLote, LocalDateTime fechaVencimiento,
+                           Long productoId, String nombreProducto, String codigoSku,
+                           Long almacenId, String nombreAlmacen, BigDecimal stockActual)
+            implements LoteAlertaActivaProjection {
+        @Override
+        public Long getLoteProductoId() {return loteProductoId;}
+
+        @Override
+        public String getCodigoLote() {return codigoLote;}
+
+        @Override
+        public LocalDateTime getFechaVencimiento() {return fechaVencimiento;}
+
+        @Override
+        public Long getProductoId() {return productoId;}
+
+        @Override
+        public String getNombreProducto() {return nombreProducto;}
+
+        @Override
+        public String getCodigoSku() {return codigoSku;}
+
+        @Override
+        public Long getAlmacenId() {return almacenId;}
+
+        @Override
+        public String getNombreAlmacen() {return nombreAlmacen;}
+
+        @Override
+        public BigDecimal getStockActual() {return stockActual;}
+    }
+}


### PR DESCRIPTION
## Summary
- expose a detailed /api/inventario/alertas response that includes stock mínimo, stock máximo, y vencimientos con severidad y metadatos listos para UI
- calcular stock por producto/almacén sin filtrar estados ni agotados, y agregar consultas para lotes por vencer/vencidos
- asegurar acceso sólo a roles de inventario y añadir pruebas unitarias/web para el servicio y controlador de alertas

## Testing
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694292c1dee88333a10c44e18950fdfa)