### PR TITLE
Fix session activity tracking and enforce latest login

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProvider.java
@@ -81,23 +81,19 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         LocalDateTime ahora = LocalDateTime.now();
         LocalDateTime ultimaActividad = usuario.getUltimaActividad();
 
-        if (ultimaActividad != null) {
-            long minutosInactivo = java.time.Duration.between(ultimaActividad, ahora).toMinutes();
-            if (minutosInactivo > maxIdleMinutes) {
-                Long nuevaVersion = usuarioSessionVersion + 1;
-                usuario.setSessionVersion(nuevaVersion);
-                usuario.setUltimaActividad(ahora);
-                usuarioRepository.save(usuario);
-                throw new SesionInactivaException("La sesión ha expirado por inactividad.");
-            }
+        // Si nunca se ha registrado actividad (valor null), consideramos la sesión inactiva para forzar un nuevo login.
+        if (ultimaActividad == null) {
+            throw new SesionInactivaException("La sesión ha expirado por inactividad.");
         }
 
-        boolean actualizarActividad = ultimaActividad == null
-                || java.time.Duration.between(ultimaActividad, ahora).toMinutes() >= 1;
-        if (actualizarActividad) {
-            usuario.setUltimaActividad(ahora);
-            usuarioRepository.save(usuario);
+        long minutosInactivo = java.time.Duration.between(ultimaActividad, ahora).toMinutes();
+        if (minutosInactivo > maxIdleMinutes) {
+            throw new SesionInactivaException("La sesión ha expirado por inactividad.");
         }
+
+        // Sesión válida: refrescamos última actividad para mantenerla viva.
+        usuario.setUltimaActividad(ahora);
+        usuarioRepository.save(usuario);
     }
 
     private String requestUsername(String token) {

--- a/src/main/java/com/willyes/clemenintegra/shared/security/service/AuthServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/service/AuthServiceImpl.java
@@ -92,7 +92,7 @@ public class AuthServiceImpl implements AuthService {
         Long versionActual = usuario.getSessionVersion() != null ? usuario.getSessionVersion() : 0L;
         usuario.setSessionVersion(versionActual + 1);
         usuario.setUltimaActividad(LocalDateTime.now());
-        usuarioRepository.save(usuario);
+        usuarioRepository.saveAndFlush(usuario);
 
         String token = jwtTokenService.generarToken(usuario);
         return new AuthResponseDTO(token, usuario.getNombreUsuario(), usuario.getRol().name());

--- a/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -85,10 +85,65 @@ class JwtAuthenticationProviderTest {
                 .thenReturn(new DefaultClaims().setSubject("user"));
         when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
         when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
-        when(usuarioRepository.save(eq(usuario))).thenReturn(usuario);
 
         assertThrows(SesionInactivaException.class,
                 () -> provider.authenticate(new JwtAuthenticationToken("token")));
+        verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    void lanzaSesionInactivaCuandoUltimaActividadEsNull() {
+        Usuario usuario = Usuario.builder()
+                .id(1L)
+                .nombreUsuario("user")
+                .clave("pass")
+                .nombreCompleto("Nombre")
+                .correo("correo@test.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .sessionVersion(1L)
+                .ultimaActividad(null)
+                .build();
+
+        when(jwtTokenService.extraerClaims("token"))
+                .thenReturn(new DefaultClaims().setSubject("user"));
+        when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+
+        assertThrows(SesionInactivaException.class,
+                () -> provider.authenticate(new JwtAuthenticationToken("token")));
+        verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    void actualizaUltimaActividadCuandoSesionEsValida() {
+        LocalDateTime hace2Min = LocalDateTime.now().minusMinutes(2);
+        Usuario usuario = Usuario.builder()
+                .id(1L)
+                .nombreUsuario("user")
+                .clave("pass")
+                .nombreCompleto("Nombre")
+                .correo("correo@test.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .sessionVersion(1L)
+                .ultimaActividad(hace2Min)
+                .build();
+
+        when(jwtTokenService.extraerClaims("token"))
+                .thenReturn(new DefaultClaims().setSubject("user"));
+        when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+        when(usuarioRepository.save(eq(usuario))).thenReturn(usuario);
+
+        provider.authenticate(new JwtAuthenticationToken("token"));
+
         verify(usuarioRepository, times(1)).save(eq(usuario));
+        verify(jwtTokenService, times(1)).extraerClaims("token");
+        verify(jwtTokenService, times(1)).getSessionVersion("token");
+        assertNotNull(usuario.getUltimaActividad());
+        assertTrue(usuario.getUltimaActividad().isAfter(hace2Min));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/shared/security/service/AuthServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/service/AuthServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.willyes.clemenintegra.shared.security.service;
+
+import com.willyes.clemenintegra.shared.dto.auth.AuthResponseDTO;
+import com.willyes.clemenintegra.shared.dto.auth.Codigo2FARequestDTO;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.notification.EmailService;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplTest {
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtTokenService jwtTokenService;
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    private Usuario usuario;
+
+    @BeforeEach
+    void setUp() {
+        usuario = Usuario.builder()
+                .id(10L)
+                .nombreUsuario("tester")
+                .clave("encoded-pass")
+                .nombreCompleto("Tester QA")
+                .correo("tester@qa.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .codigo2FA("123456")
+                .codigo2FAExpiraEn(LocalDateTime.now().plusMinutes(2))
+                .sessionVersion(3L)
+                .build();
+    }
+
+    @Test
+    void verificarCodigo2FAIncrementaVersionYActualizaUltimaActividad() {
+        Codigo2FARequestDTO request = new Codigo2FARequestDTO("tester", "123456");
+
+        when(usuarioRepository.findByNombreUsuario("tester")).thenReturn(Optional.of(usuario));
+        when(jwtTokenService.generarToken(any(Usuario.class))).thenReturn("jwt-token");
+        when(usuarioRepository.saveAndFlush(any(Usuario.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        AuthResponseDTO response = authService.verificarCodigo2FA(request);
+
+        assertNotNull(response);
+        assertEquals("jwt-token", response.token());
+
+        ArgumentCaptor<Usuario> usuarioCaptor = ArgumentCaptor.forClass(Usuario.class);
+        verify(usuarioRepository).saveAndFlush(usuarioCaptor.capture());
+
+        Usuario actualizado = usuarioCaptor.getValue();
+        assertEquals(4L, actualizado.getSessionVersion());
+        assertNotNull(actualizado.getUltimaActividad());
+        assertNull(actualizado.getCodigo2FA());
+        assertNull(actualizado.getCodigo2FAExpiraEn());
+        verify(jwtTokenService).generarToken(actualizado);
+    }
+}


### PR DESCRIPTION
## Summary
- Increment and persist session version and last activity when completing 2FA login.
- Enforce session version/inactivity checks on every authenticated request and refresh last activity when valid.
- Add unit tests covering session validation logic and session version updates during 2FA.

## Testing
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1212d0b083339abcc8cbe0995674)