### PR TITLE
Map QUIMICO_MICROBIOLOGICO → "AMBOS" and add legacy microbiological template fallback

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EspecificacionesCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EspecificacionesCalidadServiceImpl.java
@@ -116,11 +116,20 @@ public class EspecificacionesCalidadServiceImpl implements EspecificacionesCalid
     @Transactional(readOnly = true)
     @Override
     public List<PlantillaAnalisisMicrobiologicoResumenDTO> listarPlantillasMicroPorProducto(Long productoId) {
-        obtenerProducto(productoId);
-        return plantillaRepository.findByProducto_IdOrderByVersionDesc(productoId)
-                .stream()
-                .map(plantillaMapper::toResumenDTO)
-                .toList();
+        List<PlantillaAnalisisMicrobiologico> plantillas = plantillaRepository
+                .findByProducto_IdOrderByVersionDesc(productoId);
+        if (!plantillas.isEmpty()) {
+            return plantillas.stream()
+                    .map(plantillaMapper::toResumenDTO)
+                    .toList();
+        }
+        // Fallback legacy: si no hay plantillas por producto_id, usar la plantilla asociada al producto.
+        Producto producto = obtenerProducto(productoId);
+        PlantillaAnalisisMicrobiologico plantillaLegacy = producto.getPlantillaAnalisisMicrobiologico();
+        if (plantillaLegacy == null) {
+            return List.of();
+        }
+        return List.of(plantillaMapper.toResumenDTO(plantillaLegacy));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoResponseDTO.java
@@ -60,11 +60,17 @@ public class ProductoResponseDTO {
         this.stockSeguridad = producto.getStockSeguridad();
         this.stockMaximoPlaneacion = producto.getStockMaximoPlaneacion();
         this.activo = producto.isActivo();
-        this.tipoAnalisisCalidad = com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.fromFlags(
-                producto.isRequiereAnalisisFisico(),
-                producto.isRequiereAnalisisQuimico(),
-                producto.isRequiereAnalisisMicrobiologico()
-        ).name();
+        com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad tipoAnalisis =
+                com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.fromFlags(
+                        producto.isRequiereAnalisisFisico(),
+                        producto.isRequiereAnalisisQuimico(),
+                        producto.isRequiereAnalisisMicrobiologico()
+                );
+        this.tipoAnalisisCalidad = switch (tipoAnalisis) {
+            case FISICO -> "FISICO_QUIMICO";
+            case QUIMICO_MICROBIOLOGICO -> "AMBOS";
+            default -> tipoAnalisis.name();
+        };
         this.rendimiento = producto.getRendimientoUnidad() != null ? producto.getRendimientoUnidad() : BigDecimal.ZERO;
         this.unidadMedida = producto.getUnidadMedida() != null
                 ? new UnidadMedidaResponseDTO(
@@ -134,4 +140,3 @@ public class ProductoResponseDTO {
     public void setInactivable(Boolean inactivable) {this.inactivable = inactivable;}
     // PROD-FLAGS END
 }
-

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/LoteProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/LoteProductoMapper.java
@@ -77,10 +77,9 @@ public interface LoteProductoMapper {
         }
         return switch (valor) {
             case FISICO -> "FISICO_QUIMICO";
-            case QUIMICO_MICROBIOLOGICO -> "MICROBIOLOGICO";
+            case QUIMICO_MICROBIOLOGICO -> "AMBOS";
             default -> valor.name();
         };
     }
 
 }
-

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapper.java
@@ -81,7 +81,7 @@ public interface ProductoMapper {
         }
         return switch (valor) {
             case FISICO -> "FISICO_QUIMICO";
-            case QUIMICO_MICROBIOLOGICO -> "MICROBIOLOGICO";
+            case QUIMICO_MICROBIOLOGICO -> "AMBOS";
             default -> valor.name();
         };
     }
@@ -135,5 +135,4 @@ public interface ProductoMapper {
     }
 
 }
