### PR TITLE
Unify lote calidad lifecycle rules

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/AuditoriaLoteResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/AuditoriaLoteResponseDTO.java
@@ -43,6 +43,7 @@ public class AuditoriaLoteResponseDTO {
     private List<EvaluacionResumenDTO> evaluaciones;
     private List<IncidenteDTO> incidentes;
     private List<RetencionDTO> retenciones;
+    private boolean inconsistenciaRetencion;
     private boolean tieneNoConformidadAsociada;
     private boolean tieneNoConformidadActiva;
     private String codigoNoConformidadPrincipal;

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/RetencionLote.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/RetencionLote.java
@@ -32,7 +32,7 @@ public class RetencionLote {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "motivo", nullable = false,
-            columnDefinition = "ENUM('NO_CONFORMIDAD','OTRO')")
+            columnDefinition = "ENUM('NO_CONFORMIDAD','REEVALUACION','OTRO')")
     private MotivoRetencion motivo;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -55,4 +55,3 @@ public class RetencionLote {
             foreignKey = @ForeignKey(name = "fk_retencion_usuario"))
     private Usuario aprobadoPor;
 }
-

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/MotivoRetencion.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/MotivoRetencion.java
@@ -2,5 +2,6 @@ package com.willyes.clemenintegra.calidad.model.enums;
 
 public enum MotivoRetencion {
     NO_CONFORMIDAD,
+    REEVALUACION,
     OTRO
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImpl.java
@@ -78,6 +78,9 @@ public class AuditoriaLoteServiceImpl implements AuditoriaLoteService {
                 .map(this::mapRetencion)
                 .toList();
 
+        boolean inconsistenciaRetencion = retenciones.isEmpty()
+                && lote.getEstado() == com.willyes.clemenintegra.inventario.model.enums.EstadoLote.RETENIDO;
+
         CondicionUsoResponseDTO condicionUso = condicionUsoService.getActivasByLote(loteId).stream()
                 .findFirst()
                 .orElse(null);
@@ -164,6 +167,7 @@ public class AuditoriaLoteServiceImpl implements AuditoriaLoteService {
                 .evaluaciones(evaluaciones)
                 .incidentes(incidentes)
                 .retenciones(retenciones)
+                .inconsistenciaRetencion(inconsistenciaRetencion)
                 .tieneNoConformidadAsociada(tieneNoConformidadAsociada)
                 .tieneNoConformidadActiva(tieneNoConformidadActiva)
                 .codigoNoConformidadPrincipal(noConformidadPrincipal.map(NoConformidad::getCodigo).orElse(null))

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteService.java
@@ -30,12 +30,21 @@ public interface RetencionLoteService {
                           NoConformidad noConformidad,
                           Usuario usuario);
 
+    RetencionLote retenerLote(Long loteId,
+                              MotivoRetencion motivo,
+                              String descripcion,
+                              NoConformidad noConformidad,
+                              Usuario usuario,
+                              boolean moverACuarentena);
+
     RetencionLote asegurarRetencionNoConformidad(LoteProducto lote,
                                                   String descripcion,
                                                   NoConformidad noConformidad,
                                                   Usuario usuario);
 
     RetencionLote levantar(Long retencionId, Usuario usuario);
+
+    RetencionLote levantarRetencion(Long retencionId, Usuario usuario);
 
     Optional<RetencionLote> obtenerActivaPorLote(Long loteId);
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/RetencionLoteServiceImpl.java
@@ -10,6 +10,9 @@ import com.willyes.clemenintegra.calidad.repository.RetencionLoteRepository;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.calidad.service.AnalisisCalidadHelper;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +36,8 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
 
     private final RetencionLoteRepository repository;
     private final LoteProductoRepository loteRepository;
+    private final AlmacenRepository almacenRepository;
+    private final InventoryCatalogResolver catalogResolver;
     private final UsuarioRepository usuarioRepository;
     private final RetencionLoteMapper mapper;
 
@@ -50,7 +55,9 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
         Usuario user = usuarioRepository.findById(dto.getAprobadoPorId())
                 .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + dto.getAprobadoPorId()));
         RetencionLote entity = mapper.toEntity(dto, lote, user);
-        return mapper.toDTO(repository.save(entity));
+        RetencionLote guardada = repository.save(entity);
+        sincronizarEstadoRetenido(guardada.getLote(), guardada);
+        return mapper.toDTO(guardada);
     }
 
     @Transactional
@@ -73,7 +80,16 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
 
         existing.setEstado(dto.getEstado());
         existing.setAprobadoPor(user);
