### PR TITLE
Fix JWT filter dependency cycle

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
@@ -1,31 +1,46 @@
 package com.willyes.clemenintegra.shared.security;
 
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.exception.SesionInactivaException;
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
-import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
-
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
+import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.core.Authentication;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final AuthenticationManager authenticationManager;
+    private final ObjectProvider<JwtTokenService> jwtTokenServiceProvider;
+    private final ObjectProvider<CustomUserDetailsService> userDetailsServiceProvider;
+    private final ObjectProvider<UsuarioRepository> usuarioRepositoryProvider;
+
+    @Value("${security.session.max-idle-minutes:20}")
+    private long maxIdleMinutes;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -48,31 +63,46 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             final String token = authHeader.substring(7);
             try {
-                Authentication authRequest = new JwtAuthenticationToken(token);
-                Authentication authResult  = authenticationManager.authenticate(authRequest);
-                SecurityContextHolder.getContext().setAuthentication(authResult);
-                log.debug("Usuario {} autenticado en {}", authResult.getName(), uri);
-                log.debug("Authorities asignadas: {}", authResult.getAuthorities());
+                JwtTokenService jwtTokenService = jwtTokenServiceProvider.getIfAvailable();
+                CustomUserDetailsService userDetailsService = userDetailsServiceProvider.getIfAvailable();
+                UsuarioRepository usuarioRepository = usuarioRepositoryProvider.getIfAvailable();
+
+                if (jwtTokenService == null || userDetailsService == null || usuarioRepository == null) {
+                    log.debug("Componentes de seguridad no disponibles, se omite autenticación para {}", uri);
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
+                Claims claims = jwtTokenService.extraerClaims(token);
+                String username = claims.getSubject();
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                validarSesion(token, userDetails, jwtTokenService, usuarioRepository);
+
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, token, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.debug("Usuario {} autenticado en {}", authentication.getName(), uri);
+                log.debug("Authorities asignadas: {}", authentication.getAuthorities());
             } catch (SesionInvalidadaException | SesionInactivaException ex) {
                 log.warn("Sesión rechazada [{}] en {} {}: {}",
                         ex.getClass().getSimpleName(), request.getMethod(), uri,
                         (ex.getMessage() != null ? ex.getMessage() : "sin mensaje"));
                 SecurityContextHolder.clearContext();
                 throw ex;
-            } catch (org.springframework.security.core.AuthenticationException ex) {
-                log.warn("Auth failed [{}] en {} {}: {}",
-                        ex.getClass().getSimpleName(), request.getMethod(), uri,
-                        (ex.getMessage() != null ? ex.getMessage() : "sin mensaje"));
-                SecurityContextHolder.clearContext();
-                throw ex; // deja que ExceptionTranslationFilter genere el 401
-            } catch (io.jsonwebtoken.ExpiredJwtException ex) {
+            } catch (ExpiredJwtException ex) {
                 log.warn("JWT expirado en {} {}: {}", request.getMethod(), uri, ex.getMessage());
                 SecurityContextHolder.clearContext();
-                throw new org.springframework.security.authentication.BadCredentialsException("JWT expirado", ex);
-            } catch (io.jsonwebtoken.security.SignatureException ex) {
+                throw new BadCredentialsException("JWT expirado", ex);
+            } catch (SignatureException ex) {
                 log.warn("Firma JWT inválida en {} {}: {}", request.getMethod(), uri, ex.getMessage());
                 SecurityContextHolder.clearContext();
-                throw new org.springframework.security.authentication.BadCredentialsException("Firma JWT inválida", ex);
+                throw new BadCredentialsException("Firma JWT inválida", ex);
+            } catch (JwtException ex) {
+                log.warn("Token inválido en {} {}: {}", request.getMethod(), uri, ex.getMessage());
+                SecurityContextHolder.clearContext();
+                throw new BadCredentialsException("Token inválido", ex);
             }
         } else {
             log.debug("Solicitud sin encabezado Authorization en {}", uri);
@@ -81,5 +111,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // ¡OJO!: no atrapar Exception genérica aquí
         filterChain.doFilter(request, response);
     }
-}
 
