### PR TITLE
Homologate calidad report endpoints and add report facade

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/CalidadAuditoriaController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/CalidadAuditoriaController.java
@@ -1,11 +1,9 @@
 package com.willyes.clemenintegra.calidad.controller;
 
 import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
-import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.service.AuditoriaLotePdfService;
 import com.willyes.clemenintegra.calidad.service.AuditoriaLoteService;
 import com.willyes.clemenintegra.calidad.service.CarpetaLotePdfService;
-import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
 import com.willyes.clemenintegra.calidad.service.ReporteInvimaBpmPdfService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -15,10 +13,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/calidad")
@@ -28,7 +23,6 @@ public class CalidadAuditoriaController {
 
     private final AuditoriaLoteService auditoriaLoteService;
     private final AuditoriaLotePdfService auditoriaLotePdfService;
-    private final EvaluacionCalidadService evaluacionCalidadService;
     private final CarpetaLotePdfService carpetaLotePdfService;
     private final ReporteInvimaBpmPdfService reporteInvimaBpmPdfService;
 
@@ -38,32 +32,22 @@ public class CalidadAuditoriaController {
     }
 
     @GetMapping(path = "/auditoria-lote/{loteId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    // Reporte: PDF de auditoría/carpeta de lote usado en inspecciones de Calidad.
     public ResponseEntity<byte[]> descargarPdfAuditoria(@PathVariable Long loteId) {
         AuditoriaLoteResponseDTO auditoria = auditoriaLoteService.obtenerAuditoriaDeLote(loteId);
         byte[] pdf = auditoriaLotePdfService.generarPdf(auditoria);
-        String nombreArchivo = "AuditoriaLote_" + (auditoria.getCodigoLote() != null ? auditoria.getCodigoLote() : loteId) + ".pdf";
+        String nombreArchivo = "auditoria-lote-" + (auditoria.getCodigoLote() != null ? auditoria.getCodigoLote() : loteId) + ".pdf";
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_PDF)
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
                 .body(pdf);
     }
 
-    @GetMapping(path = "/reportes/evaluaciones/excel", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-    public ResponseEntity<byte[]> exportarEvaluacionesExcel(@RequestParam(required = false) LocalDate fechaInicio,
-                                                            @RequestParam(required = false) LocalDate fechaFin,
-                                                            @RequestParam(required = false) ResultadoEvaluacion resultado) {
-        byte[] excel = evaluacionCalidadService.generarReporteEvaluacionesExcel(fechaInicio, fechaFin, resultado);
-        String nombreArchivo = "EvaluacionesCalidad_" + java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmm")) + ".xlsx";
-        return ResponseEntity.ok()
-                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
-                .body(excel);
-    }
-
     @GetMapping(path = "/reportes/lotes/{loteId}/carpeta", produces = MediaType.APPLICATION_PDF_VALUE)
+    // Reporte: PDF de carpeta de lote (expediente de calidad).
     public ResponseEntity<byte[]> descargarCarpetaLote(@PathVariable Long loteId) {
         byte[] pdf = carpetaLotePdfService.generarCarpeta(loteId);
-        String nombreArchivo = "CarpetaLote_" + loteId + ".pdf";
+        String nombreArchivo = "carpeta-lote-" + loteId + ".pdf";
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_PDF)
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
@@ -71,9 +55,10 @@ public class CalidadAuditoriaController {
     }
 
     @GetMapping(path = "/reportes/invima-bpm/lote/{loteId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    // Reporte: PDF INVIMA/BPM v1 para auditoría/regulador.
     public ResponseEntity<byte[]> descargarReporteInvimaBpm(@PathVariable Long loteId) {
         byte[] pdf = reporteInvimaBpmPdfService.generarPdf(loteId);
-        String nombreArchivo = "INVIMA_BPM_" + loteId + ".pdf";
+        String nombreArchivo = "invima-bpm-" + loteId + ".pdf";
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_PDF)
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")

--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
@@ -166,13 +166,14 @@ public class EvaluacionCalidadController {
 
     @GetMapping(path = "/{evaluacionId}/micro/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
     @PreAuthorize("hasAnyAuthority('ROL_MICROBIOLOGO','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    // Reporte: PDF de análisis microbiológico asociado a una evaluación de calidad.
     public ResponseEntity<byte[]> descargarPdfMicro(@PathVariable Long evaluacionId) {
         byte[] pdf = resultadoAnalisisMicroService.obtenerPdfMicro(evaluacionId);
-        String nombreArchivo = "MICRO_" + evaluacionId + ".pdf";
+        String nombreArchivo = "analisis-micro-" + evaluacionId + ".pdf";
         try {
             EvaluacionCalidadResponseDTO dto = service.obtenerPorId(evaluacionId);
             if (dto != null && dto.getNombreLote() != null) {
-                nombreArchivo = "MICRO_" + dto.getNombreLote() + ".pdf";
+                nombreArchivo = "analisis-micro-" + dto.getNombreLote() + ".pdf";
             }
         } catch (Exception ignored) {
             // Se mantiene el nombre por defecto si no se puede resolver el lote
@@ -180,7 +181,7 @@ public class EvaluacionCalidadController {
 
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_PDF)
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + nombreArchivo)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
                 .body(pdf);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/ReportesCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/ReportesCalidadController.java
@@ -1,0 +1,104 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.service.AuditoriaLoteService;
+import com.willyes.clemenintegra.calidad.service.CarpetaLotePdfService;
+import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
+import com.willyes.clemenintegra.calidad.service.ReporteInvimaBpmPdfService;
+import com.willyes.clemenintegra.calidad.service.ResultadoAnalisisMicroService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+/**
+ * Fachada de reportes de Calidad (INVIMA/BPM).
+ * <ul>
+ *     <li>Excel evaluaciones: {@code GET /api/calidad/reportes/evaluaciones/excel}</li>
+ *     <li>Carpeta de lote: {@code GET /api/calidad/reportes/lote/{loteId}/carpeta-pdf}</li>
+ *     <li>PDF análisis microbiológico: {@code GET /api/calidad/reportes/lote/{loteId}/analisis-micro-pdf}</li>
+ *     <li>PDF INVIMA/BPM v1: {@code GET /api/calidad/reportes/invima-bpm/v1/pdf?loteId=}</li>
+ * </ul>
+ * Roles con acceso: Jefe de Calidad, Analista de Calidad, Microbiólogo y Super Admin.
+ * La lógica de generación en servicios se considera estable y válida para auditoría/regulador.
+ */
+@RestController
+@RequestMapping("/api/calidad/reportes")
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_SUPER_ADMIN')")
+public class ReportesCalidadController {
+
+    private final EvaluacionCalidadService evaluacionCalidadService;
+    private final CarpetaLotePdfService carpetaLotePdfService;
+    private final AuditoriaLoteService auditoriaLoteService;
+    private final ResultadoAnalisisMicroService resultadoAnalisisMicroService;
+    private final ReporteInvimaBpmPdfService reporteInvimaBpmPdfService;
+
+    @GetMapping(path = "/evaluaciones/excel", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    // Reporte: Excel consolidado de evaluaciones de calidad.
+    public ResponseEntity<byte[]> exportarEvaluacionesExcel(@RequestParam(required = false) LocalDate fechaInicio,
+                                                            @RequestParam(required = false) LocalDate fechaFin,
+                                                            @RequestParam(required = false) ResultadoEvaluacion resultado) {
+        byte[] excel = evaluacionCalidadService.generarReporteEvaluacionesExcel(fechaInicio, fechaFin, resultado);
+        String nombreArchivo = "reporte-evaluaciones-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmm")) + ".xlsx";
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
+                .body(excel);
+    }
+
+    @GetMapping(path = "/lote/{loteId}/carpeta-pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    // Reporte: PDF de carpeta de lote (expediente de calidad).
+    public ResponseEntity<byte[]> descargarCarpetaLote(@PathVariable Long loteId) {
+        byte[] pdf = carpetaLotePdfService.generarCarpeta(loteId);
+        String nombreArchivo = "carpeta-lote-" + loteId + ".pdf";
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
+                .body(pdf);
+    }
+
+    @GetMapping(path = "/lote/{loteId}/analisis-micro-pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    // Reporte: PDF de análisis microbiológico asociado al lote.
+    public ResponseEntity<byte[]> descargarAnalisisMicro(@PathVariable Long loteId) {
+        AuditoriaLoteResponseDTO auditoria = auditoriaLoteService.obtenerAuditoriaDeLote(loteId);
+        if (auditoria.getEvaluaciones() == null || auditoria.getEvaluaciones().isEmpty()) {
+            throw new ResponseStatusException(NOT_FOUND, "No hay evaluaciones con PDF microbiológico para el lote");
+        }
+        AuditoriaLoteResponseDTO.EvaluacionResumenDTO evaluacion = auditoria.getEvaluaciones().stream()
+                .filter(AuditoriaLoteResponseDTO.EvaluacionResumenDTO::isPdfMicroDisponible)
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "No hay PDF microbiológico disponible para el lote"));
+        byte[] pdf = resultadoAnalisisMicroService.obtenerPdfMicro(evaluacion.getId());
+        String nombreArchivo = "analisis-micro-" + (auditoria.getCodigoLote() != null ? auditoria.getCodigoLote() : loteId) + ".pdf";
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
+                .body(pdf);
+    }
+
+    @GetMapping(path = "/invima-bpm/v1/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    // Reporte: PDF INVIMA/BPM v1 para auditoría/regulador.
+    public ResponseEntity<byte[]> descargarInvimaBpm(@RequestParam Long loteId) {
+        byte[] pdf = reporteInvimaBpmPdfService.generarPdf(loteId);
+        String nombreArchivo = "invima-bpm-" + loteId + ".pdf";
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + nombreArchivo + "\"")
+                .body(pdf);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadAuditoriaControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadAuditoriaControllerSmokeTest.java
@@ -1,0 +1,85 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.service.AuditoriaLotePdfService;
+import com.willyes.clemenintegra.calidad.service.AuditoriaLoteService;
+import com.willyes.clemenintegra.calidad.service.CarpetaLotePdfService;
+import com.willyes.clemenintegra.calidad.service.ReporteInvimaBpmPdfService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CalidadAuditoriaController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CalidadAuditoriaControllerSmokeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuditoriaLoteService auditoriaLoteService;
+
+    @MockBean
+    private AuditoriaLotePdfService auditoriaLotePdfService;
+
+    @MockBean
+    private CarpetaLotePdfService carpetaLotePdfService;
+
+    @MockBean
+    private ReporteInvimaBpmPdfService reporteInvimaBpmPdfService;
+
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    void descargaPdfAuditoria_respondePdfConNombre() throws Exception {
+        AuditoriaLoteResponseDTO auditoria = AuditoriaLoteResponseDTO.builder()
+                .codigoLote("L-100")
+                .build();
+        given(auditoriaLoteService.obtenerAuditoriaDeLote(10L)).willReturn(auditoria);
+        given(auditoriaLotePdfService.generarPdf(auditoria)).willReturn("pdf".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(get("/api/calidad/auditoria-lote/10/pdf"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"auditoria-lote-L-100.pdf\""))
+                .andExpect(content().bytes("pdf".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void descargarCarpetaLote_respondePdfConNombre() throws Exception {
+        given(carpetaLotePdfService.generarCarpeta(5L)).willReturn("pdf".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(get("/api/calidad/reportes/lotes/5/carpeta"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"carpeta-lote-5.pdf\""))
+                .andExpect(content().bytes("pdf".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void descargarReporteInvimaBpm_respondePdfConNombre() throws Exception {
+        given(reporteInvimaBpmPdfService.generarPdf(eq(7L))).willReturn("pdf".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(get("/api/calidad/reportes/invima-bpm/lote/7/pdf"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"invima-bpm-7.pdf\""))
+                .andExpect(content().bytes("pdf".getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerSmokeTest.java
@@ -1,0 +1,57 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
+import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
+import com.willyes.clemenintegra.calidad.service.PlantillaAnalisisMicroService;
+import com.willyes.clemenintegra.calidad.service.ResultadoAnalisisMicroService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(EvaluacionCalidadController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class EvaluacionCalidadControllerSmokeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EvaluacionCalidadService evaluacionCalidadService;
+
+    @MockBean
+    private ResultadoAnalisisMicroService resultadoAnalisisMicroService;
+
+    @MockBean
+    private PlantillaAnalisisMicroService plantillaAnalisisMicroService;
+
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    void descargarPdfMicro_respondePdfConNombre() throws Exception {
+        EvaluacionCalidadResponseDTO evaluacion = new EvaluacionCalidadResponseDTO();
+        evaluacion.setNombreLote("L-500");
+        given(resultadoAnalisisMicroService.obtenerPdfMicro(5L)).willReturn("pdf".getBytes(StandardCharsets.UTF_8));
+        given(evaluacionCalidadService.obtenerPorId(5L)).willReturn(evaluacion);
+
+        mockMvc.perform(get("/api/calidad/evaluaciones/5/micro/pdf"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"analisis-micro-L-500.pdf\""))
+                .andExpect(content().bytes("pdf".getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/ReportesCalidadControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/ReportesCalidadControllerSmokeTest.java
@@ -1,0 +1,108 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.service.AuditoriaLoteService;
+import com.willyes.clemenintegra.calidad.service.CarpetaLotePdfService;
+import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
+import com.willyes.clemenintegra.calidad.service.ReporteInvimaBpmPdfService;
+import com.willyes.clemenintegra.calidad.service.ResultadoAnalisisMicroService;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportesCalidadController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ReportesCalidadControllerSmokeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EvaluacionCalidadService evaluacionCalidadService;
+
+    @MockBean
+    private CarpetaLotePdfService carpetaLotePdfService;
+
+    @MockBean
+    private AuditoriaLoteService auditoriaLoteService;
+
+    @MockBean
+    private ResultadoAnalisisMicroService resultadoAnalisisMicroService;
+
+    @MockBean
+    private ReporteInvimaBpmPdfService reporteInvimaBpmPdfService;
+
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    void exportarEvaluacionesExcel_respondeExcelConNombre() throws Exception {
+        given(evaluacionCalidadService.generarReporteEvaluacionesExcel(any(), any(), any()))
+                .willReturn("excel".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(get("/api/calidad/reportes/evaluaciones/excel"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, Matchers.containsString("reporte-evaluaciones-")))
+                .andExpect(content().bytes("excel".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void descargarCarpetaLote_respondePdfConNombre() throws Exception {
+        given(carpetaLotePdfService.generarCarpeta(9L)).willReturn("pdf".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(get("/api/calidad/reportes/lote/9/carpeta-pdf"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"carpeta-lote-9.pdf\""))
+                .andExpect(content().bytes("pdf".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void descargarAnalisisMicro_respondePdfConNombre() throws Exception {
+        AuditoriaLoteResponseDTO auditoria = AuditoriaLoteResponseDTO.builder()
+                .codigoLote("L-999")
+                .evaluaciones(List.of(AuditoriaLoteResponseDTO.EvaluacionResumenDTO.builder()
+                        .id(12L)
+                        .pdfMicroDisponible(true)
+                        .build()))
+                .build();
+        given(auditoriaLoteService.obtenerAuditoriaDeLote(9L)).willReturn(auditoria);
+        given(resultadoAnalisisMicroService.obtenerPdfMicro(12L)).willReturn("pdf".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(get("/api/calidad/reportes/lote/9/analisis-micro-pdf"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"analisis-micro-L-999.pdf\""))
+                .andExpect(content().bytes("pdf".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void descargarInvimaBpm_respondePdfConNombre() throws Exception {
+        given(reporteInvimaBpmPdfService.generarPdf(eq(3L))).willReturn("pdf".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(get("/api/calidad/reportes/invima-bpm/v1/pdf").param("loteId", "3"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"invima-bpm-3.pdf\""))
+                .andExpect(content().bytes("pdf".getBytes(StandardCharsets.UTF_8)));
+    }
+}


### PR DESCRIPTION
### Motivation

- Unificar y estabilizar los endpoints de exportación del módulo de Calidad para consumo desde una pantalla única de “Reportes INVIMA/BPM”.
- Asegurar `Content-Type` y `Content-Disposition` consistentes con nombres de archivo legibles para todos los reportes (PDF / XLSX).
- Mantener roles y autorizaciones coherentes para accesos de Calidad y facilitar auditoría documental de los endpoints.
- Proveer un punto de referencia (fachada) que reexponga los reportes existentes sin mover la lógica de generación.

### Description

- Estandaricé los encabezados y nombres de archivo de los endpoints existentes en `EvaluacionCalidadController` y `CalidadAuditoriaController`, por ejemplo cambiando a nombres legibles como `analisis-micro-<id|lote>.pdf`, `auditoria-lote-<codigo>.pdf`, `carpeta-lote-<id>.pdf` y `reporte-evaluaciones-YYYYMMDD-HHmm.xlsx`.
- Añadí comentarios (`// Reporte: ...`) sobre los métodos que sirven reportes para documentar qué genera cada endpoint y en qué contexto se usa.
- Creé el controlador fachada `ReportesCalidadController` bajo `GET /api/calidad/reportes` que reexpone métodos finos que delegan a los servicios ya existentes: `GET /evaluaciones/excel`, `GET /lote/{loteId}/carpeta-pdf`, `GET /lote/{loteId}/analisis-micro-pdf` y `GET /invima-bpm/v1/pdf`.
- Agregué smoke tests para verificar que los endpoints devuelven `200` y payloads con `Content-Type` y `Content-Disposition` esperados: `CalidadAuditoriaControllerSmokeTest`, `EvaluacionCalidadControllerSmokeTest` y `ReportesCalidadControllerSmokeTest`.

### Testing

- Ejecuté los tests de integración mínima con Maven: `mvn -q -Dtest=CalidadAuditoriaControllerSmokeTest,EvaluacionCalidadControllerSmokeTest,ReportesCalidadControllerSmokeTest test`.
- La primera ejecución falló por falta de un bean de seguridad en el contexto de pruebas; añadí `@MockBean JwtAuthenticationProvider` a los tests para aislar el controlador.
- Tras añadir los mocks de seguridad volví a ejecutar los mismos tests y las pruebas de humo se ejecutaron (arranque del contexto y verificaciones de respuesta HTTP) sin errores de aserción en las comprobaciones implementadas.
- Los tests añadidos ejercitan los `Content-Type` y el header `Content-Disposition` y verifican que se devuelve contenido no vacío para cada endpoint comprobado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949927b4b2c83338997ef2c8baaa5e6)