### PR TITLE
Corregir criterio de /lotes/por-evaluar para incluir lotes con disciplinas pendientes

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteProductoResponseDTO.java
@@ -29,6 +29,13 @@ public class LoteProductoResponseDTO {
     private boolean requiereAnalisisFisico;
     private boolean requiereAnalisisQuimico;
     private boolean requiereAnalisisMicrobiologico;
+    private boolean tieneEvaluacionFisica;
+    private boolean tieneEvaluacionQuimicoMicro;
+    private Long evaluacionQuimicoMicroId;
+    private boolean tieneResultadosMicro;
+    private boolean pendienteFisico;
+    private boolean pendienteQuimico;
+    private boolean pendienteMicro;
     private String nombreAlmacen;
     private String ubicacionAlmacen;
     private String nombreUsuarioLiberador;

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/LoteProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/LoteProductoMapper.java
@@ -27,6 +27,13 @@ public interface LoteProductoMapper {
     @Mapping(target = "requiereAnalisisFisico", expression = "java(lote.getProducto() != null && lote.getProducto().isRequiereAnalisisFisico())")
     @Mapping(target = "requiereAnalisisQuimico", expression = "java(lote.getProducto() != null && lote.getProducto().isRequiereAnalisisQuimico())")
     @Mapping(target = "requiereAnalisisMicrobiologico", expression = "java(lote.getProducto() != null && lote.getProducto().isRequiereAnalisisMicrobiologico())")
+    @Mapping(target = "tieneEvaluacionFisica", ignore = true)
+    @Mapping(target = "tieneEvaluacionQuimicoMicro", ignore = true)
+    @Mapping(target = "evaluacionQuimicoMicroId", ignore = true)
+    @Mapping(target = "tieneResultadosMicro", ignore = true)
+    @Mapping(target = "pendienteFisico", ignore = true)
+    @Mapping(target = "pendienteQuimico", ignore = true)
+    @Mapping(target = "pendienteMicro", ignore = true)
     @Mapping(target = "nombreUsuarioLiberador", expression = "java(lote.getUsuarioLiberador()!=null ? lote.getUsuarioLiberador().getNombreCompleto() : null)")
     @Mapping(target = "evaluaciones", ignore = true)
     @Mapping(target = "lotePsOrigenId", expression = "java(lote.getLotePsOrigen()!=null ? lote.getLotePsOrigen().getId() : null)")
@@ -45,6 +52,13 @@ public interface LoteProductoMapper {
     @Mapping(target = "requiereAnalisisFisico", expression = "java(entity.getProducto() != null && entity.getProducto().isRequiereAnalisisFisico())")
     @Mapping(target = "requiereAnalisisQuimico", expression = "java(entity.getProducto() != null && entity.getProducto().isRequiereAnalisisQuimico())")
     @Mapping(target = "requiereAnalisisMicrobiologico", expression = "java(entity.getProducto() != null && entity.getProducto().isRequiereAnalisisMicrobiologico())")
+    @Mapping(target = "tieneEvaluacionFisica", ignore = true)
+    @Mapping(target = "tieneEvaluacionQuimicoMicro", ignore = true)
+    @Mapping(target = "evaluacionQuimicoMicroId", ignore = true)
+    @Mapping(target = "tieneResultadosMicro", ignore = true)
+    @Mapping(target = "pendienteFisico", ignore = true)
+    @Mapping(target = "pendienteQuimico", ignore = true)
+    @Mapping(target = "pendienteMicro", ignore = true)
     @Mapping(source = "almacen.nombre", target = "nombreAlmacen")
     @Mapping(source = "almacen.ubicacion", target = "ubicacionAlmacen")
     @Mapping(source = "usuarioLiberador.nombreCompleto", target = "nombreUsuarioLiberador")
@@ -69,5 +83,4 @@ public interface LoteProductoMapper {
     }
 
 }
-
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -181,13 +181,22 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         List<LoteProductoResponseDTO> filtrados = lotesOrdenados.stream()
                 .map(lote -> {
                     List<EvaluacionCalidad> evaluaciones = evaluacionRepository.findByLoteProductoId(lote.getId());
-                    if (tieneEvaluacionesRequeridas(lote.getProducto(), evaluaciones)) {
+                    EstadoEvaluacionPendiente estado = calcularEstadoEvaluacionPendiente(lote.getProducto(), evaluaciones);
+                    // Criterio "por evaluar": incluir el lote si falta al menos una disciplina requerida.
+                    if (!estado.estaPendiente()) {
                         return null;
                     }
                     LoteProductoResponseDTO dto = loteProductoMapper.toDto(lote);
                     dto.setEvaluaciones(evaluaciones.stream()
                             .map(EvaluacionCalidad::getTipoEvaluacion)
                             .toList());
+                    dto.setTieneEvaluacionFisica(estado.tieneEvaluacionFisica);
+                    dto.setTieneEvaluacionQuimicoMicro(estado.tieneEvaluacionQuimicoMicro);
+                    dto.setEvaluacionQuimicoMicroId(estado.evaluacionQuimicoMicroId);
+                    dto.setTieneResultadosMicro(estado.tieneResultadosMicro);
+                    dto.setPendienteFisico(estado.pendienteFisico);
+                    dto.setPendienteQuimico(estado.pendienteQuimico);
+                    dto.setPendienteMicro(estado.pendienteMicro);
                     if (lote.getProducto() != null) {
                         PlantillaAnalisisMicroDTO plantillaDto = plantillaAnalisisMicroService.obtenerPorProducto(lote.getProducto().getId().longValue());
                         if (plantillaDto != null) {
@@ -289,18 +298,58 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         return loteProductoMapper.toResponseDTO(lote);
     }
 
-    private boolean tieneEvaluacionesRequeridas(Producto producto, List<EvaluacionCalidad> evaluaciones) {
+    private EstadoEvaluacionPendiente calcularEstadoEvaluacionPendiente(Producto producto,
+                                                                        List<EvaluacionCalidad> evaluaciones) {
+        EstadoEvaluacionPendiente estado = new EstadoEvaluacionPendiente();
         if (producto == null) {
-            return false;
+            return estado;
         }
         List<EvaluacionCalidad> seguras = evaluaciones == null ? List.of() : evaluaciones;
-        LoteProducto loteTemporal = new LoteProducto();
-        loteTemporal.setProducto(producto);
+        estado.requiereAnalisisFisico = requiereFisico(producto);
+        estado.requiereAnalisisQuimico = requiereQuimico(producto);
+        estado.requiereAnalisisMicro = requiereMicro(producto);
 
-        var validacion = validarDisciplinasCompletas(loteTemporal, seguras,
-                resultadoAnalisisMicrobiologicoRepository::existsByEvaluacionId);
+        estado.tieneEvaluacionFisica = seguras.stream()
+                .anyMatch(e -> e.getTipoEvaluacion() == TipoEvaluacion.FISICO);
+        List<EvaluacionCalidad> evaluacionesQM = seguras.stream()
+                .filter(e -> e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .toList();
+        estado.tieneEvaluacionQuimicoMicro = !evaluacionesQM.isEmpty();
+        estado.evaluacionQuimicoMicroId = evaluacionesQM.stream()
+                .max(java.util.Comparator.comparing(EvaluacionCalidad::getFechaEvaluacion,
+                        java.util.Comparator.nullsLast(java.time.LocalDateTime::compareTo)))
+                .map(EvaluacionCalidad::getId)
+                .orElse(null);
 
-        return validacion.esValido();
+        List<Long> evaluacionIds = evaluacionesQM.stream()
+                .map(EvaluacionCalidad::getId)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        estado.tieneResultadosMicro = !evaluacionIds.isEmpty()
+                && !resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(evaluacionIds).isEmpty();
+
+        estado.pendienteFisico = estado.requiereAnalisisFisico && !estado.tieneEvaluacionFisica;
+        estado.pendienteQuimico = estado.requiereAnalisisQuimico && !estado.tieneEvaluacionQuimicoMicro;
+        estado.pendienteMicro = estado.requiereAnalisisMicro
+                && (!estado.tieneEvaluacionQuimicoMicro || !estado.tieneResultadosMicro);
+        return estado;
+    }
+
+    private static class EstadoEvaluacionPendiente {
+        private boolean requiereAnalisisFisico;
+        private boolean requiereAnalisisQuimico;
+        private boolean requiereAnalisisMicro;
+        private boolean tieneEvaluacionFisica;
+        private boolean tieneEvaluacionQuimicoMicro;
+        private Long evaluacionQuimicoMicroId;
+        private boolean tieneResultadosMicro;
+        private boolean pendienteFisico;
+        private boolean pendienteQuimico;
+        private boolean pendienteMicro;
+
+        private boolean estaPendiente() {
+            return pendienteFisico || pendienteQuimico || pendienteMicro;
+        }
     }
 
     @Override

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImplTest.java
@@ -10,6 +10,7 @@ import com.willyes.clemenintegra.calidad.repository.ResultadoAnalisisMicrobiolog
 import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
 import com.willyes.clemenintegra.calidad.service.NoConformidadService;
 import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
+import com.willyes.clemenintegra.calidad.service.PlantillaAnalisisMicroService;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
@@ -34,6 +35,7 @@ import com.willyes.clemenintegra.shared.service.UsuarioService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -41,6 +43,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
@@ -50,10 +59,13 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
@@ -75,6 +87,7 @@ class LoteProductoServiceImplTest {
     @Mock private RetencionLoteService retencionLoteService;
     @Mock private NoConformidadService noConformidadService;
     @Mock private CondicionUsoService condicionUsoService;
+    @Mock private PlantillaAnalisisMicroService plantillaAnalisisMicroService;
     @Mock private CondicionUsoRepository condicionUsoRepository;
     @Mock private CondicionUsoMapper condicionUsoMapper;
     @Mock private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
@@ -93,6 +106,11 @@ class LoteProductoServiceImplTest {
         when(noConformidadService.obtenerActivaPorLote(anyLong())).thenReturn(Optional.empty());
         when(movimientoInventarioRepository.existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(
                 any(), anyLong(), anyLong(), anyLong(), any())).thenReturn(false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -272,6 +290,111 @@ class LoteProductoServiceImplTest {
     }
 
     @Test
+    @DisplayName("Lista por evaluar mantiene lote F+M hasta completar microbiológico")
+    void listarPorEvaluarMantieneLoteFisicoMicroIncompleto() {
+        mockAuthWithRoles("ROL_SUPER_ADMIN");
+
+        Producto producto = productoConCategoria(TipoCategoria.PRODUCTO_TERMINADO);
+        producto.setRequiereAnalisisFisico(true);
+        producto.setRequiereAnalisisQuimico(false);
+        producto.setRequiereAnalisisMicrobiologico(true);
+        producto.recomputarTipoAnalisisDesdeBanderas();
+
+        LoteProducto lote = loteEnCuarentena(40L, producto, 7, BigDecimal.ONE);
+
+        EvaluacionCalidad evalFisico = evaluacionFisica(400L, lote);
+        EvaluacionCalidad evalQM = evaluacionQuimicoMicro(401L, lote);
+
+        when(loteProductoRepository.findAll(any(Specification.class), any(Sort.class)))
+                .thenReturn(List.of(lote), List.of(lote), List.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(40L))
+                .thenReturn(List.of(), List.of(evalFisico), List.of(evalFisico, evalQM));
+        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(anyList()))
+                .thenReturn(List.of(com.willyes.clemenintegra.calidad.model.ResultadoAnalisisMicrobiologico.builder()
+                        .id(1L)
+                        .evaluacion(evalQM)
+                        .build()));
+        when(loteProductoMapper.toDto(any())).thenAnswer(inv -> LoteProductoResponseDTO.builder()
+                .id(((LoteProducto) inv.getArgument(0)).getId())
+                .build());
+        when(plantillaAnalisisMicroService.obtenerPorProducto(anyLong())).thenReturn(null);
+
+        Page<LoteProductoResponseDTO> sinEvaluaciones = service.obtenerLotesPorEvaluar(PageRequest.of(0, 10));
+        assertThat(sinEvaluaciones.getContent()).hasSize(1);
+        assertThat(sinEvaluaciones.getContent().get(0).isPendienteMicro()).isTrue();
+
+        Page<LoteProductoResponseDTO> conFisico = service.obtenerLotesPorEvaluar(PageRequest.of(0, 10));
+        assertThat(conFisico.getContent()).hasSize(1);
+        assertThat(conFisico.getContent().get(0).isPendienteMicro()).isTrue();
+
+        Page<LoteProductoResponseDTO> completo = service.obtenerLotesPorEvaluar(PageRequest.of(0, 10));
+        assertThat(completo.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Lista por evaluar incluye lote Q+M sin resultados micro y lo excluye al completarlos")
+    void listarPorEvaluarLoteQuimicoMicro() {
+        mockAuthWithRoles("ROL_SUPER_ADMIN");
+
+        Producto producto = productoConCategoria(TipoCategoria.PRODUCTO_TERMINADO);
+        producto.setRequiereAnalisisFisico(false);
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+        producto.recomputarTipoAnalisisDesdeBanderas();
+
+        LoteProducto lote = loteEnCuarentena(41L, producto, 7, BigDecimal.ONE);
+        EvaluacionCalidad evalQM = evaluacionQuimicoMicro(402L, lote);
+
+        when(loteProductoRepository.findAll(any(Specification.class), any(Sort.class)))
+                .thenReturn(List.of(lote), List.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(41L))
+                .thenReturn(List.of(evalQM), List.of(evalQM));
+        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(anyList()))
+                .thenReturn(Collections.emptyList(), List.of(com.willyes.clemenintegra.calidad.model.ResultadoAnalisisMicrobiologico.builder()
+                        .id(2L)
+                        .evaluacion(evalQM)
+                        .build()));
+        when(loteProductoMapper.toDto(any())).thenAnswer(inv -> LoteProductoResponseDTO.builder()
+                .id(((LoteProducto) inv.getArgument(0)).getId())
+                .build());
+        when(plantillaAnalisisMicroService.obtenerPorProducto(anyLong())).thenReturn(null);
+
+        Page<LoteProductoResponseDTO> sinResultados = service.obtenerLotesPorEvaluar(PageRequest.of(0, 10));
+        assertThat(sinResultados.getContent()).hasSize(1);
+        assertThat(sinResultados.getContent().get(0).isPendienteMicro()).isTrue();
+
+        Page<LoteProductoResponseDTO> conResultados = service.obtenerLotesPorEvaluar(PageRequest.of(0, 10));
+        assertThat(conResultados.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Lista por evaluar excluye lote solo físico cuando ya tiene evaluación física")
+    void listarPorEvaluarLoteSoloFisico() {
+        mockAuthWithRoles("ROL_SUPER_ADMIN");
+
+        Producto producto = productoConCategoria(TipoCategoria.PRODUCTO_TERMINADO);
+        producto.setRequiereAnalisisFisico(true);
+        producto.setRequiereAnalisisQuimico(false);
+        producto.setRequiereAnalisisMicrobiologico(false);
+        producto.recomputarTipoAnalisisDesdeBanderas();
+
+        LoteProducto lote = loteEnCuarentena(42L, producto, 7, BigDecimal.ONE);
+        EvaluacionCalidad evalFisico = evaluacionFisica(403L, lote);
+
+        when(loteProductoRepository.findAll(any(Specification.class), any(Sort.class)))
+                .thenReturn(List.of(lote));
+        when(evaluacionRepository.findByLoteProductoId(42L))
+                .thenReturn(List.of(evalFisico));
+        when(loteProductoMapper.toDto(any())).thenAnswer(inv -> LoteProductoResponseDTO.builder()
+                .id(((LoteProducto) inv.getArgument(0)).getId())
+                .build());
+        when(plantillaAnalisisMicroService.obtenerPorProducto(anyLong())).thenReturn(null);
+
+        Page<LoteProductoResponseDTO> resultado = service.obtenerLotesPorEvaluar(PageRequest.of(0, 10));
+        assertThat(resultado.getContent()).isEmpty();
+    }
+
+    @Test
     @DisplayName("Bloquea liberación si falta resultados microbiológicos")
     void bloqueaLiberacionSinResultadosMicro() {
         Usuario jefeCalidad = usuarioConRol(RolUsuario.ROL_JEFE_CALIDAD);
@@ -379,5 +502,32 @@ class LoteProductoServiceImplTest {
                         .build()))
                 .build();
     }
-}
 
+    private EvaluacionCalidad evaluacionFisica(Long id, LoteProducto lote) {
+        return EvaluacionCalidad.builder()
+                .id(id)
+                .tipoEvaluacion(TipoEvaluacion.FISICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .observaciones("ok")
+                .loteProducto(lote)
+                .build();
+    }
+
+    private EvaluacionCalidad evaluacionQuimicoMicro(Long id, LoteProducto lote) {
+        return EvaluacionCalidad.builder()
+                .id(id)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .observaciones("ok")
+                .loteProducto(lote)
+                .build();
+    }
+
+    private void mockAuthWithRoles(String... roles) {
+        var authorities = Stream.of(roles)
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken("user", "pass", authorities));
+    }
+}


### PR DESCRIPTION
### Motivation
- El endpoint `GET /api/lotes/por-evaluar` estaba excluyendo lotes cuando sólo faltaba una disciplina (p. ej. faltaban resultados microbiológicos) porque se filtraba por "evaluaciones completas" en lugar de "evaluaciones incompletas".
- Se requiere que un lote aparezca en "por evaluar" si su `estado` está en `(EN_CUARENTENA, RETENIDO)` y falta al menos una disciplina requerida (FISICO, QUIMICO, MICRO).
- Mantener el modelo de datos existente: `FISICO` es evaluación, `QUIMICO_MICROBIOLOGICO` es la contenedora Q/M y los resultados micro están en `resultado_analisis_microbiologico`.

### Description
- Ajusta la construcción del listado en `LoteProductoServiceImpl.obtenerLotesPorEvaluar(...)` para calcular por lote si hay disciplinas pendientes y usar ese criterio (incluir si falta al menos una disciplina requerida).
- Añadido cálculo `calcularEstadoEvaluacionPendiente(...)` que determina: `tieneEvaluacionFisica`, `tieneEvaluacionQuimicoMicro`, `evaluacionQuimicoMicroId`, `tieneResultadosMicro` y las banderas `pendienteFisico/pendienteQuimico/pendienteMicro`.
- Se ampliaron los DTO/mapper para exponer información útil al frontend: nuevos campos en `LoteProductoResponseDTO` (`tieneEvaluacionFisica`, `tieneEvaluacionQuimicoMicro`, `evaluacionQuimicoMicroId`, `tieneResultadosMicro`, `pendienteFisico`, `pendienteQuimico`, `pendienteMicro`) y se marcaron como gestionados explícitamente en `LoteProductoMapper`.
- Se añadieron pruebas unitarias en `LoteProductoServiceImplTest` que cubren los escenarios solicitados: F+M (sin evaluaciones / con F / con QM+resultados), Q+M (QM sin resultados / con resultados) y sólo F (con F => excluir).

### Testing
- Nuevas pruebas unitarias en `src/test/java/.../LoteProductoServiceImplTest.java` que validan los casos F+M, Q+M y sólo F.
- Ejecutado: `mvn -Dtest=LoteProductoServiceImplTest test` — todas las pruebas de ese suite pasaron correctamente.
- No se realizaron cambios a enums ni migraciones de datos; la solución es puramente lógica y de DTOs para no provocar reprocesos.
- Se mantuvo compatibilidad del contrato del endpoint: se agregan campos opcionales al DTO para que el frontend pueda mostrar disciplina(s) pendientes sin romper integraciones existentes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458e38a31c83338b2d4017366d0a22)