### PR TITLE
Alinear auditoría de calidad: fecha en movimientos, NC asociada y flags de detalle

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/AuditoriaLoteResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/AuditoriaLoteResponseDTO.java
@@ -43,6 +43,11 @@ public class AuditoriaLoteResponseDTO {
     private List<EvaluacionResumenDTO> evaluaciones;
     private List<IncidenteDTO> incidentes;
     private List<RetencionDTO> retenciones;
+    private boolean tieneNoConformidadAsociada;
+    private boolean tieneNoConformidadActiva;
+    private String codigoNoConformidadPrincipal;
+    private String estadoNoConformidadPrincipal;
+    private String motivoRetencion;
     private CondicionUsoDTO condicionUsoActiva;
     private List<MovimientoDTO> movimientos;
 
@@ -153,6 +158,7 @@ public class AuditoriaLoteResponseDTO {
     public static class MovimientoDTO {
         private Long id;
         private LocalDateTime fechaMovimiento;
+        private LocalDateTime fecha;
         private TipoMovimiento tipoMovimiento;
         private ClasificacionMovimientoInventario clasificacion;
         private BigDecimal cantidad;

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCalidadDetalleDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionCalidadDetalleDTO.java
@@ -24,7 +24,11 @@ public class EvaluacionCalidadDetalleDTO {
 
     private boolean requiereAnalisisFisico;
     private boolean requiereAnalisisQuimico;
+    private boolean requiereAnalisisQuimicoMicro;
     private boolean requiereAnalisisMicrobiologico;
+
+    private boolean tieneEvaluacionFisica;
+    private boolean tieneEvaluacionQuimicaMicro;
 
     private boolean tieneResultadosFisicos;
     private boolean tieneResultadosQuimicos;

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapper.java
@@ -241,6 +241,11 @@ public class EvaluacionCalidadMapper {
 
         boolean esFisico = evaluacion.getTipoEvaluacion() == TipoEvaluacion.FISICO;
         boolean esQuimicoMicro = evaluacion.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO;
+        java.util.List<EvaluacionCalidad> evaluacionesSeguras = evaluacionesLote == null ? java.util.List.of() : evaluacionesLote;
+        boolean tieneEvaluacionFisica = evaluacionesSeguras.stream()
+                .anyMatch(e -> e.getTipoEvaluacion() == TipoEvaluacion.FISICO);
+        boolean tieneEvaluacionQuimicoMicro = evaluacionesSeguras.stream()
+                .anyMatch(e -> e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO);
 
         AnalisisCalidadHelper.EstadoDisciplinasCalidad estadoDisciplinas = AnalisisCalidadHelper.calcularEstadoDisciplinas(
                 producto,
@@ -258,7 +263,10 @@ public class EvaluacionCalidadMapper {
                 .observaciones(evaluacion.getObservaciones())
                 .requiereAnalisisFisico(requiereFisico(producto))
                 .requiereAnalisisQuimico(requiereQuimico(producto))
+                .requiereAnalisisQuimicoMicro(requiereQuimico(producto))
                 .requiereAnalisisMicrobiologico(requiereMicro(producto))
+                .tieneEvaluacionFisica(tieneEvaluacionFisica)
+                .tieneEvaluacionQuimicaMicro(tieneEvaluacionQuimicoMicro)
                 .tieneResultadosFisicos(esFisico)
                 .tieneResultadosQuimicos(esQuimicoMicro)
                 .tieneResultadosMicro(resultadosMicro != null && !resultadosMicro.isEmpty())

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImpl.java
@@ -56,8 +56,12 @@ public class AuditoriaLoteServiceImpl implements AuditoriaLoteService {
 
         EstadoCalidadLoteResponseDTO estadoCalidad = loteProductoService.obtenerEstadoCalidad(loteId);
 
-        List<AuditoriaLoteResponseDTO.IncidenteDTO> incidentes = noConformidadRepository.findByLote_Id(loteId).stream()
-                .sorted(Comparator.comparing(NoConformidad::getFechaRegistro, Comparator.nullsLast(java.time.LocalDateTime::compareTo)))
+        List<NoConformidad> noConformidades = noConformidadRepository.findByLote_Id(loteId);
+        List<NoConformidad> noConformidadesOrdenadas = noConformidades.stream()
+                .sorted(Comparator.comparing(NoConformidad::getFechaRegistro,
+                        Comparator.nullsLast(java.time.LocalDateTime::compareTo)))
+                .toList();
+        List<AuditoriaLoteResponseDTO.IncidenteDTO> incidentes = noConformidadesOrdenadas.stream()
                 .map(nc -> AuditoriaLoteResponseDTO.IncidenteDTO.builder()
                         .id(nc.getId())
                         .codigo(nc.getCodigo())
@@ -96,6 +100,26 @@ public class AuditoriaLoteServiceImpl implements AuditoriaLoteService {
                 lote.getProducto(),
                 evaluacionesLote,
                 evaluacionesConResultadosMicro::contains);
+
+        boolean tieneNoConformidadAsociada = !noConformidadesOrdenadas.isEmpty();
+        boolean tieneNoConformidadActiva = noConformidadesOrdenadas.stream()
+                .anyMatch(nc -> nc.getEstado() == com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad.ABIERTA);
+        Optional<NoConformidad> noConformidadPrincipal = noConformidadesOrdenadas.stream()
+                .filter(nc -> nc.getEstado() == com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad.ABIERTA)
+                .max(Comparator.comparing(NoConformidad::getFechaRegistro,
+                        Comparator.nullsLast(java.time.LocalDateTime::compareTo)));
+        if (noConformidadPrincipal.isEmpty()) {
+            noConformidadPrincipal = noConformidadesOrdenadas.stream()
+                    .max(Comparator.comparing(NoConformidad::getFechaRegistro,
+                            Comparator.nullsLast(java.time.LocalDateTime::compareTo)));
+        }
+
+        String motivoRetencion = null;
+        if (retenciones.isEmpty()
+                && lote.getEstado() == com.willyes.clemenintegra.inventario.model.enums.EstadoLote.RETENIDO
+                && tieneNoConformidadAsociada) {
+            motivoRetencion = "NC";
+        }
 
         String almacenActual = lote.getAlmacen() != null ? lote.getAlmacen().getNombre() : null;
         String ubicacionActual = lote.getAlmacen() != null ? lote.getAlmacen().getUbicacion() : null;
@@ -140,6 +164,14 @@ public class AuditoriaLoteServiceImpl implements AuditoriaLoteService {
                 .evaluaciones(evaluaciones)
                 .incidentes(incidentes)
                 .retenciones(retenciones)
+                .tieneNoConformidadAsociada(tieneNoConformidadAsociada)
+                .tieneNoConformidadActiva(tieneNoConformidadActiva)
+                .codigoNoConformidadPrincipal(noConformidadPrincipal.map(NoConformidad::getCodigo).orElse(null))
+                .estadoNoConformidadPrincipal(noConformidadPrincipal
+                        .map(NoConformidad::getEstado)
+                        .map(Enum::name)
+                        .orElse(null))
+                .motivoRetencion(motivoRetencion)
                 .condicionUsoActiva(mapCondicion(condicionUso))
                 .movimientos(movimientos)
                 .build();
@@ -172,6 +204,7 @@ public class AuditoriaLoteServiceImpl implements AuditoriaLoteService {
         return AuditoriaLoteResponseDTO.MovimientoDTO.builder()
                 .id(mov.getId())
                 .fechaMovimiento(mov.getFechaIngreso())
+                .fecha(mov.getFechaIngreso())
                 .tipoMovimiento(mov.getTipoMovimiento())
                 .clasificacion(mov.getClasificacion())
                 .cantidad(mov.getCantidad())

--- a/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/mapper/EvaluacionCalidadMapperTest.java
@@ -61,7 +61,10 @@ class EvaluacionCalidadMapperTest {
         assertThat(dto.getCodigoLote()).isEqualTo("L001");
         assertThat(dto.isRequiereAnalisisFisico()).isTrue();
         assertThat(dto.isRequiereAnalisisQuimico()).isTrue();
+        assertThat(dto.isRequiereAnalisisQuimicoMicro()).isTrue();
         assertThat(dto.isRequiereAnalisisMicrobiologico()).isTrue();
+        assertThat(dto.isTieneEvaluacionFisica()).isFalse();
+        assertThat(dto.isTieneEvaluacionQuimicaMicro()).isTrue();
         assertThat(dto.isTieneResultadosQuimicos()).isTrue();
         assertThat(dto.isTieneResultadosMicro()).isTrue();
         assertThat(dto.getResultadosMicro()).hasSize(1);

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImplTest.java
@@ -154,8 +154,13 @@ class AuditoriaLoteServiceImplTest {
         assertThat(dto.getIncidentes().get(0).isTieneCapa()).isTrue();
         assertThat(dto.getRetenciones()).hasSize(1);
         assertThat(dto.getMovimientos()).hasSize(1);
+        assertThat(dto.getMovimientos().get(0).getFecha()).isEqualTo(mov.getFechaIngreso());
         assertThat(dto.getEvaluaciones()).hasSize(1);
         assertThat(dto.getEvaluaciones().get(0).isTieneResultadosMicro()).isTrue();
+        assertThat(dto.isTieneNoConformidadAsociada()).isTrue();
+        assertThat(dto.isTieneNoConformidadActiva()).isTrue();
+        assertThat(dto.getCodigoNoConformidadPrincipal()).isEqualTo("NC-001");
+        assertThat(dto.getEstadoNoConformidadPrincipal()).isEqualTo("ABIERTA");
     }
 
     @Test
@@ -262,7 +267,13 @@ class AuditoriaLoteServiceImplTest {
 
         when(loteProductoRepository.findById(4L)).thenReturn(Optional.of(lote));
         when(loteProductoService.obtenerEstadoCalidad(4L)).thenReturn(estado);
-        when(noConformidadRepository.findByLote_Id(4L)).thenReturn(List.of());
+        NoConformidad nc = NoConformidad.builder()
+                .id(8L)
+                .codigo("NC-RET-01")
+                .estado(EstadoNoConformidad.ABIERTA)
+                .fechaRegistro(LocalDateTime.now())
+                .build();
+        when(noConformidadRepository.findByLote_Id(4L)).thenReturn(List.of(nc));
         when(retencionLoteService.obtenerRetencionesActivas(4L)).thenReturn(List.of());
         when(condicionUsoService.getActivasByLote(4L)).thenReturn(List.of());
         when(movimientoInventarioRepository.findByLote_IdOrderByFechaIngresoDesc(4L)).thenReturn(List.of());
@@ -273,6 +284,9 @@ class AuditoriaLoteServiceImplTest {
         assertThat(dto.getEstadoLote()).isEqualTo("RETENIDO");
         assertThat(dto.getEstadoCalidad().getEstadoLote()).isEqualTo("RETENIDO");
         assertThat(dto.getEstadoCalidad().isTieneRetencionActiva()).isFalse();
+        assertThat(dto.getMotivoRetencion()).isEqualTo("NC");
+        assertThat(dto.isTieneNoConformidadAsociada()).isTrue();
+        assertThat(dto.isTieneNoConformidadActiva()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Alinear los DTOs y la lógica de auditoría con el frontend: exponer la `fecha` de movimientos y evitar valores nulos en la columna Fecha.
- Mostrar correctamente que un lote está retenido por una No Conformidad (NC) y exponer datos principales de la NC en la auditoría.
- Unificar la información de disciplinas requeridas/estado entre la auditoría y el detalle de evaluación usando las banderas por disciplina del `Producto`.

### Description

- Auditoría:
  - Se añadió metadata de NC y retención en `AuditoriaLoteResponseDTO`: `tieneNoConformidadAsociada`, `tieneNoConformidadActiva`, `codigoNoConformidadPrincipal`, `estadoNoConformidadPrincipal`, `motivoRetencion`.
  - En `AuditoriaLoteServiceImpl` se recopilan y ordenan las `NoConformidad` del lote, se calculan las flags/NC principal y se infiere `motivoRetencion = "NC"` cuando el lote está `RETENIDO` sin retenciones activas pero con NC asociada.
  - Movimientos: se añadió el alias `fecha` en `AuditoriaLoteResponseDTO.MovimientoDTO` y `mapMovimiento` ahora rellena explícitamente `.fecha(mov.getFechaIngreso())` además de `fechaMovimiento`.
- Detalle de evaluación:
  - `EvaluacionCalidadDetalleDTO` expone nuevos campos: `requiereAnalisisQuimicoMicro`, `tieneEvaluacionFisica`, `tieneEvaluacionQuimicaMicro`.
  - `EvaluacionCalidadMapper#toDetalleDTO` calcula y rellena `tieneEvaluacionFisica` / `tieneEvaluacionQuimicoMicro` basándose en las evaluaciones del lote y mantiene el uso de `AnalisisCalidadHelper` para estados de disciplina.
- Tests:
  - Actualizadas aserciones en `AuditoriaLoteServiceImplTest` para verificar `movimientos.fecha` y las nuevas propiedades de NC/motivoRetencion.
  - Actualizadas aserciones en `EvaluacionCalidadMapperTest` para los nuevos flags en el DTO.

### Testing

- Unit tests modified: `AuditoriaLoteServiceImplTest` and `EvaluacionCalidadMapperTest` were updated to assert the new fields and mapping behavior.
- A targeted Maven run was attempted with `mvn -q -Dtest=AuditoriaLoteServiceImplTest,EvaluacionCalidadMapperTest test` but the process was interrupted and did not complete; tests were adjusted accordingly in the codebase.
- No integration or e2e tests were run as part of this change.
- Please run the full test suite (`mvn test`) in CI to validate all modules before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d4fb60b08333b5998a108f8ec28e)