### PR TITLE
Ensure criticidad reasons are populated for MRP outputs

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
@@ -411,14 +411,17 @@ public class MrpServiceImpl implements MrpService {
                 ? BigDecimal.valueOf(leadTimeDias).divide(BigDecimal.valueOf(7), 2, RoundingMode.HALF_UP)
                 : null;
 
+        boolean esCritico = false;
         if (semanasCobertura.compareTo(BigDecimal.ONE) < 0) {
             razones.add("COBERTURA_MENOR_A_1_SEMANA");
+            esCritico = true;
         }
         if (leadTimeSemanas != null && semanasCobertura.compareTo(leadTimeSemanas) < 0) {
             razones.add("COBERTURA_MENOR_A_LEAD_TIME");
+            esCritico = true;
         }
 
-        if (!razones.isEmpty()) {
+        if (esCritico) {
             sugerencia.setNivelCriticidad("CRITICO");
             sugerencia.setEsCritico(true);
             sugerencia.setRazonesCriticidad(razones);

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
@@ -167,4 +167,90 @@ class MrpControllerTest {
         assertNotNull(sugerenciaDto.getNivelCriticidad());
         assertNotNull(sugerenciaDto.getEsCritico());
     }
+
+    @Test
+    void obtenerDebeRetornarRazonesCriticidadParaAltoYCritico() {
+        FormulaProductoRepository formulaProductoRepository = mock(FormulaProductoRepository.class);
+        LoteProductoRepository loteProductoRepository = mock(LoteProductoRepository.class);
+        OrdenCompraDetalleRepository ordenCompraDetalleRepository = mock(OrdenCompraDetalleRepository.class);
+        CorridaMrpRepository corridaMrpRepository = mock(CorridaMrpRepository.class);
+        MrpServiceImpl service = new MrpServiceImpl(
+                formulaProductoRepository,
+                loteProductoRepository,
+                ordenCompraDetalleRepository,
+                corridaMrpRepository
+        );
+        MrpController controller = new MrpController(
+                service,
+                mock(PlanProduccionService.class),
+                mock(MrpReporteService.class)
+        );
+
+        CorridaMrp corrida = CorridaMrp.builder()
+                .id(100L)
+                .horizonteInicio(java.time.LocalDate.of(2024, 1, 1))
+                .horizonteFin(java.time.LocalDate.of(2024, 1, 14))
+                .detalles(new java.util.ArrayList<>())
+                .build();
+
+        CategoriaProducto categoria = CategoriaProducto.builder()
+                .id(3L)
+                .nombre("Categoria 3")
+                .build();
+        Producto productoAlto = Producto.builder()
+                .id(50)
+                .codigoSku("SKU-ALTO")
+                .nombre("Producto Alto")
+                .categoriaProducto(categoria)
+                .leadTimeCompraDias(7)
+                .build();
+        DetalleCorridaMrp detalleAlto = DetalleCorridaMrp.builder()
+                .id(101L)
+                .corrida(corrida)
+                .producto(productoAlto)
+                .requerimientoBruto(BigDecimal.valueOf(50))
+                .inventarioDisponible(BigDecimal.valueOf(40))
+                .recepcionesProgramadas(BigDecimal.valueOf(10))
+                .requerimientoNeto(BigDecimal.valueOf(5))
+                .nivelBom(1)
+                .build();
+
+        Producto productoCritico = Producto.builder()
+                .id(60)
+                .codigoSku("SKU-CRITICO")
+                .nombre("Producto Critico")
+                .categoriaProducto(categoria)
+                .leadTimeCompraDias(21)
+                .build();
+        DetalleCorridaMrp detalleCritico = DetalleCorridaMrp.builder()
+                .id(102L)
+                .corrida(corrida)
+                .producto(productoCritico)
+                .requerimientoBruto(BigDecimal.valueOf(50))
+                .inventarioDisponible(BigDecimal.valueOf(5))
+                .recepcionesProgramadas(BigDecimal.ZERO)
+                .requerimientoNeto(BigDecimal.valueOf(45))
+                .nivelBom(1)
+                .build();
+
+        corrida.getDetalles().add(detalleAlto);
+        corrida.getDetalles().add(detalleCritico);
+        when(corridaMrpRepository.findWithDetallesById(100L)).thenReturn(Optional.of(corrida));
+
+        ResponseEntity<?> response = controller.obtener(100L);
+        CorridaMrpResponseDTO dto = (CorridaMrpResponseDTO) response.getBody();
+
+        assertNotNull(dto);
+        assertEquals(2, dto.getDetalles().size());
+        CorridaMrpResponseDTO.DetalleCorridaMrpDTO detalleDtoAlto = dto.getDetalles().get(0);
+        assertNotNull(detalleDtoAlto.getRazonesCriticidad());
+        assertEquals("ALTO", detalleDtoAlto.getCriticidad());
+        assertTrue(detalleDtoAlto.getRazonesCriticidad().contains("COBERTURA_MENOR_A_3_SEMANAS"));
+
+        CorridaMrpResponseDTO.DetalleCorridaMrpDTO detalleDtoCritico = dto.getDetalles().get(1);
+        assertNotNull(detalleDtoCritico.getRazonesCriticidad());
+        assertEquals("CRITICO", detalleDtoCritico.getCriticidad());
+        assertTrue(detalleDtoCritico.getRazonesCriticidad().contains("COBERTURA_MENOR_A_1_SEMANA"));
+        assertTrue(detalleDtoCritico.getRazonesCriticidad().contains("COBERTURA_MENOR_A_LEAD_TIME"));
+    }
 }

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -202,6 +203,70 @@ class MrpServiceImplTest {
                 .orElse(null);
 
         assertEquals(TipoSugerenciaAbastecimiento.FABRICAR, tipoSugerenciaSemi);
+    }
+
+    @Test
+    void asignaRazonesParaCriticidadAlta() {
+        Producto producto = Producto.builder()
+                .id(30)
+                .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.MATERIA_PRIMA).build())
+                .leadTimeCompraDias(7)
+                .build();
+        CorridaMrp corrida = CorridaMrp.builder()
+                .horizonteInicio(LocalDate.of(2024, 1, 1))
+                .horizonteFin(LocalDate.of(2024, 1, 14))
+                .build();
+        DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
+                .corrida(corrida)
+                .producto(producto)
+                .requerimientoBruto(BigDecimal.valueOf(50))
+                .inventarioDisponible(BigDecimal.valueOf(40))
+                .recepcionesProgramadas(BigDecimal.valueOf(10))
+                .requerimientoNeto(BigDecimal.ZERO)
+                .nivelBom(1)
+                .build();
+
+        List<com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento> sugerencias =
+                service.generarSugerencias(List.of(detalle));
+
+        assertEquals(1, sugerencias.size());
+        com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento sugerencia = sugerencias.get(0);
+        assertEquals("ALTO", sugerencia.getNivelCriticidad());
+        assertNotNull(sugerencia.getRazonesCriticidad());
+        assertEquals(1, sugerencia.getRazonesCriticidad().size());
+        assertEquals("COBERTURA_MENOR_A_3_SEMANAS", sugerencia.getRazonesCriticidad().get(0));
+    }
+
+    @Test
+    void asignaRazonesParaCriticidadCritica() {
+        Producto producto = Producto.builder()
+                .id(40)
+                .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.MATERIA_PRIMA).build())
+                .leadTimeCompraDias(21)
+                .build();
+        CorridaMrp corrida = CorridaMrp.builder()
+                .horizonteInicio(LocalDate.of(2024, 1, 1))
+                .horizonteFin(LocalDate.of(2024, 1, 14))
+                .build();
+        DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
+                .corrida(corrida)
+                .producto(producto)
+                .requerimientoBruto(BigDecimal.valueOf(50))
+                .inventarioDisponible(BigDecimal.valueOf(5))
+                .recepcionesProgramadas(BigDecimal.ZERO)
+                .requerimientoNeto(BigDecimal.valueOf(45))
+                .nivelBom(1)
+                .build();
+
+        List<com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento> sugerencias =
+                service.generarSugerencias(List.of(detalle));
+
+        assertEquals(1, sugerencias.size());
+        com.willyes.clemenintegra.planeacion.model.SugerenciaAbastecimiento sugerencia = sugerencias.get(0);
+        assertEquals("CRITICO", sugerencia.getNivelCriticidad());
+        assertNotNull(sugerencia.getRazonesCriticidad());
+        assertTrue(sugerencia.getRazonesCriticidad().contains("COBERTURA_MENOR_A_1_SEMANA"));
+        assertTrue(sugerencia.getRazonesCriticidad().contains("COBERTURA_MENOR_A_LEAD_TIME"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- refine criticidad assignment to always include reasons for critical and high coverage cases
- add service-level tests for ALTO and CRITICO criticidad reasons
- validate controller responses return criticidad reasons for ALTO/CRITICO via GET corrida

## Testing
- mvn -q -Dtest=MrpServiceImplTest,MrpControllerTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ef749a90c8333b6a63fbe824dcb9f)