### PR TITLE
Alinear métricas enriquecidas en GET de corridas MRP

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
@@ -180,19 +180,48 @@ public class MrpServiceImpl implements MrpService {
         }
 
         for (DetalleCorridaMrp detalle : requerimientosNetos) {
-            if (detalle.getRequerimientoNeto() == null ||
-                    detalle.getRequerimientoNeto().compareTo(BigDecimal.ZERO) <= 0) {
-                continue;
+            SugerenciaAbastecimiento sugerencia = prepararSugerencia(detalle);
+            if (sugerencia != null) {
+                sugerencias.add(sugerencia);
             }
-            Producto producto = detalle.getProducto();
-            TipoSugerenciaAbastecimiento tipo = determinarTipo(producto);
-            Integer leadTime = obtenerLeadTime(tipo, producto);
-            LocalDate fechaNecesidad = detalle.getCorrida() != null && detalle.getCorrida().getHorizonteFin() != null
-                    ? detalle.getCorrida().getHorizonteFin()
-                    : LocalDate.now();
-            LocalDate fechaLanzamiento = leadTime != null ? fechaNecesidad.minusDays(leadTime) : fechaNecesidad;
+        }
+        return sugerencias;
+    }
 
-            SugerenciaAbastecimiento sugerencia = SugerenciaAbastecimiento.builder()
+    @Override
+    @Transactional(readOnly = true)
+    public CorridaMrp obtenerCorrida(Long id) {
+        CorridaMrp corrida = corridaMrpRepository.findWithDetallesById(id)
+                .orElseThrow(() -> new NoSuchElementException("Corrida MRP no encontrada"));
+        // Las métricas de cobertura y criticidad son transitorias; al cargar desde BD deben recalcularse
+        // para que el GET entregue el mismo DTO enriquecido que el POST.
+        enriquecerCorrida(corrida);
+        return corrida;
+    }
+
+    private void enriquecerCorrida(CorridaMrp corrida) {
+        if (corrida == null || corrida.getDetalles() == null) {
+            return;
+        }
+        corrida.getDetalles().forEach(this::prepararSugerencia);
+    }
+
+    private SugerenciaAbastecimiento prepararSugerencia(DetalleCorridaMrp detalle) {
+        if (detalle == null || detalle.getRequerimientoNeto() == null ||
+                detalle.getRequerimientoNeto().compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        Producto producto = detalle.getProducto();
+        TipoSugerenciaAbastecimiento tipo = determinarTipo(producto);
+        Integer leadTime = obtenerLeadTime(tipo, producto);
+        LocalDate fechaNecesidad = detalle.getCorrida() != null && detalle.getCorrida().getHorizonteFin() != null
+                ? detalle.getCorrida().getHorizonteFin()
+                : LocalDate.now();
+        LocalDate fechaLanzamiento = leadTime != null ? fechaNecesidad.minusDays(leadTime) : fechaNecesidad;
+
+        SugerenciaAbastecimiento sugerencia = detalle.getSugerencia();
+        if (sugerencia == null) {
+            sugerencia = SugerenciaAbastecimiento.builder()
                     .detalleCorrida(detalle)
                     .tipo(tipo)
                     .cantidadSugerida(detalle.getRequerimientoNeto())
@@ -201,30 +230,46 @@ public class MrpServiceImpl implements MrpService {
                     .leadTimeDias(leadTime)
                     .estado(EstadoSugerenciaAbastecimiento.PENDIENTE)
                     .build();
-            // Métricas de consumo y cobertura para exponer al frontend.
-            BigDecimal consumoTotal = Optional.ofNullable(detalle.getRequerimientoBruto()).orElse(BigDecimal.ZERO);
-            sugerencia.setConsumoTotalPeriodo(consumoTotal);
-
-            BigDecimal horizonteSemanas = calcularHorizonteSemanas(detalle.getCorrida());
-            BigDecimal consumoSemanalPromedio = calcularConsumoSemanalPromedio(consumoTotal, horizonteSemanas);
-            sugerencia.setConsumoSemanalPromedio(consumoSemanalPromedio);
-
-            BigDecimal semanasCobertura = calcularSemanasCobertura(detalle, consumoSemanalPromedio);
-            sugerencia.setSemanasCobertura(semanasCobertura);
-
-            // Determinar criticidad basada en la cobertura y lead time.
-            asignarCriticidad(sugerencia, leadTime);
             detalle.setSugerencia(sugerencia);
-            sugerencias.add(sugerencia);
+        } else {
+            sugerencia.setDetalleCorrida(detalle);
+            if (sugerencia.getTipo() == null) {
+                sugerencia.setTipo(tipo);
+            }
+            if (sugerencia.getCantidadSugerida() == null) {
+                sugerencia.setCantidadSugerida(detalle.getRequerimientoNeto());
+            }
+            if (sugerencia.getFechaNecesidad() == null) {
+                sugerencia.setFechaNecesidad(fechaNecesidad);
+            }
+            if (sugerencia.getFechaSugeridaLanzamiento() == null) {
+                sugerencia.setFechaSugeridaLanzamiento(fechaLanzamiento);
+            }
+            if (sugerencia.getLeadTimeDias() == null) {
+                sugerencia.setLeadTimeDias(leadTime);
+            }
+            if (sugerencia.getEstado() == null) {
+                sugerencia.setEstado(EstadoSugerenciaAbastecimiento.PENDIENTE);
+            }
         }
-        return sugerencias;
+
+        enriquecerMetricas(detalle, sugerencia, leadTime);
+        return sugerencia;
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public CorridaMrp obtenerCorrida(Long id) {
-        return corridaMrpRepository.findWithDetallesById(id)
-                .orElseThrow(() -> new NoSuchElementException("Corrida MRP no encontrada"));
+    private void enriquecerMetricas(DetalleCorridaMrp detalle, SugerenciaAbastecimiento sugerencia, Integer leadTimeDias) {
+        BigDecimal consumoTotal = Optional.ofNullable(detalle.getRequerimientoBruto()).orElse(BigDecimal.ZERO);
+        sugerencia.setConsumoTotalPeriodo(consumoTotal);
+
+        BigDecimal horizonteSemanas = calcularHorizonteSemanas(detalle.getCorrida());
+        BigDecimal consumoSemanalPromedio = calcularConsumoSemanalPromedio(consumoTotal, horizonteSemanas);
+        sugerencia.setConsumoSemanalPromedio(consumoSemanalPromedio);
+
+        BigDecimal semanasCobertura = calcularSemanasCobertura(detalle, consumoSemanalPromedio);
+        sugerencia.setSemanasCobertura(semanasCobertura);
+
+        Integer leadTimeParaCriticidad = leadTimeDias != null ? leadTimeDias : sugerencia.getLeadTimeDias();
+        asignarCriticidad(sugerencia, leadTimeParaCriticidad);
     }
 
     private Map<String, BigDecimal> construirMapaNetos(Optional<CorridaMrp> corridaAnterior) {

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
@@ -6,18 +6,28 @@ import com.willyes.clemenintegra.planeacion.dto.CorridaMrpResponseDTO;
 import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.enums.TipoCambioMrp;
+import com.willyes.clemenintegra.planeacion.repository.CorridaMrpRepository;
 import com.willyes.clemenintegra.planeacion.service.MrpReporteService;
 import com.willyes.clemenintegra.planeacion.service.MrpService;
+import com.willyes.clemenintegra.planeacion.service.impl.MrpServiceImpl;
 import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraDetalleRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class MrpControllerTest {
 
@@ -89,5 +99,72 @@ class MrpControllerTest {
         assertEquals(TipoCambioMrp.AUMENTO.name(), dto.getDetalles().get(1).getTipoCambio());
         assertEquals(TipoCambioMrp.SIN_CAMBIO.name(), dto.getDetalles().get(2).getTipoCambio());
     }
-}
 
+    @Test
+    void obtenerDebeEnriquecerMetricasParaGet() {
+        FormulaProductoRepository formulaProductoRepository = mock(FormulaProductoRepository.class);
+        LoteProductoRepository loteProductoRepository = mock(LoteProductoRepository.class);
+        OrdenCompraDetalleRepository ordenCompraDetalleRepository = mock(OrdenCompraDetalleRepository.class);
+        CorridaMrpRepository corridaMrpRepository = mock(CorridaMrpRepository.class);
+        MrpServiceImpl service = new MrpServiceImpl(
+                formulaProductoRepository,
+                loteProductoRepository,
+                ordenCompraDetalleRepository,
+                corridaMrpRepository
+        );
+        MrpController controller = new MrpController(
+                service,
+                mock(PlanProduccionService.class),
+                mock(MrpReporteService.class)
+        );
+
+        CategoriaProducto categoria = CategoriaProducto.builder()
+                .id(2L)
+                .nombre("Materia Prima")
+                .build();
+        Producto producto = Producto.builder()
+                .id(10)
+                .codigoSku("SKU-PS-1")
+                .nombre("Producto Semielaborado")
+                .categoriaProducto(categoria)
+                .leadTimeCompraDias(7)
+                .build();
+
+        CorridaMrp corrida = CorridaMrp.builder()
+                .id(99L)
+                .horizonteInicio(java.time.LocalDate.of(2024, 1, 1))
+                .horizonteFin(java.time.LocalDate.of(2024, 1, 14))
+                .detalles(new java.util.ArrayList<>())
+                .build();
+        DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
+                .id(100L)
+                .corrida(corrida)
+                .producto(producto)
+                .requerimientoBruto(BigDecimal.valueOf(50))
+                .inventarioDisponible(BigDecimal.valueOf(10))
+                .recepcionesProgramadas(BigDecimal.valueOf(5))
+                .requerimientoNeto(BigDecimal.valueOf(20))
+                .nivelBom(1)
+                .build();
+        corrida.getDetalles().add(detalle);
+        when(corridaMrpRepository.findWithDetallesById(99L)).thenReturn(Optional.of(corrida));
+
+        ResponseEntity<?> response = controller.obtener(99L);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody() instanceof CorridaMrpResponseDTO);
+        CorridaMrpResponseDTO dto = (CorridaMrpResponseDTO) response.getBody();
+        assertNotNull(dto.getDetalles());
+        assertEquals(1, dto.getDetalles().size());
+        CorridaMrpResponseDTO.DetalleCorridaMrpDTO detalleDto = dto.getDetalles().get(0);
+        assertNotNull(detalleDto.getConsumoSemanalPromedio());
+        assertNotNull(detalleDto.getSemanasCobertura());
+
+        assertNotNull(dto.getSugerencias());
+        assertEquals(1, dto.getSugerencias().size());
+        CorridaMrpResponseDTO.SugerenciaAbastecimientoDTO sugerenciaDto = dto.getSugerencias().get(0);
+        assertNotNull(sugerenciaDto.getConsumoSemanalPromedio());
+        assertNotNull(sugerenciaDto.getSemanasCobertura());
+        assertNotNull(sugerenciaDto.getNivelCriticidad());
+        assertNotNull(sugerenciaDto.getEsCritico());
+    }
+}


### PR DESCRIPTION
## Summary
- Refactorizar el cálculo de métricas y criticidad de sugerencias en MrpServiceImpl para reutilizarlo al recuperar corridas
- Recalcular métricas transitorias al obtener corridas por GET para devolver el mismo DTO enriquecido que en POST
- Agregar prueba del controlador que valida la presencia de métricas y criticidad en la respuesta GET de corridas

## Testing
- mvn -q -Dtest=MrpServiceImplTest,MrpControllerTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee5c69e348333bf4bb9bf0f7dbf0e)