### PR TITLE
Prevent stock máximo alerts without configured threshold

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -236,7 +236,7 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
                p.codigo_sku         AS codigoSku,
                lp.almacenes_id      AS almacenId,
                a.nombre             AS nombreAlmacen,
-               COALESCE(lp.stock_lote - COALESCE(lp.stock_reservado, 0), 0) AS stockActual
+               GREATEST(lp.stock_lote - COALESCE(lp.stock_reservado, 0), 0) AS stockActual
         FROM lotes_productos lp
                  JOIN productos p ON p.id = lp.productos_id
                  JOIN almacenes a ON a.id = lp.almacenes_id

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioServiceImpl.java
@@ -118,7 +118,7 @@ public class AlertaInventarioServiceImpl implements AlertaInventarioService {
                         .build());
             }
 
-            if (stockMaximo != null && stockActual.compareTo(stockMaximo) > 0) {
+            if (stockMaximo != null && stockMaximo.compareTo(BigDecimal.ZERO) > 0 && stockActual.compareTo(stockMaximo) > 0) {
                 alertas.add(AlertaInventarioResponseDTO.builder()
                         .tipo(AlertaInventarioTipo.STOCK_MAXIMO)
                         .severidad(AlertaInventarioSeveridad.ADVERTENCIA)
@@ -140,7 +140,7 @@ public class AlertaInventarioServiceImpl implements AlertaInventarioService {
                 continue;
             }
 
-            BigDecimal stockActual = defaultBigDecimal(lote.getStockActual());
+            BigDecimal stockActual = defaultBigDecimal(lote.getStockActual()).max(BigDecimal.ZERO);
             if (fechaVencimiento.isBefore(ahora)) {
                 alertas.add(AlertaInventarioResponseDTO.builder()
                         .tipo(AlertaInventarioTipo.LOTE_VENCIDO)

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/AlertaInventarioServiceImplTest.java
@@ -108,6 +108,59 @@ class AlertaInventarioServiceImplTest {
                 });
     }
 
+    @Test
+    @DisplayName("No genera alerta de stock máximo cuando el umbral no está configurado o es cero")
+    void noGeneraStockMaximoCuandoUmbralNoConfigurado() {
+        when(loteProductoRepository.sumarStockParaAlertas()).thenReturn(List.of(
+                new StockRow(1L, "Producto A", "SKU-A", 10L, "Almacén 1",
+                        BigDecimal.ONE, BigDecimal.ZERO, BigDecimal.TEN)
+        ));
+        when(loteProductoRepository.listarLotesConVencimiento()).thenReturn(List.of());
+
+        List<AlertaInventarioResponseDTO> alertas = service.obtenerAlertasInventario(15);
+
+        assertThat(alertas)
+                .extracting(AlertaInventarioResponseDTO::getTipo)
+                .doesNotContain(AlertaInventarioTipo.STOCK_MAXIMO);
+    }
+
+    @Test
+    @DisplayName("Genera alerta de stock máximo cuando el umbral está configurado y el stock lo supera")
+    void generaStockMaximoConUmbralConfigurado() {
+        when(loteProductoRepository.sumarStockParaAlertas()).thenReturn(List.of(
+                new StockRow(1L, "Producto A", "SKU-A", 10L, "Almacén 1",
+                        BigDecimal.ZERO, BigDecimal.valueOf(5), BigDecimal.TEN)
+        ));
+        when(loteProductoRepository.listarLotesConVencimiento()).thenReturn(List.of());
+
+        List<AlertaInventarioResponseDTO> alertas = service.obtenerAlertasInventario(15);
+
+        assertThat(alertas)
+                .filteredOn(a -> a.getTipo() == AlertaInventarioTipo.STOCK_MAXIMO)
+                .singleElement()
+                .satisfies(alerta -> {
+                    assertThat(alerta.getStockActual()).isEqualByComparingTo("10");
+                    assertThat(alerta.getUmbral()).isEqualByComparingTo("5");
+                });
+    }
+
+    @Test
+    @DisplayName("El stock actual del lote en alertas de vencimiento nunca es negativo")
+    void stockActualDeLoteNoEsNegativo() {
+        when(loteProductoRepository.sumarStockParaAlertas()).thenReturn(List.of());
+        when(loteProductoRepository.listarLotesConVencimiento()).thenReturn(List.of(
+                new LoteRow(201L, "L-NEG", LocalDateTime.parse("2025-01-10T00:00:00"), 5L, "Producto Neg", "SKU-N",
+                        20L, "Almacén N", BigDecimal.valueOf(-5))
+        ));
+
+        List<AlertaInventarioResponseDTO> alertas = service.obtenerAlertasInventario(10);
+
+        assertThat(alertas)
+                .filteredOn(a -> a.getTipo() == AlertaInventarioTipo.LOTE_VENCIDO)
+                .singleElement()
+                .satisfies(alerta -> assertThat(alerta.getStockActual()).isEqualByComparingTo(BigDecimal.ZERO));
+    }
+
     private record StockRow(Long productoId, String nombreProducto, String codigoSku, Long almacenId, String nombreAlmacen,
                             BigDecimal stockMinimo, BigDecimal stockMaximoPlaneacion, BigDecimal stockActual)
             implements StockAlertaProjection {


### PR DESCRIPTION
## Summary
- Ignore stock máximo alerts when the planning threshold is null or zero and clamp lot stock values to zero in alerts
- Ensure the lotes con vencimiento projection never returns negative stock values
- Add unit coverage for stock máximo thresholds and non-negative lot stock in alert generation

## Testing
- mvn test -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942de6d5ad48333b8d3734a4be424f8)