### PR TITLE
Expose vigente version id in Documento DTO and map latest version

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/documental/dto/DocumentoDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/documental/dto/DocumentoDTO.java
@@ -23,4 +23,5 @@ public class DocumentoDTO {
     private String creadoPorNombre;
     private Integer numeroVersionVigente;
     private LocalDateTime fechaEmisionVersionVigente;
+    private Long versionVigenteId;
 }

--- a/src/main/java/com/willyes/clemenintegra/documental/mapper/DocumentoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/documental/mapper/DocumentoMapper.java
@@ -27,6 +27,7 @@ public final class DocumentoMapper {
                 .creadoPorNombre(nombreUsuario(documento.getCreadoPor()))
                 .numeroVersionVigente(versionVigente != null ? versionVigente.getNumeroVersion() : null)
                 .fechaEmisionVersionVigente(versionVigente != null ? versionVigente.getFechaEmision() : null)
+                .versionVigenteId(versionVigente != null ? versionVigente.getId() : null)
                 .build();
     }
 

--- a/src/main/java/com/willyes/clemenintegra/documental/repository/DocumentoVersionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/documental/repository/DocumentoVersionRepository.java
@@ -14,6 +14,8 @@ public interface DocumentoVersionRepository extends JpaRepository<DocumentoVersi
 
     Optional<DocumentoVersion> findFirstByDocumentoIdAndVigenteTrue(Long documentoId);
 
+    Optional<DocumentoVersion> findTopByDocumentoIdOrderByNumeroVersionDesc(Long documentoId);
+
     @Query("select max(v.numeroVersion) from DocumentoVersion v where v.documento.id = :documentoId")
     Optional<Integer> findMaxNumeroVersionByDocumentoId(@Param("documentoId") Long documentoId);
 }

--- a/src/main/java/com/willyes/clemenintegra/documental/service/ControlDocumentalServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/documental/service/ControlDocumentalServiceImpl.java
@@ -83,7 +83,7 @@ public class ControlDocumentalServiceImpl implements ControlDocumentalService {
 
         return documentos.map(documento -> {
             DocumentoVersion vigente = versionRepository
-                    .findFirstByDocumentoIdAndVigenteTrue(documento.getId())
+                    .findTopByDocumentoIdOrderByNumeroVersionDesc(documento.getId())
                     .orElse(null);
             return DocumentoMapper.toDTO(documento, vigente);
         });
@@ -133,7 +133,8 @@ public class ControlDocumentalServiceImpl implements ControlDocumentalService {
                         "Documento no encontrado.",
                         Map.of("documentoId", documentoId)));
 
-        DocumentoVersion vigente = versionRepository.findFirstByDocumentoIdAndVigenteTrue(documentoId).orElse(null);
+        DocumentoVersion vigente = versionRepository.findTopByDocumentoIdOrderByNumeroVersionDesc(documentoId)
+                .orElse(null);
 
         List<DocumentoVersionDTO> versiones = versionRepository.findByDocumentoIdOrderByNumeroVersionDesc(documentoId)
                 .stream()

--- a/src/test/java/com/willyes/clemenintegra/documental/service/ControlDocumentalServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/documental/service/ControlDocumentalServiceTest.java
@@ -120,4 +120,41 @@ class ControlDocumentalServiceTest {
         assertThat(existente.isVigente()).isFalse();
         assertThat(versionDos.isVigente()).isTrue();
     }
+
+    @Test
+    void detalleDocumentoIncluyeVersionVigente() {
+        Usuario usuario = Usuario.builder()
+                .id(10L)
+                .nombreUsuario("jperez")
+                .nombreCompleto("Juan Perez")
+                .build();
+
+        Documento documento = Documento.builder()
+                .id(1L)
+                .codigo("DOC-001")
+                .nombre("Procedimiento limpieza")
+                .tipo(TipoDocumento.PROCEDIMIENTO)
+                .area(AreaDocumento.CALIDAD)
+                .estado(EstadoDocumento.VIGENTE)
+                .creadoPor(usuario)
+                .build();
+
+        DocumentoVersion version = DocumentoVersion.builder()
+                .id(5L)
+                .documento(documento)
+                .numeroVersion(2)
+                .fechaEmision(LocalDateTime.now())
+                .vigente(true)
+                .build();
+
+        when(documentoRepository.findById(1L)).thenReturn(Optional.of(documento));
+        when(versionRepository.findTopByDocumentoIdOrderByNumeroVersionDesc(1L))
+                .thenReturn(Optional.of(version));
+        when(versionRepository.findByDocumentoIdOrderByNumeroVersionDesc(1L)).thenReturn(List.of(version));
+
+        var detalle = service.obtenerDetalleDocumento(1L);
+
+        assertThat(detalle.getDocumento().getNumeroVersionVigente()).isEqualTo(2);
+        assertThat(detalle.getDocumento().getVersionVigenteId()).isEqualTo(5L);
+    }
 }


### PR DESCRIPTION
### Motivation

- Allow the frontend to know the ID of the current (vigente) document version so it can enable a "Download vigente" action.  
- Provide a deterministic way to pick the vigente version by exposing the version with the highest `numeroVersion` without changing backend validation rules.  
- Fix UI problems that arise when the DTO lacks the version ID and the frontend cannot display `numeroVersionVigente`/`fechaEmisionVersionVigente` or trigger downloads.  
- No frontend files were present in the repo so only backend changes were applied here.

### Description

- Added a new field `versionVigenteId` to `DocumentoDTO` to carry the ID of the current version (`src/main/java/com/willyes/clemenintegra/documental/dto/DocumentoDTO.java`).  
- Mapped the new field in the DTO builder inside `DocumentoMapper.toDTO` using the provided `DocumentoVersion` (`src/main/java/com/willyes/clemenintegra/documental/mapper/DocumentoMapper.java`).  
- Added repository query `findTopByDocumentoIdOrderByNumeroVersionDesc` and switched service lookups to use it so the latest version is resolved by highest `numeroVersion` (`src/main/java/com/willyes/clemenintegra/documental/repository/DocumentoVersionRepository.java` and `ControlDocumentalServiceImpl.java`).  
- Added a unit test `detalleDocumentoIncluyeVersionVigente` to `ControlDocumentalServiceTest` to assert `numeroVersionVigente` and `versionVigenteId` are returned for a document with versions (`src/test/java/com/willyes/clemenintegra/documental/service/ControlDocumentalServiceTest.java`).

### Testing

- Added unit test `detalleDocumentoIncluyeVersionVigente` to verify `numeroVersionVigente` and `versionVigenteId` are populated for a document with a latest version.  
- Existing service behavior for creating and adding versions was left unchanged and existing tests in `ControlDocumentalServiceTest` were retained.  
- No automated test suite was executed as part of this change.  
- Manual verification or CI test run is recommended to confirm all tests pass after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69495d8a7a788333849e93ca927b0ac5)