### PR TITLE
Centralize JWT session validation

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
@@ -1,46 +1,31 @@
 package com.willyes.clemenintegra.shared.security;
 
-import com.willyes.clemenintegra.shared.model.Usuario;
-import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.exception.SesionInactivaException;
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
-import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
-import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.security.SignatureException;
+import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.time.Duration;
-import java.time.LocalDateTime;
 
 @Slf4j
 @Component
+@ConditionalOnBean(AuthenticationManager.class)
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final ObjectProvider<JwtTokenService> jwtTokenServiceProvider;
-    private final ObjectProvider<CustomUserDetailsService> userDetailsServiceProvider;
-    private final ObjectProvider<UsuarioRepository> usuarioRepositoryProvider;
-
-    @Value("${security.session.max-idle-minutes:20}")
-    private long maxIdleMinutes;
+    private final AuthenticationManager authenticationManager;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -63,82 +48,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             final String token = authHeader.substring(7);
             try {
-                JwtTokenService jwtTokenService = jwtTokenServiceProvider.getIfAvailable();
-                CustomUserDetailsService userDetailsService = userDetailsServiceProvider.getIfAvailable();
-                UsuarioRepository usuarioRepository = usuarioRepositoryProvider.getIfAvailable();
-
-                if (jwtTokenService == null || userDetailsService == null || usuarioRepository == null) {
-                    log.debug("Componentes de seguridad no disponibles, se omite autenticación para {}", uri);
-                    filterChain.doFilter(request, response);
-                    return;
-                }
-
-                Claims claims = jwtTokenService.extraerClaims(token);
-                String username = claims.getSubject();
-                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-                validarSesion(token, userDetails, jwtTokenService, usuarioRepository);
-
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                        userDetails, token, userDetails.getAuthorities());
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                JwtAuthenticationToken authenticationRequest = new JwtAuthenticationToken(token);
+                Authentication authentication = authenticationManager.authenticate(authenticationRequest);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-
                 log.debug("Usuario {} autenticado en {}", authentication.getName(), uri);
-                log.debug("Authorities asignadas: {}", authentication.getAuthorities());
             } catch (SesionInvalidadaException | SesionInactivaException ex) {
                 log.warn("Sesión rechazada [{}] en {} {}: {}",
                         ex.getClass().getSimpleName(), request.getMethod(), uri,
                         (ex.getMessage() != null ? ex.getMessage() : "sin mensaje"));
                 SecurityContextHolder.clearContext();
                 throw ex;
-            } catch (ExpiredJwtException ex) {
-                log.warn("JWT expirado en {} {}: {}", request.getMethod(), uri, ex.getMessage());
+            } catch (AuthenticationException ex) {
+                log.warn("Autenticación rechazada en {} {}: {}", request.getMethod(), uri, ex.getMessage());
                 SecurityContextHolder.clearContext();
-                throw new BadCredentialsException("JWT expirado", ex);
-            } catch (SignatureException ex) {
-                log.warn("Firma JWT inválida en {} {}: {}", request.getMethod(), uri, ex.getMessage());
-                SecurityContextHolder.clearContext();
-                throw new BadCredentialsException("Firma JWT inválida", ex);
-            } catch (JwtException ex) {
-                log.warn("Token inválido en {} {}: {}", request.getMethod(), uri, ex.getMessage());
-                SecurityContextHolder.clearContext();
-                throw new BadCredentialsException("Token inválido", ex);
+                throw ex;
             }
         } else {
             log.debug("Solicitud sin encabezado Authorization en {}", uri);
         }
 
-        // ¡OJO!: no atrapar Exception genérica aquí
         filterChain.doFilter(request, response);
