### PR TITLE
Allow buyer access to reports and explode semi-finished in MRP

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
@@ -40,6 +40,8 @@ import java.util.*;
 @Transactional
 public class MrpServiceImpl implements MrpService {
 
+    private static final int MAX_NIVEL_EXPLOSION = 5;
+
     private final FormulaProductoRepository formulaProductoRepository;
     private final LoteProductoRepository loteProductoRepository;
     private final OrdenCompraDetalleRepository ordenCompraDetalleRepository;
@@ -101,6 +103,10 @@ public class MrpServiceImpl implements MrpService {
             return requerimientos;
         }
 
+        Map<Producto, BigDecimal> requerimientosSemiElaborados = new HashMap<>();
+        LocalDate horizonteInicio = plan.getSemanaInicio();
+        LocalDate horizonteFin = plan.getSemanaFin();
+
         for (PlanProduccionDetalle detallePlan : plan.getDetalles()) {
             if (detallePlan.getProducto() == null || detallePlan.getCantidadPlanificada() == null) {
                 continue;
@@ -120,11 +126,18 @@ public class MrpServiceImpl implements MrpService {
                 if (detalleFormula.getInsumo() == null || detalleFormula.getCantidadNecesaria() == null) {
                     continue;
                 }
+                Producto insumo = detalleFormula.getInsumo();
                 BigDecimal requerido = detalleFormula.getCantidadNecesaria()
                         .multiply(detallePlan.getCantidadPlanificada());
-                requerimientos.merge(detalleFormula.getInsumo(), requerido, BigDecimal::add);
+                requerimientos.merge(insumo, requerido, BigDecimal::add);
+
+                if (esProductoSemiElaborado(insumo)) {
+                    requerimientosSemiElaborados.merge(insumo, requerido, BigDecimal::add);
+                }
             }
         }
+
+        explotarProductosSemiElaborados(requerimientosSemiElaborados, requerimientos, horizonteInicio, horizonteFin);
 
         return requerimientos;
     }
@@ -285,9 +298,11 @@ public class MrpServiceImpl implements MrpService {
     }
 
     private TipoSugerenciaAbastecimiento determinarTipo(Producto producto) {
-        if (producto != null && producto.getCategoriaProducto() != null
-                && producto.getCategoriaProducto().getTipo() == TipoCategoria.PRODUCTO_TERMINADO) {
-            return TipoSugerenciaAbastecimiento.FABRICAR;
+        if (producto != null && producto.getCategoriaProducto() != null) {
+            TipoCategoria tipo = producto.getCategoriaProducto().getTipo();
+            if (tipo == TipoCategoria.PRODUCTO_TERMINADO || tipo == TipoCategoria.PRODUCTO_SEMI_ELABORADO) {
+                return TipoSugerenciaAbastecimiento.FABRICAR;
+            }
         }
         return TipoSugerenciaAbastecimiento.COMPRA;
     }
@@ -377,5 +392,86 @@ public class MrpServiceImpl implements MrpService {
         sugerencia.setNivelCriticidad("BAJO");
         sugerencia.setEsCritico(false);
         sugerencia.setRazonesCriticidad(razones);
+    }
+
+    private void explotarProductosSemiElaborados(Map<Producto, BigDecimal> requerimientosSemiElaborados,
+                                                 Map<Producto, BigDecimal> requerimientos,
+                                                 LocalDate horizonteInicio,
+                                                 LocalDate horizonteFin) {
+        if (requerimientosSemiElaborados.isEmpty()) {
+            return;
+        }
+        Set<Long> visitados = new HashSet<>();
+        for (Map.Entry<Producto, BigDecimal> entry : requerimientosSemiElaborados.entrySet()) {
+            Producto producto = entry.getKey();
+            BigDecimal bruto = entry.getValue() != null ? entry.getValue() : BigDecimal.ZERO;
+            BigDecimal neto = calcularRequerimientoNetoTemporal(producto, bruto, horizonteInicio, horizonteFin);
+            if (neto.compareTo(BigDecimal.ZERO) > 0) {
+                explotarSemiElaboradoRecursivo(producto, neto, requerimientos, horizonteInicio, horizonteFin, visitados, 1);
+            }
+        }
+    }
+
+    private void explotarSemiElaboradoRecursivo(Producto semiElaborado,
+                                                BigDecimal requeridoNeto,
+                                                Map<Producto, BigDecimal> requerimientos,
+                                                LocalDate horizonteInicio,
+                                                LocalDate horizonteFin,
+                                                Set<Long> visitados,
+                                                int nivel) {
+        if (semiElaborado == null || semiElaborado.getId() == null || requeridoNeto == null) {
+            return;
+        }
+        if (nivel > MAX_NIVEL_EXPLOSION) {
+            log.warn("Se alcanzó la profundidad máxima de explosión ({}) para el producto {}", MAX_NIVEL_EXPLOSION, semiElaborado.getId());
+            return;
+        }
+        if (!visitados.add(semiElaborado.getId().longValue())) {
+            log.warn("Detectado ciclo en explosión de BOM para el producto {}", semiElaborado.getId());
+            return;
+        }
+
+        Optional<FormulaProducto> formulaOpt = formulaProductoRepository
+                .findByProductoIdAndEstadoAndActivoTrue(semiElaborado.getId().longValue(), EstadoFormula.APROBADA);
+        if (formulaOpt.isEmpty() || formulaOpt.get().getDetalles() == null) {
+            log.warn("No se encontró fórmula aprobada para el producto {}", semiElaborado.getId());
+            visitados.remove(semiElaborado.getId().longValue());
+            return;
+        }
+
+        for (DetalleFormula detalleFormula : formulaOpt.get().getDetalles()) {
+            if (detalleFormula.getInsumo() == null || detalleFormula.getCantidadNecesaria() == null) {
+                continue;
+            }
+            Producto insumo = detalleFormula.getInsumo();
+            BigDecimal requerido = detalleFormula.getCantidadNecesaria().multiply(requeridoNeto);
+            requerimientos.merge(insumo, requerido, BigDecimal::add);
+
+            if (esProductoSemiElaborado(insumo)) {
+                BigDecimal netoHijo = calcularRequerimientoNetoTemporal(insumo, requerido, horizonteInicio, horizonteFin);
+                if (netoHijo.compareTo(BigDecimal.ZERO) > 0) {
+                    explotarSemiElaboradoRecursivo(insumo, netoHijo, requerimientos, horizonteInicio, horizonteFin, visitados, nivel + 1);
+                }
+            }
+        }
+        visitados.remove(semiElaborado.getId().longValue());
+    }
+
+    private BigDecimal calcularRequerimientoNetoTemporal(Producto producto,
+                                                         BigDecimal bruto,
+                                                         LocalDate horizonteInicio,
+                                                         LocalDate horizonteFin) {
+        if (bruto == null) {
+            return BigDecimal.ZERO;
+        }
+        BigDecimal inventario = obtenerInventarioDisponible(producto);
+        BigDecimal recepciones = obtenerRecepcionesProgramadas(producto, horizonteInicio, horizonteFin);
+        return bruto.subtract(inventario).subtract(recepciones).max(BigDecimal.ZERO);
+    }
+
+    private boolean esProductoSemiElaborado(Producto producto) {
+        return producto != null
+                && producto.getCategoriaProducto() != null
+                && producto.getCategoriaProducto().getTipo() == TipoCategoria.PRODUCTO_SEMI_ELABORADO;
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -252,6 +252,7 @@ public class SecurityConfig {
                     auth.requestMatchers("/api/reportes/**").hasAnyAuthority(
                             RolUsuario.ROL_ALMACENISTA.name(),
                             RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_COMPRADOR.name(),
                             RolUsuario.ROL_ANALISTA_CALIDAD.name(),
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ReporteInventarioControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ReporteInventarioControllerSmokeTest.java
@@ -15,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,6 +32,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 @TestPropertySource(properties = {"DB_SECURPASS=dummy", "DB_SECURNAME=dummy"})
 class ReporteInventarioControllerSmokeTest {
+
+    @TestConfiguration
+    @EnableMethodSecurity(prePostEnabled = true)
+    static class MethodSecurityConfig {
+        // Habilita @PreAuthorize en slice tests.
+    }
 
     @Autowired
     private MockMvc mockMvc;
@@ -74,6 +82,19 @@ class ReporteInventarioControllerSmokeTest {
                         .param("fechaInicio", "2024-01-01")
                         .param("fechaFin", "2024-01-31"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ANALISTA_CALIDAD")
+    @DisplayName("GET /api/reportes/alta-rotacion responde 403 para roles no permitidos")
+    void altaRotacion_restringidoParaRolesNoAutorizados() throws Exception {
+        when(reporteInventarioService.generarReporteAltaRotacion(any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(new XSSFWorkbook());
+
+        mockMvc.perform(get("/api/reportes/alta-rotacion")
+                        .param("fechaInicio", "2024-01-01")
+                        .param("fechaFin", "2024-01-31"))
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
@@ -1,16 +1,23 @@
 package com.willyes.clemenintegra.planeacion.service.impl;
 
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.OrdenCompraDetalleRepository;
-import com.willyes.clemenintegra.inventario.model.Producto;
-import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionDetalle;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoCorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import com.willyes.clemenintegra.planeacion.model.enums.TipoCambioMrp;
+import com.willyes.clemenintegra.planeacion.model.enums.TipoSugerenciaAbastecimiento;
 import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -117,6 +124,84 @@ class MrpServiceImplTest {
 
         assertEquals(BigDecimal.valueOf(5), netos.get(0).getRequerimientoNeto());
         assertEquals(BigDecimal.valueOf(4), netos.get(0).getRecepcionesProgramadas());
+    }
+
+    @Test
+    void explotaSemiElaboradoYPropagaRequerimientos() {
+        Producto productoTerminado = Producto.builder()
+                .id(10)
+                .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.PRODUCTO_TERMINADO).build())
+                .build();
+        Producto semiElaborado = Producto.builder()
+                .id(20)
+                .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO).build())
+                .build();
+        Producto insumoFinal = Producto.builder()
+                .id(30)
+                .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.MATERIA_PRIMA).build())
+                .build();
+
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .estado(EstadoPlanProduccion.CONFIRMADO)
+                .semanaInicio(LocalDate.of(2024, 2, 5))
+                .semanaFin(LocalDate.of(2024, 2, 11))
+                .detalles(new ArrayList<>())
+                .build();
+        plan.getDetalles().add(PlanProduccionDetalle.builder()
+                .plan(plan)
+                .producto(productoTerminado)
+                .cantidadPlanificada(BigDecimal.ONE)
+                .build());
+
+        FormulaProducto formulaPt = FormulaProducto.builder()
+                .producto(productoTerminado)
+                .estado(EstadoFormula.APROBADA)
+                .detalles(List.of(DetalleFormula.builder()
+                        .insumo(semiElaborado)
+                        .cantidadNecesaria(BigDecimal.TEN)
+                        .build()))
+                .build();
+        FormulaProducto formulaPs = FormulaProducto.builder()
+                .producto(semiElaborado)
+                .estado(EstadoFormula.APROBADA)
+                .detalles(List.of(DetalleFormula.builder()
+                        .insumo(insumoFinal)
+                        .cantidadNecesaria(BigDecimal.valueOf(2))
+                        .build()))
+                .build();
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(productoTerminado.getId().longValue(), EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaPt));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(semiElaborado.getId().longValue(), EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaPs));
+
+        mockInventarioDisponible(Map.of(
+                semiElaborado.getId().longValue(), BigDecimal.valueOf(3),
+                insumoFinal.getId().longValue(), BigDecimal.ZERO
+        ));
+        mockRecepcionesProgramadas(Map.of(semiElaborado.getId().longValue(), BigDecimal.ONE));
+
+        Map<Producto, BigDecimal> brutos = service.calcularRequerimientosBrutos(plan);
+
+        assertEquals(BigDecimal.TEN, brutos.get(semiElaborado));
+        assertEquals(BigDecimal.valueOf(12), brutos.get(insumoFinal));
+
+        List<DetalleCorridaMrp> netos = service.calcularRequerimientosNetos(
+                brutos, plan.getSemanaInicio(), plan.getSemanaFin());
+        Map<Integer, DetalleCorridaMrp> netosPorProducto = netos.stream()
+                .collect(java.util.stream.Collectors.toMap(d -> d.getProducto().getId(), d -> d));
+
+        assertEquals(BigDecimal.valueOf(6), netosPorProducto.get(semiElaborado.getId()).getRequerimientoNeto());
+        assertEquals(BigDecimal.valueOf(12), netosPorProducto.get(insumoFinal.getId()).getRequerimientoNeto());
+
+        List<com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento> sugerencias = service.generarSugerencias(netos);
+        TipoSugerenciaAbastecimiento tipoSugerenciaSemi = sugerencias.stream()
+                .filter(s -> s.getDetalleCorrida().getProducto().getId().equals(semiElaborado.getId()))
+                .findFirst()
+                .map(com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento::getTipo)
+                .orElse(null);
+
+        assertEquals(TipoSugerenciaAbastecimiento.FABRICAR, tipoSugerenciaSemi);
     }
 
     @Test
@@ -284,9 +369,26 @@ class MrpServiceImplTest {
         when(loteProductoRepository.sumarPorEstado(anyLong())).thenReturn(resultados);
     }
 
+    private void mockInventarioDisponible(Map<Long, BigDecimal> cantidadesPorProducto) {
+        when(loteProductoRepository.sumarPorEstado(anyLong())).thenAnswer(invocation -> {
+            Long productoId = invocation.getArgument(0);
+            BigDecimal cantidad = cantidadesPorProducto.getOrDefault(productoId, BigDecimal.ZERO);
+            return List.<Object[]>of(new Object[]{EstadoLote.DISPONIBLE, cantidad});
+        });
+    }
+
     private void mockRecepcionesProgramadas(BigDecimal cantidad) {
         when(ordenCompraDetalleRepository.sumarCantidadPendientePorProductoYEstadoYFechas(
                 anyLong(), anyList(), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(cantidad);
+    }
+
+    private void mockRecepcionesProgramadas(Map<Long, BigDecimal> cantidadesPorProducto) {
+        when(ordenCompraDetalleRepository.sumarCantidadPendientePorProductoYEstadoYFechas(
+                anyLong(), anyList(), any(LocalDate.class), any(LocalDate.class)))
+                .thenAnswer(invocation -> {
+                    Long productoId = invocation.getArgument(0);
+                    return cantidadesPorProducto.getOrDefault(productoId, BigDecimal.ZERO);
+                });
     }
 }


### PR DESCRIPTION
## Summary
- allow ROL_COMPRADOR to access inventory rotation reports and enforce unauthorized access coverage in smoke tests
- adjust MRP suggestion typing to treat semi-finished products as fabrication and explode their BOM when net requirements remain
- add regression coverage for multi-level PS explosion and report endpoints

## Testing
- mvn -q -Dtest=MrpServiceImplTest,ReporteInventarioControllerSmokeTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed23bf5c88333ad362b1c71e1da6d)