-
 

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EspecificacionesCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EspecificacionesCalidadServiceImplTest.java
@@ -192,4 +192,31 @@ class EspecificacionesCalidadServiceImplTest {
         assertThat(captor.getValue()).hasSize(1);
         verify(productoRepository).save(producto);
     }
+
+    @Test
+    void debeListarPlantillaLegacyCuandoNoHayPlantillasPorProducto() {
+        Producto producto = Producto.builder()
+                .id(5)
+                .codigoSku("MP0126")
+                .nombre("CHONTADURO")
+                .build();
+
+        PlantillaAnalisisMicrobiologico legacy = PlantillaAnalisisMicrobiologico.builder()
+                .id(500L)
+                .producto(producto)
+                .nombre("Plantilla legacy")
+                .version(1)
+                .vigente(true)
+                .build();
+        producto.setPlantillaAnalisisMicrobiologico(legacy);
+
+        when(plantillaRepository.findByProducto_IdOrderByVersionDesc(5L)).thenReturn(List.of());
+        when(productoRepository.findById(5L)).thenReturn(Optional.of(producto));
+
+        var resultado = service.listarPlantillasMicroPorProducto(5L);
+
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getId()).isEqualTo(500L);
+        assertThat(resultado.get(0).getCodigoSku()).isEqualTo("MP0126");
+    }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapperTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/mapper/ProductoMapperTest.java
@@ -1,0 +1,29 @@
+package com.willyes.clemenintegra.inventario.mapper;
+
+import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductoMapperTest {
+
+    private final ProductoMapper mapper = Mappers.getMapper(ProductoMapper.class);
+
+    @Test
+    void exponeAmbosCuandoRequiereQuimicoYMicroSinFisico() {
+        Producto producto = Producto.builder()
+                .id(10)
+                .codigoSku("MP0126")
+                .nombre("CHONTADURO")
+                .build();
+        producto.setRequiereAnalisisFisico(false);
+        producto.setRequiereAnalisisQuimico(true);
+        producto.setRequiereAnalisisMicrobiologico(true);
+
+        ProductoResponseDTO dto = mapper.toDto(producto);
+
+        assertThat(dto.getTipoAnalisisCalidad()).isEqualTo("AMBOS");
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure products with chemical+micro flags surface `tipoAnalisisCalidad = "AMBOS"` in responses so the UI can enable both QC flows.  
- Support legacy data where a product references a microbiological template via `producto.plantillaAnalisisMicrobiologico` instead of `plantillas_analisis_micro.producto_id`.  
- Keep existing endpoint shapes and DTO formats while fixing incorrect enum-to-string translation and missing legacy fallback.  

### Description
- Change mapping logic in `ProductoMapper` and `LoteProductoMapper` so `TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO` is serialized as `"AMBOS"`.  
- Update `ProductoResponseDTO` constructor to derive the string `tipoAnalisisCalidad` from flags and map the combined chemical+micro case to `"AMBOS"`.  
- Add a fallback in `EspecificacionesCalidadServiceImpl.listarPlantillasMicroPorProducto` that, when `plantillaRepository.findByProducto_IdOrderByVersionDesc(productoId)` returns empty, fetches the `Producto` and returns its `plantillaAnalisisMicrobiologico` (if present) as a single resumen DTO.  
- Add unit tests: `ProductoMapperTest` to assert `tipoAnalisisCalidad == "AMBOS"` for quimico+micro flags, and an additional test in `EspecificacionesCalidadServiceImplTest` to validate the legacy-template fallback path.  

### Testing
- Added unit tests `ProductoMapperTest` and an extra case in `EspecificacionesCalidadServiceImplTest` covering the legacy fallback behavior.  
- Attempted to run the focused tests with `mvn -q test -Dtest=ProductoMapperTest,EspecificacionesCalidadServiceImplTest`, but the run hung and was interrupted (no successful test run completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949be277a588333884c71bc1a3a4ca5)