### PR TITLE
Add production indicators export and alert support

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/IndicadoresProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/IndicadoresProduccionController.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.produccion.controller;
 import com.willyes.clemenintegra.produccion.dto.AlertaOrdenProduccionDTO;
 import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
 import com.willyes.clemenintegra.produccion.service.ProduccionIndicadoresService;
+import com.willyes.clemenintegra.produccion.service.ReporteIndicadoresProduccionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -20,13 +23,15 @@ import java.util.List;
 public class IndicadoresProduccionController {
 
     private final ProduccionIndicadoresService produccionIndicadoresService;
+    private final ReporteIndicadoresProduccionService reporteIndicadoresProduccionService;
 
     @GetMapping("/indicadores")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<IndicadoresProduccionResponseDTO> obtenerIndicadores(
             @RequestParam LocalDate fechaInicio,
-            @RequestParam LocalDate fechaFin) {
-        return ResponseEntity.ok(produccionIndicadoresService.calcularIndicadores(fechaInicio, fechaFin));
+            @RequestParam LocalDate fechaFin,
+            @RequestParam(required = false, defaultValue = "3") Integer diasAlerta) {
+        return ResponseEntity.ok(produccionIndicadoresService.calcularIndicadores(fechaInicio, fechaFin, diasAlerta));
     }
 
     @GetMapping("/ordenes/alertas")
@@ -35,5 +40,23 @@ public class IndicadoresProduccionController {
             @RequestParam(required = false) LocalDate fechaReferencia,
             @RequestParam(required = false, defaultValue = "3") Integer diasVentana) {
         return ResponseEntity.ok(produccionIndicadoresService.obtenerOrdenesConAlertas(fechaReferencia, diasVentana));
+    }
+
+    @GetMapping(value = "/indicadores/export/excel", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<byte[]> exportarIndicadoresExcel(
+            @RequestParam LocalDate fechaInicio,
+            @RequestParam LocalDate fechaFin,
+            @RequestParam(required = false, defaultValue = "3") Integer diasAlerta) {
+        IndicadoresProduccionResponseDTO indicadores = produccionIndicadoresService
+                .calcularIndicadores(fechaInicio, fechaFin, diasAlerta);
+        byte[] excel = reporteIndicadoresProduccionService.generarExcelIndicadores(indicadores, fechaInicio, fechaFin);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=indicadores-produccion.xlsx");
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(excel);
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/IndicadoresProduccionResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/IndicadoresProduccionResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Data
 @Builder
@@ -16,4 +17,14 @@ public class IndicadoresProduccionResponseDTO {
     private BigDecimal cantidadTotalPlanificada;
     private BigDecimal cantidadTotalProducida;
     private long ordenesAbiertasConVencimientoVencido;
+
+    /**
+     * Lista opcional de alertas de OP próximas a vencer o retrasadas para el rango consultado.
+     */
+    private List<AlertaOrdenProduccionDTO> alertas;
+
+    /**
+     * Ventana de días utilizada para calcular las alertas. Solo informativo.
+     */
+    private Integer diasAlerta;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresService.java
@@ -10,5 +10,7 @@ public interface ProduccionIndicadoresService {
 
     IndicadoresProduccionResponseDTO calcularIndicadores(LocalDate fechaInicio, LocalDate fechaFin);
 
+    IndicadoresProduccionResponseDTO calcularIndicadores(LocalDate fechaInicio, LocalDate fechaFin, Integer diasAlerta);
+
     List<AlertaOrdenProduccionDTO> obtenerOrdenesConAlertas(LocalDate fechaReferencia, int diasVentana);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ProduccionIndicadoresServiceImpl.java
@@ -27,6 +27,13 @@ public class ProduccionIndicadoresServiceImpl implements ProduccionIndicadoresSe
 
     @Override
     public IndicadoresProduccionResponseDTO calcularIndicadores(LocalDate fechaInicio, LocalDate fechaFin) {
+        return calcularIndicadores(fechaInicio, fechaFin, null);
+    }
+
+    @Override
+    public IndicadoresProduccionResponseDTO calcularIndicadores(LocalDate fechaInicio,
+                                                                LocalDate fechaFin,
+                                                                Integer diasAlerta) {
         LocalDateTime desde = fechaInicio.atStartOfDay();
         LocalDateTime hasta = fechaFin.atTime(LocalTime.MAX);
         List<OrdenProduccion> ordenes = ordenProduccionRepository.findByFechaFinBetween(desde, hasta);
@@ -74,6 +81,8 @@ public class ProduccionIndicadoresServiceImpl implements ProduccionIndicadoresSe
                 .cantidadTotalPlanificada(cantidadPlanificada)
                 .cantidadTotalProducida(cantidadProducida)
                 .ordenesAbiertasConVencimientoVencido(ordenesAbiertasVencidas)
+                .alertas(obtenerOrdenesConAlertas(null, diasAlerta != null ? diasAlerta : 3))
+                .diasAlerta(diasAlerta != null ? diasAlerta : 3)
                 .build();
     }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteIndicadoresProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteIndicadoresProduccionService.java
@@ -1,0 +1,13 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
+
+import java.time.LocalDate;
+
+public interface ReporteIndicadoresProduccionService {
+
+    byte[] generarExcelIndicadores(IndicadoresProduccionResponseDTO indicadores,
+                                   LocalDate fechaInicio,
+                                   LocalDate fechaFin);
+}
+

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteIndicadoresProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ReporteIndicadoresProduccionServiceImpl.java
@@ -1,0 +1,93 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.AlertaOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Slf4j
+public class ReporteIndicadoresProduccionServiceImpl implements ReporteIndicadoresProduccionService {
+
+    @Override
+    public byte[] generarExcelIndicadores(IndicadoresProduccionResponseDTO indicadores,
+                                          LocalDate fechaInicio,
+                                          LocalDate fechaFin) {
+        try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            construirHojaKpis(workbook, indicadores, fechaInicio, fechaFin);
+            construirHojaAlertas(workbook, indicadores.getAlertas());
+            workbook.write(out);
+            return out.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando Excel de indicadores de producción", e);
+            throw new IllegalStateException("No se pudo generar el Excel de indicadores de producción", e);
+        }
+    }
+
+    private void construirHojaKpis(Workbook workbook,
+                                   IndicadoresProduccionResponseDTO indicadores,
+                                   LocalDate fechaInicio,
+                                   LocalDate fechaFin) {
+        Sheet sheet = workbook.createSheet("KPIs");
+        int rowIdx = 0;
+        rowIdx = crearFila(sheet, rowIdx, "Rango consultado", fechaInicio + " a " + fechaFin);
+        rowIdx = crearFila(sheet, rowIdx, "Total órdenes periodo", indicadores.getTotalOrdenesPeriodo());
+        rowIdx = crearFila(sheet, rowIdx, "Órdenes en tiempo", indicadores.getOrdenesEnTiempo());
+        rowIdx = crearFila(sheet, rowIdx, "Órdenes retrasadas", indicadores.getOrdenesRetrasadas());
+        rowIdx = crearFila(sheet, rowIdx, "% cumplimiento", indicadores.getPorcentajeCumplimiento());
+        rowIdx = crearFila(sheet, rowIdx, "Cantidad total planificada", indicadores.getCantidadTotalPlanificada());
+        rowIdx = crearFila(sheet, rowIdx, "Cantidad total producida", indicadores.getCantidadTotalProducida());
+        rowIdx = crearFila(sheet, rowIdx, "Órdenes abiertas vencidas", indicadores.getOrdenesAbiertasConVencimientoVencido());
+        if (indicadores.getDiasAlerta() != null) {
+            crearFila(sheet, rowIdx, "Ventana alertas (días)", indicadores.getDiasAlerta());
+        }
+        sheet.autoSizeColumn(0);
+        sheet.autoSizeColumn(1);
+    }
+
+    private void construirHojaAlertas(Workbook workbook, List<AlertaOrdenProduccionDTO> alertas) {
+        Sheet sheet = workbook.createSheet("Alertas");
+        Row header = sheet.createRow(0);
+        String[] headers = {"Código OP", "Producto", "Fecha compromiso", "Tipo alerta", "Estado"};
+        for (int i = 0; i < headers.length; i++) {
+            header.createCell(i).setCellValue(headers[i]);
+        }
+
+        int rowIdx = 1;
+        if (alertas != null) {
+            for (AlertaOrdenProduccionDTO alerta : alertas) {
+                Row row = sheet.createRow(rowIdx++);
+                row.createCell(0).setCellValue(valueOf(alerta.getCodigoOrden()));
+                row.createCell(1).setCellValue(valueOf(alerta.getProductoPrincipal()));
+                row.createCell(2).setCellValue(alerta.getFechaCompromiso() != null ? alerta.getFechaCompromiso().toString() : "");
+                row.createCell(3).setCellValue(valueOf(alerta.getTipoAlerta()));
+                row.createCell(4).setCellValue(valueOf(alerta.getEstado()));
+            }
+        }
+        for (int i = 0; i < headers.length; i++) {
+            sheet.autoSizeColumn(i);
+        }
+    }
+
+    private int crearFila(Sheet sheet, int rowIdx, String clave, Object valor) {
+        Row row = sheet.createRow(rowIdx);
+        row.createCell(0).setCellValue(clave);
+        if (valor instanceof Number number) {
+            row.createCell(1).setCellValue(number.doubleValue());
+        } else {
+            row.createCell(1).setCellValue(valueOf(valor));
+        }
+        return rowIdx + 1;
+    }
+
+    private String valueOf(Object valor) {
+        return valor == null ? "" : valor.toString();
+    }
+}
+

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/ReporteIndicadoresProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/ReporteIndicadoresProduccionServiceImplTest.java
@@ -1,0 +1,52 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.AlertaOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReporteIndicadoresProduccionServiceImplTest {
+
+    private final ReporteIndicadoresProduccionServiceImpl service = new ReporteIndicadoresProduccionServiceImpl();
+
+    @Test
+    @DisplayName("generarExcelIndicadores crea workbook con hojas KPIs y Alertas")
+    void generarExcelIndicadores_creaHojas() throws Exception {
+        IndicadoresProduccionResponseDTO dto = IndicadoresProduccionResponseDTO.builder()
+                .totalOrdenesPeriodo(5)
+                .ordenesEnTiempo(3)
+                .ordenesRetrasadas(2)
+                .porcentajeCumplimiento(60.0)
+                .cantidadTotalPlanificada(new BigDecimal("100"))
+                .cantidadTotalProducida(new BigDecimal("80"))
+                .ordenesAbiertasConVencimientoVencido(1)
+                .diasAlerta(4)
+                .alertas(List.of(
+                        AlertaOrdenProduccionDTO.builder()
+                                .codigoOrden("OP-1")
+                                .productoPrincipal("Producto A")
+                                .fechaCompromiso(LocalDate.now())
+                                .tipoAlerta("PROXIMA_VENCER")
+                                .estado("EN_PROCESO")
+                                .build()))
+                .build();
+
+        byte[] excel = service.generarExcelIndicadores(dto, LocalDate.now().minusDays(1), LocalDate.now());
+
+        try (Workbook workbook = new XSSFWorkbook(new ByteArrayInputStream(excel))) {
+            assertThat(workbook.getNumberOfSheets()).isGreaterThanOrEqualTo(2);
+            assertThat(workbook.getSheet("KPIs")).isNotNull();
+            assertThat(workbook.getSheet("Alertas")).isNotNull();
+        }
+    }
+}
+

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/IndicadoresProduccionExportControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/IndicadoresProduccionExportControllerTest.java
@@ -1,0 +1,109 @@
+package com.willyes.clemenintegra.produccion.web;
+
+import com.willyes.clemenintegra.produccion.controller.IndicadoresProduccionController;
+import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
+import com.willyes.clemenintegra.produccion.service.ProduccionIndicadoresService;
+import com.willyes.clemenintegra.produccion.service.ReporteIndicadoresProduccionService;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(IndicadoresProduccionController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
+class IndicadoresProduccionExportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProduccionIndicadoresService produccionIndicadoresService;
+    @MockBean
+    private ReporteIndicadoresProduccionService reporteIndicadoresProduccionService;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void bypassFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("exporta indicadores en excel con headers correctos")
+    void exportarIndicadoresExcel_ok() throws Exception {
+        IndicadoresProduccionResponseDTO indicadores = IndicadoresProduccionResponseDTO.builder()
+                .totalOrdenesPeriodo(1)
+                .ordenesEnTiempo(1)
+                .ordenesRetrasadas(0)
+                .porcentajeCumplimiento(100.0)
+                .cantidadTotalPlanificada(new BigDecimal("10"))
+                .cantidadTotalProducida(new BigDecimal("10"))
+                .ordenesAbiertasConVencimientoVencido(0)
+                .diasAlerta(3)
+                .build();
+        byte[] excelBytes = "excel".getBytes();
+
+        when(produccionIndicadoresService.calcularIndicadores(any(LocalDate.class), any(LocalDate.class), any()))
+                .thenReturn(indicadores);
+        when(reporteIndicadoresProduccionService.generarExcelIndicadores(any(), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(excelBytes);
+
+        var result = mockMvc.perform(get("/api/produccion/indicadores/export/excel")
+                        .param("fechaInicio", "2024-01-01")
+                        .param("fechaFin", "2024-01-31")
+                        .param("diasAlerta", "5"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", org.hamcrest.Matchers.containsString("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")))
+                .andExpect(header().string("Content-Disposition", org.hamcrest.Matchers.containsString("indicadores-produccion.xlsx")))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")))
+                .andReturn();
+
+        assertThat(result.getResponse().getContentAsByteArray()).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Extend production indicators endpoint to accept configurable `diasAlerta` and return alert details alongside KPIs
- Add Excel export endpoint/service for indicators with KPI and alert worksheets
- Cover the new export flow with MVC and service tests

## Testing
- `mvn -q test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943026986b48333b313f3a4c3694e77)