### PR TITLE
Add CAPA deadline field and preserve observations

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/CapaDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/CapaDTO.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.dto;
 
 import com.willyes.clemenintegra.calidad.model.enums.*;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -15,11 +16,15 @@ public class CapaDTO {
 
     private Long id;
 
+    private String noConformidadCodigo;
+
     @NotNull(message = "La no conformidad es obligatoria")
     private Long noConformidadId;
 
     @NotNull(message = "El tipo de CAPA es obligatorio")
     private TipoCapa tipo;
+
+    private String responsableNombre;
 
     @NotNull(message = "El responsable es obligatorio")
     private Long responsableId;
@@ -29,8 +34,11 @@ public class CapaDTO {
 
     private LocalDateTime fechaCierre;
 
+    private LocalDateTime fechaLimite;
+
     private EstadoCapa estado;
 
+    @JsonAlias("descripcion")
     private String observaciones;
 
     @Builder.Default

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/CapaMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/CapaMapper.java
@@ -23,11 +23,14 @@ public class CapaMapper {
     public CapaDTO toDTO(Capa entity, List<CapaArchivo> archivos) {
         return CapaDTO.builder()
                 .id(entity.getId())
+                .noConformidadCodigo(Optional.ofNullable(entity.getNoConformidad()).map(c -> c.getCodigo()).orElse(null))
                 .noConformidadId(entity.getNoConformidad().getId())
                 .tipo(entity.getTipo())
+                .responsableNombre(Optional.ofNullable(entity.getResponsable()).map(Usuario::getNombreCompleto).orElse(null))
                 .responsableId(entity.getResponsable().getId())
                 .fechaInicio(entity.getFechaInicio())
                 .fechaCierre(entity.getFechaCierre())
+                .fechaLimite(entity.getFechaLimite())
                 .estado(entity.getEstado())
                 .observaciones(entity.getObservaciones())
                 .archivosAdjuntos(Optional.ofNullable(archivos).orElse(List.of()).stream()
@@ -53,6 +56,7 @@ public class CapaMapper {
                 .responsable(responsable)
                 .fechaInicio(inicio)
                 .fechaCierre(cierre)
+                .fechaLimite(dto.getFechaLimite())
                 .estado(estado)
                 .observaciones(dto.getObservaciones())
                 .build();

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/Capa.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/Capa.java
@@ -39,6 +39,9 @@ public class Capa {
     @Column(name = "fecha_cierre")
     private LocalDateTime fechaCierre;
 
+    @Column(name = "fecha_limite")
+    private LocalDateTime fechaLimite;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "estado", columnDefinition = "ENUM('ACTIVA','CERRADA','VENCIDA')", nullable = false)
     private EstadoCapa estado;
@@ -46,4 +49,3 @@ public class Capa {
     @Column(name = "observaciones", columnDefinition = "TEXT")
     private String observaciones;
 }
-

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/CapaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/CapaServiceImpl.java
@@ -89,6 +89,7 @@ public class CapaServiceImpl implements CapaService {
         if (dto.getFechaCierre() != null) {
             existing.setFechaCierre(dto.getFechaCierre());
         }
+        existing.setFechaLimite(dto.getFechaLimite());
         if (dto.getEstado() != null) {
             existing.setEstado(dto.getEstado());
             if (EstadoCapa.CERRADA.equals(dto.getEstado()) && existing.getFechaCierre() == null) {

--- a/src/main/resources/db/migration/V20251219__add_capa_fecha_limite.sql
+++ b/src/main/resources/db/migration/V20251219__add_capa_fecha_limite.sql
@@ -1,0 +1,2 @@
+ALTER TABLE capa
+    ADD COLUMN fecha_limite DATETIME(6) NULL;

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/CapaControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/CapaControllerTest.java
@@ -19,11 +19,15 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.mock.web.MockMultipartFile;
 
+import org.mockito.ArgumentCaptor;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -91,6 +95,56 @@ class CapaControllerTest {
                         .content("{\"noConformidadId\":9,\"tipo\":\"CORRECTIVA\",\"responsableId\":5,\"fechaInicio\":\"2024-05-01T10:00:00\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(2));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void crearCapaAceptaDescripcionComoObservaciones() throws Exception {
+        LocalDateTime inicio = LocalDateTime.of(2024, 5, 1, 10, 0);
+        LocalDateTime limite = inicio.plusDays(5);
+        CapaDTO respuesta = CapaDTO.builder()
+                .id(4L)
+                .noConformidadId(9L)
+                .noConformidadCodigo("NC-9")
+                .responsableId(5L)
+                .responsableNombre("Responsable QA")
+                .tipo(TipoCapa.CORRECTIVA)
+                .estado(EstadoCapa.ACTIVA)
+                .fechaInicio(inicio)
+                .fechaLimite(limite)
+                .observaciones("Texto desde servicio")
+                .build();
+
+        ArgumentCaptor<CapaDTO> captor = ArgumentCaptor.forClass(CapaDTO.class);
+        when(capaService.crear(any(CapaDTO.class))).thenAnswer(invocation -> {
+            CapaDTO dto = invocation.getArgument(0);
+            return CapaDTO.builder()
+                    .id(respuesta.getId())
+                    .noConformidadId(respuesta.getNoConformidadId())
+                    .noConformidadCodigo(respuesta.getNoConformidadCodigo())
+                    .responsableId(respuesta.getResponsableId())
+                    .responsableNombre(respuesta.getResponsableNombre())
+                    .tipo(respuesta.getTipo())
+                    .estado(respuesta.getEstado())
+                    .fechaInicio(respuesta.getFechaInicio())
+                    .fechaLimite(respuesta.getFechaLimite())
+                    .observaciones(dto.getObservaciones())
+                    .build();
+        });
+
+        mockMvc.perform(post("/api/calidad/capas")
+                        .contentType(APPLICATION_JSON)
+                        .content("{\"noConformidadId\":9,\"tipo\":\"CORRECTIVA\",\"responsableId\":5," +
+                                "\"fechaInicio\":\"2024-05-01T10:00:00\",\"fechaLimite\":\"2024-05-06T10:00:00\"," +
+                                "\"descripcion\":\"Detalle observado\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.observaciones").value("Detalle observado"))
+                .andExpect(jsonPath("$.fechaLimite").value("2024-05-06T10:00:00"))
+                .andExpect(jsonPath("$.noConformidadCodigo").value("NC-9"))
+                .andExpect(jsonPath("$.responsableNombre").value("Responsable QA"));
+
+        verify(capaService).crear(captor.capture());
+        assertThat(captor.getValue().getObservaciones()).isEqualTo("Detalle observado");
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/CapaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/CapaServiceImplTest.java
@@ -86,6 +86,48 @@ class CapaServiceImplTest {
     }
 
     @Test
+    void creaCapaPersisteObservacionesYFechaLimite() {
+        LocalDateTime inicio = LocalDateTime.now();
+        LocalDateTime limite = inicio.plusDays(7);
+        CapaDTO dto = CapaDTO.builder()
+                .noConformidadId(5L)
+                .tipo(TipoCapa.CORRECTIVA)
+                .responsableId(8L)
+                .fechaInicio(inicio)
+                .fechaLimite(limite)
+                .observaciones("Detalle de prueba")
+                .build();
+
+        NoConformidad noConformidad = NoConformidad.builder()
+                .id(5L)
+                .codigo("NC-123")
+                .build();
+        Usuario responsable = Usuario.builder()
+                .id(8L)
+                .nombreCompleto("Responsable QA")
+                .build();
+
+        when(noConformidadRepository.findById(5L)).thenReturn(Optional.of(noConformidad));
+        when(usuarioRepository.findById(8L)).thenReturn(Optional.of(responsable));
+        when(capaRepository.save(any(Capa.class))).thenAnswer(invocation -> {
+            Capa guardada = invocation.getArgument(0);
+            guardada.setId(33L);
+            return guardada;
+        });
+
+        CapaDTO result = service.crear(dto);
+
+        ArgumentCaptor<Capa> captor = ArgumentCaptor.forClass(Capa.class);
+        verify(capaRepository).save(captor.capture());
+        assertThat(captor.getValue().getObservaciones()).isEqualTo("Detalle de prueba");
+        assertThat(captor.getValue().getFechaLimite()).isEqualTo(limite);
+        assertThat(result.getObservaciones()).isEqualTo("Detalle de prueba");
+        assertThat(result.getFechaLimite()).isEqualTo(limite);
+        assertThat(result.getNoConformidadCodigo()).isEqualTo("NC-123");
+        assertThat(result.getResponsableNombre()).isEqualTo("Responsable QA");
+    }
+
+    @Test
     void cerrarCapaActualizaEstadoYFecha() {
         Capa capa = Capa.builder()
                 .id(10L)
@@ -107,6 +149,7 @@ class CapaServiceImplTest {
         assertThat(captor.getValue().getEstado()).isEqualTo(EstadoCapa.CERRADA);
         assertThat(captor.getValue().getFechaCierre()).isNotNull();
         assertThat(respuesta.getEstado()).isEqualTo(EstadoCapa.CERRADA);
+        assertThat(respuesta.getFechaCierre()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add fecha_limite column to CAPA with Flyway migration and map it through the entity, DTO, and mapper alongside noConformidadCodigo and responsableNombre
- accept observaciones via descripcion alias, keep fechaCierre when closing CAPAs, and expose observaciones/fechaLimite in responses
- extend CAPA service and controller tests to cover observaciones persistence, fechaLimite handling, and the close operation

## Testing
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694430e0293883339bb7db979ea761d0)