-        return mapper.toDTO(repository.save(existing));
+        RetencionLote guardada = repository.save(existing);
+        if (guardada.getEstado() == EstadoRetencion.RETENIDO) {
+            sincronizarEstadoRetenido(lote, guardada);
+        } else if (guardada.getEstado() == EstadoRetencion.LIBERADO) {
+            List<RetencionLote> activas = repository.findByLote_IdAndEstado(lote.getId(), EstadoRetencion.RETENIDO);
+            if (activas.isEmpty()) {
+                actualizarEstadoPostLevantamiento(lote);
+            }
+        }
+        return mapper.toDTO(guardada);
     }
 
     public RetencionLoteDTO obtenerPorId(Long id) {
@@ -93,6 +109,17 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
                                  String descripcion,
                                  NoConformidad noConformidad,
                                  Usuario usuario) {
+        return retenerLote(loteId, motivo, descripcion, noConformidad, usuario, false);
+    }
+
+    @Override
+    @Transactional
+    public RetencionLote retenerLote(Long loteId,
+                                     MotivoRetencion motivo,
+                                     String descripcion,
+                                     NoConformidad noConformidad,
+                                     Usuario usuario,
+                                     boolean moverACuarentena) {
         if (loteId == null) {
             throw new IllegalArgumentException("Lote requerido");
         }
@@ -136,7 +163,10 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
             resultado = repository.save(nueva);
         }
 
-        asegurarEstadoRetenido(lote);
+        sincronizarEstadoRetenido(lote, resultado);
+        if (moverACuarentena) {
+            asegurarAlmacenCuarentena(lote);
+        }
         return resultado;
     }
 
@@ -155,6 +185,12 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
     @Override
     @Transactional
     public RetencionLote levantar(Long retencionId, Usuario usuario) {
+        return levantarRetencion(retencionId, usuario);
+    }
+
+    @Override
+    @Transactional
+    public RetencionLote levantarRetencion(Long retencionId, Usuario usuario) {
         if (!esJefeOSuper()) {
             throw new AccessDeniedException("Solo Jefe de Calidad o Super Admin pueden levantar retenciones");
         }
@@ -177,7 +213,15 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
         }
         retencion.setEstado(EstadoRetencion.LIBERADO);
         retencion.setFechaLiberacion(LocalDateTime.now());
-        return repository.save(retencion);
+        RetencionLote guardada = repository.save(retencion);
+        LoteProducto lote = guardada.getLote();
+        if (lote != null) {
+            List<RetencionLote> activas = repository.findByLote_IdAndEstado(lote.getId(), EstadoRetencion.RETENIDO);
+            if (activas.isEmpty()) {
+                actualizarEstadoPostLevantamiento(lote);
+            }
+        }
+        return guardada;
     }
 
     @Override
@@ -198,9 +242,48 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
         return repository.findByLote_IdAndEstado(loteId, EstadoRetencion.RETENIDO);
     }
 
