### PR TITLE
Calidad: endpoint consolidado de alertas de lotes

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/AlertasCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/AlertasCalidadController.java
@@ -1,0 +1,25 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.dto.ResumenAlertasCalidadDTO;
+import com.willyes.clemenintegra.calidad.service.AlertasCalidadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/calidad/alertas")
+@RequiredArgsConstructor
+public class AlertasCalidadController {
+
+    private final AlertasCalidadService alertasCalidadService;
+
+    @GetMapping("/resumen")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ResumenAlertasCalidadDTO> obtenerResumen(@RequestParam(defaultValue = "30") int diasUmbral) {
+        return ResponseEntity.ok(alertasCalidadService.obtenerAlertas(diasUmbral));
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/AlertaLoteCalidadDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/AlertaLoteCalidadDTO.java
@@ -1,0 +1,29 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import com.willyes.clemenintegra.calidad.model.enums.TipoAlertaLoteCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AlertaLoteCalidadDTO {
+
+    private Long loteId;
+    private String codigoLote;
+    private Long productoId;
+    private String codigoSku;
+    private String nombreProducto;
+    private Long almacenId;
+    private String nombreAlmacen;
+    private EstadoLote estadoLote;
+    private LocalDateTime fechaVencimiento;
+    private Integer diasParaVencer;
+    private TipoAlertaLoteCalidad tipoAlerta;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/ResumenAlertasCalidadDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/ResumenAlertasCalidadDTO.java
@@ -1,0 +1,22 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResumenAlertasCalidadDTO {
+
+    private List<AlertaLoteCalidadDTO> lotesProximosVencer;
+    private List<AlertaLoteCalidadDTO> lotesVencidos;
+    private List<AlertaLoteCalidadDTO> lotesPendientesLiberar;
+    private Integer totalProximosVencer;
+    private Integer totalVencidos;
+    private Integer totalPendientesLiberar;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/model/enums/TipoAlertaLoteCalidad.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/model/enums/TipoAlertaLoteCalidad.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.calidad.model.enums;
+
+public enum TipoAlertaLoteCalidad {
+    PROXIMO_VENCER,
+    VENCIDO,
+    PENDIENTE_LIBERAR
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AlertasCalidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AlertasCalidadService.java
@@ -1,0 +1,99 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.AlertaLoteCalidadDTO;
+import com.willyes.clemenintegra.calidad.dto.ResumenAlertasCalidadDTO;
+import com.willyes.clemenintegra.calidad.model.enums.TipoAlertaLoteCalidad;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AlertasCalidadService {
+
+    private static final int DIAS_UMBRAL_DEFECTO = 30;
+    private static final EnumSet<EstadoLote> ESTADOS_ALERTA_VENCIMIENTO = EnumSet.of(
+            EstadoLote.DISPONIBLE,
+            EstadoLote.LIBERADO,
+            EstadoLote.EN_CUARENTENA,
+            EstadoLote.RETENIDO
+    );
+    private static final EnumSet<EstadoLote> ESTADOS_PENDIENTES_LIBERAR = EnumSet.of(
+            EstadoLote.EN_CUARENTENA,
+            EstadoLote.RETENIDO
+    );
+
+    private final LoteProductoRepository loteProductoRepository;
+    private Clock clock = Clock.systemDefaultZone();
+
+    public ResumenAlertasCalidadDTO obtenerAlertas(int diasUmbral) {
+        int umbral = diasUmbral > 0 ? diasUmbral : DIAS_UMBRAL_DEFECTO;
+        LocalDate hoy = LocalDate.now(clock);
+        LocalDateTime inicio = hoy.atStartOfDay();
+        LocalDateTime fin = hoy.plusDays(umbral).atTime(LocalTime.MAX);
+
+        // Radiografía: FEFO/vencimientos ya se consultan en Inventarios con
+        // - LoteProductoRepository#findByFechaVencimientoBetweenFetchProducto / #findVencidosFetch
+        // - LoteProductoRepository#listarLotesConVencimiento y FEFO en #findFefoSalidaPt
+        // Radiografía: pendientes de liberar se listan en LoteProductoServiceImpl#obtenerLotesPorEvaluar
+        // y en AlertaInventarioServiceImpl#obtenerLotesRetenidosOCuarentenaProlongados.
+        List<LoteProducto> proximos = loteProductoRepository.findAlertasProximasVencer(inicio, fin, ESTADOS_ALERTA_VENCIMIENTO);
+        List<LoteProducto> vencidos = loteProductoRepository.findAlertasVencidos(inicio, ESTADOS_ALERTA_VENCIMIENTO);
+        List<LoteProducto> pendientes = loteProductoRepository.findAlertasPendientesLiberar(ESTADOS_PENDIENTES_LIBERAR);
+
+        List<AlertaLoteCalidadDTO> lotesProximos = proximos.stream()
+                .map(lote -> mapAlerta(lote, TipoAlertaLoteCalidad.PROXIMO_VENCER, hoy))
+                .toList();
+        List<AlertaLoteCalidadDTO> lotesVencidos = vencidos.stream()
+                .map(lote -> mapAlerta(lote, TipoAlertaLoteCalidad.VENCIDO, hoy))
+                .toList();
+        List<AlertaLoteCalidadDTO> lotesPendientesLiberar = pendientes.stream()
+                .map(lote -> mapAlerta(lote, TipoAlertaLoteCalidad.PENDIENTE_LIBERAR, hoy))
+                .toList();
+
+        // TODO: enganchar aquí una futura notificación automática (correo/job) con las alertas consolidadas.
+        return ResumenAlertasCalidadDTO.builder()
+                .lotesProximosVencer(lotesProximos)
+                .lotesVencidos(lotesVencidos)
+                .lotesPendientesLiberar(lotesPendientesLiberar)
+                .totalProximosVencer(lotesProximos.size())
+                .totalVencidos(lotesVencidos.size())
+                .totalPendientesLiberar(lotesPendientesLiberar.size())
+                .build();
+    }
+
+    private AlertaLoteCalidadDTO mapAlerta(LoteProducto lote, TipoAlertaLoteCalidad tipo, LocalDate hoy) {
+        LocalDateTime fechaVencimiento = lote.getFechaVencimiento();
+        Integer diasParaVencer = null;
+        if (fechaVencimiento != null) {
+            diasParaVencer = (int) ChronoUnit.DAYS.between(hoy, fechaVencimiento.toLocalDate());
+        }
+        return AlertaLoteCalidadDTO.builder()
+                .loteId(lote.getId())
+                .codigoLote(lote.getCodigoLote())
+                .productoId(lote.getProducto() != null ? lote.getProducto().getId().longValue() : null)
+                .codigoSku(lote.getProducto() != null ? lote.getProducto().getCodigoSku() : null)
+                .nombreProducto(lote.getProducto() != null ? lote.getProducto().getNombre() : null)
+                .almacenId(lote.getAlmacen() != null ? lote.getAlmacen().getId().longValue() : null)
+                .nombreAlmacen(lote.getAlmacen() != null ? lote.getAlmacen().getNombre() : null)
+                .estadoLote(lote.getEstado())
+                .fechaVencimiento(fechaVencimiento)
+                .diasParaVencer(diasParaVencer)
+                .tipoAlerta(tipo)
+                .build();
+    }
+
+    void setClock(Clock clock) {
+        this.clock = clock == null ? Clock.systemDefaultZone() : clock;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -45,6 +45,17 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
          FROM LoteProducto lp
          JOIN FETCH lp.producto p
          JOIN FETCH lp.almacen a
+        WHERE lp.fechaVencimiento BETWEEN :inicio AND :fin
+          AND lp.estado IN :estados
+    """)
+    List<LoteProducto> findAlertasProximasVencer(@Param("inicio") LocalDateTime inicio,
+                                                 @Param("fin") LocalDateTime fin,
+                                                 @Param("estados") Collection<EstadoLote> estados);
+    @Query("""
+       SELECT lp
+         FROM LoteProducto lp
+         JOIN FETCH lp.producto p
+         JOIN FETCH lp.almacen a
         WHERE lp.fechaVencimiento < :corte
           AND (:productoId IS NULL OR p.id = :productoId)
           AND (:almacenId  IS NULL OR a.id = :almacenId)
@@ -52,8 +63,26 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     List<LoteProducto> findVencidosFetch(@Param("corte") LocalDateTime corte,
                                          @Param("productoId") Long productoId,
                                          @Param("almacenId") Long almacenId);
+    @Query("""
+       SELECT lp
+         FROM LoteProducto lp
+         JOIN FETCH lp.producto p
+         JOIN FETCH lp.almacen a
+        WHERE lp.fechaVencimiento < :corte
+          AND lp.estado IN :estados
+    """)
+    List<LoteProducto> findAlertasVencidos(@Param("corte") LocalDateTime corte,
+                                           @Param("estados") Collection<EstadoLote> estados);
     Optional<LoteProducto> findByCodigoLoteAndProductoIdAndAlmacenId(String codigoLote, Integer productoId, Integer almacenId);
     List<LoteProducto> findByEstadoIn(List<EstadoLote> estados);
+    @Query("""
+       SELECT lp
+         FROM LoteProducto lp
+         JOIN FETCH lp.producto p
+         JOIN FETCH lp.almacen a
+        WHERE lp.estado IN :estados
+    """)
+    List<LoteProducto> findAlertasPendientesLiberar(@Param("estados") Collection<EstadoLote> estados);
     List<LoteProducto> findByEstadoInAndProducto_TipoAnalisisIn(List<EstadoLote> estados, List<TipoAnalisisCalidad> tipos);
     List<LoteProducto> findByFechaVencimientoBeforeAndEstadoNotIn(LocalDateTime fecha,
                                                                   List<EstadoLote> estados);

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AlertasCalidadServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AlertasCalidadServiceTest.java
@@ -1,0 +1,125 @@
+package com.willyes.clemenintegra.calidad.service;
+
+import com.willyes.clemenintegra.calidad.dto.ResumenAlertasCalidadDTO;
+import com.willyes.clemenintegra.calidad.model.enums.TipoAlertaLoteCalidad;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AlertasCalidadServiceTest {
+
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+
+    @InjectMocks
+    private AlertasCalidadService service;
+
+    @BeforeEach
+    void setUpClock() {
+        service.setClock(Clock.fixed(Instant.parse("2025-01-15T10:00:00Z"), ZoneId.of("UTC")));
+    }
+
+    @Test
+    @DisplayName("Incluye lotes próximos a vencer dentro del umbral con diasParaVencer positivo")
+    void incluyeLotesProximosAVencer() {
+        LoteProducto lote = crearLote(1L, "L-PRX", EstadoLote.DISPONIBLE, LocalDateTime.parse("2025-01-20T00:00:00"));
+
+        when(loteProductoRepository.findAlertasProximasVencer(any(), any(), any()))
+                .thenReturn(List.of(lote));
+        when(loteProductoRepository.findAlertasVencidos(any(), any())).thenReturn(List.of());
+        when(loteProductoRepository.findAlertasPendientesLiberar(any())).thenReturn(List.of());
+
+        ResumenAlertasCalidadDTO resumen = service.obtenerAlertas(30);
+
+        assertThat(resumen.getLotesProximosVencer())
+                .singleElement()
+                .satisfies(alerta -> {
+                    assertThat(alerta.getTipoAlerta()).isEqualTo(TipoAlertaLoteCalidad.PROXIMO_VENCER);
+                    assertThat(alerta.getDiasParaVencer()).isEqualTo(5);
+                });
+        assertThat(resumen.getTotalProximosVencer()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Incluye lotes vencidos con diasParaVencer negativo")
+    void incluyeLotesVencidos() {
+        LoteProducto lote = crearLote(2L, "L-VENC", EstadoLote.LIBERADO, LocalDateTime.parse("2025-01-10T00:00:00"));
+
+        when(loteProductoRepository.findAlertasProximasVencer(any(), any(), any()))
+                .thenReturn(List.of());
+        when(loteProductoRepository.findAlertasVencidos(any(), any())).thenReturn(List.of(lote));
+        when(loteProductoRepository.findAlertasPendientesLiberar(any())).thenReturn(List.of());
+
+        ResumenAlertasCalidadDTO resumen = service.obtenerAlertas(30);
+
+        assertThat(resumen.getLotesVencidos())
+                .singleElement()
+                .satisfies(alerta -> {
+                    assertThat(alerta.getTipoAlerta()).isEqualTo(TipoAlertaLoteCalidad.VENCIDO);
+                    assertThat(alerta.getDiasParaVencer()).isEqualTo(-5);
+                });
+        assertThat(resumen.getTotalVencidos()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Incluye lotes en cuarentena o retenido como pendientes de liberar")
+    void incluyeLotesPendientesLiberar() {
+        LoteProducto lote = crearLote(3L, "L-PEND", EstadoLote.RETENIDO, null);
+
+        when(loteProductoRepository.findAlertasProximasVencer(any(), any(), any()))
+                .thenReturn(List.of());
+        when(loteProductoRepository.findAlertasVencidos(any(), any())).thenReturn(List.of());
+        when(loteProductoRepository.findAlertasPendientesLiberar(any())).thenReturn(List.of(lote));
+
+        ResumenAlertasCalidadDTO resumen = service.obtenerAlertas(30);
+
+        assertThat(resumen.getLotesPendientesLiberar())
+                .singleElement()
+                .satisfies(alerta -> {
+                    assertThat(alerta.getTipoAlerta()).isEqualTo(TipoAlertaLoteCalidad.PENDIENTE_LIBERAR);
+                    assertThat(alerta.getDiasParaVencer()).isNull();
+                });
+        assertThat(resumen.getTotalPendientesLiberar()).isEqualTo(1);
+    }
+
+    private LoteProducto crearLote(Long id, String codigo, EstadoLote estado, LocalDateTime fechaVencimiento) {
+        Producto producto = Producto.builder()
+                .id(10)
+                .codigoSku("SKU-10")
+                .nombre("Producto X")
+                .build();
+        Almacen almacen = Almacen.builder()
+                .id(20)
+                .nombre("Almacén Central")
+                .build();
+        return LoteProducto.builder()
+                .id(id)
+                .codigoLote(codigo)
+                .estado(estado)
+                .fechaVencimiento(fechaVencimiento)
+                .producto(producto)
+                .almacen(almacen)
+                .stockLote(java.math.BigDecimal.ONE)
+                .build();
+    }
+}


### PR DESCRIPTION
### Motivation

- Proveer al módulo Calidad un endpoint consolidado de alertas para mostrar lotes próximos a vencer, vencidos y pendientes de liberar usando la lógica de estados y fechas existente.
- Reutilizar la intención de consultas y reportes actuales (FEFO / vencimientos / retenciones) sin romper APIs de Inventarios.

### Description

- Se añaden los DTOs `AlertaLoteCalidadDTO` y `ResumenAlertasCalidadDTO` y el enum `TipoAlertaLoteCalidad` para modelar las alertas consolidadas.
- Se creó el servicio `AlertasCalidadService` con el método `obtenerAlertas(int diasUmbral)` que consulta nuevos métodos del repositorio y calcula `diasParaVencer` (positivo/negativo/null) y deja un `TODO` para enganchar notificaciones futuras.
- Se añadieron consultas JPA en `LoteProductoRepository` (`findAlertasProximasVencer`, `findAlertasVencidos`, `findAlertasPendientesLiberar`) para filtrar por estado y fechas de manera eficiente sin alterar métodos existentes.
- Se expone el endpoint REST `GET /api/calidad/alertas/resumen` en `AlertasCalidadController` protegido por `@PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")`.

### Testing

- Se agregó `AlertasCalidadServiceTest` con casos para lotes próximos a vencer, vencidos y pendientes de liberar y verificación de `diasParaVencer` (positivo, negativo y null).
- Se ejecutó `mvn -q -Dtest=AlertasCalidadServiceTest test` y las pruebas unitarias relevantes pasaron correctamente.
- Las nuevas consultas del repositorio se usan únicamente por el nuevo servicio para evitar romper consumidores existentes.
- No se implementaron jobs ni envío de correos en esta entrega; existe un `TODO` en el servicio para la futura notificación automática.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694987322ba88333ae9945f40060bb9e)