### PR TITLE
Ensure coverage uses gross demand when net requirement is zero

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
@@ -207,10 +207,14 @@ public class MrpServiceImpl implements MrpService {
     }
 
     private SugerenciaAbastecimiento prepararSugerencia(DetalleCorridaMrp detalle) {
-        if (detalle == null || detalle.getRequerimientoNeto() == null ||
-                detalle.getRequerimientoNeto().compareTo(BigDecimal.ZERO) <= 0) {
+        if (detalle == null) {
             return null;
         }
+        BigDecimal requerimientoBruto = Optional.ofNullable(detalle.getRequerimientoBruto()).orElse(BigDecimal.ZERO);
+        if (requerimientoBruto.compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        BigDecimal requerimientoNeto = Optional.ofNullable(detalle.getRequerimientoNeto()).orElse(BigDecimal.ZERO);
         Producto producto = detalle.getProducto();
         TipoSugerenciaAbastecimiento tipo = determinarTipo(producto);
         Integer leadTime = obtenerLeadTime(tipo, producto);
@@ -224,7 +228,7 @@ public class MrpServiceImpl implements MrpService {
             sugerencia = SugerenciaAbastecimiento.builder()
                     .detalleCorrida(detalle)
                     .tipo(tipo)
-                    .cantidadSugerida(detalle.getRequerimientoNeto())
+                    .cantidadSugerida(requerimientoNeto)
                     .fechaNecesidad(fechaNecesidad)
                     .fechaSugeridaLanzamiento(fechaLanzamiento)
                     .leadTimeDias(leadTime)
@@ -237,7 +241,7 @@ public class MrpServiceImpl implements MrpService {
                 sugerencia.setTipo(tipo);
             }
             if (sugerencia.getCantidadSugerida() == null) {
-                sugerencia.setCantidadSugerida(detalle.getRequerimientoNeto());
+                sugerencia.setCantidadSugerida(requerimientoNeto);
             }
             if (sugerencia.getFechaNecesidad() == null) {
                 sugerencia.setFechaNecesidad(fechaNecesidad);

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
@@ -332,6 +332,38 @@ class MrpServiceImplTest {
     }
 
     @Test
+    void calculaConsumoYCoberturaAunqueElNetoSeaCero() {
+        CorridaMrp corrida = CorridaMrp.builder()
+                .horizonteInicio(LocalDate.of(2024, 2, 5))
+                .horizonteFin(LocalDate.of(2024, 2, 11))
+                .build();
+        Producto producto = Producto.builder()
+                .id(105)
+                .leadTimeCompraDias(7)
+                .build();
+        DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
+                .corrida(corrida)
+                .producto(producto)
+                .requerimientoBruto(BigDecimal.valueOf(50))
+                .inventarioDisponible(BigDecimal.valueOf(200))
+                .recepcionesProgramadas(BigDecimal.ZERO)
+                .requerimientoNeto(BigDecimal.ZERO)
+                .nivelBom(1)
+                .build();
+
+        List<com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento> sugerencias = service.generarSugerencias(List.of(detalle));
+
+        assertEquals(1, sugerencias.size());
+        com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento sugerencia = sugerencias.get(0);
+
+        assertEquals(BigDecimal.valueOf(50.00).setScale(2), sugerencia.getConsumoSemanalPromedio());
+        assertEquals(BigDecimal.valueOf(4.00).setScale(2), sugerencia.getSemanasCobertura());
+        assertEquals(Boolean.FALSE, sugerencia.getEsCritico());
+        assertNotNull(sugerencia.getConsumoSemanalPromedio());
+        assertNotNull(sugerencia.getSemanasCobertura());
+    }
+
+    @Test
     void calculaConsumoYcoberturaCuandoHorizonteEsMenorAUnaSemana() {
         CorridaMrp corrida = CorridaMrp.builder()
                 .horizonteInicio(LocalDate.of(2025, 12, 28))


### PR DESCRIPTION
## Summary
- calculate consumption and coverage metrics even when net requirements are zero by deriving them from gross demand
- keep criticidad evaluation tied to coverage regardless of net requirement
- add regression test covering scenarios with zero net requirement but positive inventory

## Testing
- mvn -q -Dtest=MrpServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eef8bad448333bac395f8c7ea85d9)