### PR TITLE
Enable CAPA lifecycle and attachments

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/CapaController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/CapaController.java
@@ -1,15 +1,27 @@
 package com.willyes.clemenintegra.calidad.controller;
 
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDTO;
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDescargaDTO;
 import com.willyes.clemenintegra.calidad.dto.CapaDTO;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoCapa;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import com.willyes.clemenintegra.calidad.service.CapaService;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/calidad/capas")
@@ -32,14 +44,46 @@ public class CapaController {
         return ResponseEntity.ok(service.obtenerPorId(id));
     }
 
-    @PostMapping
-    public ResponseEntity<CapaDTO> crear(@RequestBody CapaDTO dto) {
-        return ResponseEntity.ok(service.crear(dto));
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CapaDTO> crear(@Valid @RequestBody CapaDTO dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.crear(dto));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<CapaDTO> actualizar(@PathVariable Long id, @RequestBody CapaDTO dto) {
+    public ResponseEntity<CapaDTO> actualizar(@PathVariable Long id, @Valid @RequestBody CapaDTO dto) {
         return ResponseEntity.ok(service.actualizar(id, dto));
+    }
+
+    @PatchMapping("/{id}/cerrar")
+    public ResponseEntity<CapaDTO> cerrar(@PathVariable Long id) {
+        return ResponseEntity.ok(service.cerrar(id));
+    }
+
+    @PostMapping(path = "/{id}/archivos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CapaArchivoDTO> adjuntarArchivo(@PathVariable Long id,
+                                                          @RequestPart("archivo") MultipartFile archivo,
+                                                          @RequestPart(value = "nombreVisible", required = false) String nombreVisible,
+                                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long usuarioId = userDetails != null ? userDetails.getId() : null;
+        CapaArchivoDTO respuesta = service.adjuntarArchivo(id, archivo, nombreVisible, usuarioId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(respuesta);
+    }
+
+    @GetMapping("/{id}/archivos")
+    public ResponseEntity<List<CapaArchivoDTO>> listarArchivos(@PathVariable Long id) {
+        return ResponseEntity.ok(service.listarArchivos(id));
+    }
+
+    @GetMapping("/{capaId}/archivos/{archivoId}")
+    public ResponseEntity<ByteArrayResource> descargarArchivo(@PathVariable Long capaId, @PathVariable Long archivoId) {
+        CapaArchivoDescargaDTO archivo = service.descargarArchivo(capaId, archivoId);
+        MediaType mediaType = archivo.getContentType() != null
+                ? MediaType.parseMediaType(archivo.getContentType())
+                : MediaType.APPLICATION_OCTET_STREAM;
+        return ResponseEntity.ok()
+                .contentType(mediaType)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + archivo.getNombreArchivo() + "\"")
+                .body(new ByteArrayResource(archivo.getContenido()));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/CapaArchivoDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/CapaArchivoDTO.java
@@ -1,0 +1,21 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CapaArchivoDTO {
+    private Long id;
+    private String nombreArchivo;
+    private String nombreVisible;
+    private String contentType;
+    private Long tamanoBytes;
+    private LocalDateTime fechaCreacion;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/CapaArchivoDescargaDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/CapaArchivoDescargaDTO.java
@@ -1,0 +1,12 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class CapaArchivoDescargaDTO {
+    byte[] contenido;
+    String nombreArchivo;
+    String contentType;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/CapaDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/CapaDTO.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -28,9 +29,10 @@ public class CapaDTO {
 
     private LocalDateTime fechaCierre;
 
-    @NotNull(message = "El estado es obligatorio")
     private EstadoCapa estado;
 
     private String observaciones;
-}
 
+    @Builder.Default
+    private List<CapaArchivoDTO> archivosAdjuntos = List.of();
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/CapaMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/CapaMapper.java
@@ -1,14 +1,26 @@
 package com.willyes.clemenintegra.calidad.mapper;
 
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDTO;
 import com.willyes.clemenintegra.calidad.dto.CapaDTO;
 import com.willyes.clemenintegra.calidad.model.Capa;
+import com.willyes.clemenintegra.calidad.model.CapaArchivo;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoCapa;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 @Component
 public class CapaMapper {
 
     public CapaDTO toDTO(Capa entity) {
+        return toDTO(entity, Collections.emptyList());
+    }
+
+    public CapaDTO toDTO(Capa entity, List<CapaArchivo> archivos) {
         return CapaDTO.builder()
                 .id(entity.getId())
                 .noConformidadId(entity.getNoConformidad().getId())
@@ -18,22 +30,42 @@ public class CapaMapper {
                 .fechaCierre(entity.getFechaCierre())
                 .estado(entity.getEstado())
                 .observaciones(entity.getObservaciones())
+                .archivosAdjuntos(Optional.ofNullable(archivos).orElse(List.of()).stream()
+                        .map(this::toArchivoDTO)
+                        .toList())
                 .build();
     }
 
     public Capa toEntity(CapaDTO dto,
                          com.willyes.clemenintegra.calidad.model.NoConformidad noConformidad,
                          Usuario responsable) {
+        LocalDateTime inicio = dto.getFechaInicio() != null ? dto.getFechaInicio() : LocalDateTime.now();
+        EstadoCapa estado = dto.getEstado() != null ? dto.getEstado() : EstadoCapa.ACTIVA;
+        LocalDateTime cierre = dto.getFechaCierre();
+        if (EstadoCapa.CERRADA.equals(estado) && cierre == null) {
+            cierre = LocalDateTime.now();
+        }
+
         return Capa.builder()
                 .id(dto.getId())
                 .noConformidad(noConformidad)
                 .tipo(dto.getTipo())
                 .responsable(responsable)
-                .fechaInicio(dto.getFechaInicio())
-                .fechaCierre(dto.getFechaCierre())
-                .estado(dto.getEstado())
+                .fechaInicio(inicio)
+                .fechaCierre(cierre)
+                .estado(estado)
                 .observaciones(dto.getObservaciones())
                 .build();
     }
-}
 
+    public CapaArchivoDTO toArchivoDTO(CapaArchivo archivo) {
+        return CapaArchivoDTO.builder()
+                .id(archivo.getId())
+                .nombreArchivo(archivo.getNombreArchivo())
+                .nombreVisible(archivo.getNombreVisible())
+                .contentType(archivo.getContentType())
+                .tamanoBytes(archivo.getTamanoBytes())
+                .fechaCreacion(archivo.getFechaCreacion())
+                .build();
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/CapaArchivo.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/CapaArchivo.java
@@ -1,0 +1,44 @@
+package com.willyes.clemenintegra.calidad.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "capa_archivos")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CapaArchivo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "capa_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_capa_archivos_capa"))
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Capa capa;
+
+    @Column(name = "nombre_archivo", nullable = false, length = 255)
+    private String nombreArchivo;
+
+    @Column(name = "nombre_visible")
+    private String nombreVisible;
+
+    @Column(name = "content_type", length = 150)
+    private String contentType;
+
+    @Column(name = "tamano_bytes")
+    private Long tamanoBytes;
+
+    @Column(name = "creado_por")
+    private Long creadoPor;
+
+    @Column(name = "fecha_creacion", nullable = false)
+    private LocalDateTime fechaCreacion;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/CapaArchivoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/CapaArchivoRepository.java
@@ -1,0 +1,15 @@
+package com.willyes.clemenintegra.calidad.repository;
+
+import com.willyes.clemenintegra.calidad.model.CapaArchivo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CapaArchivoRepository extends JpaRepository<CapaArchivo, Long> {
+    List<CapaArchivo> findByCapa_Id(Long capaId);
+
+    List<CapaArchivo> findByCapa_IdIn(List<Long> capaIds);
+
+    Optional<CapaArchivo> findByIdAndCapa_Id(Long archivoId, Long capaId);
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/CapaService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/CapaService.java
@@ -1,10 +1,15 @@
 package com.willyes.clemenintegra.calidad.service;
 
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDTO;
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDescargaDTO;
 import com.willyes.clemenintegra.calidad.dto.CapaDTO;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoCapa;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface CapaService {
     Page<CapaDTO> listar(EstadoCapa estado, SeveridadNoConformidad severidad, Pageable pageable);
@@ -12,4 +17,8 @@ public interface CapaService {
     CapaDTO actualizar(Long id, CapaDTO dto);
     CapaDTO obtenerPorId(Long id);
     void eliminar(Long id);
+    CapaDTO cerrar(Long id);
+    CapaArchivoDTO adjuntarArchivo(Long capaId, MultipartFile archivo, String nombreVisible, Long usuarioId);
+    List<CapaArchivoDTO> listarArchivos(Long capaId);
+    CapaArchivoDescargaDTO descargarArchivo(Long capaId, Long archivoId);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/CapaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/CapaServiceImpl.java
@@ -1,28 +1,51 @@
 package com.willyes.clemenintegra.calidad.service;
 
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDTO;
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDescargaDTO;
 import com.willyes.clemenintegra.calidad.dto.CapaDTO;
 import com.willyes.clemenintegra.calidad.mapper.CapaMapper;
 import com.willyes.clemenintegra.calidad.model.Capa;
+import com.willyes.clemenintegra.calidad.model.CapaArchivo;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoCapa;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
-import com.willyes.clemenintegra.calidad.repository.*;
+import com.willyes.clemenintegra.calidad.repository.CapaArchivoRepository;
+import com.willyes.clemenintegra.calidad.repository.CapaRepository;
+import com.willyes.clemenintegra.calidad.repository.NoConformidadRepository;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
-import java.util.NoSuchElementException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CapaServiceImpl implements CapaService {
 
     private final CapaRepository capaRepository;
     private final NoConformidadRepository noConformidadRepository;
     private final UsuarioRepository usuarioRepository;
+    private final CapaArchivoRepository capaArchivoRepository;
     private final CapaMapper mapper;
 
+    @Override
+    @Transactional(readOnly = true)
     public Page<CapaDTO> listar(EstadoCapa estado, SeveridadNoConformidad severidad, Pageable pageable) {
         Page<Capa> page;
         if (estado != null && severidad != null) {
@@ -34,43 +57,224 @@ public class CapaServiceImpl implements CapaService {
         } else {
             page = capaRepository.findAll(pageable);
         }
-        return page.map(mapper::toDTO);
+
+        Map<Long, List<CapaArchivo>> adjuntos = agruparAdjuntos(page.getContent());
+
+        return page.map(capa -> mapper.toDTO(
+                capa,
+                adjuntos.getOrDefault(capa.getId(), List.of())));
     }
 
+    @Override
     public CapaDTO crear(CapaDTO dto) {
-        var nc = noConformidadRepository.findById(dto.getNoConformidadId())
-                .orElseThrow(() -> new NoSuchElementException("No conformidad no encontrada con ID: " + dto.getNoConformidadId()));
-        var user = usuarioRepository.findById(dto.getResponsableId())
-                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + dto.getResponsableId()));
+        validarCamposObligatorios(dto);
+        var nc = obtenerNoConformidad(dto.getNoConformidadId());
+        var user = obtenerResponsable(dto.getResponsableId());
         Capa entity = mapper.toEntity(dto, nc, user);
-        return mapper.toDTO(capaRepository.save(entity));
+        Capa guardada = capaRepository.save(entity);
+        return mapper.toDTO(guardada, List.of());
     }
 
+    @Override
     public CapaDTO actualizar(Long id, CapaDTO dto) {
-        Capa existing = capaRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("CAPA no encontrada con ID: " + id));
-        var nc = noConformidadRepository.findById(dto.getNoConformidadId())
-                .orElseThrow(() -> new NoSuchElementException("No conformidad no encontrada con ID: " + dto.getNoConformidadId()));
-        var user = usuarioRepository.findById(dto.getResponsableId())
-                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + dto.getResponsableId()));
+        validarCamposObligatorios(dto);
+        Capa existing = obtenerCapa(id);
+        var nc = obtenerNoConformidad(dto.getNoConformidadId());
+        var user = obtenerResponsable(dto.getResponsableId());
+
         existing.setNoConformidad(nc);
         existing.setTipo(dto.getTipo());
         existing.setResponsable(user);
         existing.setFechaInicio(dto.getFechaInicio());
-        existing.setFechaCierre(dto.getFechaCierre());
-        existing.setEstado(dto.getEstado());
+        if (dto.getFechaCierre() != null) {
+            existing.setFechaCierre(dto.getFechaCierre());
+        }
+        if (dto.getEstado() != null) {
+            existing.setEstado(dto.getEstado());
+            if (EstadoCapa.CERRADA.equals(dto.getEstado()) && existing.getFechaCierre() == null) {
+                existing.setFechaCierre(LocalDateTime.now());
+            }
+        }
         existing.setObservaciones(dto.getObservaciones());
-        return mapper.toDTO(capaRepository.save(existing));
+
+        Capa guardada = capaRepository.save(existing);
+        return mapper.toDTO(guardada, capaArchivoRepository.findByCapa_Id(id));
     }
 
+    @Override
+    @Transactional(readOnly = true)
     public CapaDTO obtenerPorId(Long id) {
-        return capaRepository.findById(id)
-                .map(mapper::toDTO)
-                .orElseThrow(() -> new NoSuchElementException("CAPA no encontrada con ID: " + id));
+        Capa capa = obtenerCapa(id);
+        return mapper.toDTO(capa, capaArchivoRepository.findByCapa_Id(id));
     }
 
+    @Override
     public void eliminar(Long id) {
         capaRepository.deleteById(id);
     }
-}
 
+    @Override
+    public CapaDTO cerrar(Long id) {
+        Capa capa = obtenerCapa(id);
+        if (EstadoCapa.CERRADA.equals(capa.getEstado()) && capa.getFechaCierre() != null) {
+            return mapper.toDTO(capa, capaArchivoRepository.findByCapa_Id(id));
+        }
+        capa.setEstado(EstadoCapa.CERRADA);
+        if (capa.getFechaCierre() == null) {
+            capa.setFechaCierre(LocalDateTime.now());
+        }
+        Capa guardada = capaRepository.save(capa);
+        return mapper.toDTO(guardada, capaArchivoRepository.findByCapa_Id(id));
+    }
+
+    @Override
+    public CapaArchivoDTO adjuntarArchivo(Long capaId, MultipartFile archivo, String nombreVisible, Long usuarioId) {
+        if (archivo == null || archivo.isEmpty()) {
+            throw new IllegalArgumentException("El archivo adjunto es obligatorio");
+        }
+        Capa capa = obtenerCapa(capaId);
+        try {
+            Path uploadRoot = obtenerDirectorioAdjuntos();
+            Files.createDirectories(uploadRoot);
+
+            String nombreOriginal = archivo.getOriginalFilename();
+            String nombreSanitizado = sanitizarNombreArchivo(nombreOriginal != null ? nombreOriginal : "archivo");
+            String nombreArchivo = UUID.randomUUID() + "_" + nombreSanitizado;
+
+            Path destino = uploadRoot.resolve(nombreArchivo);
+            archivo.transferTo(destino.toFile());
+
+            CapaArchivo entity = CapaArchivo.builder()
+                    .capa(capa)
+                    .nombreArchivo(nombreArchivo)
+                    .nombreVisible(nombreVisible != null && !nombreVisible.isBlank() ? nombreVisible : nombreOriginal)
+                    .contentType(archivo.getContentType())
+                    .tamanoBytes(archivo.getSize())
+                    .creadoPor(usuarioId)
+                    .fechaCreacion(LocalDateTime.now())
+                    .build();
+
+            CapaArchivo guardado = capaArchivoRepository.save(entity);
+            return mapper.toArchivoDTO(guardado);
+        } catch (IOException e) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.ERROR_INTERNO,
+                    "No se pudo guardar el archivo de la CAPA.",
+                    e.getMessage());
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CapaArchivoDTO> listarArchivos(Long capaId) {
+        validarExistenciaCapa(capaId);
+        return capaArchivoRepository.findByCapa_Id(capaId).stream()
+                .map(mapper::toArchivoDTO)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CapaArchivoDescargaDTO descargarArchivo(Long capaId, Long archivoId) {
+        validarExistenciaCapa(capaId);
+        CapaArchivo archivo = capaArchivoRepository.findByIdAndCapa_Id(archivoId, capaId)
+                .orElseThrow(() -> new CustomBusinessException(
+                        ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Archivo no encontrado para la CAPA.",
+                        Map.of("capaId", capaId, "archivoId", archivoId)));
+        Path ruta = obtenerDirectorioAdjuntos().resolve(archivo.getNombreArchivo()).normalize();
+        if (!Files.exists(ruta)) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                    "El archivo físico no existe.",
+                    Map.of("capaId", capaId, "archivoId", archivoId, "archivo", archivo.getNombreArchivo()));
+        }
+        try {
+            byte[] contenido = Files.readAllBytes(ruta);
+            String nombreDescarga = archivo.getNombreVisible() != null && !archivo.getNombreVisible().isBlank()
+                    ? archivo.getNombreVisible()
+                    : archivo.getNombreArchivo();
+            return CapaArchivoDescargaDTO.builder()
+                    .contenido(contenido)
+                    .nombreArchivo(nombreDescarga)
+                    .contentType(archivo.getContentType())
+                    .build();
+        } catch (IOException e) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.ERROR_INTERNO,
+                    "No se pudo leer el archivo adjunto.",
+                    e.getMessage());
+        }
+    }
+
+    private void validarCamposObligatorios(CapaDTO dto) {
+        if (dto == null) {
+            throw new IllegalArgumentException("La CAPA es obligatoria");
+        }
+        if (dto.getNoConformidadId() == null) {
+            throw new IllegalArgumentException("La no conformidad es obligatoria");
+        }
+        if (dto.getTipo() == null) {
+            throw new IllegalArgumentException("El tipo de CAPA es obligatorio");
+        }
+        if (dto.getResponsableId() == null) {
+            throw new IllegalArgumentException("El responsable es obligatorio");
+        }
+        if (dto.getFechaInicio() == null) {
+            throw new IllegalArgumentException("La fecha de inicio es obligatoria");
+        }
+    }
+
+    private com.willyes.clemenintegra.calidad.model.NoConformidad obtenerNoConformidad(Long id) {
+        return noConformidadRepository.findById(id)
+                .orElseThrow(() -> new CustomBusinessException(
+                        ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "No conformidad no encontrada.",
+                        Map.of("noConformidadId", id)));
+    }
+
+    private Usuario obtenerResponsable(Long id) {
+        return usuarioRepository.findById(id)
+                .orElseThrow(() -> new CustomBusinessException(
+                        ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Usuario no encontrado.",
+                        Map.of("usuarioId", id)));
+    }
+
+    private Capa obtenerCapa(Long id) {
+        return capaRepository.findById(id)
+                .orElseThrow(() -> new CustomBusinessException(
+                        ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "CAPA no encontrada.",
+                        Map.of("capaId", id)));
+    }
+
+    private Map<Long, List<CapaArchivo>> agruparAdjuntos(List<Capa> capas) {
+        List<Long> ids = capas == null ? List.of() : capas.stream()
+                .map(Capa::getId)
+                .filter(Objects::nonNull)
+                .toList();
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        return capaArchivoRepository.findByCapa_IdIn(ids).stream()
+                .collect(Collectors.groupingBy(ca -> ca.getCapa().getId()));
+    }
+
+    private void validarExistenciaCapa(Long capaId) {
+        if (capaId == null || !capaRepository.existsById(capaId)) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                    "CAPA no encontrada.",
+                    Map.of("capaId", capaId));
+        }
+    }
+
+    private Path obtenerDirectorioAdjuntos() {
+        return Paths.get(System.getProperty("user.dir"), "uploads", "capas");
+    }
+
+    private String sanitizarNombreArchivo(String nombreOriginal) {
+        return nombreOriginal.replaceAll("[^a-zA-Z0-9._-]", "_");
+    }
+}

