### PR TITLE
Fix calidad PDF generation: XHTML templates, PdfGenerationException, and tests

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLotePdfService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLotePdfService.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.calidad.service;
 
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.shared.exception.PdfGenerationException;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StreamUtils;
@@ -88,7 +89,7 @@ public class AuditoriaLotePdfService {
             builder.run();
             return out.toByteArray();
         } catch (Exception e) {
-            throw new IllegalStateException("No se pudo generar el PDF de auditoría de lote", e);
+            throw new PdfGenerationException("No se pudo generar el PDF de auditoría de lote", e);
         }
     }
 
@@ -101,7 +102,7 @@ public class AuditoriaLotePdfService {
                 return index > 0 ? html.substring(index) : html;
             }
         } catch (Exception e) {
-            throw new IllegalStateException("No se pudo cargar la plantilla de auditoría de lote", e);
+            throw new PdfGenerationException("No se pudo cargar la plantilla de auditoría de lote", e);
         }
     }
 
@@ -116,4 +117,3 @@ public class AuditoriaLotePdfService {
         return fecha == null ? "" : fecha.format(FECHA_FORMATO);
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/CarpetaLotePdfService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/CarpetaLotePdfService.java
@@ -4,6 +4,7 @@ import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import com.willyes.clemenintegra.shared.exception.PdfGenerationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
@@ -50,7 +51,7 @@ public class CarpetaLotePdfService {
             builder.run();
             return out.toByteArray();
         } catch (Exception e) {
-            throw new IllegalStateException("No se pudo generar la carpeta de lote", e);
+            throw new PdfGenerationException("No se pudo generar la carpeta de lote", e);
         }
     }
 
@@ -63,7 +64,7 @@ public class CarpetaLotePdfService {
                 return index > 0 ? html.substring(index) : html;
             }
         } catch (Exception e) {
-            throw new IllegalStateException("No se pudo cargar la plantilla de carpeta de lote", e);
+            throw new PdfGenerationException("No se pudo cargar la plantilla de carpeta de lote", e);
         }
     }
 

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -108,6 +108,12 @@ public class GlobalExceptionHandler {
         return buildResponse(ApiErrorCode.SOLICITUD_INVALIDA, ex.getMessage(), null);
     }
 