-    private void asegurarEstadoRetenido(LoteProducto lote) {
-        if (lote != null && lote.getEstado() != EstadoLote.RETENIDO) {
+    private void sincronizarEstadoRetenido(LoteProducto lote, RetencionLote retencion) {
+        if (lote == null || lote.getEstado() == null) {
+            return;
+        }
+        if (lote.getEstado() == EstadoLote.RECHAZADO || lote.getEstado() == EstadoLote.VENCIDO) {
+            return;
+        }
+        if (lote.getEstado() != EstadoLote.RETENIDO && retencion != null
+                && retencion.getEstado() == EstadoRetencion.RETENIDO) {
             lote.setEstado(EstadoLote.RETENIDO);
+            loteRepository.save(lote);
+        }
+    }
+
+    private void actualizarEstadoPostLevantamiento(LoteProducto lote) {
+        if (lote == null || lote.getEstado() == null) {
+            return;
+        }
+        if (lote.getEstado() == EstadoLote.RECHAZADO || lote.getEstado() == EstadoLote.VENCIDO) {
+            return;
+        }
+        boolean requiereAnalisis = AnalisisCalidadHelper.requiereFisico(lote.getProducto())
+                || AnalisisCalidadHelper.requiereQuimico(lote.getProducto())
+                || AnalisisCalidadHelper.requiereMicro(lote.getProducto());
+        lote.setEstado(requiereAnalisis ? EstadoLote.EN_CUARENTENA : EstadoLote.DISPONIBLE);
+        if (requiereAnalisis) {
+            asegurarAlmacenCuarentena(lote);
+        }
+        loteRepository.save(lote);
+    }
+
+    private void asegurarAlmacenCuarentena(LoteProducto lote) {
+        if (lote == null) {
+            return;
+        }
+        Long cuarentenaId = catalogResolver.getAlmacenCuarentenaId();
+        if (cuarentenaId == null) {
+            return;
+        }
+        if (lote.getAlmacen() == null || !cuarentenaId.equals(lote.getAlmacen().getId().longValue())) {
+            lote.setAlmacen(almacenRepository.findById(cuarentenaId)
+                    .orElseGet(() -> new com.willyes.clemenintegra.inventario.model.Almacen(Math.toIntExact(cuarentenaId))));
             loteRepository.save(lote);
         }
     }
@@ -223,4 +306,3 @@ public class RetencionLoteServiceImpl implements RetencionLoteService {
         return false;
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteCalidadValidator.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteCalidadValidator.java
@@ -1,6 +1,8 @@
 package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
+import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
+import com.willyes.clemenintegra.calidad.service.NoConformidadService;
 import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
@@ -24,9 +26,25 @@ public class LoteCalidadValidator {
     );
 
     private final RetencionLoteService retencionLoteService;
+    private final NoConformidadService noConformidadService;
+    private final CondicionUsoService condicionUsoService;
 
     public void validarLoteUtilizable(LoteProducto lote) {
         EstadoLote estado = lote != null ? lote.getEstado() : null;
+
+        if (lote != null && lote.getId() != null) {
+            noConformidadService.obtenerActivaPorLote(lote.getId()).ifPresent(nc -> {
+                throw new CustomBusinessException(ApiErrorCode.BLOQUEO_NC_ACTIVA,
+                        "El lote tiene una no conformidad abierta y no puede utilizarse.",
+                        Map.of("loteId", lote.getId(), "ncId", nc.getId()));
+            });
+
+            if (!condicionUsoService.getActivasByLote(lote.getId()).isEmpty()) {
+                throw new CustomBusinessException(ApiErrorCode.BLOQUEO_CONDICION_USO,
+                        "El lote tiene una condición de uso activa y no puede utilizarse.",
+                        Map.of("loteId", lote.getId()));
+            }
+        }
 
         if (!ESTADOS_NO_PERMITIDOS.contains(estado)) {
             return;
@@ -48,4 +66,3 @@ public class LoteCalidadValidator {
                         "estado", estado != null ? estado.name() : null));
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -118,6 +118,14 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         if (!requiereAnalisis) {
             lote.setEstado(EstadoLote.DISPONIBLE);
         } else {
+            // Regla de negocio: los lotes con análisis requerido deben ingresar a cuarentena.
+            Long cuarentenaId = catalogResolver.getAlmacenCuarentenaId();
+            if (cuarentenaId == null) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_CUARENTENA_NO_CONFIGURADO");
+            }
+            almacen = almacenRepo.findById(cuarentenaId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_CUARENTENA_INEXISTENTE"));
+            lote.setAlmacen(almacen);
             lote.setEstado(EstadoLote.EN_CUARENTENA);
         }
 
@@ -265,24 +273,21 @@ public class LoteProductoServiceImpl implements LoteProductoService {
                     Map.of("loteId", loteId, "estadoActual", estadoActual.name()));
         }
 
-        if (!EnumSet.of(EstadoLote.LIBERADO, EstadoLote.RECHAZADO, EstadoLote.DISPONIBLE).contains(estadoActual)) {
+        if (!EnumSet.of(EstadoLote.LIBERADO, EstadoLote.DISPONIBLE).contains(estadoActual)) {
             throw new CustomBusinessException(ApiErrorCode.OPERACION_NO_PERMITIDA,
                     "El lote no puede reabrirse desde su estado actual.",
                     Map.of("loteId", loteId, "estadoActual", estadoActual.name()));
         }
 
-        Long cuarentenaId = catalogResolver.getAlmacenCuarentenaId();
-        if (cuarentenaId == null) {
-            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_CUARENTENA_NO_CONFIGURADO");
-        }
-
         Almacen almacenPrevio = lote.getAlmacen();
-        Almacen almacenCuarentena = almacenRepo.findById(cuarentenaId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_CUARENTENA_INEXISTENTE"));
+        retencionLoteService.retenerLote(lote.getId(),
+                MotivoRetencion.REEVALUACION,
+                motivo.trim(),
+                null,
+                usuarioActual,
+                true);
 
-        lote.setEstado(EstadoLote.RETENIDO);
-        lote.setAlmacen(almacenCuarentena);
-        lote = loteRepo.save(lote);
+        lote = loteRepo.findById(loteId).orElse(lote);
 
         registrarBitacoraReapertura(lote,
                 estadoActual,
@@ -483,23 +488,9 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     @Transactional
     @Override
     public LoteProductoResponseDTO liberarLote(Long id) {
-        LoteProducto lote = loteRepo.findById(id)
-                .orElseThrow(() -> new java.util.NoSuchElementException("Lote no encontrado"));
-
-        validarEvaluacionesExistentes(id);
-        validarNoConformidadesParaLiberacion(lote.getId());
-
-        if (lote.getEstado() != EstadoLote.EN_CUARENTENA
-                && lote.getEstado() != EstadoLote.RETENIDO) {
-            throw new IllegalStateException("El lote no puede ser liberado desde su estado actual");
-        }
-
-        lote.setEstado(EstadoLote.LIBERADO);
-        lote.setFechaLiberacion(LocalDateTime.now());
-        lote.setUsuarioLiberador(usuarioService.obtenerUsuarioAutenticado());
-
-        loteRepo.save(lote);
-        return loteProductoMapper.toResponseDTO(lote);
+        // Alias de liberación por calidad. Se recomienda usar /api/calidad/lotes/{id}/liberar.
+        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+        return liberarLoteConReglasCalidad(id, usuario, true);
     }
 
     @Transactional
@@ -578,20 +569,9 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     @Transactional
     @Override
     public LoteProductoResponseDTO liberarLoteRetenido(Long id) {
-        LoteProducto lote = loteRepo.findById(id)
-                .orElseThrow(() -> new java.util.NoSuchElementException("Lote no encontrado"));
-        validarEvaluacionesExistentes(id);
-        validarNoConformidadesParaLiberacion(lote.getId());
-        if (lote.getEstado() != EstadoLote.RETENIDO) {
-            throw new CustomBusinessException(ApiErrorCode.BLOQUEO_ESTADO_CUARENTENA,
-                    "El lote debe estar en estado RETENIDO para liberarlo.",
-                    Map.of("loteId", id, "estadoActual", lote.getEstado() != null ? lote.getEstado().name() : null));
-        }
-        lote.setEstado(EstadoLote.LIBERADO);
-        lote.setFechaLiberacion(LocalDateTime.now());
-        lote.setUsuarioLiberador(usuarioService.obtenerUsuarioAutenticado());
-        loteRepo.save(lote);
-        return loteProductoMapper.toResponseDTO(lote);
+        // Alias de liberación por calidad. Se recomienda usar /api/calidad/lotes/{id}/liberar.
+        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+        return liberarLoteConReglasCalidad(id, usuario, true);
     }
 
     @Override
@@ -603,7 +583,10 @@ public class LoteProductoServiceImpl implements LoteProductoService {
             throw new CustomBusinessException(ApiErrorCode.ROL_INSUFICIENTE,
                     "Solo el Jefe de Calidad o Super Admin pueden liberar lotes.");
         }
+        return liberarLoteConReglasCalidad(loteId, usuarioActual, true);
+    }
 
+    private LoteProductoResponseDTO liberarLoteConReglasCalidad(Long loteId, Usuario usuarioActual, boolean moverAlmacen) {
         EstadoLote estadoLiberado;
         ClasificacionMovimientoInventario clasificacion;
         try {
@@ -627,28 +610,23 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         LoteProducto lote = loteProductoRepository.findByIdForUpdate(loteId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Lote no encontrado"));
 
-        Producto producto = lote.getProducto();
-        Long destinoPrincipalId = catalogResolver.resolveAlmacenPrincipal(producto);
-        Long almacenCuarentenaId = catalogResolver.getAlmacenCuarentenaId();
-        if (destinoPrincipalId.equals(lote.getAlmacen().getId().longValue())
-                && lote.getEstado() == estadoLiberado
-                && lote.getFechaLiberacion() != null
-                && lote.getUsuarioLiberador() != null) {
-            boolean movExistente = movimientoInventarioRepository
-                    .existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(
-                            TipoMovimiento.TRANSFERENCIA, lote.getId(), almacenCuarentenaId, destinoPrincipalId, clasificacion);
-            if (movExistente) {
-                return loteProductoMapper.toResponseDTO(lote);
-            }
+        if (lote.getEstado() == EstadoLote.RECHAZADO || lote.getEstado() == EstadoLote.VENCIDO) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_LIBERABLE");
+        }
+        if (lote.getEstado() != EstadoLote.EN_CUARENTENA && lote.getEstado() != EstadoLote.RETENIDO) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_EN_CUARENTENA");
         }
 
-        if (!almacenCuarentenaId.equals(lote.getAlmacen().getId().longValue()) || lote.getEstado() != EstadoLote.EN_CUARENTENA) {
-            Long almacenId = Long.valueOf(lote.getAlmacen().getId());
-            EstadoLote estadoLote = lote.getEstado();
+        Long almacenCuarentenaId = catalogResolver.getAlmacenCuarentenaId();
+        if (almacenCuarentenaId == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_CUARENTENA_NO_CONFIGURADO");
+        }
+        if (lote.getAlmacen() == null || !almacenCuarentenaId.equals(lote.getAlmacen().getId().longValue())) {
+            Long almacenId = lote.getAlmacen() != null ? Long.valueOf(lote.getAlmacen().getId()) : null;
             log.info("[INVENTARIO] intento de liberar lote fuera de cuarentena. loteId={} almacenId={} estado={}",
-                    loteId, almacenId, estadoLote);
+                    loteId, almacenId, lote.getEstado());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                    "LOTE_NO_EN_CUARENTENA (almacenId=" + almacenId + ", estado=" + estadoLote + ")");
+                    "LOTE_NO_EN_CUARENTENA (almacenId=" + almacenId + ", estado=" + lote.getEstado() + ")");
         }
         if (lote.getStockReservado() != null && lote.getStockReservado().compareTo(BigDecimal.ZERO) > 0) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_CON_RESERVAS");
@@ -660,19 +638,35 @@ public class LoteProductoServiceImpl implements LoteProductoService {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_SIN_STOCK");
         }
 
-        List<EvaluacionCalidad> evaluaciones = evaluacionRepository.findByLoteProductoId(loteId);
-        java.util.Set<Long> evaluacionesConResultadosMicro = obtenerEvaluacionesConResultadosMicro(evaluaciones);
-        var validacion = validarDisciplinasCompletas(lote, evaluaciones,
-                evaluacionId -> evaluacionesConResultadosMicro.contains(evaluacionId));
-        if (!validacion.esValido()) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, validacion.getPrimerMensaje());
+        validarEvaluacionesExistentes(loteId);
+        validarDisciplinasParaLiberacion(lote);
+        validarNoConformidadesParaLiberacion(loteId);
+        validarRetencionesParaLiberacion(loteId);
+        validarCondicionesUsoParaLiberacion(loteId);
+
+        Producto producto = lote.getProducto();
+        Long destinoPrincipalId = catalogResolver.resolveAlmacenPrincipal(producto);
+        if (destinoPrincipalId == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_DESTINO_NO_CONFIGURADO");
         }
 
-        validarNoConformidadesParaLiberacion(loteId);
+        if (moverAlmacen && destinoPrincipalId.equals(lote.getAlmacen().getId().longValue())
+                && lote.getEstado() == estadoLiberado
+                && lote.getFechaLiberacion() != null
+                && lote.getUsuarioLiberador() != null) {
+            boolean movExistente = movimientoInventarioRepository
+                    .existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(
+                            TipoMovimiento.TRANSFERENCIA, lote.getId(), almacenCuarentenaId, destinoPrincipalId, clasificacion);
+            if (movExistente) {
+                return loteProductoMapper.toResponseDTO(lote);
+            }
+        }
 
         Almacen origen = lote.getAlmacen();
-        Almacen destino = almacenRepo.findById(destinoPrincipalId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_DESTINO_INEXISTENTE"));
+        Almacen destino = moverAlmacen
+                ? almacenRepo.findById(destinoPrincipalId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_DESTINO_INEXISTENTE"))
+                : origen;
         BigDecimal cantidad = lote.getStockLote();
 
         lote.setEstado(estadoLiberado);
@@ -683,23 +677,25 @@ public class LoteProductoServiceImpl implements LoteProductoService {
 
         log.info("[INVENTARIO] liberación de lote completada destino={} tipoProducto={} loteId={}",
                 destinoPrincipalId,
-                producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getTipo() : null,
+                producto != null && producto.getCategoriaProducto() != null ? producto.getCategoriaProducto().getTipo() : null,
                 loteId);
 
-        MovimientoInventario mov = MovimientoInventario.builder()
-                .cantidad(cantidad)
-                .tipoMovimiento(TipoMovimiento.TRANSFERENCIA)
-                .clasificacion(clasificacion)
-                .registradoPor(usuarioActual)
-                .producto(producto)
-                .lote(lote)
-                .almacenOrigen(origen)
-                .almacenDestino(destino)
-                .motivoMovimiento(motivo)
-                .tipoMovimientoDetalle(tipoDetalle)
-                .ordenProduccion(lote.getOrdenProduccion())
-                .build();
-        movimientoInventarioRepository.save(mov);
+        if (moverAlmacen) {
+            MovimientoInventario mov = MovimientoInventario.builder()
+                    .cantidad(cantidad)
+                    .tipoMovimiento(TipoMovimiento.TRANSFERENCIA)
+                    .clasificacion(clasificacion)
+                    .registradoPor(usuarioActual)
+                    .producto(producto)
+                    .lote(lote)
+                    .almacenOrigen(origen)
+                    .almacenDestino(destino)
+                    .motivoMovimiento(motivo)
+                    .tipoMovimientoDetalle(tipoDetalle)
+                    .ordenProduccion(lote.getOrdenProduccion())
+                    .build();
+            movimientoInventarioRepository.save(mov);
+        }
 
         return loteProductoMapper.toResponseDTO(lote);
     }
@@ -845,6 +841,34 @@ public class LoteProductoServiceImpl implements LoteProductoService {
         });
         if (retencionNcActiva) {
             log.debug("[INVENTARIO] retención por NC verificada con NC cerrada para lote {}", loteId);
+        }
+    }
+
+    private void validarRetencionesParaLiberacion(Long loteId) {
+        var retenciones = retencionLoteService.obtenerRetencionesActivas(loteId);
+        if (retenciones != null && !retenciones.isEmpty()) {
+            throw new CustomBusinessException(ApiErrorCode.CALIDAD_LOTE_NO_LIBERADO,
+                    "No es posible liberar un lote con retenciones activas.",
+                    Map.of("loteId", loteId));
+        }
+    }
+
+    private void validarCondicionesUsoParaLiberacion(Long loteId) {
+        var condiciones = condicionUsoService.getActivasByLote(loteId);
+        if (condiciones != null && !condiciones.isEmpty()) {
+            throw new CustomBusinessException(ApiErrorCode.BLOQUEO_CONDICION_USO,
+                    "No es posible liberar un lote con condiciones de uso activas.",
+                    Map.of("loteId", loteId));
+        }
+    }
+
+    private void validarDisciplinasParaLiberacion(LoteProducto lote) {
+        List<EvaluacionCalidad> evaluaciones = evaluacionRepository.findByLoteProductoId(lote.getId());
+        java.util.Set<Long> evaluacionesConResultadosMicro = obtenerEvaluacionesConResultadosMicro(evaluaciones);
+        var validacion = validarDisciplinasCompletas(lote, evaluaciones,
+                evaluacionId -> evaluacionesConResultadosMicro.contains(evaluacionId));
+        if (!validacion.esValido()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, validacion.getPrimerMensaje());
         }
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -1584,14 +1584,15 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                                             Almacen destino, Usuario usuario, BigDecimal cantidad,
                                             MotivoMovimiento motivoMovimiento) {
         if (dto.loteProductoId() != null) {
-            LoteProducto existente = loteProductoRepository.findById(dto.loteProductoId())
-                    .orElseThrow(() -> {
-                        log.warn(
-                                "crearLoteRecepcion: lote no encontrado loteId={} productoId={} destinoId={} cantidad={}",
-                                dto.loteProductoId(), producto.getId(),
-                                destino != null ? destino.getId() : null, cantidad);
-                        return new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_ENCONTRADO");
-                    });
+            Optional<LoteProducto> existenteOpt = loteProductoRepository.findById(dto.loteProductoId());
+            if (existenteOpt.isEmpty()) {
+                log.warn(
+                        "crearLoteRecepcion: lote no encontrado loteId={} productoId={} destinoId={} cantidad={}",
+                        dto.loteProductoId(), producto.getId(),
+                        destino != null ? destino.getId() : null, cantidad);
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_ENCONTRADO");
+            }
+            LoteProducto existente = existenteOpt.get();
             BigDecimal nuevo = Optional.ofNullable(existente.getStockLote()).orElse(BigDecimal.ZERO).add(cantidad);
             existente.setStockLote(nuevo);
             existente.setAlmacen(destino);
@@ -1610,6 +1611,15 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         validarFechaVencimientoRecepcion(dto.fechaVencimiento());
 
         boolean requiereAnalisis = requiereFisico(producto) || requiereQuimico(producto) || requiereMicro(producto);
+        if (requiereAnalisis) {
+            // Regla de negocio: un lote con análisis requerido no puede ingresar a almacenes operativos.
+            Long cuarentenaId = catalogResolver.getAlmacenCuarentenaId();
+            if (cuarentenaId == null) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_CUARENTENA_NO_CONFIGURADO");
+            }
+            destino = almacenRepository.findById(cuarentenaId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_CUARENTENA_INEXISTENTE"));
+        }
 
         LoteProducto lote = LoteProducto.builder()
                 .codigoLote(dto.codigoLote())

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/ApiErrorCode.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/ApiErrorCode.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum ApiErrorCode {
 
     BLOQUEO_RETENCION_NC(HttpStatus.CONFLICT),
+    BLOQUEO_NC_ACTIVA(HttpStatus.CONFLICT),
+    BLOQUEO_CONDICION_USO(HttpStatus.CONFLICT),
     BLOQUEO_ESTADO_CUARENTENA(HttpStatus.CONFLICT),
     CALIDAD_LOTE_NO_LIBERADO(HttpStatus.UNPROCESSABLE_ENTITY),
     NC_ABIERTA(HttpStatus.CONFLICT),

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImplTest.java
@@ -153,6 +153,7 @@ class AuditoriaLoteServiceImplTest {
         assertThat(dto.getIncidentes()).hasSize(1);
         assertThat(dto.getIncidentes().get(0).isTieneCapa()).isTrue();
         assertThat(dto.getRetenciones()).hasSize(1);
+        assertThat(dto.isInconsistenciaRetencion()).isFalse();
         assertThat(dto.getMovimientos()).hasSize(1);
         assertThat(dto.getMovimientos().get(0).getFecha()).isEqualTo(mov.getFechaIngreso());
         assertThat(dto.getEvaluaciones()).hasSize(1);
@@ -284,6 +285,7 @@ class AuditoriaLoteServiceImplTest {
         assertThat(dto.getEstadoLote()).isEqualTo("RETENIDO");
         assertThat(dto.getEstadoCalidad().getEstadoLote()).isEqualTo("RETENIDO");
         assertThat(dto.getEstadoCalidad().isTieneRetencionActiva()).isFalse();
+        assertThat(dto.isInconsistenciaRetencion()).isTrue();
         assertThat(dto.getMotivoRetencion()).isEqualTo("NC");
         assertThat(dto.isTieneNoConformidadAsociada()).isTrue();
         assertThat(dto.isTieneNoConformidadActiva()).isTrue();

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/LoteCalidadValidatorTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/LoteCalidadValidatorTest.java
@@ -2,6 +2,10 @@ package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import com.willyes.clemenintegra.calidad.model.RetencionLote;
+import com.willyes.clemenintegra.calidad.dto.CondicionUsoResponseDTO;
+import com.willyes.clemenintegra.calidad.model.NoConformidad;
+import com.willyes.clemenintegra.calidad.service.CondicionUsoService;
+import com.willyes.clemenintegra.calidad.service.NoConformidadService;
 import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
@@ -13,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -25,12 +30,16 @@ class LoteCalidadValidatorTest {
 
     @Mock
     private RetencionLoteService retencionLoteService;
+    @Mock
+    private NoConformidadService noConformidadService;
+    @Mock
+    private CondicionUsoService condicionUsoService;
 
     private LoteCalidadValidator validator;
 
     @BeforeEach
     void setUp() {
-        validator = new LoteCalidadValidator(retencionLoteService);
+        validator = new LoteCalidadValidator(retencionLoteService, noConformidadService, condicionUsoService);
     }
 
     @Test
@@ -51,6 +60,9 @@ class LoteCalidadValidatorTest {
         lote.setId(10L);
         lote.setEstado(EstadoLote.EN_CUARENTENA);
 
+        when(noConformidadService.obtenerActivaPorLote(anyLong())).thenReturn(Optional.empty());
+        when(condicionUsoService.getActivasByLote(anyLong())).thenReturn(List.of());
+
         assertThatThrownBy(() -> validator.validarLoteUtilizable(lote))
                 .isInstanceOf(CustomBusinessException.class)
                 .extracting("code")
@@ -68,11 +80,43 @@ class LoteCalidadValidatorTest {
         retencion.setMotivo(MotivoRetencion.NO_CONFORMIDAD);
 
         when(retencionLoteService.obtenerActivaPorLote(anyLong())).thenReturn(Optional.of(retencion));
+        when(noConformidadService.obtenerActivaPorLote(anyLong())).thenReturn(Optional.empty());
+        when(condicionUsoService.getActivasByLote(anyLong())).thenReturn(List.of());
 
         assertThatThrownBy(() -> validator.validarLoteUtilizable(lote))
                 .isInstanceOf(CustomBusinessException.class)
                 .extracting("code")
                 .isEqualTo(ApiErrorCode.BLOQUEO_RETENCION_NC);
     }
-}
 
+    @Test
+    void bloqueaLoteLiberadoConNcActiva() {
+        LoteProducto lote = new LoteProducto();
+        lote.setId(40L);
+        lote.setEstado(EstadoLote.LIBERADO);
+
+        NoConformidad nc = new NoConformidad();
+        nc.setId(99L);
+        when(noConformidadService.obtenerActivaPorLote(40L)).thenReturn(Optional.of(nc));
+
+        assertThatThrownBy(() -> validator.validarLoteUtilizable(lote))
+                .isInstanceOf(CustomBusinessException.class)
+                .extracting("code")
+                .isEqualTo(ApiErrorCode.BLOQUEO_NC_ACTIVA);
+    }
+
+    @Test
+    void bloqueaLoteLiberadoConCondicionUsoActiva() {
+        LoteProducto lote = new LoteProducto();
+        lote.setId(50L);
+        lote.setEstado(EstadoLote.LIBERADO);
+
+        when(noConformidadService.obtenerActivaPorLote(50L)).thenReturn(Optional.empty());
+        when(condicionUsoService.getActivasByLote(50L)).thenReturn(List.of(CondicionUsoResponseDTO.builder().id(1L).build()));
+
+        assertThatThrownBy(() -> validator.validarLoteUtilizable(lote))
+                .isInstanceOf(CustomBusinessException.class)
+                .extracting("code")
+                .isEqualTo(ApiErrorCode.BLOQUEO_CONDICION_USO);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImplTest.java
@@ -104,6 +104,7 @@ class LoteProductoServiceImplTest {
 
         when(retencionLoteService.obtenerRetencionesActivas(anyLong())).thenReturn(Collections.emptyList());
         when(noConformidadService.obtenerActivaPorLote(anyLong())).thenReturn(Optional.empty());
+        when(condicionUsoService.getActivasByLote(anyLong())).thenReturn(Collections.emptyList());
         when(movimientoInventarioRepository.existsByTipoMovimientoAndLoteIdAndAlmacenOrigenIdAndAlmacenDestinoIdAndClasificacion(
                 any(), anyLong(), anyLong(), anyLong(), any())).thenReturn(false);
     }
@@ -229,6 +230,9 @@ class LoteProductoServiceImplTest {
         LoteProducto entidad = LoteProducto.builder()
                 .id(44L)
                 .estado(null)
+                .stockLote(BigDecimal.TEN)
+                .producto(producto)
+                .almacen(almacen)
                 .stockReservado(BigDecimal.ZERO)
                 .build();
 
@@ -240,8 +244,12 @@ class LoteProductoServiceImplTest {
         when(loteProductoMapper.toResponseDTO(entidad)).thenAnswer(inv -> LoteProductoResponseDTO.builder()
                 .estado(entidad.getEstado())
                 .build());
-        when(loteProductoRepository.findById(44L)).thenReturn(Optional.of(entidad));
+        mockCatalogosBasicos(13L, 12L);
+        when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(9L);
+        when(catalogResolver.resolveAlmacenPrincipal(producto)).thenReturn(2L);
+        when(loteProductoRepository.findByIdForUpdate(44L)).thenReturn(Optional.of(entidad));
         when(evaluacionRepository.findByLoteProductoId(44L)).thenReturn(evaluacionesConforme());
+        when(almacenRepo.findById(2L)).thenReturn(Optional.of(almacenConId(2)));
 
         LoteProductoResponseDTO creado = service.crearLote(request);
 
@@ -253,6 +261,7 @@ class LoteProductoServiceImplTest {
         assertThat(entidad.getEstado()).isEqualTo(EstadoLote.LIBERADO);
         assertThat(entidad.getFechaLiberacion()).isNotNull();
         assertThat(entidad.getUsuarioLiberador()).isEqualTo(usuario);
+        assertThat(entidad.getAlmacen().getId()).isEqualTo(2L);
         assertThat(liberado.getEstado()).isEqualTo(EstadoLote.LIBERADO);
     }
 
@@ -287,6 +296,37 @@ class LoteProductoServiceImplTest {
 
         assertThat(lote.getEstado()).isEqualTo(EstadoLote.LIBERADO);
         assertThat(lote.getAlmacen().getId()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("Reabrir lote crea retención de reevaluación y mantiene trazabilidad")
+    void reabrirLoteCreaRetencionReevaluacion() {
+        Usuario jefeCalidad = usuarioConRol(RolUsuario.ROL_JEFE_CALIDAD);
+        Producto producto = productoConCategoria(TipoCategoria.PRODUCTO_TERMINADO);
+        LoteProducto lote = LoteProducto.builder()
+                .id(60L)
+                .estado(EstadoLote.LIBERADO)
+                .producto(producto)
+                .almacen(almacenConId(2))
+                .build();
+
+        when(loteProductoRepository.findByIdForUpdate(60L)).thenReturn(Optional.of(lote));
+        when(loteProductoRepository.findById(60L)).thenReturn(Optional.of(lote));
+
+        com.willyes.clemenintegra.calidad.dto.ReaperturaLoteRequestDTO dto =
+                com.willyes.clemenintegra.calidad.dto.ReaperturaLoteRequestDTO.builder()
+                        .motivo("Reevaluación por desviación")
+                        .build();
+
+        service.reabrirParaReevaluacion(60L, dto, jefeCalidad);
+
+        verify(retencionLoteService).retenerLote(
+                60L,
+                com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion.REEVALUACION,
+                "Reevaluación por desviación",
+                null,
+                jefeCalidad,
+                true);
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Close gaps found in lote quality lifecycle: desynchronization between `LoteProducto.estado` and `retencion_lote`, inconsistent quarantine placement on creation/recepcion, and differing liberation rules between inventory and quality endpoints.
- Ensure retentions created from UI/NC/evaluations and reaperturas produce consistent lote state and (when required) place lotes in the quarantine almacén.
- Centralize liberation logic so all liberaciones enforce the same business rules (evaluaciones completas, NC cerradas, no retenciones/condiciones activas) and keep `LoteCalidadValidator` as single movement gate.
- Improve auditability by surfacing retención/state inconsistencies in the auditoría DTO.

### Description
- Sync retenciones <-> lote state
  - Added `MotivoRetencion.REEVALUACION` and extended `RetencionLote.motivo` enum values.
  - Extended `RetencionLoteService` with `retenerLote(...)` and `levantarRetencion(...)` signatures.
  - Implemented `RetencionLoteServiceImpl` to: create/activate retenciones and always set `LoteProducto.estado = RETENIDO` (unless RECHAZADO/VENCIDO); when the last retención is levantada, set lote back to `EN_CUARENTENA` or `DISPONIBLE` depending on product analysis; optionally move lote to almacén cuarentena. (files changed: `RetencionLoteService.java`, `RetencionLoteServiceImpl.java`, `MotivoRetencion.java`, `RetencionLote.java`)
- Unify liberación rules
  - Consolidated liberación behavior into `LoteProductoServiceImpl.liberarLoteConReglasCalidad(...)`. All liberación endpoints (`/api/lotes/{id}/liberar`, `/liberar-retenido`, and the quality endpoint) now delegate to the same validation + action: require cuarentena origin, no NC abiertas, no retenciones activas, no condiciones de uso activas, evaluaciones/completitud por disciplina; set `LIBERADO`, set `fechaLiberacion/usuario` and (optionally) create transfer movement to almacén principal. (file: `LoteProductoServiceImpl.java`)
- Cuarentena & reception
  - On lote creation / recepción, if the product requires analysis the code now enforces assignment to the configured almacén cuarentena (or rejects if not configured). (file: `MovimientoInventarioServiceImpl.java`, `LoteProductoServiceImpl.java`)
- Validator & audit
  - `LoteCalidadValidator` extended to block movements when there is an active NC open or when there are active `CondicionUso` restrictions, adding new API error codes `BLOQUEO_NC_ACTIVA` and `BLOQUEO_CONDICION_USO`. (file: `LoteCalidadValidator.java`, `ApiErrorCode.java`)
  - `AuditoriaLoteServiceImpl` now sets `inconsistenciaRetencion` flag when lote is `RETENIDO` but no active row exists in `retencion_lote`, to surface mismatches. (file: `AuditoriaLoteServiceImpl.java`, `AuditoriaLoteResponseDTO.java`)
- Tests
  - Updated/added unit tests to cover new behavior and prevent regressions: `LoteCalidadValidatorTest`, `LoteProductoServiceImplTest`, `AuditoriaLoteServiceImplTest`.
  - Minor test harness adjustments to stub new service calls (catalog/condición/NC).

### Testing
- Ran the test suite with: `mvn -q test`.
- Updated unit tests executed as part of the suite (notably `LoteCalidadValidatorTest`, `LoteProductoServiceImplTest`, `AuditoriaLoteServiceImplTest`). The cycle was iterated until the updated tests covering retention syncing, liberation flow and audit inconsistency passed locally.

If you want, I can split these changes into smaller PRs (retenciones, liberación unificada, validator/audit) or prepare a short migration note describing DB enum update and runtime expectations for `inventory.cuarentena` configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945e472e1a88333b45e71fa81110c9e)