--- a/src/main/java/db/migration/V20251031__capa_archivos.java
+++ b/src/main/java/db/migration/V20251031__capa_archivos.java
@@ -1,0 +1,37 @@
+package db.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+public class V20251031__capa_archivos extends BaseJavaMigration {
+    @Override
+    public void migrate(Context context) throws Exception {
+        var conn = context.getConnection();
+        try (var st = conn.createStatement()) {
+            st.execute("""
+                    CREATE TABLE IF NOT EXISTS capa_archivos (
+                        id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                        capa_id BIGINT NOT NULL,
+                        nombre_archivo VARCHAR(255) NOT NULL,
+                        nombre_visible VARCHAR(255) NULL,
+                        content_type VARCHAR(150) NULL,
+                        tamano_bytes BIGINT NULL,
+                        creado_por BIGINT NULL,
+                        fecha_creacion DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        CONSTRAINT fk_capa_archivos_capa FOREIGN KEY (capa_id)
+                            REFERENCES capa (id)
+                            ON DELETE CASCADE
+                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+                    """);
+
+            try {
+                st.execute("""
+                        CREATE INDEX idx_capa_archivos_capa_id
+                        ON capa_archivos (capa_id);
+                        """);
+            } catch (Exception ignored) {
+                // Si ya existe el índice, continuar
+            }
+        }
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/CapaControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/CapaControllerTest.java
@@ -1,0 +1,143 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDTO;
+import com.willyes.clemenintegra.calidad.dto.CapaDTO;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoCapa;
+import com.willyes.clemenintegra.calidad.model.enums.TipoCapa;
+import com.willyes.clemenintegra.calidad.service.CapaService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CapaController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(CapaControllerTest.MethodSecurityTestConfig.class)
+class CapaControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CapaService capaService;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void listarCapasDevuelvePagina() throws Exception {
+        CapaDTO capa = CapaDTO.builder()
+                .id(1L)
+                .noConformidadId(9L)
+                .responsableId(3L)
+                .tipo(TipoCapa.CORRECTIVA)
+                .estado(EstadoCapa.ACTIVA)
+                .fechaInicio(LocalDateTime.now())
+                .build();
+        when(capaService.listar(any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(capa)));
+
+        mockMvc.perform(get("/api/calidad/capas"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(1));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void crearCapaRetorna201() throws Exception {
+        CapaDTO respuesta = CapaDTO.builder()
+                .id(2L)
+                .noConformidadId(9L)
+                .responsableId(5L)
+                .tipo(TipoCapa.CORRECTIVA)
+                .estado(EstadoCapa.ACTIVA)
+                .fechaInicio(LocalDateTime.now())
+                .build();
+
+        when(capaService.crear(any(CapaDTO.class))).thenReturn(respuesta);
+
+        mockMvc.perform(post("/api/calidad/capas")
+                        .contentType(APPLICATION_JSON)
+                        .content("{\"noConformidadId\":9,\"tipo\":\"CORRECTIVA\",\"responsableId\":5,\"fechaInicio\":\"2024-05-01T10:00:00\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(2));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void cerrarCapaRetornaOk() throws Exception {
+        CapaDTO respuesta = CapaDTO.builder()
+                .id(3L)
+                .noConformidadId(2L)
+                .responsableId(7L)
+                .tipo(TipoCapa.PREVENTIVA)
+                .estado(EstadoCapa.CERRADA)
+                .fechaInicio(LocalDateTime.now().minusDays(1))
+                .fechaCierre(LocalDateTime.now())
+                .build();
+        when(capaService.cerrar(3L)).thenReturn(respuesta);
+
+        mockMvc.perform(patch("/api/calidad/capas/3/cerrar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.estado").value("CERRADA"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void adjuntarArchivoRetorna201() throws Exception {
+        MockMultipartFile archivo = new MockMultipartFile(
+                "archivo",
+                "plan.txt",
+                "text/plain",
+                "contenido".getBytes()
+        );
+
+        when(capaService.adjuntarArchivo(eq(4L), any(), any(), any()))
+                .thenReturn(CapaArchivoDTO.builder()
+                        .id(11L)
+                        .nombreArchivo("plan_guardado.txt")
+                        .nombreVisible("plan.txt")
+                        .build());
+
+        mockMvc.perform(multipart("/api/calidad/capas/4/archivos")
+                        .file(archivo)
+                        .param("nombreVisible", "plan.txt"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(11));
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class MethodSecurityTestConfig {
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/CapaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/CapaServiceImplTest.java
@@ -1,0 +1,170 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.CapaDTO;
+import com.willyes.clemenintegra.calidad.mapper.CapaMapper;
+import com.willyes.clemenintegra.calidad.model.Capa;
+import com.willyes.clemenintegra.calidad.model.CapaArchivo;
+import com.willyes.clemenintegra.calidad.model.NoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.EstadoCapa;
+import com.willyes.clemenintegra.calidad.model.enums.TipoCapa;
+import com.willyes.clemenintegra.calidad.repository.CapaArchivoRepository;
+import com.willyes.clemenintegra.calidad.repository.CapaRepository;
+import com.willyes.clemenintegra.calidad.repository.NoConformidadRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CapaServiceImplTest {
+
+    @Mock
+    private CapaRepository capaRepository;
+    @Mock
+    private NoConformidadRepository noConformidadRepository;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private CapaArchivoRepository capaArchivoRepository;
+
+    private CapaServiceImpl service;
+    private final CapaMapper mapper = new CapaMapper();
+    private String originalUserDir;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        service = new CapaServiceImpl(capaRepository, noConformidadRepository, usuarioRepository, capaArchivoRepository, mapper);
+        originalUserDir = System.getProperty("user.dir");
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setProperty("user.dir", originalUserDir);
+    }
+
+    @Test
+    void creaCapaConEstadoPorDefecto() {
+        CapaDTO dto = CapaDTO.builder()
+                .noConformidadId(5L)
+                .tipo(TipoCapa.CORRECTIVA)
+                .responsableId(8L)
+                .fechaInicio(LocalDateTime.now())
+                .observaciones("obs")
+                .build();
+
+        when(noConformidadRepository.findById(5L)).thenReturn(Optional.of(NoConformidad.builder().id(5L).build()));
+        when(usuarioRepository.findById(8L)).thenReturn(Optional.of(Usuario.builder().id(8L).build()));
+        when(capaRepository.save(any(Capa.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CapaDTO result = service.crear(dto);
+
+        ArgumentCaptor<Capa> captor = ArgumentCaptor.forClass(Capa.class);
+        verify(capaRepository).save(captor.capture());
+        assertThat(captor.getValue().getEstado()).isEqualTo(EstadoCapa.ACTIVA);
+        assertThat(captor.getValue().getFechaInicio()).isNotNull();
+        assertThat(result.getNoConformidadId()).isEqualTo(5L);
+    }
+
+    @Test
+    void cerrarCapaActualizaEstadoYFecha() {
+        Capa capa = Capa.builder()
+                .id(10L)
+                .estado(EstadoCapa.ACTIVA)
+                .fechaInicio(LocalDateTime.now().minusDays(1))
+                .noConformidad(NoConformidad.builder().id(1L).build())
+                .responsable(Usuario.builder().id(2L).build())
+                .tipo(TipoCapa.PREVENTIVA)
+                .build();
+
+        when(capaRepository.findById(10L)).thenReturn(Optional.of(capa));
+        when(capaRepository.save(any(Capa.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(capaArchivoRepository.findByCapa_Id(10L)).thenReturn(List.of());
+
+        CapaDTO respuesta = service.cerrar(10L);
+
+        ArgumentCaptor<Capa> captor = ArgumentCaptor.forClass(Capa.class);
+        verify(capaRepository).save(captor.capture());
+        assertThat(captor.getValue().getEstado()).isEqualTo(EstadoCapa.CERRADA);
+        assertThat(captor.getValue().getFechaCierre()).isNotNull();
+        assertThat(respuesta.getEstado()).isEqualTo(EstadoCapa.CERRADA);
+    }
+
+    @Test
+    void cerrarCapaIdempotenteNoDuplicaActualizacion() {
+        LocalDateTime fechaCierre = LocalDateTime.now().minusDays(2);
+        Capa capa = Capa.builder()
+                .id(3L)
+                .estado(EstadoCapa.CERRADA)
+                .fechaCierre(fechaCierre)
+                .fechaInicio(LocalDateTime.now().minusDays(5))
+                .noConformidad(NoConformidad.builder().id(1L).build())
+                .responsable(Usuario.builder().id(2L).build())
+                .tipo(TipoCapa.CORRECTIVA)
+                .build();
+
+        when(capaRepository.findById(3L)).thenReturn(Optional.of(capa));
+        when(capaArchivoRepository.findByCapa_Id(3L)).thenReturn(List.of());
+
+        CapaDTO respuesta = service.cerrar(3L);
+
+        verify(capaRepository, never()).save(any());
+        assertThat(respuesta.getFechaCierre()).isEqualTo(fechaCierre);
+    }
+
+    @Test
+    void adjuntarArchivoGuardaMetadatosYArchivo() throws Exception {
+        System.setProperty("user.dir", tempDir.toString());
+
+        Capa capa = Capa.builder()
+                .id(4L)
+                .estado(EstadoCapa.ACTIVA)
+                .fechaInicio(LocalDateTime.now())
+                .noConformidad(NoConformidad.builder().id(1L).build())
+                .responsable(Usuario.builder().id(2L).build())
+                .tipo(TipoCapa.CORRECTIVA)
+                .build();
+
+        MockMultipartFile archivo = new MockMultipartFile(
+                "archivo",
+                "evidencia.txt",
+                "text/plain",
+                "contenido-prueba".getBytes()
+        );
+
+        when(capaRepository.findById(4L)).thenReturn(Optional.of(capa));
+        when(capaArchivoRepository.save(any(CapaArchivo.class))).thenAnswer(invocation -> {
+            CapaArchivo ca = invocation.getArgument(0);
+            ca.setId(7L);
+            return ca;
+        });
+
+        var dto = service.adjuntarArchivo(4L, archivo, "visible.txt", 20L);
+
+        assertThat(dto.getId()).isEqualTo(7L);
+        assertThat(dto.getNombreVisible()).isEqualTo("visible.txt");
+        assertThat(dto.getContentType()).isEqualTo("text/plain");
+
+        Path rutaArchivo = tempDir.resolve(Path.of("uploads", "capas", dto.getNombreArchivo()));
+        assertThat(Files.exists(rutaArchivo)).isTrue();
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImplTest.java
@@ -82,5 +82,6 @@ class NoConformidadServiceImplTest {
         ArgumentCaptor<NoConformidad> captor = ArgumentCaptor.forClass(NoConformidad.class);
         verify(repository).save(captor.capture());
         assertThat(captor.getValue().getEstado()).isEqualTo(EstadoNoConformidad.CERRADA);
+        assertThat(captor.getValue().getFechaCierre()).isNotNull();
     }
 }


### PR DESCRIPTION
## Summary
- Add CAPA REST support for creation with default state, idempotent closure, and attachment upload/download endpoints with security preserved
- Persist CAPA attachments via new entity/repository and Flyway migration, exposing metadata in DTOs
- Expand coverage with controller/service tests plus updated NC closure expectations

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69441ebbcbfc8333a553a9dfa9461d58)