### PR TITLE
Ensure JWT filter runs for protected endpoints

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
@@ -3,21 +3,23 @@ package com.willyes.clemenintegra.shared.security;
 import com.willyes.clemenintegra.shared.security.exception.SesionInactivaException;
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
 import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -26,6 +28,23 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final AuthenticationManager authenticationManager;
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+    private final List<String> publicMatchers = List.of(
+            "/api/auth/**",
+            "/api/public/**",
+            "/actuator/health",
+            "/actuator/health/**",
+            "/actuator/info",
+            "/v3/api-docs/**",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/swagger-resources",
+            "/configuration/ui",
+            "/configuration/security",
+            "/webjars/**",
+            "/auth/login"
+    );
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -35,7 +54,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         final String uri = request.getRequestURI();
 
         if (shouldSkipFilter(request, uri)) {
-            log.debug("JwtAuthenticationFilter: URI {} excluida, continúa la cadena", uri);
             filterChain.doFilter(request, response);
             return;
         }
@@ -61,9 +79,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private boolean shouldSkipFilter(HttpServletRequest request, String uri) {
-        return "OPTIONS".equalsIgnoreCase(request.getMethod())
-                || uri.startsWith("/api/auth")
-                || uri.startsWith("/api/public/")
-                || "/auth/login".equals(uri);
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            log.debug("JwtAuthenticationFilter: URI {} excluida por método OPTIONS", uri);
+            return true;
+        }
+
+        return publicMatchers.stream()
+                .filter(pattern -> antPathMatcher.match(pattern, uri))
+                .peek(pattern -> log.debug("JwtAuthenticationFilter: URI {} excluida por patrón público {}", uri, pattern))
+                .findFirst()
+                .isPresent();
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -4,6 +4,8 @@ import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.model.UsuarioPrincipal;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -15,6 +17,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -25,16 +28,18 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
+@Slf4j
 public class SecurityConfig {
 
     private final UsuarioInactivoFilter usuarioInactivoFilter;
     private final RequestTimingFilter requestTimingFilter;
-    private final org.springframework.beans.factory.ObjectProvider<JwtAuthenticationProvider> jwtAuthenticationProvider;
+    private final ObjectProvider<JwtAuthenticationProvider> jwtAuthenticationProviderProvider;
 
     // Orígenes permitidos por perfil (lista separada por comas)
     @Value("${app.cors.allowed-origins:}")
@@ -42,32 +47,39 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationManager authenticationManager(HttpSecurity http,
-                                                       org.springframework.beans.factory.ObjectProvider<JwtAuthenticationProvider> jwtAuthenticationProvider,
-                                                       org.springframework.beans.factory.ObjectProvider<UserDetailsService> userDetailsService,
-                                                       org.springframework.beans.factory.ObjectProvider<PasswordEncoder> passwordEncoder) throws Exception {
+                                                       UserDetailsService userDetailsService,
+                                                       ObjectProvider<PasswordEncoder> passwordEncoderProvider) throws Exception {
         AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
-        JwtAuthenticationProvider provider = jwtAuthenticationProvider.getIfAvailable();
-        if (provider != null) {
-            builder.authenticationProvider(provider);
+        JwtAuthenticationProvider jwtAuthenticationProvider = jwtAuthenticationProviderProvider.getIfAvailable();
+        if (jwtAuthenticationProvider != null) {
+            builder.authenticationProvider(jwtAuthenticationProvider);
+        } else {
+            log.warn("SecurityConfig: JwtAuthenticationProvider no está disponible, se usará AuthenticationManager sin el provider personalizado");
         }
-        UserDetailsService uds = userDetailsService.getIfAvailable();
-        PasswordEncoder encoder = passwordEncoder.getIfAvailable();
-        if (uds != null && encoder != null) {
-            builder.userDetailsService(uds).passwordEncoder(encoder);
+
+        PasswordEncoder passwordEncoder = passwordEncoderProvider.orderedStream().findFirst().orElse(null);
+        if (passwordEncoder != null) {
+            builder.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder);
+        } else {
+            log.warn("SecurityConfig: PasswordEncoder no está disponible, se registrará UserDetailsService sin codificador");
+            builder.userDetailsService(userDetailsService);
         }
-        return builder.build();
+        AuthenticationManager authenticationManager = builder.build();
+        log.debug("SecurityConfig: AuthenticationManager configurado con UserDetailsService{}{}",
+                jwtAuthenticationProvider != null ? " y JwtAuthenticationProvider" : "",
+                passwordEncoder != null ? " y PasswordEncoder" : "");
+        return authenticationManager;
     }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
-                                                   org.springframework.beans.factory.ObjectProvider<JwtAuthenticationFilter> jwtAuthenticationFilterProvider) throws Exception {
-        JwtAuthenticationProvider provider = jwtAuthenticationProvider.getIfAvailable();
-        JwtAuthenticationFilter jwtAuthenticationFilter = jwtAuthenticationFilterProvider.getIfAvailable();
-
+                                                   ObjectProvider<JwtAuthenticationFilter> jwtAuthenticationFilterProvider,
+                                                   AuthenticationManager authenticationManager) throws Exception {
         http
                 .cors(org.springframework.security.config.Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationManager(authenticationManager)
                 .authorizeHttpRequests(auth -> {
                     auth.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
 
@@ -278,17 +290,28 @@ public class SecurityConfig {
                                 }
                 ));
 
-        if (jwtAuthenticationFilter != null) {
-            http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                    .addFilterAfter(usuarioInactivoFilter, JwtAuthenticationFilter.class)
-                    .addFilterAfter(requestTimingFilter, JwtAuthenticationFilter.class);
-        }
-
-        if (provider != null) {
-            http.authenticationProvider(provider);
+        JwtAuthenticationProvider jwtAuthenticationProvider = jwtAuthenticationProviderProvider.getIfAvailable();
+        if (jwtAuthenticationProvider != null) {
+            JwtAuthenticationFilter jwtAuthenticationFilter = jwtAuthenticationFilterProvider.getIfAvailable();
+            if (jwtAuthenticationFilter != null) {
+                log.debug("SecurityConfig: Registrando JwtAuthenticationFilter y JwtAuthenticationProvider en la cadena de filtros");
+                http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                        .addFilterAfter(usuarioInactivoFilter, JwtAuthenticationFilter.class)
+                        .addFilterAfter(requestTimingFilter, JwtAuthenticationFilter.class);
+            } else {
+                log.warn("SecurityConfig: JwtAuthenticationFilter no disponible, la cadena se construirá sin el filtro JWT");
+            }
+            http.authenticationProvider(jwtAuthenticationProvider);
         }
 
         return http.build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(PasswordEncoder.class)
+    public PasswordEncoder passwordEncoderFallback() {
+        log.warn("SecurityConfig: registrando PasswordEncoder delegating por no existir uno definido en el contexto");
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
     @Bean

--- a/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.willyes.clemenintegra.shared.security;
+
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
+import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class JwtAuthenticationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private JwtTokenService jwtTokenService;
+
+    @SpyBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @SpyBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @BeforeEach
+    void setUp() {
+        unidadMedidaRepository.deleteAll();
+        usuarioRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Un token válido pasa por el filtro y provider permitiendo acceder a endpoints protegidos")
+    void tokenValidoDebePermitirAccesoAEndpointProtegido() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("carlos_test")
+                .clave("dummy")
+                .nombreCompleto("Carlos Test")
+                .correo("carlos@test.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .sessionVersion(1L)
+                .ultimaActividad(LocalDateTime.now())
+                .build());
+
+        unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Kilogramo")
+                .simbolo("kg")
+                .build());
+
+        String token = jwtTokenService.generarToken(usuario);
+
+        mockMvc.perform(get("/api/unidades")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].nombre").value(equalToIgnoringCase("Kilogramo")));
+
+        verify(jwtAuthenticationFilter, atLeastOnce()).doFilter(any(), any(), any());
+
+        ArgumentCaptor<org.springframework.security.core.Authentication> authenticationCaptor =
+                ArgumentCaptor.forClass(org.springframework.security.core.Authentication.class);
+        verify(jwtAuthenticationProvider, atLeastOnce()).authenticate(authenticationCaptor.capture());
+
+        assertThat(authenticationCaptor.getAllValues().stream()
+                .anyMatch(authentication -> authentication instanceof JwtAuthenticationToken)).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- tighten JwtAuthenticationFilter path matching and only register when the AuthenticationManager is available
- make SecurityConfig register the shared AuthenticationManager/provider and filter safely across test slices
- add an integration test to prove valid JWTs authenticate protected inventory endpoints

## Testing
- mvn test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3f36241c8333a19f551ba96b466d)