### PR TITLE
Fix JWT session validation and authentication flow

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
@@ -34,11 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         final String uri = request.getRequestURI();
 
-        // 1) Deja pasar preflight CORS y endpoints públicos
-        if ("OPTIONS".equalsIgnoreCase(request.getMethod())
-                || uri.startsWith("/api/auth")
-                || uri.startsWith("/api/public/")
-                || "/auth/login".equals(uri)) {
+        if (shouldSkipFilter(request, uri)) {
+            log.debug("JwtAuthenticationFilter: URI {} excluida, continúa la cadena", uri);
             filterChain.doFilter(request, response);
             return;
         }
@@ -48,25 +45,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             final String token = authHeader.substring(7);
             try {
+                log.debug("JwtAuthenticationFilter: token encontrado, delegando en AuthenticationManager para URI {}", uri);
                 JwtAuthenticationToken authenticationRequest = new JwtAuthenticationToken(token);
                 Authentication authentication = authenticationManager.authenticate(authenticationRequest);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.debug("Usuario {} autenticado en {}", authentication.getName(), uri);
-            } catch (SesionInvalidadaException | SesionInactivaException ex) {
-                log.warn("Sesión rechazada [{}] en {} {}: {}",
-                        ex.getClass().getSimpleName(), request.getMethod(), uri,
-                        (ex.getMessage() != null ? ex.getMessage() : "sin mensaje"));
-                SecurityContextHolder.clearContext();
-                throw ex;
-            } catch (AuthenticationException ex) {
-                log.warn("Autenticación rechazada en {} {}: {}", request.getMethod(), uri, ex.getMessage());
+            } catch (SesionInvalidadaException | SesionInactivaException | AuthenticationException ex) {
                 SecurityContextHolder.clearContext();
                 throw ex;
             }
         } else {
-            log.debug("Solicitud sin encabezado Authorization en {}", uri);
+            log.debug("JwtAuthenticationFilter: sin token, continúa como anónimo para URI {}", uri);
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean shouldSkipFilter(HttpServletRequest request, String uri) {
+        return "OPTIONS".equalsIgnoreCase(request.getMethod())
+                || uri.startsWith("/api/auth")
+                || uri.startsWith("/api/public/")
+                || "/auth/login".equals(uri);
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProvider.java
@@ -40,18 +40,21 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         String token = (String) authentication.getCredentials();
+        Claims claims;
         try {
-            Claims claims = jwtTokenService.extraerClaims(token);
+            claims = jwtTokenService.extraerClaims(token);
             String username = claims.getSubject();
             Usuario usuario = usuarioRepository.findByNombreUsuario(username)
                     .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado"));
 
-            validarSesion(token, usuario);
+            validarSesion(claims, usuario);
 
             CustomUserDetails principal = new CustomUserDetails(usuario);
-            return new UsernamePasswordAuthenticationToken(
+            UsernamePasswordAuthenticationToken authenticated = new UsernamePasswordAuthenticationToken(
                     principal, token, principal.getAuthorities()
             );
+            log.debug("JwtAuthenticationProvider: sesión válida para usuario {}, version {}", username, usuario.getSessionVersion());
+            return authenticated;
         } catch (ExpiredJwtException e) {
             log.warn("Token expirado para solicitud de {}", requestUsername(token));
             throw new BadCredentialsException("Token expirado", e);
@@ -69,15 +72,17 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         }
     }
 
-    private void validarSesion(String token, Usuario usuario) {
+    private void validarSesion(Claims claims, Usuario usuario) {
         if (!usuario.isActivo() || usuario.isBloqueado()) {
             throw new BadCredentialsException("Usuario inactivo o bloqueado");
         }
 
-        Long tokenSessionVersion = jwtTokenService.getSessionVersion(token);
+        Long tokenSessionVersion = jwtTokenService.getSessionVersion(claims);
         Long usuarioSessionVersion = Optional.ofNullable(usuario.getSessionVersion()).orElse(0L);
 
         if (!usuarioSessionVersion.equals(tokenSessionVersion)) {
+            log.debug("JwtAuthenticationProvider: sesión invalidada para usuario {} (tokenVersion={}, dbVersion={})",
+                    usuario.getNombreUsuario(), tokenSessionVersion, usuarioSessionVersion);
             throw new SesionInvalidadaException(
                     String.format("La sesión fue invalidada (token=%d, bd=%d) para usuario %d",
                             tokenSessionVersion, usuarioSessionVersion, usuario.getId())
@@ -85,16 +90,18 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         }
 
         LocalDateTime ultimaActividad = usuario.getUltimaActividad();
-        if (ultimaActividad == null) {
-            throw new SesionInactivaException("La sesión ha expirado por inactividad.");
+        LocalDateTime ahora = LocalDateTime.now();
+
+        if (ultimaActividad != null) {
+            long minutosInactivo = Duration.between(ultimaActividad, ahora).toMinutes();
+            if (minutosInactivo > maxIdleMinutes) {
+                log.debug("JwtAuthenticationProvider: sesión inactiva para usuario {} (idleMinutes={}, maxIdle={})",
+                        usuario.getNombreUsuario(), minutosInactivo, maxIdleMinutes);
+                throw new SesionInactivaException("La sesión ha expirado por inactividad.");
+            }
         }
 
-        long minutosInactivo = Duration.between(ultimaActividad, LocalDateTime.now()).toMinutes();
-        if (minutosInactivo > maxIdleMinutes) {
-            throw new SesionInactivaException("La sesión ha expirado por inactividad.");
-        }
-
-        usuario.setUltimaActividad(LocalDateTime.now());
+        usuario.setUltimaActividad(ahora);
         usuarioRepository.save(usuario);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -8,13 +8,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,8 +25,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -42,8 +41,21 @@ public class SecurityConfig {
     private String allowedOriginsProp;
 
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
-        return config.getAuthenticationManager();
+    public AuthenticationManager authenticationManager(HttpSecurity http,
+                                                       org.springframework.beans.factory.ObjectProvider<JwtAuthenticationProvider> jwtAuthenticationProvider,
+                                                       org.springframework.beans.factory.ObjectProvider<UserDetailsService> userDetailsService,
+                                                       org.springframework.beans.factory.ObjectProvider<PasswordEncoder> passwordEncoder) throws Exception {
+        AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        JwtAuthenticationProvider provider = jwtAuthenticationProvider.getIfAvailable();
+        if (provider != null) {
+            builder.authenticationProvider(provider);
+        }
+        UserDetailsService uds = userDetailsService.getIfAvailable();
+        PasswordEncoder encoder = passwordEncoder.getIfAvailable();
+        if (uds != null && encoder != null) {
+            builder.userDetailsService(uds).passwordEncoder(encoder);
+        }
+        return builder.build();
     }
 
     @Bean

--- a/src/main/java/com/willyes/clemenintegra/shared/security/service/JwtTokenService.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/service/JwtTokenService.java
@@ -8,4 +8,5 @@ public interface JwtTokenService {
     Claims extraerClaims(String token);
     String extraerNombreUsuario(String token);
     Long getSessionVersion(String token);
+    Long getSessionVersion(Claims claims);
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/security/service/JwtTokenServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/service/JwtTokenServiceImpl.java
@@ -51,11 +51,16 @@ public class JwtTokenServiceImpl implements JwtTokenService {
     }
 
     public Long getSessionVersion(String token) {
-        Claims claims = extraerClaims(token);
+        return getSessionVersion(extraerClaims(token));
+    }
+
+    @Override
+    public Long getSessionVersion(Claims claims) {
         Object value = claims.get("sessionVersion");
         if (value == null) {
-            throw new IllegalArgumentException("El token no contiene sessionVersion");
+            return 0L;
         }
+
         if (value instanceof Integer i) {
             return i.longValue();
         }

--- a/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
@@ -7,12 +7,14 @@ import com.willyes.clemenintegra.shared.security.exception.SesionInactivaExcepti
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
 import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
 import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.impl.DefaultClaims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -52,9 +54,10 @@ class JwtAuthenticationProviderTest {
                 .sessionVersion(2L)
                 .build();
 
-        when(jwtTokenService.extraerClaims("token"))
-                .thenReturn(new DefaultClaims().setSubject("user"));
-        when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
+        Claims claims = new DefaultClaims();
+        claims.setSubject("user");
+        when(jwtTokenService.extraerClaims("token")).thenReturn(claims);
+        when(jwtTokenService.getSessionVersion(claims)).thenReturn(1L);
         when(usuarioRepository.findByNombreUsuario("user")).thenReturn(java.util.Optional.of(usuario));
 
         assertThrows(SesionInvalidadaException.class,
@@ -78,9 +81,10 @@ class JwtAuthenticationProviderTest {
                 .ultimaActividad(hace25Min)
                 .build();
 
-        when(jwtTokenService.extraerClaims("token"))
-                .thenReturn(new DefaultClaims().setSubject("user"));
-        when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
+        Claims claims = new DefaultClaims();
+        claims.setSubject("user");
+        when(jwtTokenService.extraerClaims("token")).thenReturn(claims);
+        when(jwtTokenService.getSessionVersion(claims)).thenReturn(1L);
         when(usuarioRepository.findByNombreUsuario("user")).thenReturn(java.util.Optional.of(usuario));
 
         assertThrows(SesionInactivaException.class,
@@ -89,7 +93,7 @@ class JwtAuthenticationProviderTest {
     }
 
     @Test
-    void lanzaSesionInactivaCuandoUltimaActividadEsNull() {
+    void permitePrimeraActividadCuandoUltimaActividadEsNull() {
         Usuario usuario = Usuario.builder()
                 .id(1L)
                 .nombreUsuario("user")
@@ -103,14 +107,18 @@ class JwtAuthenticationProviderTest {
                 .ultimaActividad(null)
                 .build();
 
-        when(jwtTokenService.extraerClaims("token"))
-                .thenReturn(new DefaultClaims().setSubject("user"));
-        when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
+        Claims claims = new DefaultClaims();
+        claims.setSubject("user");
+        when(jwtTokenService.extraerClaims("token")).thenReturn(claims);
+        when(jwtTokenService.getSessionVersion(claims)).thenReturn(1L);
         when(usuarioRepository.findByNombreUsuario("user")).thenReturn(java.util.Optional.of(usuario));
+        when(usuarioRepository.save(usuario)).thenReturn(usuario);
 
-        assertThrows(SesionInactivaException.class,
-                () -> provider.authenticate(new JwtAuthenticationToken("token")));
-        verify(usuarioRepository, never()).save(any());
+        var authentication = provider.authenticate(new JwtAuthenticationToken("token"));
+
+        verify(usuarioRepository, times(1)).save(usuario);
+        assertNotNull(usuario.getUltimaActividad());
+        assertTrue(authentication.isAuthenticated());
     }
 
     @Test
@@ -129,9 +137,10 @@ class JwtAuthenticationProviderTest {
                 .ultimaActividad(hace2Min)
                 .build();
 
-        when(jwtTokenService.extraerClaims("token"))
-                .thenReturn(new DefaultClaims().setSubject("user"));
-        when(jwtTokenService.getSessionVersion("token")).thenReturn(1L);
+        Claims claims = new DefaultClaims();
+        claims.setSubject("user");
+        when(jwtTokenService.extraerClaims("token")).thenReturn(claims);
+        when(jwtTokenService.getSessionVersion(claims)).thenReturn(1L);
         when(usuarioRepository.findByNombreUsuario("user")).thenReturn(java.util.Optional.of(usuario));
         when(usuarioRepository.save(eq(usuario))).thenReturn(usuario);
 
@@ -139,11 +148,38 @@ class JwtAuthenticationProviderTest {
 
         verify(usuarioRepository, times(1)).save(eq(usuario));
         verify(jwtTokenService, times(1)).extraerClaims("token");
-        verify(jwtTokenService, times(1)).getSessionVersion("token");
+        verify(jwtTokenService, times(1)).getSessionVersion(claims);
         assertNotNull(usuario.getUltimaActividad());
         assertTrue(usuario.getUltimaActividad().isAfter(hace2Min));
         assertTrue(authentication.isAuthenticated());
         assertEquals("user", authentication.getName());
         assertEquals(1, authentication.getAuthorities().size());
+    }
+
+    @Test
+    void aceptaVersionPorDefectoCuandoTokenNoTieneSessionVersion() {
+        Usuario usuario = Usuario.builder()
+                .id(1L)
+                .nombreUsuario("user")
+                .clave("pass")
+                .nombreCompleto("Nombre")
+                .correo("correo@test.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .sessionVersion(0L)
+                .ultimaActividad(LocalDateTime.now())
+                .build();
+
+        Claims claims = new DefaultClaims();
+        claims.setSubject("user");
+        when(jwtTokenService.extraerClaims("token")).thenReturn(claims);
+        when(jwtTokenService.getSessionVersion(claims)).thenReturn(0L);
+        when(usuarioRepository.findByNombreUsuario("user")).thenReturn(java.util.Optional.of(usuario));
+        when(usuarioRepository.save(usuario)).thenReturn(usuario);
+
+        Authentication authentication = provider.authenticate(new JwtAuthenticationToken("token"));
+
+        assertTrue(authentication.isAuthenticated());
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/shared/security/service/JwtTokenServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/service/JwtTokenServiceImplTest.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.shared.security.service;
 
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,5 +36,19 @@ class JwtTokenServiceImplTest {
         var claims = service.extraerClaims(token);
         assertEquals("tester", claims.getSubject());
         assertEquals(99L, ((Number) claims.get("usuarioId")).longValue());
+    }
+
+    @Test
+    void devuelveCeroCuandoTokenNoTieneSessionVersion() {
+        JwtTokenServiceImpl service = new JwtTokenServiceImpl(SECRET);
+        String token = Jwts.builder()
+                .setSubject("legacy")
+                .setIssuedAt(new java.util.Date())
+                .signWith(io.jsonwebtoken.security.Keys.hmacShaKeyFor(SECRET.getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+                        io.jsonwebtoken.SignatureAlgorithm.HS256)
+                .compact();
+
+        Long version = service.getSessionVersion(token);
+        assertEquals(0L, version);
     }
 }


### PR DESCRIPTION
## Summary
- simplify the JWT authentication filter to only extract bearer tokens, delegate to the authentication manager, and log delegation/anonymous paths
- centralize session version and idle validation in the JWT provider, add backward-compatible token parsing, and make the security config tolerant of optional providers
- extend unit coverage for session version defaults and valid/invalid/idle authentication paths

## Testing
- mvn test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b381f1dd0833380e4d484539cb711)