### PR TITLE
Expose `metodo` and parameter counts in microbiology templates

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/ParametroAnalisisMicrobiologicoDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/ParametroAnalisisMicrobiologicoDTO.java
@@ -10,6 +10,7 @@ import lombok.*;
 public class ParametroAnalisisMicrobiologicoDTO {
     private Long id;
     private String nombreParametro;
+    private String metodo;
     private String unidad;
     private String criterioAceptacion;
     private TipoResultadoAnalisis tipoResultado;

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/PlantillaAnalisisMicrobiologicoResumenDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/PlantillaAnalisisMicrobiologicoResumenDTO.java
@@ -21,4 +21,5 @@ public class PlantillaAnalisisMicrobiologicoResumenDTO {
     private LocalDate fechaVigenciaHasta;
     private String creadoPorNombre;
     private LocalDateTime fechaCreacion;
+    private Integer numeroParametros;
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/mapper/PlantillaAnalisisMicrobiologicoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/mapper/PlantillaAnalisisMicrobiologicoMapper.java
@@ -19,6 +19,7 @@ public interface PlantillaAnalisisMicrobiologicoMapper {
     @Mapping(target = "codigoSku", source = "producto", qualifiedByName = "mapProductoCodigo")
     @Mapping(target = "nombreProducto", source = "producto", qualifiedByName = "mapProductoNombre")
     @Mapping(target = "numeroVersion", source = "version")
+    @Mapping(target = "numeroParametros", expression = "java(entity.getParametros() != null ? entity.getParametros().size() : 0)")
     @Mapping(target = "creadoPorNombre", source = "creadoPor", qualifiedByName = "mapNombreUsuario")
     @Mapping(target = "fechaCreacion", source = "createdAt")
     PlantillaAnalisisMicrobiologicoResumenDTO toResumenDTO(PlantillaAnalisisMicrobiologico entity);
@@ -32,6 +33,7 @@ public interface PlantillaAnalisisMicrobiologicoMapper {
     PlantillaAnalisisMicrobiologicoDetalleDTO toDetalleDTO(PlantillaAnalisisMicrobiologico entity);
 
     @Mapping(target = "nombreParametro", source = "nombreEnsayo")
+    @Mapping(target = "metodo", source = "metodo")
     @Mapping(target = "criterioAceptacion", source = "especificacion")
     @Mapping(target = "orden", source = "orden")
     ParametroAnalisisMicrobiologicoDTO toParametroDTO(ParametroAnalisisMicrobiologico parametro);

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EspecificacionesCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EspecificacionesCalidadServiceImplTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -218,5 +219,60 @@ class EspecificacionesCalidadServiceImplTest {
         assertThat(resultado).hasSize(1);
         assertThat(resultado.get(0).getId()).isEqualTo(500L);
         assertThat(resultado.get(0).getCodigoSku()).isEqualTo("MP0126");
+    }
+
+    @Test
+    void debeMapearNumeroVersionVigenteYParametrosEnResumenMicro() {
+        PlantillaAnalisisMicrobiologico plantilla = PlantillaAnalisisMicrobiologico.builder()
+                .id(600L)
+                .nombre("Micro MP")
+                .version(2)
+                .vigente(true)
+                .parametros(IntStream.rangeClosed(1, 10)
+                        .mapToObj(i -> ParametroAnalisisMicrobiologico.builder()
+                                .id((long) i)
+                                .nombreEnsayo("Parametro " + i)
+                                .tipoResultado(TipoResultadoAnalisis.NUMERICO)
+                                .orden(i)
+                                .build())
+                        .toList())
+                .build();
+
+        when(plantillaRepository.findByProducto_IdOrderByVersionDesc(6L)).thenReturn(List.of(plantilla));
+
+        var resultado = service.listarPlantillasMicroPorProducto(6L);
+
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getNumeroVersion()).isEqualTo(2);
+        assertThat(resultado.get(0).isVigente()).isTrue();
+        assertThat(resultado.get(0).getNumeroParametros()).isEqualTo(10);
+    }
+
+    @Test
+    void debeIncluirMetodoEnDetalleDeParametrosMicro() {
+        ParametroAnalisisMicrobiologico parametro = ParametroAnalisisMicrobiologico.builder()
+                .id(701L)
+                .nombreEnsayo("Mesofilos")
+                .metodo("ISO 4833-1:2013 / USP <61>")
+                .unidad("UFC/g")
+                .especificacion("<100")
+                .tipoResultado(TipoResultadoAnalisis.NUMERICO)
+                .orden(1)
+                .build();
+        PlantillaAnalisisMicrobiologico plantilla = PlantillaAnalisisMicrobiologico.builder()
+                .id(700L)
+                .nombre("Plantilla micro detalle")
+                .parametros(List.of(parametro))
+                .build();
+
+        when(plantillaRepository.findById(700L)).thenReturn(Optional.of(plantilla));
+
+        var detalle = service.obtenerDetallePlantillaMicro(700L);
+
+        assertThat(detalle.getParametros()).hasSize(1);
+        assertThat(detalle.getParametros().get(0).getNombreParametro()).isEqualTo("Mesofilos");
+        assertThat(detalle.getParametros().get(0).getMetodo()).isEqualTo("ISO 4833-1:2013 / USP <61>");
+        assertThat(detalle.getParametros().get(0).getCriterioAceptacion()).isEqualTo("<100");
+        assertThat(detalle.getParametros().get(0).getTipoResultado()).isEqualTo(TipoResultadoAnalisis.NUMERICO);
     }
 }


### PR DESCRIPTION
### Motivation
- The frontend needs to show the parameter `metodo` and the real parameter count for microbiology templates, but the current DTOs/mapper did not expose them. 
- Fix the summary DTO to expose the template version and the actual number of parameters, and fix the detail DTO to include each parameter's `metodo` so the modal can display Method, Parameter, Limit, Unit and Result Type. 
- Keep existing endpoint URLs and property names to maintain backward compatibility with the rest of the module. 

### Description
- Added `numeroParametros` to `PlantillaAnalisisMicrobiologicoResumenDTO` and populated it from `entity.getParametros().size()` in the mapper via `@Mapping(..., expression = "java(entity.getParametros() != null ? entity.getParametros().size() : 0)")`.
- Added `metodo` to `ParametroAnalisisMicrobiologicoDTO` and mapped it from `ParametroAnalisisMicrobiologico.metodo` in `PlantillaAnalisisMicrobiologicoMapper` so detail responses include the method for each parameter.
- Updated `PlantillaAnalisisMicrobiologicoMapper` to map both the new summary field and the parameter `metodo`, while preserving existing mappings for version, vigente and other properties so endpoints remain compatible.
- Added unit tests in `EspecificacionesCalidadServiceImplTest` to verify that the summary exposes `numeroVersion`, `vigente` and `numeroParametros`, and that the detail DTO includes `metodo` plus the existing parameter fields.

### Testing
- Added unit tests: `EspecificacionesCalidadServiceImplTest#debeMapearNumeroVersionVigenteYParametrosEnResumenMicro` and `EspecificacionesCalidadServiceImplTest#debeIncluirMetodoEnDetalleDeParametrosMicro` which were executed as part of the test suite.
- Executed `mvn test` to run the full automated test suite in the project.
- The new service-level unit tests ran as part of the suite and passed, but the full build failed because one unrelated test failed: `CalidadAuditoriaControllerTest.exportaExcelEvaluaciones` returned 404 instead of the expected 200.
- Test run summary: overall test run ended with 1 failure (the unrelated controller test), causing the Maven build to fail; the changes added here did not introduce the failing test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949d2547f288333896d865e14c4d1bf)