### PR TITLE
Derivar fecha_compromiso_entrega desde fechaNecesidad (detalles OC)

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -35,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.StreamUtils;
 import java.io.InputStream;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -71,6 +72,8 @@ public class OrdenCompraController {
         }
         
         // 2. Crear orden y detalles dentro de la misma transacción
+        LocalDate fechaCompromisoEntrega = ordenCompraService.calcularFechaCompromisoEntrega(dto.getDetalles());
+
         OrdenCompra orden = OrdenCompra.builder()
                 .proveedor(proveedor)
                 .estado(EstadoOrdenCompra.CREADA)
@@ -81,7 +84,7 @@ public class OrdenCompraController {
                 .descuento(dto.getDescuento() != null
                         ? dto.getDescuento()
                         : BigDecimal.ZERO)
-                .fechaCompromisoEntrega(dto.getFechaCompromisoEntrega())
+                .fechaCompromisoEntrega(fechaCompromisoEntrega)
                 .build();
 
         orden.setCodigoOrden(ordenCompraService.generarCodigoOrdenCompra());
@@ -137,7 +140,7 @@ public class OrdenCompraController {
         }
 
         orden.setObservaciones(dto.getObservaciones());
-        orden.setFechaCompromisoEntrega(dto.getFechaCompromisoEntrega());
+        orden.setFechaCompromisoEntrega(ordenCompraService.calcularFechaCompromisoEntrega(dto.getDetalles()));
 
         // Eliminar detalles anteriores
         detalleRepository.deleteByOrdenCompra_Id(id);
@@ -157,6 +160,7 @@ public class OrdenCompraController {
                     .valorTotal(valorTotal)
                     .iva(d.getIva())
                     .cantidadRecibida(BigDecimal.ZERO)
+                    .fechaNecesidad(d.getFechaNecesidad())
                     .build();
         }).toList();
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraService.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDetalleRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.OrdenCompraResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.OrdenCompraMapper;
 import com.willyes.clemenintegra.inventario.model.HistorialEstadoOrden;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -65,6 +67,17 @@ public class OrdenCompraService {
         String prefijo = "OC-CLEMEN-" + fecha;
         Long contador = ordenCompraRepository.countByCodigoOrdenStartingWith(prefijo);
         return prefijo + "-" + String.format("%02d", contador + 1);
+    }
+
+    public LocalDate calcularFechaCompromisoEntrega(List<OrdenCompraDetalleRequestDTO> detalles) {
+        if (detalles == null) {
+            return null;
+        }
+        return detalles.stream()
+                .map(OrdenCompraDetalleRequestDTO::getFechaNecesidad)
+                .filter(Objects::nonNull)
+                .min(LocalDate::compareTo)
+                .orElse(null);
     }
 
     /**

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/OrdenCompraServiceTransitionTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/OrdenCompraServiceTransitionTest.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDetalleRequestDTO;
 import com.willyes.clemenintegra.inventario.model.HistorialEstadoOrden;
 import com.willyes.clemenintegra.inventario.model.OrdenCompra;
 import com.willyes.clemenintegra.inventario.model.OrdenCompraDetalle;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -163,6 +165,36 @@ class OrdenCompraServiceTransitionTest {
         assertEquals(ApiErrorCode.ROL_INSUFICIENTE, ex.getCode());
     }
 
+    @Test
+    void calculaFechaCompromisoEntregaConUnDetalle() {
+        LocalDate fecha = LocalDate.of(2025, 12, 10);
+        List<OrdenCompraDetalleRequestDTO> detalles = List.of(detalleRequest(fecha));
+
+        LocalDate result = ordenCompraService.calcularFechaCompromisoEntrega(detalles);
+
+        assertEquals(fecha, result);
+    }
+
+    @Test
+    void calculaFechaCompromisoEntregaConDosDetallesEligeLaMasTemprana() {
+        LocalDate fecha1 = LocalDate.of(2025, 12, 10);
+        LocalDate fecha2 = LocalDate.of(2025, 12, 15);
+        List<OrdenCompraDetalleRequestDTO> detalles = List.of(detalleRequest(fecha1), detalleRequest(fecha2));
+
+        LocalDate result = ordenCompraService.calcularFechaCompromisoEntrega(detalles);
+
+        assertEquals(fecha1, result);
+    }
+
+    @Test
+    void calculaFechaCompromisoEntregaConDetallesSinFechaRetornaNull() {
+        List<OrdenCompraDetalleRequestDTO> detalles = List.of(detalleRequest(null), detalleRequest(null));
+
+        LocalDate result = ordenCompraService.calcularFechaCompromisoEntrega(detalles);
+
+        assertNull(result);
+    }
+
     private OrdenCompraDetalle detalle(BigDecimal cantidad, BigDecimal recibida) {
         return OrdenCompraDetalle.builder()
                 .cantidad(cantidad)
@@ -171,6 +203,16 @@ class OrdenCompraServiceTransitionTest {
                 .valorUnitario(BigDecimal.ONE)
                 .iva(BigDecimal.ZERO)
                 .build();
+    }
+
+    private OrdenCompraDetalleRequestDTO detalleRequest(LocalDate fechaNecesidad) {
+        return new OrdenCompraDetalleRequestDTO(
+                1L,
+                new BigDecimal("1.000"),
+                new BigDecimal("2.500"),
+                new BigDecimal("0.00"),
+                fechaNecesidad
+        );
     }
 
     private CustomUserDetails buildUser(Long id, RolUsuario rol) {


### PR DESCRIPTION
###Motivation
- La columna `ordenes_compra.fecha_compromiso_entrega` estaba quedando `NULL` al crear OCs desde la app. Hay que poblarla a partir de las fechas de necesidad por detalle para habilitar la vista/filtrado de OCs "ATRASADAS".
- No se implementan notificaciones por correo; el cambio es solo de persistencia/visualización.

###Description
- Agregado método público `calcularFechaCompromisoEntrega(List<OrdenCompraDetalleRequestDTO>)` en `OrdenCompraService` que devuelve `MIN(detalle.fechaNecesidad)` ignorando nulos (`null` si no hay fechas). (archivo: `src/main/java/com/willyes/clemenintegra/inventario/service/OrdenCompraService.java`, aprox. líneas 72–81).
- En el `OrdenCompraController` se invoca el cálculo en los flujos de creación y actualización:
  - En `crear(...)` se calcula `fechaCompromisoEntrega` y se setea en la entidad antes de guardar. (archivo: `src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java`, aprox. líneas 70–90).
  - En `actualizar(...)` se recalcula y setea `orden.setFechaCompromisoEntrega(...)` antes de guardar y se persiste `fechaNecesidad` para cada detalle nuevo. (mismo archivo, aprox. líneas 142–170).
- Se preserva la lógica de transiciones/roles existente; no se tocan reglas de auditoría ni roles.
- Añadidas pruebas unitarias en `OrdenCompraServiceTransitionTest` para los tres escenarios solicitados:
  - Un solo detalle con `fechaNecesidad` → usa esa fecha.
  - Dos detalles → toma la fecha mínima.
  - Detalles sin `fechaNecesidad` → resultado `null`.
  (archivo: `src/test/java/com/willyes/clemenintegra/inventario/service/OrdenCompraServiceTransitionTest.java`, aprox. líneas 168–196).

###Testing
- Se añadió la suite de tests unitarios mencionada en el archivo de tests (`OrdenCompraServiceTransitionTest`).
- Se intentó ejecutar los tests concretos con: `mvn -q -Dtest=OrdenCompraServiceTransitionTest test`. La ejecución fue iniciada pero se interrumpió por duración prolongada; no se dispone de un resultado completo de ejecución en esta sesión. ⚠️
- Cambios confirmados con commit: "Calcular fecha compromiso entrega desde detalles" (3 archivos modificados: controller, service, test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69448e8f68108333940532d1386479c9)