+    @ExceptionHandler(PdfGenerationException.class)
+    public ResponseEntity<ErrorResponseDTO> handlePdfGeneration(PdfGenerationException ex,
+                                                                HttpServletRequest request) {
+        return buildResponse(ApiErrorCode.ERROR_INTERNO, ex.getMessage(), null);
+    }
+
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponseDTO> handleTypeMismatch(MethodArgumentTypeMismatchException ex,
                                                                HttpServletRequest request) {

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/PdfGenerationException.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/PdfGenerationException.java
@@ -1,0 +1,12 @@
+package com.willyes.clemenintegra.shared.exception;
+
+public class PdfGenerationException extends RuntimeException {
+
+    public PdfGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PdfGenerationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/templates/calidad/auditoria-lote.ftl
+++ b/src/main/resources/templates/calidad/auditoria-lote.ftl
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
     <title>Auditoría de Lote</title>
     <style>
-        body { font-family: Arial, sans-serif; font-size: 12px; }
+        @page { size: A4; margin: 20px; }
+        body { font-family: Arial, sans-serif; font-size: 11px; margin: 0; padding: 0; }
         h1 { text-align: center; }
         table { width: 100%; border-collapse: collapse; margin-top: 10px; }
         th, td { border: 1px solid #ccc; padding: 6px; }

--- a/src/main/resources/templates/calidad/carpeta-lote.ftl
+++ b/src/main/resources/templates/calidad/carpeta-lote.ftl
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
     <title>Carpeta de Lote</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 16px; }
+        @page { size: A4; margin: 20px; }
+        body { font-family: Arial, sans-serif; font-size: 11px; margin: 0; padding: 0; }
         h1, h2 { color: #1d3557; }
         table { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
         th, td { border: 1px solid #b5c3d3; padding: 8px; font-size: 12px; }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLotePdfServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLotePdfServiceTest.java
@@ -1,0 +1,43 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuditoriaLotePdfServiceTest {
+
+    @Test
+    void generaPdfSinErrores() {
+        AuditoriaLoteResponseDTO auditoria = AuditoriaLoteResponseDTO.builder()
+                .codigoLote("LT-100")
+                .nombreProducto("Producto A")
+                .categoriaProducto("Categoria")
+                .tipoAnalisisCalidad("FISICO")
+                .estadoLote("LIBERADO")
+                .fechaFabricacion(LocalDateTime.of(2024, 1, 10, 8, 0))
+                .fechaVencimiento(LocalDateTime.of(2025, 1, 10, 8, 0))
+                .stockLote(new BigDecimal("120.5"))
+                .nombreAlmacenActual("Almacen Central")
+                .ubicacionAlmacenActual("Rack A1")
+                .estadoCalidad(EstadoCalidadLoteResponseDTO.builder()
+                        .estadoLote("LIBERADO")
+                        .retencionActiva(false)
+                        .build())
+                .incidentes(List.of())
+                .movimientos(List.of())
+                .build();
+
+        AuditoriaLotePdfService service = new AuditoriaLotePdfService();
+
+        byte[] pdf = service.generarPdf(auditoria);
+
+        assertThat(pdf).isNotNull();
+        assertThat(pdf.length).isGreaterThan(100);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/CarpetaLotePdfServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/CarpetaLotePdfServiceTest.java
@@ -1,0 +1,52 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CarpetaLotePdfServiceTest {
+
+    @Mock
+    private AuditoriaLoteService auditoriaLoteService;
+
+    @Mock
+    private EvaluacionCalidadRepository evaluacionCalidadRepository;
+
+    @Test
+    void generaCarpetaSinErrores() {
+        AuditoriaLoteResponseDTO auditoria = AuditoriaLoteResponseDTO.builder()
+                .loteId(1L)
+                .codigoLote("LT-200")
+                .nombreProducto("Producto B")
+                .estadoLote("CUARENTENA")
+                .fechaFabricacion(LocalDateTime.of(2024, 2, 10, 9, 0))
+                .estadoCalidad(EstadoCalidadLoteResponseDTO.builder()
+                        .estadoLote("CUARENTENA")
+                        .retencionActiva(true)
+                        .build())
+                .incidentes(List.of())
+                .movimientos(List.of())
+                .build();
+
+        when(auditoriaLoteService.obtenerAuditoriaDeLote(1L)).thenReturn(auditoria);
+        when(evaluacionCalidadRepository.findByLoteProductoId(1L)).thenReturn(List.of());
+
+        CarpetaLotePdfService service = new CarpetaLotePdfService(auditoriaLoteService, evaluacionCalidadRepository);
+
+        byte[] pdf = service.generarCarpeta(1L);
+
+        assertThat(pdf).isNotNull();
+        assertThat(pdf.length).isGreaterThan(100);
+    }
+}


### PR DESCRIPTION
### Motivation
- HTML templates used to render PDFs were not strictly XHTML-compliant (e.g. `<meta>` not self-closed) causing openhtmltopdf SAX parse errors when generating PDF for auditoría and carpeta.
- Keep visual/style consistency with the working microbiology PDF template and avoid propagating low-level openhtmltopdf exceptions to controllers.
- Ensure regressions are caught by lightweight automated tests for the PDF generation services.
- Only the presentation layer and error handling should change; business logic remains intact.

### Description
- Fixed templates to be compatible with openhtmltopdf and aligned base PDF styles with the microbiology report:
  - `src/main/resources/templates/calidad/auditoria-lote.ftl` — added `meta` self-close (`<meta charset="UTF-8" />`) and page/body CSS (`@page`, font sizing, margins).
  - `src/main/resources/templates/calidad/carpeta-lote.ftl` — same XHTML/style adjustments.
- Introduced a dedicated runtime exception `PdfGenerationException` (`src/main/java/com/willyes/clemenintegra/shared/exception/PdfGenerationException.java`) to wrap PDF/template load errors.
- Updated PDF services to throw `PdfGenerationException` instead of leaking generic `IllegalStateException`:
  - `AuditoriaLotePdfService` — replaced `IllegalStateException` with `PdfGenerationException` on render/load errors.
  - `CarpetaLotePdfService` — same change.
- Mapped the new exception in the global handler so PDF failures return a consistent API error (`GlobalExceptionHandler`): added handler for `PdfGenerationException` returning `ApiErrorCode.ERROR_INTERNO`.
- Added minimal unit tests that exercise PDF generation and assert non-empty bytes to avoid regressions:
  - `src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLotePdfServiceTest.java`
  - `src/test/java/com/willyes/clemenintegra/calidad/service/CarpetaLotePdfServiceTest.java`

### Testing
- Added automated unit tests (see classes above) that instantiate the PDF services and assert that generated `byte[]` is non-null and has length > 100.
- No test execution was performed in this rollout (tests were added but not run here).
- Manual verification expectation: after CI runs the new tests, `AnalisisMicroPdfServiceTest` style shows the project has runnable PDF tests and these new tests should behave similarly.
- If CI reports openhtmltopdf errors, templates may need further XHTML adjustments (this PR targets the common early causes: self-closing tags and base CSS alignment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945e0d457108333a0a345bff5834fe5)