### PR TITLE
Add CAPA attachment download support

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/CapaController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/CapaController.java
@@ -74,7 +74,7 @@ public class CapaController {
         return ResponseEntity.ok(service.listarArchivos(id));
     }
 
-    @GetMapping("/{capaId}/archivos/{archivoId}")
+    @GetMapping({"/{capaId}/archivos/{archivoId}/descargar", "/{capaId}/archivos/{archivoId}"})
     public ResponseEntity<ByteArrayResource> descargarArchivo(@PathVariable Long capaId, @PathVariable Long archivoId) {
         CapaArchivoDescargaDTO archivo = service.descargarArchivo(capaId, archivoId);
         MediaType mediaType = archivo.getContentType() != null

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/CapaControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/CapaControllerTest.java
@@ -1,10 +1,14 @@
 package com.willyes.clemenintegra.calidad.controller;
 
 import com.willyes.clemenintegra.calidad.dto.CapaArchivoDTO;
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDescargaDTO;
 import com.willyes.clemenintegra.calidad.dto.CapaDTO;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoCapa;
 import com.willyes.clemenintegra.calidad.model.enums.TipoCapa;
 import com.willyes.clemenintegra.calidad.service.CapaService;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.exception.GlobalExceptionHandler;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -13,6 +17,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -20,7 +25,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.mock.web.MockMultipartFile;
 
 import org.mockito.ArgumentCaptor;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -31,12 +35,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = CapaController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import(CapaControllerTest.MethodSecurityTestConfig.class)
+@Import({CapaControllerTest.MethodSecurityTestConfig.class, GlobalExceptionHandler.class})
 class CapaControllerTest {
 
     @Autowired
@@ -188,6 +194,64 @@ class CapaControllerTest {
                         .param("nombreVisible", "plan.txt"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(11));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void flujoAdjuntosListaYDescarga() throws Exception {
+        MockMultipartFile archivo = new MockMultipartFile(
+                "archivo",
+                "plan.txt",
+                "text/plain",
+                "contenido".getBytes()
+        );
+
+        when(capaService.adjuntarArchivo(eq(4L), any(), any(), any()))
+                .thenReturn(CapaArchivoDTO.builder()
+                        .id(11L)
+                        .nombreArchivo("plan_guardado.txt")
+                        .nombreVisible("plan.txt")
+                        .contentType("text/plain")
+                        .build());
+        when(capaService.listarArchivos(4L)).thenReturn(List.of(
+                CapaArchivoDTO.builder()
+                        .id(11L)
+                        .nombreArchivo("plan_guardado.txt")
+                        .nombreVisible("plan legible.txt")
+                        .build()));
+        when(capaService.descargarArchivo(4L, 11L))
+                .thenReturn(CapaArchivoDescargaDTO.builder()
+                        .contenido("contenido".getBytes())
+                        .nombreArchivo("plan legible.txt")
+                        .contentType("text/plain")
+                        .build());
+
+        mockMvc.perform(multipart("/api/calidad/capas/4/archivos")
+                        .file(archivo)
+                        .param("nombreVisible", "plan.txt"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(11));
+
+        mockMvc.perform(get("/api/calidad/capas/4/archivos"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(11));
+
+        mockMvc.perform(get("/api/calidad/capas/4/archivos/11/descargar"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"plan legible.txt\""))
+                .andExpect(content().bytes("contenido".getBytes()))
+                .andExpect(header().string("Content-Type", "text/plain"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void descargarArchivoNoEncontradoDevuelve404() throws Exception {
+        when(capaService.descargarArchivo(9L, 77L))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "Archivo no encontrado"));
+
+        mockMvc.perform(get("/api/calidad/capas/9/archivos/77/descargar"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RECURSO_NO_ENCONTRADO"));
     }
 
     @TestConfiguration

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/CapaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/CapaServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.calidad.service;
 
+import com.willyes.clemenintegra.calidad.dto.CapaArchivoDescargaDTO;
 import com.willyes.clemenintegra.calidad.dto.CapaDTO;
 import com.willyes.clemenintegra.calidad.mapper.CapaMapper;
 import com.willyes.clemenintegra.calidad.model.Capa;
@@ -10,6 +11,8 @@ import com.willyes.clemenintegra.calidad.model.enums.TipoCapa;
 import com.willyes.clemenintegra.calidad.repository.CapaArchivoRepository;
 import com.willyes.clemenintegra.calidad.repository.CapaRepository;
 import com.willyes.clemenintegra.calidad.repository.NoConformidadRepository;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -29,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -209,5 +213,50 @@ class CapaServiceImplTest {
 
         Path rutaArchivo = tempDir.resolve(Path.of("uploads", "capas", dto.getNombreArchivo()));
         assertThat(Files.exists(rutaArchivo)).isTrue();
+    }
+
+    @Test
+    void descargarArchivoRetornaContenidoYNombreVisible() throws Exception {
+        System.setProperty("user.dir", tempDir.toString());
+        Files.createDirectories(tempDir.resolve(Path.of("uploads", "capas")));
+        Files.writeString(tempDir.resolve(Path.of("uploads", "capas", "almacenado.txt")), "contenido-archivo");
+
+        CapaArchivo archivo = CapaArchivo.builder()
+                .id(12L)
+                .capa(Capa.builder().id(6L).build())
+                .nombreArchivo("almacenado.txt")
+                .nombreVisible("visible.txt")
+                .contentType("text/plain")
+                .tamanoBytes(20L)
+                .build();
+
+        when(capaRepository.existsById(6L)).thenReturn(true);
+        when(capaArchivoRepository.findByIdAndCapa_Id(12L, 6L)).thenReturn(Optional.of(archivo));
+
+        CapaArchivoDescargaDTO dto = service.descargarArchivo(6L, 12L);
+
+        assertThat(dto.getNombreArchivo()).isEqualTo("visible.txt");
+        assertThat(dto.getContentType()).isEqualTo("text/plain");
+        assertThat(new String(dto.getContenido())).isEqualTo("contenido-archivo");
+    }
+
+    @Test
+    void descargarArchivoInexistenteEnDiscoLanza404() {
+        System.setProperty("user.dir", tempDir.toString());
+
+        CapaArchivo archivo = CapaArchivo.builder()
+                .id(8L)
+                .capa(Capa.builder().id(2L).build())
+                .nombreArchivo("no_existe.txt")
+                .build();
+
+        when(capaRepository.existsById(2L)).thenReturn(true);
+        when(capaArchivoRepository.findByIdAndCapa_Id(8L, 2L)).thenReturn(Optional.of(archivo));
+
+        assertThatThrownBy(() -> service.descargarArchivo(2L, 8L))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("no existe")
+                .satisfies(ex -> assertThat(((CustomBusinessException) ex).getCode())
+                        .isEqualTo(ApiErrorCode.RECURSO_NO_ENCONTRADO));
     }
 }


### PR DESCRIPTION
## Summary
- add explicit CAPA attachment download route with backward-compatible mapping
- cover upload, list, and download flows plus error handling through MockMvc
- verify service download behavior for missing files and preserved metadata

## Testing
- mvn -Dtest=CapaServiceImplTest,CapaControllerTest,CapaControllerSecurityTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694442f6011c8333a9d018bb7286e802)