### PR TITLE
Add attachments handling for purchase orders

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraDocumentoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraDocumentoController.java
@@ -1,0 +1,61 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDocumentoDescargaDTO;
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDocumentoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDocumentoUploadForm;
+import com.willyes.clemenintegra.inventario.service.OrdenCompraDocumentoService;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/ordenes-compra")
+@RequiredArgsConstructor
+public class OrdenCompraDocumentoController {
+
+    private final OrdenCompraDocumentoService documentoService;
+
+    @PostMapping(value = "/{ordenCompraId}/documentos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    public List<OrdenCompraDocumentoResponseDTO> subirDocumentos(
+            @PathVariable Long ordenCompraId,
+            @RequestPart("archivos") List<MultipartFile> archivos,
+            @org.springframework.web.bind.annotation.ModelAttribute OrdenCompraDocumentoUploadForm form,
+            @AuthenticationPrincipal CustomUserDetails usuarioAutenticado) {
+        return documentoService.subirDocumentos(
+                ordenCompraId,
+                archivos,
+                form != null ? form.getDocumentosAdjuntos() : null,
+                usuarioAutenticado != null ? usuarioAutenticado.getId() : null);
+    }
+
+    @GetMapping("/{ordenCompraId}/documentos")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
+    public List<OrdenCompraDocumentoResponseDTO> listarDocumentos(@PathVariable Long ordenCompraId) {
+        return documentoService.listar(ordenCompraId);
+    }
+
+    @GetMapping("/documentos/{documentoId}/download")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Resource> descargar(@PathVariable Long documentoId) {
+        OrdenCompraDocumentoDescargaDTO descarga = documentoService.descargar(documentoId);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(descarga.contentType()))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + descarga.nombreArchivo() + "\"")
+                .body(descarga.recurso());
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/DocumentoMetaDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/DocumentoMetaDTO.java
@@ -1,0 +1,16 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import com.willyes.clemenintegra.inventario.model.enums.TipoDocumentoOrdenCompra;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DocumentoMetaDTO {
+    private String nombreVisible;
+    private TipoDocumentoOrdenCompra tipoDocumento;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDocumentoDescargaDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDocumentoDescargaDTO.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import org.springframework.core.io.Resource;
+
+public record OrdenCompraDocumentoDescargaDTO(Resource recurso, String nombreArchivo, String contentType) {
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDocumentoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDocumentoResponseDTO.java
@@ -1,0 +1,23 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import com.willyes.clemenintegra.inventario.model.enums.TipoDocumentoOrdenCompra;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrdenCompraDocumentoResponseDTO {
+    private Long id;
+    private TipoDocumentoOrdenCompra tipoDocumento;
+    private String nombreVisible;
+    private String contentType;
+    private Long size;
+    private LocalDateTime fechaCreacion;
+    private String creadoPorNombre;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDocumentoUploadForm.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/OrdenCompraDocumentoUploadForm.java
@@ -1,0 +1,16 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrdenCompraDocumentoUploadForm {
+    private List<DocumentoMetaDTO> documentosAdjuntos;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/OrdenCompraDocumento.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/OrdenCompraDocumento.java
@@ -1,0 +1,58 @@
+package com.willyes.clemenintegra.inventario.model;
+
+import com.willyes.clemenintegra.inventario.model.enums.TipoDocumentoOrdenCompra;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "orden_compra_documentos")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrdenCompraDocumento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orden_compra_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_oc_documento_oc"))
+    private OrdenCompra ordenCompra;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_documento", length = 20, nullable = false)
+    private TipoDocumentoOrdenCompra tipoDocumento;
+
+    @Column(name = "nombre_visible", nullable = false, length = 255)
+    private String nombreVisible;
+
+    @Column(name = "nombre_archivo", nullable = false, length = 255)
+    private String nombreArchivo;
+
+    @Column(name = "content_type", length = 100)
+    private String contentType;
+
+    @Column(name = "size")
+    private Long size;
+
+    @Column(name = "storage_path", nullable = false, length = 500)
+    private String storagePath;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creado_por_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_oc_documento_usuario"))
+    private Usuario creadoPor;
+
+    @Column(name = "fecha_creacion", nullable = false)
+    private LocalDateTime fechaCreacion;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/model/enums/TipoDocumentoOrdenCompra.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/enums/TipoDocumentoOrdenCompra.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.inventario.model.enums;
+
+public enum TipoDocumentoOrdenCompra {
+    CERTIFICADO,
+    FACTURA,
+    GUIA
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/OrdenCompraDocumentoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/OrdenCompraDocumentoRepository.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.OrdenCompraDocumento;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrdenCompraDocumentoRepository extends JpaRepository<OrdenCompraDocumento, Long> {
+    List<OrdenCompraDocumento> findByOrdenCompra_Id(Long ordenCompraId);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraDocumentoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraDocumentoService.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.DocumentoMetaDTO;
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDocumentoDescargaDTO;
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDocumentoResponseDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface OrdenCompraDocumentoService {
+
+    List<OrdenCompraDocumentoResponseDTO> subirDocumentos(Long ordenCompraId,
+                                                          List<MultipartFile> archivos,
+                                                          List<DocumentoMetaDTO> metadata,
+                                                          Long usuarioId);
+
+    List<OrdenCompraDocumentoResponseDTO> listar(Long ordenCompraId);
+
+    OrdenCompraDocumentoDescargaDTO descargar(Long documentoId);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraDocumentoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraDocumentoServiceImpl.java
@@ -1,0 +1,204 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.DocumentoMetaDTO;
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDocumentoDescargaDTO;
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDocumentoResponseDTO;
+import com.willyes.clemenintegra.inventario.model.OrdenCompra;
+import com.willyes.clemenintegra.inventario.model.OrdenCompraDocumento;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraDocumentoRepository;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraRepository;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrdenCompraDocumentoServiceImpl implements OrdenCompraDocumentoService {
+
+    private final OrdenCompraRepository ordenCompraRepository;
+    private final OrdenCompraDocumentoRepository documentoRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    private static final DateTimeFormatter NOMBRE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    @Override
+    @Transactional
+    public List<OrdenCompraDocumentoResponseDTO> subirDocumentos(Long ordenCompraId,
+                                                                 List<MultipartFile> archivos,
+                                                                 List<DocumentoMetaDTO> metadata,
+                                                                 Long usuarioId) {
+        if (archivos == null || archivos.isEmpty()) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "Debe adjuntar al menos un archivo válido");
+        }
+        if (usuarioId == null) {
+            throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA, "El usuario autenticado es obligatorio");
+        }
+
+        OrdenCompra ordenCompra = ordenCompraRepository.findById(ordenCompraId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "La orden de compra no existe"));
+
+        Usuario usuario = usuarioRepository.findById(usuarioId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "Usuario no encontrado"));
+
+        List<OrdenCompraDocumento> guardados = new ArrayList<>();
+        for (int i = 0; i < archivos.size(); i++) {
+            MultipartFile archivo = archivos.get(i);
+            if (archivo == null || archivo.isEmpty()) {
+                throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "Debe adjuntar un archivo válido");
+            }
+            DocumentoMetaDTO meta = obtenerMeta(metadata, i);
+            validarMeta(meta);
+
+            String nombreOriginal = archivo.getOriginalFilename();
+            String nombreSanitizado = sanitizeFilename(nombreOriginal != null ? nombreOriginal : archivo.getName());
+            String nombreInterno = construirNombreInterno(nombreSanitizado);
+
+            Path rutaBase = Paths.get(System.getProperty("user.dir"), "uploads", "ordenes-compra",
+                    ordenCompraId.toString()).toAbsolutePath().normalize();
+            Path rutaUploads = Paths.get(System.getProperty("user.dir"), "uploads").toAbsolutePath().normalize();
+
+            try {
+                Files.createDirectories(rutaBase);
+                Path destino = rutaBase.resolve(nombreInterno);
+                Path destinoNormalizado = destino.toAbsolutePath().normalize();
+
+                if (!destinoNormalizado.startsWith(rutaUploads)) {
+                    throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "Ruta de almacenamiento inválida");
+                }
+
+                archivo.transferTo(destino.toFile());
+
+                OrdenCompraDocumento documento = new OrdenCompraDocumento();
+                documento.setOrdenCompra(ordenCompra);
+                documento.setTipoDocumento(meta.getTipoDocumento());
+                documento.setNombreVisible(meta.getNombreVisible());
+                documento.setNombreArchivo(nombreInterno);
+                documento.setContentType(archivo.getContentType());
+                documento.setSize(archivo.getSize());
+                documento.setStoragePath(Paths.get("uploads", "ordenes-compra", ordenCompraId.toString(), nombreInterno).toString());
+                documento.setCreadoPor(usuario);
+                documento.setFechaCreacion(LocalDateTime.now());
+
+                guardados.add(documentoRepository.save(documento));
+            } catch (IOException e) {
+                log.error("Error al almacenar documento de orden de compra {}", ordenCompraId, e);
+                throw new CustomBusinessException(ApiErrorCode.ERROR_INTERNO,
+                        "No fue posible almacenar el archivo adjunto de la orden de compra");
+            }
+        }
+
+        return guardados.stream()
+                .map(this::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OrdenCompraDocumentoResponseDTO> listar(Long ordenCompraId) {
+        return documentoRepository.findByOrdenCompra_Id(ordenCompraId).stream()
+                .map(this::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OrdenCompraDocumentoDescargaDTO descargar(Long documentoId) {
+        OrdenCompraDocumento documento = documentoRepository.findById(documentoId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "El documento solicitado no existe"));
+
+        Path rutaArchivo = Paths.get(System.getProperty("user.dir"))
+                .resolve(documento.getStoragePath()).toAbsolutePath().normalize();
+        Path rutaUploads = Paths.get(System.getProperty("user.dir"), "uploads").toAbsolutePath().normalize();
+
+        if (!rutaArchivo.startsWith(rutaUploads) || !Files.exists(rutaArchivo)) {
+            throw new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                    "El archivo físico del documento no está disponible");
+        }
+
+        try {
+            Resource recurso = new UrlResource(rutaArchivo.toUri());
+            if (!recurso.exists() || !recurso.isReadable()) {
+                throw new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "El archivo físico del documento no está disponible");
+            }
+
+            String contentType = documento.getContentType();
+            if (contentType == null) {
+                contentType = Files.probeContentType(rutaArchivo);
+            }
+
+            String nombreDescarga = documento.getNombreVisible() != null
+                    ? documento.getNombreVisible()
+                    : recurso.getFilename();
+
+            return new OrdenCompraDocumentoDescargaDTO(recurso,
+                    nombreDescarga,
+                    contentType != null ? contentType : "application/octet-stream");
+        } catch (IOException e) {
+            log.error("Error al preparar descarga del documento {}", documentoId, e);
+            throw new CustomBusinessException(ApiErrorCode.ERROR_INTERNO,
+                    "No fue posible preparar el archivo para descarga");
+        }
+    }
+
+    private OrdenCompraDocumentoResponseDTO toResponseDTO(OrdenCompraDocumento documento) {
+        return OrdenCompraDocumentoResponseDTO.builder()
+                .id(documento.getId())
+                .tipoDocumento(documento.getTipoDocumento())
+                .nombreVisible(documento.getNombreVisible())
+                .contentType(documento.getContentType())
+                .size(documento.getSize())
+                .fechaCreacion(documento.getFechaCreacion())
+                .creadoPorNombre(documento.getCreadoPor() != null ? documento.getCreadoPor().getNombreCompleto() : null)
+                .build();
+    }
+
+    private DocumentoMetaDTO obtenerMeta(List<DocumentoMetaDTO> metadata, int index) {
+        if (metadata == null || metadata.size() <= index) {
+            return null;
+        }
+        return metadata.get(index);
+    }
+
+    private void validarMeta(DocumentoMetaDTO meta) {
+        if (meta == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "Falta información de metadata para el archivo");
+        }
+        if (meta.getNombreVisible() == null || meta.getNombreVisible().isBlank()) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "El nombre visible es obligatorio");
+        }
+        if (meta.getTipoDocumento() == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "El tipo de documento es obligatorio");
+        }
+    }
+
+    private String sanitizeFilename(String nombre) {
+        return nombre.replaceAll("[^a-zA-Z0-9._-]", "_");
+    }
+
+    private String construirNombreInterno(String nombreSanitizado) {
+        String timestamp = LocalDateTime.now().format(NOMBRE_FORMATTER);
+        return timestamp + "_" + UUID.randomUUID() + "_" + nombreSanitizado;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -133,6 +133,19 @@ public class SecurityConfig {
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
+                    auth.requestMatchers(HttpMethod.POST, "/api/ordenes-compra/*/documentos").hasAnyAuthority(
+                            RolUsuario.ROL_COMPRADOR.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers(HttpMethod.GET,
+                            "/api/ordenes-compra/*/documentos",
+                            "/api/ordenes-compra/documentos/**").hasAnyAuthority(
+                            RolUsuario.ROL_COMPRADOR.name(),
+                            RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
                     auth.requestMatchers("/api/calidad/**",
                             "/api/calidad/evaluaciones/archivo/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_CALIDAD.name(),

--- a/src/main/resources/db/migration/V20251218__orden_compra_documentos.sql
+++ b/src/main/resources/db/migration/V20251218__orden_compra_documentos.sql
@@ -1,0 +1,22 @@
+create table orden_compra_documentos (
+    id bigint not null auto_increment,
+    orden_compra_id bigint not null,
+    tipo_documento varchar(20) not null,
+    nombre_visible varchar(255) not null,
+    nombre_archivo varchar(255) not null,
+    content_type varchar(100),
+    size bigint,
+    storage_path varchar(500) not null,
+    creado_por_id bigint not null,
+    fecha_creacion datetime not null default current_timestamp,
+    primary key (id)
+) ENGINE=InnoDB;
+
+alter table orden_compra_documentos
+    add constraint fk_oc_documento_oc foreign key (orden_compra_id) references ordenes_compra (id);
+
+alter table orden_compra_documentos
+    add constraint fk_oc_documento_usuario foreign key (creado_por_id) references usuarios (id);
+
+create index idx_oc_documentos_oc on orden_compra_documentos (orden_compra_id);
+create index idx_oc_documentos_tipo on orden_compra_documentos (tipo_documento);

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraDocumentoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraDocumentoControllerTest.java
@@ -1,0 +1,122 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDocumentoDescargaDTO;
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDocumentoResponseDTO;
+import com.willyes.clemenintegra.inventario.service.OrdenCompraDocumentoService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = OrdenCompraDocumentoController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+class OrdenCompraDocumentoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OrdenCompraDocumentoService documentoService;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    @DisplayName("POST /api/ordenes-compra/{id}/documentos con rol comprador retorna 200")
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void subirDocumentos_ok() throws Exception {
+        MockMultipartFile archivo = new MockMultipartFile("archivos", "cert.pdf", "application/pdf", "data".getBytes());
+
+        when(documentoService.subirDocumentos(anyLong(), any(), any(), anyLong()))
+                .thenReturn(List.of(
+                        OrdenCompraDocumentoResponseDTO.builder()
+                                .id(1L)
+                                .nombreVisible("Cert")
+                                .fechaCreacion(LocalDateTime.now())
+                                .build()));
+
+        mockMvc.perform(multipart("/api/ordenes-compra/{ocId}/documentos", 5L)
+                        .file(archivo)
+                        .param("documentosAdjuntos[0].nombreVisible", "Cert")
+                        .param("documentosAdjuntos[0].tipoDocumento", "CERTIFICADO"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("GET /api/ordenes-compra/{id}/documentos listado con rol comprador")
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void listar_ok() throws Exception {
+        when(documentoService.listar(anyLong()))
+                .thenReturn(List.of(OrdenCompraDocumentoResponseDTO.builder()
+                        .id(2L)
+                        .nombreVisible("Factura")
+                        .build()));
+
+        mockMvc.perform(get("/api/ordenes-compra/{ocId}/documentos", 7L))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("GET /api/ordenes-compra/documentos/{id}/download responde attachment")
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void descargar_ok() throws Exception {
+        when(documentoService.descargar(anyLong()))
+                .thenReturn(new OrdenCompraDocumentoDescargaDTO(new ByteArrayResource("bytes".getBytes()),
+                        "guia.pdf",
+                        "application/pdf"));
+
+        mockMvc.perform(get("/api/ordenes-compra/documentos/{docId}/download", 9L))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"guia.pdf\""));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/OrdenCompraDocumentoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/OrdenCompraDocumentoServiceImplTest.java
@@ -1,0 +1,117 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.DocumentoMetaDTO;
+import com.willyes.clemenintegra.inventario.model.OrdenCompra;
+import com.willyes.clemenintegra.inventario.model.OrdenCompraDocumento;
+import com.willyes.clemenintegra.inventario.model.enums.TipoDocumentoOrdenCompra;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraDocumentoRepository;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraRepository;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+class OrdenCompraDocumentoServiceImplTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private OrdenCompraRepository ordenCompraRepository;
+    @Mock
+    private OrdenCompraDocumentoRepository documentoRepository;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @InjectMocks
+    private OrdenCompraDocumentoServiceImpl service;
+
+    private AutoCloseable closeable;
+    private String originalUserDir;
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+        originalUserDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", tempDir.toString());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        System.setProperty("user.dir", originalUserDir);
+        closeable.close();
+    }
+
+    @Test
+    void subirDocumentos_guardaArchivosYRegistros() throws IOException {
+        OrdenCompra oc = new OrdenCompra();
+        oc.setId(5);
+        Usuario usuario = new Usuario();
+        usuario.setId(10L);
+        usuario.setNombreCompleto("Tester");
+
+        when(ordenCompraRepository.findById(anyLong())).thenReturn(java.util.Optional.of(oc));
+        when(usuarioRepository.findById(anyLong())).thenReturn(java.util.Optional.of(usuario));
+
+        AtomicLong idGen = new AtomicLong(1);
+        doAnswer(invocation -> {
+            OrdenCompraDocumento doc = invocation.getArgument(0);
+            doc.setId(idGen.getAndIncrement());
+            doc.setFechaCreacion(LocalDateTime.now());
+            return doc;
+        }).when(documentoRepository).save(any(OrdenCompraDocumento.class));
+
+        MockMultipartFile archivo1 = new MockMultipartFile("archivos", "cert.pdf", "application/pdf", "data1".getBytes());
+        MockMultipartFile archivo2 = new MockMultipartFile("archivos", "factura.png", "image/png", "data2".getBytes());
+
+        List<DocumentoMetaDTO> metadata = List.of(
+                DocumentoMetaDTO.builder().nombreVisible("Certificado A").tipoDocumento(TipoDocumentoOrdenCompra.CERTIFICADO).build(),
+                DocumentoMetaDTO.builder().nombreVisible("Factura 1").tipoDocumento(TipoDocumentoOrdenCompra.FACTURA).build()
+        );
+
+        var respuesta = service.subirDocumentos(5L, List.of(archivo1, archivo2), metadata, usuario.getId());
+
+        assertThat(respuesta).hasSize(2);
+        Path expectedDir = tempDir.resolve(Path.of("uploads", "ordenes-compra", "5"));
+        assertThat(Files.exists(expectedDir)).isTrue();
+        assertThat(Files.list(expectedDir)).hasSize(2);
+    }
+
+    @Test
+    void subirDocumentos_lanzaErrorSinMetadata() {
+        OrdenCompra oc = new OrdenCompra();
+        oc.setId(5);
+        Usuario usuario = new Usuario();
+        usuario.setId(10L);
+
+        when(ordenCompraRepository.findById(anyLong())).thenReturn(java.util.Optional.of(oc));
+        when(usuarioRepository.findById(anyLong())).thenReturn(java.util.Optional.of(usuario));
+
+        MockMultipartFile archivo = new MockMultipartFile("archivos", "cert.pdf", "application/pdf", "data1".getBytes());
+
+        assertThatThrownBy(() -> service.subirDocumentos(5L, List.of(archivo), List.of(), usuario.getId()))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("metadata");
+    }
+}


### PR DESCRIPTION
## Summary
- add a Flyway migration for the `orden_compra_documentos` table to persist purchase order document metadata and audit fields
- implement purchase order document domain, service, and controller for uploading, listing, and downloading CERTIFICADO/FACTURA/GUIA files in filesystem storage
- secure the new endpoints and cover them with unit and MVC tests

## Testing
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942ed30281883339d17fe532139f849)