### PR TITLE
Aplicar filtros de código de recepción y tipo en listado de movimientos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -334,12 +334,16 @@ public class MovimientoInventarioController {
 
     @GetMapping
     public ResponseEntity<Page<MovimientoInventarioResponseDTO>> listarTodos(
+            @RequestParam(required = false) String codigoRecepcion,
+            @RequestParam(required = false, name = "tipoMovimiento") TipoMovimiento tipoMovimiento,
+            @RequestParam(required = false, name = "tipo") TipoMovimiento tipoAlias,
             @PageableDefault(size = 10, sort = "fechaIngreso", direction = Sort.Direction.DESC) Pageable pageable) {
         if (pageable.getPageNumber() < 0 || pageable.getPageSize() < 1 || pageable.getPageSize() > 100) {
             return ResponseEntity.badRequest().build();
         }
         Pageable sanitized = PaginationUtil.sanitize(pageable, List.of("fechaIngreso", "id"), "fechaIngreso");
-        Page<MovimientoInventarioResponseDTO> movimientos = service.listarTodos(sanitized);
+        TipoMovimiento resolvedTipo = tipoMovimiento != null ? tipoMovimiento : tipoAlias;
+        Page<MovimientoInventarioResponseDTO> movimientos = service.listarTodos(codigoRecepcion, resolvedTipo, sanitized);
         return ResponseEntity.ok(movimientos);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.lang.Nullable;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -95,6 +96,19 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
     boolean existsBySolicitudMovimientoId(Long solicitudMovimientoId);
 
     Page<MovimientoInventario> findByOrdenProduccionId(Long ordenProduccionId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {
+            "producto", "lote", "almacenOrigen", "almacenDestino", "registradoPor"
+    })
+    @Query("""
+            select m
+              from MovimientoInventario m
+             where (:codigoRecepcion is null or :codigoRecepcion = '' or lower(m.codigoRecepcion) like lower(concat('%', :codigoRecepcion, '%')))
+               and (:tipoMovimiento is null or m.tipoMovimiento = :tipoMovimiento)
+            """)
+    Page<MovimientoInventario> findAllByCodigoRecepcionAndTipoMovimiento(@Nullable String codigoRecepcion,
+                                                                         @Nullable TipoMovimiento tipoMovimiento,
+                                                                         Pageable pageable);
 
     Page<MovimientoInventario> findByOrdenProduccionIdAndClasificacion(Long ordenProduccionId,
                                                                        ClasificacionMovimientoInventario clasificacion,

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioService.java
@@ -35,7 +35,7 @@ public interface MovimientoInventarioService {
 
     Workbook generarReporteMovimientosExcel(LocalDateTime inicio, LocalDateTime fin);
 
-    Page<MovimientoInventarioResponseDTO> listarTodos(Pageable pageable);
+    Page<MovimientoInventarioResponseDTO> listarTodos(String codigoRecepcion, TipoMovimiento tipoMovimiento, Pageable pageable);
 
     MovimientoInventario registrarRetiroPorVencimiento(LoteProducto lote,
                                                        InventoryVencidosProperties properties,

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -1305,13 +1305,17 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     }
 
     @Override
-    public Page<MovimientoInventarioResponseDTO> listarTodos(Pageable pageable) {
+    public Page<MovimientoInventarioResponseDTO> listarTodos(String codigoRecepcion, TipoMovimiento tipoMovimiento, Pageable pageable) {
         Sort sort = pageable.getSort().isEmpty()
                 ? Sort.by(Sort.Direction.DESC, "fechaIngreso")
                 : pageable.getSort();
 
         Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
-        Page<MovimientoInventario> movimientos = repository.findAll(sortedPageable);
+        Page<MovimientoInventario> movimientos = repository.findAllByCodigoRecepcionAndTipoMovimiento(
+                codigoRecepcion,
+                tipoMovimiento,
+                sortedPageable
+        );
         return movimientos.map(mapper::safeToResponseDTO);
     }
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepositoryFilterTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepositoryFilterTest.java
@@ -1,0 +1,197 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.MotivoMovimiento;
+import com.willyes.clemenintegra.inventario.model.TipoMovimientoDetalle;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.inventario.repository.MotivoMovimientoRepository;
+import com.willyes.clemenintegra.inventario.repository.TipoMovimientoDetalleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class MovimientoInventarioRepositoryFilterTest {
+
+    @Autowired
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private AlmacenRepository almacenRepository;
+
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+
+    @Autowired
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+
+    @Autowired
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+
+    private Usuario usuario;
+    private Producto producto;
+    private LoteProducto lote;
+    private MotivoMovimiento motivoMovimiento;
+    private TipoMovimientoDetalle tipoMovimientoDetalle;
+
+    @BeforeEach
+    void setUp() {
+        usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("tester")
+                .clave("secret")
+                .nombreCompleto("Test User")
+                .correo("test@example.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("U")
+                .codigo("U1")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("MP")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-1")
+                .nombre("Producto 1")
+                .stockMinimo(BigDecimal.ONE)
+                .activo(true)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Principal")
+                .ubicacion("Lima")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        lote = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("L-1")
+                .fechaFabricacion(LocalDateTime.now())
+                .fechaVencimiento(LocalDateTime.now().plusDays(30))
+                .stockLote(BigDecimal.TEN)
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(producto)
+                .almacen(almacen)
+                .build());
+
+        motivoMovimiento = motivoMovimientoRepository.save(MotivoMovimiento.builder()
+                .descripcion("Recepción compra")
+                .motivo(ClasificacionMovimientoInventario.RECEPCION_COMPRA)
+                .build());
+
+        tipoMovimientoDetalle = tipoMovimientoDetalleRepository.save(TipoMovimientoDetalle.builder()
+                .descripcion("GENERICA")
+                .build());
+    }
+
+    @Test
+    void filtrarPorCodigoRecepcion() {
+        crearMovimiento("RC-20251218-OC-001", TipoMovimiento.RECEPCION);
+        crearMovimiento("RC-20251218-OC-002", TipoMovimiento.RECEPCION);
+        crearMovimiento(null, TipoMovimiento.TRANSFERENCIA);
+
+        Page<MovimientoInventario> page = movimientoInventarioRepository.findAllByCodigoRecepcionAndTipoMovimiento(
+                "RC-20251218-OC-001",
+                null,
+                PageRequest.of(0, 5)
+        );
+
+        assertThat(page.getTotalElements()).isEqualTo(1);
+        assertThat(page.getContent()).hasSize(1);
+        assertThat(page.getContent().get(0).getCodigoRecepcion()).contains("RC-20251218-OC-001");
+    }
+
+    @Test
+    void filtrarPorTipoMovimiento() {
+        crearMovimiento("RC-20251218-OC-001", TipoMovimiento.RECEPCION);
+        crearMovimiento("RC-20251218-OC-002", TipoMovimiento.RECEPCION);
+        crearMovimiento(null, TipoMovimiento.TRANSFERENCIA);
+
+        Page<MovimientoInventario> page = movimientoInventarioRepository.findAllByCodigoRecepcionAndTipoMovimiento(
+                null,
+                TipoMovimiento.RECEPCION,
+                PageRequest.of(0, 5)
+        );
+
+        assertThat(page.getTotalElements()).isEqualTo(2);
+        assertThat(page.getContent()).hasSize(2);
+        assertThat(page.getContent()).allMatch(m -> m.getTipoMovimiento() == TipoMovimiento.RECEPCION);
+    }
+
+    @Test
+    void filtrarPorCodigoRecepcionYTipoMovimiento() {
+        crearMovimiento("RC-20251218-OC-001", TipoMovimiento.RECEPCION);
+        crearMovimiento("RC-20251218-OC-002", TipoMovimiento.RECEPCION);
+        crearMovimiento(null, TipoMovimiento.TRANSFERENCIA);
+
+        Page<MovimientoInventario> page = movimientoInventarioRepository.findAllByCodigoRecepcionAndTipoMovimiento(
+                "RC-20251218-OC-002",
+                TipoMovimiento.RECEPCION,
+                PageRequest.of(0, 5)
+        );
+
+        assertThat(page.getTotalElements()).isEqualTo(1);
+        assertThat(page.getContent()).hasSize(1);
+        assertThat(page.getContent().get(0).getCodigoRecepcion()).isEqualTo("RC-20251218-OC-002");
+    }
+
+    private MovimientoInventario crearMovimiento(String codigoRecepcion, TipoMovimiento tipoMovimiento) {
+        MovimientoInventario movimiento = MovimientoInventario.builder()
+                .cantidad(BigDecimal.ONE)
+                .tipoMovimiento(tipoMovimiento)
+                .clasificacion(null)
+                .fechaIngreso(LocalDateTime.now())
+                .registradoPor(usuario)
+                .producto(producto)
+                .lote(lote)
+                .motivoMovimiento(motivoMovimiento)
+                .tipoMovimientoDetalle(tipoMovimientoDetalle)
+                .codigoRecepcion(codigoRecepcion)
+                .build();
+        return movimientoInventarioRepository.save(movimiento);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/MovimientoInventarioControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/MovimientoInventarioControllerSmokeTest.java
@@ -141,7 +141,7 @@ class MovimientoInventarioControllerSmokeTest {
         Pageable pageable = PageRequest.of(0, 5);
         Page<MovimientoInventarioResponseDTO> page = new PageImpl<>(List.of(movimiento), pageable, 1);
 
-        when(movimientoInventarioService.listarTodos(any(Pageable.class))).thenReturn(page);
+        when(movimientoInventarioService.listarTodos(any(), any(), any(Pageable.class))).thenReturn(page);
 
         mockMvc.perform(get("/api/movimientos")
                         .param("page", "0")


### PR DESCRIPTION
## Summary
- Add optional codigoRecepcion and tipo/tipoMovimiento parameters to movimientos listing endpoint
- Query movements with repository filtering by codigoRecepcion and tipoMovimiento while preserving pagination
- Add repository data tests for combined filters and update controller smoke test

## Testing
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944810411d8833398a50143ce6f54a1)