+    private void validarSesion(String token,
+                               UserDetails userDetails,
+                               JwtTokenService jwtTokenService,
+                               UsuarioRepository usuarioRepository) {
+        if (!(userDetails instanceof CustomUserDetails cud)) {
+            throw new BadCredentialsException("UserDetails inválido");
+        }
+        Usuario usuario = cud.getUsuario();
+
+        Long tokenSessionVersion = jwtTokenService.getSessionVersion(token);
+        Long usuarioSessionVersion = usuario.getSessionVersion() != null ? usuario.getSessionVersion() : 0L;
+
+        if (!usuarioSessionVersion.equals(tokenSessionVersion)) {
+            throw new SesionInvalidadaException("La sesión fue invalidada porque se inició una nueva sesión para este usuario.");
+        }
+
+        LocalDateTime ultimaActividad = usuario.getUltimaActividad();
+        if (ultimaActividad == null) {
+            throw new SesionInactivaException("La sesión ha expirado por inactividad.");
+        }
+
+        long minutosInactivo = Duration.between(ultimaActividad, LocalDateTime.now()).toMinutes();
+        if (minutosInactivo > maxIdleMinutes) {
+            throw new SesionInactivaException("La sesión ha expirado por inactividad.");
+        }
+
+        usuario.setUltimaActividad(LocalDateTime.now());
+        usuarioRepository.save(usuario);
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -34,9 +34,8 @@ import java.util.List;
 public class SecurityConfig {
 
     private final UsuarioInactivoFilter usuarioInactivoFilter;
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final RequestTimingFilter requestTimingFilter;
-    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final org.springframework.beans.factory.ObjectProvider<JwtAuthenticationProvider> jwtAuthenticationProvider;
 
     // Orígenes permitidos por perfil (lista separada por comas)
     @Value("${app.cors.allowed-origins:}")
@@ -48,12 +47,14 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+        JwtAuthenticationProvider provider = jwtAuthenticationProvider.getIfAvailable();
+
         http
                 .cors(org.springframework.security.config.Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authenticationProvider(jwtAuthenticationProvider)
                 .authorizeHttpRequests(auth -> {
                     auth.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
 
@@ -266,6 +267,10 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(usuarioInactivoFilter, JwtAuthenticationFilter.class)
                 .addFilterAfter(requestTimingFilter, JwtAuthenticationFilter.class);
+
+        if (provider != null) {
+            http.authenticationProvider(provider);
+        }
 
         return http.build();
     }

--- a/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilterTest.java
@@ -1,7 +1,12 @@
 package com.willyes.clemenintegra.shared.security;
 
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.exception.SesionInactivaException;
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
-import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
+import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
+import org.springframework.beans.factory.ObjectProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,67 +17,148 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class JwtAuthenticationFilterTest {
 
-    private AuthenticationManager authenticationManager;
+    private JwtTokenService jwtTokenService;
+    private CustomUserDetailsService userDetailsService;
+    private UsuarioRepository usuarioRepository;
+    private ObjectProvider<JwtTokenService> jwtTokenServiceProvider;
+    private ObjectProvider<CustomUserDetailsService> userDetailsServiceProvider;
+    private ObjectProvider<UsuarioRepository> usuarioRepositoryProvider;
     private JwtAuthenticationFilter filter;
 
     @BeforeEach
     void setUp() {
-        authenticationManager = mock(AuthenticationManager.class);
-        filter = new JwtAuthenticationFilter(authenticationManager);
+        jwtTokenService = mock(JwtTokenService.class);
+        userDetailsService = mock(CustomUserDetailsService.class);
+        usuarioRepository = mock(UsuarioRepository.class);
+        jwtTokenServiceProvider = mock(ObjectProvider.class);
+        userDetailsServiceProvider = mock(ObjectProvider.class);
+        usuarioRepositoryProvider = mock(ObjectProvider.class);
+
+        when(jwtTokenServiceProvider.getIfAvailable()).thenReturn(jwtTokenService);
+        when(userDetailsServiceProvider.getIfAvailable()).thenReturn(userDetailsService);
+        when(usuarioRepositoryProvider.getIfAvailable()).thenReturn(usuarioRepository);
+
+        filter = new JwtAuthenticationFilter(jwtTokenServiceProvider, userDetailsServiceProvider, usuarioRepositoryProvider);
+        ReflectionTestUtils.setField(filter, "maxIdleMinutes", 20L);
         SecurityContextHolder.clearContext();
     }
 
     @Test
-    void delegaEnAuthenticationManagerYAsignaContextoCuandoTokenEsValido() throws ServletException, IOException {
+    void autenticaYActualizaUltimaActividadCuandoTokenEsValido() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer sample-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
         FilterChain chain = new MockFilterChain();
 
-        Authentication authResult = new UsernamePasswordAuthenticationToken(
-                "user", "sample-token", List.of(() -> "ROLE_USER")
-        );
-        when(authenticationManager.authenticate(any(JwtAuthenticationToken.class))).thenReturn(authResult);
+        Usuario usuario = Usuario.builder()
+                .nombreUsuario("user")
+                .sessionVersion(1L)
+                .rol(com.willyes.clemenintegra.shared.model.enums.RolUsuario.ROL_SUPER_ADMIN)
+                .ultimaActividad(java.time.LocalDateTime.now())
+                .build();
+
+        when(jwtTokenService.extraerClaims("sample-token"))
+                .thenReturn(new io.jsonwebtoken.impl.DefaultClaims().setSubject("user"));
+        when(jwtTokenService.getSessionVersion("sample-token")).thenReturn(1L);
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+        when(usuarioRepository.save(eq(usuario))).thenReturn(usuario);
 
         filter.doFilterInternal(request, response, chain);
 
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
         assertNotNull(authentication);
         assertEquals("user", authentication.getName());
         assertTrue(authentication.isAuthenticated());
 
-        ArgumentCaptor<JwtAuthenticationToken> captor = ArgumentCaptor.forClass(JwtAuthenticationToken.class);
-        verify(authenticationManager).authenticate(captor.capture());
-        assertEquals("sample-token", captor.getValue().getCredentials());
+        ArgumentCaptor<Usuario> captor = ArgumentCaptor.forClass(Usuario.class);
+        verify(usuarioRepository).save(captor.capture());
+        assertNotNull(captor.getValue().getUltimaActividad());
+        assertEquals("user", ((CustomUserDetails) authentication.getPrincipal()).getUsername());
     }
 
     @Test
-    void propagaSesionInvalidadaExceptionYNoSeteaContexto() {
+    void lanzaSesionInvalidadaCuandoVersionNoCoincide() {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer expired-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(authenticationManager.authenticate(any(JwtAuthenticationToken.class)))
-                .thenThrow(new SesionInvalidadaException("Sesion invalidada"));
+        Usuario usuario = Usuario.builder()
+                .nombreUsuario("user")
+                .sessionVersion(2L)
+                .rol(com.willyes.clemenintegra.shared.model.enums.RolUsuario.ROL_SUPER_ADMIN)
+                .ultimaActividad(java.time.LocalDateTime.now())
+                .build();
+
+        when(jwtTokenService.extraerClaims("expired-token"))
+                .thenReturn(new io.jsonwebtoken.impl.DefaultClaims().setSubject("user"));
+        when(jwtTokenService.getSessionVersion("expired-token")).thenReturn(1L);
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
 
         assertThrows(SesionInvalidadaException.class, () ->
                 filter.doFilterInternal(request, response, new MockFilterChain())
         );
 
         assertNull(SecurityContextHolder.getContext().getAuthentication());
+        verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    void lanzaSesionInactivaCuandoSuperaTiempoInactividad() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer inactive-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        java.time.LocalDateTime hace30Min = java.time.LocalDateTime.now().minusMinutes(30);
+        Usuario usuario = Usuario.builder()
+                .nombreUsuario("user")
+                .sessionVersion(1L)
+                .rol(com.willyes.clemenintegra.shared.model.enums.RolUsuario.ROL_SUPER_ADMIN)
+                .ultimaActividad(hace30Min)
+                .build();
+
+        when(jwtTokenService.extraerClaims("inactive-token"))
+                .thenReturn(new io.jsonwebtoken.impl.DefaultClaims().setSubject("user"));
+        when(jwtTokenService.getSessionVersion("inactive-token")).thenReturn(1L);
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+
+        assertThrows(SesionInactivaException.class, () ->
+                filter.doFilterInternal(request, response, new MockFilterChain())
+        );
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    void lanzaBadCredentialsParaTokenInvalido() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer bad-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtTokenService.extraerClaims("bad-token"))
+                .thenThrow(new io.jsonwebtoken.security.SignatureException("bad"));
+
+        assertThrows(BadCredentialsException.class, () ->
+                filter.doFilterInternal(request, response, new MockFilterChain())
+        );
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        verify(usuarioRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## Summary
- remove the constructor dependency between `SecurityConfig` and `JwtAuthenticationFilter` by injecting the filter only where needed and making the authentication provider optional
- refactor `JwtAuthenticationFilter` to validate tokens, session version, and inactivity directly using JWT services and repositories without requiring the security configuration
- update JWT filter unit tests to cover valid authentication, invalidated sessions, inactivity, and invalid tokens

## Testing
- mvn test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1e203f40833390bbb6baad0b0b79)