### PR TITLE
Expose allowed transitions endpoint for purchase orders

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -203,6 +203,30 @@ public class OrdenCompraController {
         return ResponseEntity.ok(HistorialEstadoOrdenMapper.toResponse(historial));
     }
 
+    @GetMapping("/{id}/transiciones")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
+    public ResponseEntity<List<String>> obtenerTransiciones(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails usuarioAutenticado) {
+        if (usuarioAutenticado == null) {
+            throw new ResponseStatusException(FORBIDDEN, "USUARIO_NO_AUTENTICADO");
+        }
+
+        OrdenCompra orden = ordenCompraService.buscarPorIdConDetalles(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Orden no encontrada"));
+
+        List<String> estados = ordenCompraService.transicionesPermitidas(
+                        orden,
+                        usuarioAutenticado.getAuthorities().stream()
+                                .map(a -> a.getAuthority())
+                                .toList())
+                .stream()
+                .map(Enum::name)
+                .toList();
+
+        return ResponseEntity.ok(estados);
+    }
+
     @GetMapping("/{id}/pdf")
     @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> pdf(@PathVariable("id") Long id) {   // <-- Long

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraService.java
@@ -22,7 +22,10 @@ import java.util.Optional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -121,6 +124,27 @@ public class OrdenCompraService {
         return historialEstadoOrdenRepository.save(historial);
     }
 
+    public List<EstadoOrdenCompra> transicionesPermitidas(OrdenCompra orden,
+                                                          Collection<String> authorities) {
+        if (orden == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "ORDEN_NO_ENCONTRADA");
+        }
+
+        RolUsuario rol = extraerRol(authorities);
+        validarRolModulo(rol);
+
+        List<EstadoOrdenCompra> permitidas = new ArrayList<>();
+        for (EstadoOrdenCompra candidato : EstadoOrdenCompra.values()) {
+            try {
+                validarTransicion(orden, candidato);
+                validarRol(orden.getEstado(), candidato, rol);
+                permitidas.add(candidato);
+            } catch (CustomBusinessException ignored) {
+            }
+        }
+        return permitidas;
+    }
+
     // Métodos adicionales futuros: crear, editar, anular, etc.
 
     private void validarTransicion(OrdenCompra orden, EstadoOrdenCompra nuevoEstado) {
@@ -169,6 +193,10 @@ public class OrdenCompraService {
 
     private void validarRol(CustomUserDetails principal, EstadoOrdenCompra estadoActual, EstadoOrdenCompra nuevoEstado) {
         RolUsuario rol = principal.getUsuario() != null ? principal.getUsuario().getRol() : null;
+        validarRol(estadoActual, nuevoEstado, rol);
+    }
+
+    private void validarRol(EstadoOrdenCompra estadoActual, EstadoOrdenCompra nuevoEstado, RolUsuario rol) {
         if (rol == null) {
             throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE, "ROL_NO_DEFINIDO");
         }
@@ -199,5 +227,26 @@ public class OrdenCompraService {
         }
 
         throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE, "ROL_SIN_PERMISO_ESTADO");
+    }
+
+    private RolUsuario extraerRol(Collection<String> authorities) {
+        if (authorities == null) {
+            return null;
+        }
+        for (String authority : authorities) {
+            try {
+                return RolUsuario.valueOf(authority);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        return null;
+    }
+
+    private void validarRolModulo(RolUsuario rol) {
+        if (!(rol == RolUsuario.ROL_SUPER_ADMIN
+                || rol == RolUsuario.ROL_COMPRADOR
+                || rol == RolUsuario.ROL_JEFE_ALMACENES)) {
+            throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE, "ROL_SIN_PERMISO_ESTADO");
+        }
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerTransicionesTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerTransicionesTest.java
@@ -1,0 +1,117 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.model.OrdenCompra;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.inventario.service.OrdenCompraService;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
+import com.willyes.clemenintegra.inventario.controller.OrdenCompraController;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.mapper.OrdenCompraMapper;
+import com.willyes.clemenintegra.inventario.mapper.RecepcionOCMapper;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraDetalleRepository;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProveedorRepository;
+import com.willyes.clemenintegra.inventario.repository.RecepcionOCRepository;
+import com.willyes.clemenintegra.inventario.service.HistorialEstadoOrdenService;
+import com.willyes.clemenintegra.inventario.service.OrdenCompraPdfService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class OrdenCompraControllerTransicionesTest {
+
+    @Mock
+    private OrdenCompraRepository ordenCompraRepository;
+    @Mock
+    private OrdenCompraDetalleRepository detalleRepository;
+    @Mock
+    private ProveedorRepository proveedorRepository;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private OrdenCompraService ordenCompraService;
+    @Mock
+    private HistorialEstadoOrdenService historialEstadoOrdenService;
+    @Mock
+    private RecepcionOCRepository recepcionOCRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private MovimientoInventarioMapper movimientoInventarioMapper;
+    @Mock
+    private RecepcionOCMapper recepcionOCMapper;
+    @Mock
+    private OrdenCompraPdfService ordenCompraPdfService;
+    @Mock
+    private OrdenCompraMapper ordenCompraMapper;
+    @InjectMocks
+    private OrdenCompraController controller;
+
+    @Test
+    void transicionesEndpointRetornaLista() {
+        OrdenCompra orden = OrdenCompra.builder()
+                .id(10)
+                .estado(EstadoOrdenCompra.CREADA)
+                .build();
+        when(ordenCompraService.buscarPorIdConDetalles(10L)).thenReturn(Optional.of(orden));
+        when(ordenCompraService.transicionesPermitidas(any(), any()))
+                .thenReturn(List.of(EstadoOrdenCompra.ENVIADA, EstadoOrdenCompra.CANCELADA));
+
+        ResponseEntity<List<String>> response = controller.obtenerTransiciones(
+                10L,
+                usuario(RolUsuario.ROL_COMPRADOR));
+
+        assertEquals(List.of("ENVIADA", "CANCELADA"), response.getBody());
+        verify(ordenCompraService).buscarPorIdConDetalles(10L);
+        verify(ordenCompraService).transicionesPermitidas(any(), any());
+    }
+
+    @Test
+    void transicionesEndpointConRolNoPermitidoRetorna403() {
+        OrdenCompra orden = OrdenCompra.builder()
+                .id(11)
+                .estado(EstadoOrdenCompra.CREADA)
+                .build();
+        when(ordenCompraService.buscarPorIdConDetalles(11L)).thenReturn(Optional.of(orden));
+        when(ordenCompraService.transicionesPermitidas(any(), any()))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE, "ROL_SIN_PERMISO_ESTADO"));
+
+        CustomBusinessException ex = assertThrows(CustomBusinessException.class, () ->
+                controller.obtenerTransiciones(11L, usuario(RolUsuario.ROL_ALMACENISTA)));
+
+        assertEquals(ApiErrorCode.ROL_INSUFICIENTE, ex.getCode());
+        verify(ordenCompraService).buscarPorIdConDetalles(11L);
+        verify(ordenCompraService).transicionesPermitidas(any(), any());
+    }
+
+    private CustomUserDetails usuario(RolUsuario rol) {
+        Usuario usuario = new Usuario();
+        usuario.setId(1L);
+        usuario.setRol(rol);
+        usuario.setNombreUsuario("tester");
+        usuario.setClave("pwd");
+        usuario.setNombreCompleto("Tester");
+        usuario.setActivo(true);
+        usuario.setBloqueado(false);
+        return new CustomUserDetails(usuario);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/OrdenCompraServiceTransitionTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/OrdenCompraServiceTransitionTest.java
@@ -111,6 +111,58 @@ class OrdenCompraServiceTransitionTest {
         verify(ordenCompraRepository).findAtrasadas(eq(pageable), any(Set.class));
     }
 
+    @Test
+    void transicionesPermitidasParaCompradorEnCreada() {
+        OrdenCompra orden = OrdenCompra.builder()
+                .estado(EstadoOrdenCompra.CREADA)
+                .detalles(List.of(detalle(new BigDecimal("1"), BigDecimal.ZERO)))
+                .build();
+
+        List<EstadoOrdenCompra> result = ordenCompraService.transicionesPermitidas(
+                orden, List.of(RolUsuario.ROL_COMPRADOR.name()));
+
+        assertEquals(List.of(EstadoOrdenCompra.ENVIADA, EstadoOrdenCompra.CANCELADA), result);
+    }
+
+    @Test
+    void transicionesPermitidasIncluyenCerradaParaJefeDeAlmacenes() {
+        OrdenCompra orden = OrdenCompra.builder()
+                .estado(EstadoOrdenCompra.RECIBIDA_COMPLETAMENTE)
+                .detalles(List.of(detalle(new BigDecimal("1"), new BigDecimal("1"))))
+                .build();
+
+        List<EstadoOrdenCompra> result = ordenCompraService.transicionesPermitidas(
+                orden, List.of(RolUsuario.ROL_JEFE_ALMACENES.name()));
+
+        assertEquals(List.of(EstadoOrdenCompra.CERRADA), result);
+    }
+
+    @Test
+    void transicionesPermitidasRetornaVacioParaCerrada() {
+        OrdenCompra orden = OrdenCompra.builder()
+                .estado(EstadoOrdenCompra.CERRADA)
+                .detalles(List.of(detalle(new BigDecimal("1"), new BigDecimal("1"))))
+                .build();
+
+        List<EstadoOrdenCompra> result = ordenCompraService.transicionesPermitidas(
+                orden, List.of(RolUsuario.ROL_SUPER_ADMIN.name()));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void transicionesPermitidasConRolNoAutorizadoLanza403() {
+        OrdenCompra orden = OrdenCompra.builder()
+                .estado(EstadoOrdenCompra.CREADA)
+                .detalles(List.of(detalle(new BigDecimal("1"), BigDecimal.ZERO)))
+                .build();
+
+        CustomBusinessException ex = assertThrows(CustomBusinessException.class, () ->
+                ordenCompraService.transicionesPermitidas(orden, List.of("ROL_ALMACENISTA")));
+
+        assertEquals(ApiErrorCode.ROL_INSUFICIENTE, ex.getCode());
+    }
+
     private OrdenCompraDetalle detalle(BigDecimal cantidad, BigDecimal recibida) {
         return OrdenCompraDetalle.builder()
                 .cantidad(cantidad)
@@ -133,4 +185,3 @@ class OrdenCompraServiceTransitionTest {
         return new CustomUserDetails(usuario);
     }
 }
-


### PR DESCRIPTION
## Summary
- add a reusable helper in `OrdenCompraService` to compute allowed state transitions and reuse role checks
- expose GET `/api/ordenes-compra/{id}/transiciones` returning the permitted next states as strings
- cover the new logic with unit tests for both the service rules and the controller endpoint

## Testing
- mvn test
- mvn -Dtest=OrdenCompraControllerTransicionesTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694460636f608333ad3347704f953469)