### PR TITLE
Garantiza acceso de SUPER_ADMIN y smoke tests de seguridad

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -60,7 +60,7 @@ public class OrdenCompraController {
     private final OrdenCompraMapper mapper;
 
     @PostMapping
-    @PreAuthorize("hasAuthority('ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<OrdenCompra> crear(@RequestBody OrdenCompraRequestDTO dto) {
         // 1. Validar proveedor

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerSecurityTest.java
@@ -1,0 +1,125 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraDetalleRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.OrdenCompraRequestDTO;
+import com.willyes.clemenintegra.inventario.model.OrdenCompra;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.Proveedor;
+import com.willyes.clemenintegra.inventario.model.enums.CondicionesPago;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.mapper.OrdenCompraMapper;
+import com.willyes.clemenintegra.inventario.mapper.RecepcionOCMapper;
+import com.willyes.clemenintegra.inventario.service.HistorialEstadoOrdenService;
+import com.willyes.clemenintegra.inventario.service.OrdenCompraPdfService;
+import com.willyes.clemenintegra.inventario.service.OrdenCompraService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        OrdenCompraController.class,
+        OrdenCompraControllerSecurityTest.MethodSecurityConfig.class
+})
+class OrdenCompraControllerSecurityTest {
+
+    @Configuration
+    @EnableMethodSecurity
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private OrdenCompraController ordenCompraController;
+
+    @MockBean
+    private OrdenCompraRepository ordenCompraRepository;
+    @MockBean
+    private OrdenCompraDetalleRepository detalleRepository;
+    @MockBean
+    private ProveedorRepository proveedorRepository;
+    @MockBean
+    private ProductoRepository productoRepository;
+    @MockBean
+    private OrdenCompraService ordenCompraService;
+    @MockBean
+    private HistorialEstadoOrdenService historialEstadoOrdenService;
+    @MockBean
+    private RecepcionOCRepository recepcionOCRepository;
+    @MockBean
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @MockBean
+    private MovimientoInventarioMapper movimientoInventarioMapper;
+    @MockBean
+    private RecepcionOCMapper recepcionOCMapper;
+    @MockBean
+    private OrdenCompraPdfService ordenCompraPdfService;
+    @MockBean
+    private OrdenCompraMapper ordenCompraMapper;
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void crearOrdenCompraPermiteSuperAdmin() throws Exception {
+        Proveedor proveedor = new Proveedor();
+        proveedor.setId(1);
+
+        Producto producto = new Producto();
+        producto.setId(2);
+
+        when(proveedorRepository.findById(1L)).thenReturn(Optional.of(proveedor));
+        when(productoRepository.findById(2L)).thenReturn(Optional.of(producto));
+        when(ordenCompraService.calcularFechaCompromisoEntrega(any())).thenReturn(LocalDate.now());
+        when(ordenCompraService.generarCodigoOrdenCompra()).thenReturn("OC-001");
+
+        OrdenCompra guardada = OrdenCompra.builder()
+                .id(10)
+                .proveedor(proveedor)
+                .fechaOrden(LocalDateTime.now())
+                .detalles(List.of())
+                .build();
+        when(ordenCompraRepository.save(any(OrdenCompra.class))).thenReturn(guardada);
+
+        OrdenCompraDetalleRequestDTO detalle = new OrdenCompraDetalleRequestDTO(
+                2L,
+                BigDecimal.ONE,
+                new BigDecimal("100.00"),
+                BigDecimal.ZERO,
+                LocalDate.now().plusDays(7)
+        );
+
+        OrdenCompraRequestDTO request = new OrdenCompraRequestDTO(
+                1L,
+                CondicionesPago.CONTADO,
+                "comprador",
+                "obs",
+                BigDecimal.ZERO,
+                LocalDate.now().plusDays(10),
+                List.of(detalle)
+        );
+
+        var response = ordenCompraController.crear(request);
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioControllerSecurityTest.java
@@ -1,0 +1,67 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
+import com.willyes.clemenintegra.inventario.service.ProductoService;
+import com.willyes.clemenintegra.inventario.service.ReporteInventarioService;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        ReporteInventarioController.class,
+        ReporteInventarioControllerSecurityTest.MethodSecurityConfig.class
+})
+class ReporteInventarioControllerSecurityTest {
+
+    @Configuration
+    @EnableMethodSecurity
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private ReporteInventarioController reporteInventarioController;
+
+    @MockBean
+    private ReporteInventarioService reporteInventarioService;
+    @MockBean
+    private ProductoService productoService;
+    @MockBean
+    private LoteProductoService loteProductoService;
+    @MockBean
+    private MovimientoInventarioService movimientoInventarioService;
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void altaRotacionPermiteSuperAdmin() throws Exception {
+        when(reporteInventarioService.generarReporteAltaRotacion(any(), any()))
+                .thenReturn(new XSSFWorkbook());
+
+        var response = reporteInventarioController.altaRotacion(
+                LocalDate.now(),
+                LocalDate.now().plusDays(1)
+        );
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerSecurityTest.java
@@ -1,0 +1,76 @@
+package com.willyes.clemenintegra.planeacion.controller;
+
+import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.service.MrpReporteService;
+import com.willyes.clemenintegra.planeacion.service.MrpService;
+import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        MrpController.class,
+        MrpControllerSecurityTest.MethodSecurityConfig.class
+})
+class MrpControllerSecurityTest {
+
+    @Configuration
+    @EnableMethodSecurity
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private MrpController mrpController;
+
+    @MockBean
+    private MrpService mrpService;
+    @MockBean
+    private PlanProduccionService planProduccionService;
+    @MockBean
+    private MrpReporteService mrpReporteService;
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void postCorridaPermiteSuperAdmin() throws Exception {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder().id(1L).build();
+        when(planProduccionService.buscarPorId(1L)).thenReturn(Optional.of(plan));
+        when(mrpService.ejecutarCorridaSemana(plan)).thenReturn(CorridaMrp.builder().id(5L).build());
+
+        MrpController.CorridaMrpRequest request = new MrpController.CorridaMrpRequest();
+        java.lang.reflect.Field planIdField = MrpController.CorridaMrpRequest.class.getDeclaredField("planSemanalId");
+        planIdField.setAccessible(true);
+        planIdField.set(request, 1L);
+
+        var response = mrpController.ejecutar(request);
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void getCorridaPermiteSuperAdmin() throws Exception {
+        when(mrpService.obtenerCorrida(9L)).thenReturn(CorridaMrp.builder().id(9L).build());
+
+        var response = mrpController.obtener(9L);
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -121,6 +121,29 @@ class OrdenProduccionControllerTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    @DisplayName("POST /api/produccion/ordenes permite SUPER_ADMIN")
+    void crearOrden_superAdminPermitido() throws Exception {
+        OrdenProduccionResponseDTO orden = new OrdenProduccionResponseDTO();
+        orden.id = 101L;
+        orden.codigoOrden = "OP-SA";
+
+        ResultadoValidacionOrdenDTO respuesta = ResultadoValidacionOrdenDTO.builder()
+                .esValida(true)
+                .mensaje("ok")
+                .orden(orden)
+                .build();
+
+        when(ordenProduccionService.crearOrden(any(OrdenProduccionRequestDTO.class))).thenReturn(respuesta);
+
+        mockMvc.perform(post("/api/produccion/ordenes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(buildRequest())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.esValida").value(true));
+    }
+
+    @Test
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     @DisplayName("POST /api/produccion/ordenes retorna 400 con code STOCK_INSUFICIENTE")
     void crearOrden_insuficiente() throws Exception {


### PR DESCRIPTION
## Summary
- Añadí ROL_SUPER_ADMIN al POST /api/inventario/ordenes para que el rol tenga acceso explícito.
- Incorporé pruebas de humo con @WithMockUser(SUPER_ADMIN) para compras, producción, MRP y reportes, asegurando respuestas 2xx.

## Endpoints cubiertos por pruebas
- POST /api/inventario/ordenes
- POST /api/produccion/ordenes
- POST /api/mrp/corridas y GET /api/mrp/corridas/{id}
- GET /api/reportes/alta-rotacion

## Testing
- mvn -q -Dtest="OrdenCompraControllerSecurityTest,OrdenProduccionControllerTest,MrpControllerSecurityTest,ReporteInventarioControllerSecurityTest" test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694efbb7926c83338f6bfaec7f892ef2)