-    }
-
-    private void validarSesion(String token,
-                               UserDetails userDetails,
-                               JwtTokenService jwtTokenService,
-                               UsuarioRepository usuarioRepository) {
-        if (!(userDetails instanceof CustomUserDetails cud)) {
-            throw new BadCredentialsException("UserDetails inválido");
-        }
-        Usuario usuario = cud.getUsuario();
-
-        Long tokenSessionVersion = jwtTokenService.getSessionVersion(token);
-        Long usuarioSessionVersion = usuario.getSessionVersion() != null ? usuario.getSessionVersion() : 0L;
-
-        if (!usuarioSessionVersion.equals(tokenSessionVersion)) {
-            throw new SesionInvalidadaException("La sesión fue invalidada porque se inició una nueva sesión para este usuario.");
-        }
-
-        LocalDateTime ultimaActividad = usuario.getUltimaActividad();
-        if (ultimaActividad == null) {
-            throw new SesionInactivaException("La sesión ha expirado por inactividad.");
-        }
-
-        long minutosInactivo = Duration.between(ultimaActividad, LocalDateTime.now()).toMinutes();
-        if (minutosInactivo > maxIdleMinutes) {
-            throw new SesionInactivaException("La sesión ha expirado por inactividad.");
-        }
-
-        usuario.setUltimaActividad(LocalDateTime.now());
-        usuarioRepository.save(usuario);
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProvider.java
@@ -4,11 +4,12 @@ import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.exception.SesionInactivaException;
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
 import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,11 +19,12 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -30,7 +32,6 @@ import java.time.LocalDateTime;
 public class JwtAuthenticationProvider implements AuthenticationProvider {
 
     private final JwtTokenService jwtTokenService;
-    private final CustomUserDetailsService userDetailsService;
     private final UsuarioRepository usuarioRepository;
 
     @Value("${security.session.max-idle-minutes:20}")
@@ -42,12 +43,14 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         try {
             Claims claims = jwtTokenService.extraerClaims(token);
             String username = claims.getSubject();
+            Usuario usuario = usuarioRepository.findByNombreUsuario(username)
+                    .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado"));
 
-            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-            validarSesion(token, userDetails);
+            validarSesion(token, usuario);
 
+            CustomUserDetails principal = new CustomUserDetails(usuario);
             return new UsernamePasswordAuthenticationToken(
-                    userDetails, token, userDetails.getAuthorities()
+                    principal, token, principal.getAuthorities()
             );
         } catch (ExpiredJwtException e) {
             log.warn("Token expirado para solicitud de {}", requestUsername(token));
@@ -66,33 +69,32 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         }
     }
 
-    private void validarSesion(String token, UserDetails userDetails) {
-        if (!(userDetails instanceof com.willyes.clemenintegra.shared.security.service.CustomUserDetails cud)) {
-            return;
+    private void validarSesion(String token, Usuario usuario) {
+        if (!usuario.isActivo() || usuario.isBloqueado()) {
+            throw new BadCredentialsException("Usuario inactivo o bloqueado");
         }
-        Usuario usuario = cud.getUsuario();
+
         Long tokenSessionVersion = jwtTokenService.getSessionVersion(token);
-        Long usuarioSessionVersion = usuario.getSessionVersion() != null ? usuario.getSessionVersion() : 0L;
+        Long usuarioSessionVersion = Optional.ofNullable(usuario.getSessionVersion()).orElse(0L);
 
         if (!usuarioSessionVersion.equals(tokenSessionVersion)) {
-            throw new SesionInvalidadaException("La sesión fue invalidada porque se inició una nueva sesión para este usuario.");
+            throw new SesionInvalidadaException(
+                    String.format("La sesión fue invalidada (token=%d, bd=%d) para usuario %d",
+                            tokenSessionVersion, usuarioSessionVersion, usuario.getId())
+            );
         }
 
-        LocalDateTime ahora = LocalDateTime.now();
         LocalDateTime ultimaActividad = usuario.getUltimaActividad();
-
-        // Si nunca se ha registrado actividad (valor null), consideramos la sesión inactiva para forzar un nuevo login.
         if (ultimaActividad == null) {
             throw new SesionInactivaException("La sesión ha expirado por inactividad.");
         }
 
-        long minutosInactivo = java.time.Duration.between(ultimaActividad, ahora).toMinutes();
+        long minutosInactivo = Duration.between(ultimaActividad, LocalDateTime.now()).toMinutes();
         if (minutosInactivo > maxIdleMinutes) {
             throw new SesionInactivaException("La sesión ha expirado por inactividad.");
         }
 
-        // Sesión válida: refrescamos última actividad para mantenerla viva.
-        usuario.setUltimaActividad(ahora);
+        usuario.setUltimaActividad(LocalDateTime.now());
         usuarioRepository.save(usuario);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -48,8 +48,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
-                                                   JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+                                                   org.springframework.beans.factory.ObjectProvider<JwtAuthenticationFilter> jwtAuthenticationFilterProvider) throws Exception {
         JwtAuthenticationProvider provider = jwtAuthenticationProvider.getIfAvailable();
+        JwtAuthenticationFilter jwtAuthenticationFilter = jwtAuthenticationFilterProvider.getIfAvailable();
 
         http
                 .cors(org.springframework.security.config.Customizer.withDefaults())
@@ -263,10 +264,13 @@ public class SecurityConfig {
                                     response.setContentType("application/json");
                                     response.getWriter().write("{\"error\":\"No autorizado\"}");
                                 }
-                ))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterAfter(usuarioInactivoFilter, JwtAuthenticationFilter.class)
-                .addFilterAfter(requestTimingFilter, JwtAuthenticationFilter.class);
+                ));
+
+        if (jwtAuthenticationFilter != null) {
+            http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                    .addFilterAfter(usuarioInactivoFilter, JwtAuthenticationFilter.class)
+                    .addFilterAfter(requestTimingFilter, JwtAuthenticationFilter.class);
+        }
 
         if (provider != null) {
             http.authenticationProvider(provider);

--- a/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilterTest.java
@@ -1,12 +1,8 @@
 package com.willyes.clemenintegra.shared.security;
 
-import com.willyes.clemenintegra.shared.model.Usuario;
-import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.exception.SesionInactivaException;
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
-import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
-import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
-import org.springframework.beans.factory.ObjectProvider;
+import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,67 +13,38 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class JwtAuthenticationFilterTest {
 
-    private JwtTokenService jwtTokenService;
-    private CustomUserDetailsService userDetailsService;
-    private UsuarioRepository usuarioRepository;
-    private ObjectProvider<JwtTokenService> jwtTokenServiceProvider;
-    private ObjectProvider<CustomUserDetailsService> userDetailsServiceProvider;
-    private ObjectProvider<UsuarioRepository> usuarioRepositoryProvider;
+    private AuthenticationManager authenticationManager;
     private JwtAuthenticationFilter filter;
 
     @BeforeEach
     void setUp() {
-        jwtTokenService = mock(JwtTokenService.class);
-        userDetailsService = mock(CustomUserDetailsService.class);
-        usuarioRepository = mock(UsuarioRepository.class);
-        jwtTokenServiceProvider = mock(ObjectProvider.class);
-        userDetailsServiceProvider = mock(ObjectProvider.class);
-        usuarioRepositoryProvider = mock(ObjectProvider.class);
-
-        when(jwtTokenServiceProvider.getIfAvailable()).thenReturn(jwtTokenService);
-        when(userDetailsServiceProvider.getIfAvailable()).thenReturn(userDetailsService);
-        when(usuarioRepositoryProvider.getIfAvailable()).thenReturn(usuarioRepository);
-
-        filter = new JwtAuthenticationFilter(jwtTokenServiceProvider, userDetailsServiceProvider, usuarioRepositoryProvider);
-        ReflectionTestUtils.setField(filter, "maxIdleMinutes", 20L);
+        authenticationManager = mock(AuthenticationManager.class);
+        filter = new JwtAuthenticationFilter(authenticationManager);
         SecurityContextHolder.clearContext();
     }
 
     @Test
-    void autenticaYActualizaUltimaActividadCuandoTokenEsValido() throws ServletException, IOException {
+    void delegaAutenticacionCuandoTokenEsValido() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer sample-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
         FilterChain chain = new MockFilterChain();
 
-        Usuario usuario = Usuario.builder()
-                .nombreUsuario("user")
-                .sessionVersion(1L)
-                .rol(com.willyes.clemenintegra.shared.model.enums.RolUsuario.ROL_SUPER_ADMIN)
-                .ultimaActividad(java.time.LocalDateTime.now())
-                .build();
-
-        when(jwtTokenService.extraerClaims("sample-token"))
-                .thenReturn(new io.jsonwebtoken.impl.DefaultClaims().setSubject("user"));
-        when(jwtTokenService.getSessionVersion("sample-token")).thenReturn(1L);
-        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
-        when(usuarioRepository.save(eq(usuario))).thenReturn(usuario);
+        UsernamePasswordAuthenticationToken authenticated =
+                new UsernamePasswordAuthenticationToken("user", "sample-token", java.util.List.of(() -> "ROLE_USER"));
+        when(authenticationManager.authenticate(any(JwtAuthenticationToken.class))).thenReturn(authenticated);
 
         filter.doFilterInternal(request, response, chain);
 
@@ -85,11 +52,9 @@ class JwtAuthenticationFilterTest {
         assertNotNull(authentication);
         assertEquals("user", authentication.getName());
         assertTrue(authentication.isAuthenticated());
-
-        ArgumentCaptor<Usuario> captor = ArgumentCaptor.forClass(Usuario.class);
-        verify(usuarioRepository).save(captor.capture());
-        assertNotNull(captor.getValue().getUltimaActividad());
-        assertEquals("user", ((CustomUserDetails) authentication.getPrincipal()).getUsername());
+        ArgumentCaptor<JwtAuthenticationToken> captor = ArgumentCaptor.forClass(JwtAuthenticationToken.class);
+        verify(authenticationManager, times(1)).authenticate(captor.capture());
+        assertEquals("sample-token", captor.getValue().getCredentials());
     }
 
     @Test
@@ -98,24 +63,15 @@ class JwtAuthenticationFilterTest {
         request.addHeader("Authorization", "Bearer expired-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        Usuario usuario = Usuario.builder()
-                .nombreUsuario("user")
-                .sessionVersion(2L)
-                .rol(com.willyes.clemenintegra.shared.model.enums.RolUsuario.ROL_SUPER_ADMIN)
-                .ultimaActividad(java.time.LocalDateTime.now())
-                .build();
-
-        when(jwtTokenService.extraerClaims("expired-token"))
-                .thenReturn(new io.jsonwebtoken.impl.DefaultClaims().setSubject("user"));
-        when(jwtTokenService.getSessionVersion("expired-token")).thenReturn(1L);
-        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+        when(authenticationManager.authenticate(any(JwtAuthenticationToken.class)))
+                .thenThrow(new SesionInvalidadaException("Sesión invalidada"));
 
         assertThrows(SesionInvalidadaException.class, () ->
                 filter.doFilterInternal(request, response, new MockFilterChain())
         );
 
         assertNull(SecurityContextHolder.getContext().getAuthentication());
-        verify(usuarioRepository, never()).save(any());
+        verify(authenticationManager, times(1)).authenticate(any(JwtAuthenticationToken.class));
     }
 
     @Test
@@ -124,41 +80,31 @@ class JwtAuthenticationFilterTest {
         request.addHeader("Authorization", "Bearer inactive-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        java.time.LocalDateTime hace30Min = java.time.LocalDateTime.now().minusMinutes(30);
-        Usuario usuario = Usuario.builder()
-                .nombreUsuario("user")
-                .sessionVersion(1L)
-                .rol(com.willyes.clemenintegra.shared.model.enums.RolUsuario.ROL_SUPER_ADMIN)
-                .ultimaActividad(hace30Min)
-                .build();
-
-        when(jwtTokenService.extraerClaims("inactive-token"))
-                .thenReturn(new io.jsonwebtoken.impl.DefaultClaims().setSubject("user"));
-        when(jwtTokenService.getSessionVersion("inactive-token")).thenReturn(1L);
-        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+        when(authenticationManager.authenticate(any(JwtAuthenticationToken.class)))
+                .thenThrow(new SesionInactivaException("Inactiva"));
 
         assertThrows(SesionInactivaException.class, () ->
                 filter.doFilterInternal(request, response, new MockFilterChain())
         );
 
         assertNull(SecurityContextHolder.getContext().getAuthentication());
-        verify(usuarioRepository, never()).save(any());
+        verify(authenticationManager, times(1)).authenticate(any(JwtAuthenticationToken.class));
     }
 
     @Test
-    void lanzaBadCredentialsParaTokenInvalido() {
+    void burbujeaErroresDeAutenticacion() {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer bad-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(jwtTokenService.extraerClaims("bad-token"))
-                .thenThrow(new io.jsonwebtoken.security.SignatureException("bad"));
+        when(authenticationManager.authenticate(any(JwtAuthenticationToken.class)))
+                .thenThrow(new org.springframework.security.authentication.BadCredentialsException("bad"));
 
-        assertThrows(BadCredentialsException.class, () ->
+        assertThrows(org.springframework.security.authentication.BadCredentialsException.class, () ->
                 filter.doFilterInternal(request, response, new MockFilterChain())
         );
 
         assertNull(SecurityContextHolder.getContext().getAuthentication());
-        verify(usuarioRepository, never()).save(any());
+        verify(authenticationManager, times(1)).authenticate(any(JwtAuthenticationToken.class));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
@@ -5,7 +5,6 @@ import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.exception.SesionInactivaException;
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
-import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
 import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
 import io.jsonwebtoken.impl.DefaultClaims;
@@ -29,15 +28,13 @@ class JwtAuthenticationProviderTest {
     @Mock
     private JwtTokenService jwtTokenService;
     @Mock
-    private CustomUserDetailsService userDetailsService;
-    @Mock
     private UsuarioRepository usuarioRepository;
 
     private JwtAuthenticationProvider provider;
 
     @BeforeEach
     void setUp() {
-        provider = new JwtAuthenticationProvider(jwtTokenService, userDetailsService, usuarioRepository);
+        provider = new JwtAuthenticationProvider(jwtTokenService, usuarioRepository);
         ReflectionTestUtils.setField(provider, "maxIdleMinutes", 20L);
     }
 
@@ -58,7 +55,7 @@ class JwtAuthenticationProviderTest {
         when(jwtTokenService.extraerClaims("token"))
                 .thenReturn(new DefaultClaims().setSubject("user"));
         when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
-        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+        when(usuarioRepository.findByNombreUsuario("user")).thenReturn(java.util.Optional.of(usuario));
 
         assertThrows(SesionInvalidadaException.class,
                 () -> provider.authenticate(new JwtAuthenticationToken("token")));
@@ -84,7 +81,7 @@ class JwtAuthenticationProviderTest {
         when(jwtTokenService.extraerClaims("token"))
                 .thenReturn(new DefaultClaims().setSubject("user"));
         when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
-        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+        when(usuarioRepository.findByNombreUsuario("user")).thenReturn(java.util.Optional.of(usuario));
 
         assertThrows(SesionInactivaException.class,
                 () -> provider.authenticate(new JwtAuthenticationToken("token")));
@@ -109,7 +106,7 @@ class JwtAuthenticationProviderTest {
         when(jwtTokenService.extraerClaims("token"))
                 .thenReturn(new DefaultClaims().setSubject("user"));
         when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
-        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+        when(usuarioRepository.findByNombreUsuario("user")).thenReturn(java.util.Optional.of(usuario));
 
         assertThrows(SesionInactivaException.class,
                 () -> provider.authenticate(new JwtAuthenticationToken("token")));
@@ -135,7 +132,7 @@ class JwtAuthenticationProviderTest {
         when(jwtTokenService.extraerClaims("token"))
                 .thenReturn(new DefaultClaims().setSubject("user"));
         when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
-        when(userDetailsService.loadUserByUsername("user")).thenReturn(new CustomUserDetails(usuario));
+        when(usuarioRepository.findByNombreUsuario("user")).thenReturn(java.util.Optional.of(usuario));
         when(usuarioRepository.save(eq(usuario))).thenReturn(usuario);
 
         var authentication = provider.authenticate(new JwtAuthenticationToken("token"));


### PR DESCRIPTION
## Summary
- Centralize JWT validation and session checks inside JwtAuthenticationProvider and delegate requests through AuthenticationManager
- Refactor JwtAuthenticationFilter to act as a thin token extractor and authenticator, avoiding duplicated session logic
- Update security configuration and unit tests to cover version mismatch, inactivity, and delegation paths

## Testing
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b2caefc5483338b3d038b47b06fec)