### PR TITLE
Enforce JWT session validation via provider

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.shared.security;
 
+import com.willyes.clemenintegra.shared.security.exception.SesionInactivaException;
+import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
 import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
 
 import jakarta.servlet.FilterChain;
@@ -7,6 +9,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -22,7 +25,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtAuthenticationProvider jwtAuthenticationProvider; // ✅ usar provider
+    private final AuthenticationManager authenticationManager;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -46,10 +49,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             final String token = authHeader.substring(7);
             try {
                 Authentication authRequest = new JwtAuthenticationToken(token);
-                Authentication authResult  = jwtAuthenticationProvider.authenticate(authRequest);
+                Authentication authResult  = authenticationManager.authenticate(authRequest);
                 SecurityContextHolder.getContext().setAuthentication(authResult);
                 log.debug("Usuario {} autenticado en {}", authResult.getName(), uri);
                 log.debug("Authorities asignadas: {}", authResult.getAuthorities());
+            } catch (SesionInvalidadaException | SesionInactivaException ex) {
+                log.warn("Sesión rechazada [{}] en {} {}: {}",
+                        ex.getClass().getSimpleName(), request.getMethod(), uri,
+                        (ex.getMessage() != null ? ex.getMessage() : "sin mensaje"));
+                SecurityContextHolder.clearContext();
+                throw ex;
             } catch (org.springframework.security.core.AuthenticationException ex) {
                 log.warn("Auth failed [{}] en {} {}: {}",
                         ex.getClass().getSimpleName(), request.getMethod(), uri,
@@ -73,6 +82,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 }
-
-
 

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
     private final UsuarioInactivoFilter usuarioInactivoFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final RequestTimingFilter requestTimingFilter;
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
 
     // Orígenes permitidos por perfil (lista separada por comas)
     @Value("${app.cors.allowed-origins:}")
@@ -52,6 +53,7 @@ public class SecurityConfig {
                 .cors(org.springframework.security.config.Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(jwtAuthenticationProvider)
                 .authorizeHttpRequests(auth -> {
                     auth.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
 

--- a/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,78 @@
+package com.willyes.clemenintegra.shared.security;
+
+import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
+import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class JwtAuthenticationFilterTest {
+
+    private AuthenticationManager authenticationManager;
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        authenticationManager = mock(AuthenticationManager.class);
+        filter = new JwtAuthenticationFilter(authenticationManager);
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void delegaEnAuthenticationManagerYAsignaContextoCuandoTokenEsValido() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer sample-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = new MockFilterChain();
+
+        Authentication authResult = new UsernamePasswordAuthenticationToken(
+                "user", "sample-token", List.of(() -> "ROLE_USER")
+        );
+        when(authenticationManager.authenticate(any(JwtAuthenticationToken.class))).thenReturn(authResult);
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication);
+        assertEquals("user", authentication.getName());
+        assertTrue(authentication.isAuthenticated());
+
+        ArgumentCaptor<JwtAuthenticationToken> captor = ArgumentCaptor.forClass(JwtAuthenticationToken.class);
+        verify(authenticationManager).authenticate(captor.capture());
+        assertEquals("sample-token", captor.getValue().getCredentials());
+    }
+
+    @Test
+    void propagaSesionInvalidadaExceptionYNoSeteaContexto() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer expired-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(authenticationManager.authenticate(any(JwtAuthenticationToken.class)))
+                .thenThrow(new SesionInvalidadaException("Sesion invalidada"));
+
+        assertThrows(SesionInvalidadaException.class, () ->
+                filter.doFilterInternal(request, response, new MockFilterChain())
+        );
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
@@ -138,12 +138,15 @@ class JwtAuthenticationProviderTest {
         when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
         when(usuarioRepository.save(eq(usuario))).thenReturn(usuario);
 
-        provider.authenticate(new JwtAuthenticationToken("token"));
+        var authentication = provider.authenticate(new JwtAuthenticationToken("token"));
 
         verify(usuarioRepository, times(1)).save(eq(usuario));
         verify(jwtTokenService, times(1)).extraerClaims("token");
         verify(jwtTokenService, times(1)).getSessionVersion("token");
         assertNotNull(usuario.getUltimaActividad());
         assertTrue(usuario.getUltimaActividad().isAfter(hace2Min));
+        assertTrue(authentication.isAuthenticated());
+        assertEquals("user", authentication.getName());
+        assertEquals(1, authentication.getAuthorities().size());
     }
 }


### PR DESCRIPTION
## Summary
- Route JWT authentication through the AuthenticationManager and register the JwtAuthenticationProvider so every request enforces session version and idle checks.
- Ensure the JWT filter delegates authentication and clears the context on invalid/idle sessions.
- Expand security tests to cover session invalidation, inactivity, and successful authentication paths.

## Testing
- mvn -Dtest=JwtAuthenticationProviderTest,JwtAuthenticationFilterTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1688b11c8333bc602dbeceefb185)