### PR TITLE
Add consumptions per stage endpoint and stage handling

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -107,6 +107,15 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
             ClasificacionMovimientoInventario clasificacion,
             Pageable pageable);
 
+    List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdOrderByFechaIngresoAsc(
+            Long ordenProduccionId,
+            Long ordenProduccionEtapaId);
+
+    List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(
+            Long ordenProduccionId,
+            Long ordenProduccionEtapaId,
+            ClasificacionMovimientoInventario clasificacion);
+
     @EntityGraph(attributePaths = {
             "producto", "lote", "almacenOrigen", "almacenDestino", "registradoPor"
     })

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -283,9 +283,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         OrdenProduccion ordenProduccion = dto.ordenProduccionId() != null
                 ? entityManager.getReference(OrdenProduccion.class, dto.ordenProduccionId())
                 : null;
-        EtapaProduccion etapaProduccion = dto.ordenProduccionEtapaId() != null
-                ? entityManager.getReference(EtapaProduccion.class, dto.ordenProduccionEtapaId())
-                : null;
+        EtapaProduccion etapaProduccion = null;
         Integer almacenParaUbicacion = almacenDestino != null
                 ? almacenDestino.getId()
                 : (almacenOrigen != null ? almacenOrigen.getId() : null);
@@ -571,6 +569,12 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
         }
         // === /OP OVERRIDES ===
+        boolean esConsumoEtapa = clasificacion == ClasificacionMovimientoInventario.SALIDA_PRODUCCION;
+        if (esConsumoEtapa && dto.ordenProduccionEtapaId() != null) {
+            etapaProduccion = entityManager.getReference(EtapaProduccion.class, dto.ordenProduccionEtapaId());
+        } else {
+            etapaProduccion = null;
+        }
 
         // Detección automática de devolución interna
         boolean devolucionInterna = false;

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -9,6 +9,7 @@ import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.service.*;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -205,6 +206,14 @@ public class OrdenProduccionController {
                                                                    @RequestParam(name = "etapaId", required = false) Long etapaId,
                                                                    Pageable pageable) {
         return service.listarMovimientos(id, etapaId, pageable);
+    }
+
+    @GetMapping("/{ordenId}/etapas/{etapaId}/consumos")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<List<MovimientoInventarioResponseDTO>> listarConsumosPorEtapa(@PathVariable Long ordenId,
+                                                                                        @PathVariable Long etapaId,
+                                                                                        @RequestParam(name = "clasificacion", required = false) ClasificacionMovimientoInventario clasificacion) {
+        return ResponseEntity.ok(service.listarConsumosPorEtapa(ordenId, etapaId, clasificacion));
     }
 
     @GetMapping("/{id}/lote")

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -10,6 +10,7 @@ import com.willyes.clemenintegra.produccion.dto.InsumoOPDTO;
 import com.willyes.clemenintegra.produccion.dto.LoteProductoResponse;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -47,6 +48,10 @@ public interface OrdenProduccionService {
     LoteProductoResponse obtenerLote(Long ordenId);
 
     Page<MovimientoInventarioResponseDTO> listarMovimientos(Long id, Long etapaId, Pageable pageable);
+
+    List<MovimientoInventarioResponseDTO> listarConsumosPorEtapa(Long ordenId,
+                                                                 Long etapaId,
+                                                                 @Nullable ClasificacionMovimientoInventario clasificacion);
 
     Page<OrdenProduccionResponseDTO> listarPaginado(String codigo,
                                                     EstadoProduccion estado,

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1582,6 +1582,23 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     }
 
     @Override
+    public List<MovimientoInventarioResponseDTO> listarConsumosPorEtapa(Long ordenId,
+                                                                        Long etapaId,
+                                                                        @Nullable ClasificacionMovimientoInventario clasificacion) {
+        ClasificacionMovimientoInventario clasificacionFiltro =
+                clasificacion != null ? clasificacion : ClasificacionMovimientoInventario.SALIDA_PRODUCCION;
+        List<MovimientoInventario> movimientos = movimientoInventarioRepository
+                .findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(
+                        ordenId,
+                        etapaId,
+                        clasificacionFiltro
+                );
+        return movimientos.stream()
+                .map(movimientoInventarioMapper::safeToResponseDTO)
+                .toList();
+    }
+
+    @Override
     @Transactional
     public OrdenProduccion cancelarOrden(Long ordenProduccionId, @Nullable String motivo) {
         OrdenProduccion orden = repository.findByIdForUpdate(ordenProduccionId)

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -37,9 +37,12 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 @WebMvcTest(controllers = OrdenProduccionController.class,
         excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class))
@@ -186,5 +189,18 @@ class OrdenProduccionControllerTest {
 
         mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/api/produccion/ordenes/{id}", 15L))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/consumos responde 200 con lista vacía")
+    void listarConsumosPorEtapa_retornaListaVacia() throws Exception {
+        when(ordenProduccionService.listarConsumosPorEtapa(5L, 7L, null)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/consumos", 5L, 7L))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        verify(ordenProduccionService).listarConsumosPorEtapa(5L, 7L, null);
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -13,6 +13,7 @@ import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.VidaUtilProducto;
 import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.MotivoMovimiento;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
@@ -1510,6 +1511,28 @@ class OrdenProduccionServiceImplTest {
                 .thenAnswer(invocation -> Optional.ofNullable(solicitudes.get(invocation.getArgument(0))));
         when(solicitudMovimientoRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
         doNothing().when(reservaLoteService).sincronizarReservasSolicitud(any());
+    }
+
+    @Test
+    void listarConsumosPorEtapa_usaClasificacionPorDefecto() {
+        MovimientoInventario movimiento = new MovimientoInventario();
+        movimiento.setId(55L);
+
+        MovimientoInventarioResponseDTO respuesta = MovimientoInventarioResponseDTO.builder()
+                .id(55L)
+                .build();
+
+        when(movimientoInventarioRepository
+                .findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(
+                        10L,
+                        20L,
+                        ClasificacionMovimientoInventario.SALIDA_PRODUCCION))
+                .thenReturn(List.of(movimiento));
+        when(movimientoInventarioMapper.safeToResponseDTO(movimiento)).thenReturn(respuesta);
+
+        List<MovimientoInventarioResponseDTO> consumos = service.listarConsumosPorEtapa(10L, 20L, null);
+
+        assertThat(consumos).containsExactly(respuesta);
     }
 
     private void stubDisponibilidadGenerica() {


### PR DESCRIPTION
## Summary
- ensure production stage references are only attached to consumption movements while keeping transfers to Pre-Bodega classified correctly
- add repository queries, service logic, and controller endpoint to list consumption movements per production stage with SALIDA_PRODUCCION as the default filter
- cover the new behavior with controller and service tests, including default classification handling for stage consumptions

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950060ec19c8333b94667d6af8b664b)