### PR TITLE
Add production stage movement tracing endpoint

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -116,6 +116,15 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
             Long ordenProduccionEtapaId,
             ClasificacionMovimientoInventario clasificacion);
 
+    List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdOrderByFechaIngresoDesc(
+            Long ordenProduccionId,
+            Long ordenProduccionEtapaId);
+
+    List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoDesc(
+            Long ordenProduccionId,
+            Long ordenProduccionEtapaId,
+            ClasificacionMovimientoInventario clasificacion);
+
     @EntityGraph(attributePaths = {
             "producto", "lote", "almacenOrigen", "almacenDestino", "registradoPor"
     })

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -216,6 +216,14 @@ public class OrdenProduccionController {
         return ResponseEntity.ok(service.listarConsumosPorEtapa(ordenId, etapaId, clasificacion));
     }
 
+    @GetMapping("/{ordenId}/etapas/{etapaId}/movimientos")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<List<MovimientoInventarioResponseDTO>> listarMovimientosPorEtapa(@PathVariable Long ordenId,
+                                                                                           @PathVariable Long etapaId,
+                                                                                           @RequestParam(name = "clasificacion", required = false) ClasificacionMovimientoInventario clasificacion) {
+        return ResponseEntity.ok(service.listarMovimientosPorEtapa(ordenId, etapaId, clasificacion));
+    }
+
     @GetMapping("/{id}/lote")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<LoteProductoResponse> obtenerLote(@PathVariable Long id) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -53,6 +53,10 @@ public interface OrdenProduccionService {
                                                                  Long etapaId,
                                                                  @Nullable ClasificacionMovimientoInventario clasificacion);
 
+    List<MovimientoInventarioResponseDTO> listarMovimientosPorEtapa(Long ordenId,
+                                                                    Long etapaId,
+                                                                    @Nullable ClasificacionMovimientoInventario clasificacion);
+
     Page<OrdenProduccionResponseDTO> listarPaginado(String codigo,
                                                     EstadoProduccion estado,
                                                     String responsable,

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1599,6 +1599,32 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     }
 
     @Override
+    public List<MovimientoInventarioResponseDTO> listarMovimientosPorEtapa(Long ordenId,
+                                                                           Long etapaId,
+                                                                           @Nullable ClasificacionMovimientoInventario clasificacion) {
+        OrdenProduccion orden = repository.findById(ordenId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ORDEN_NO_ENCONTRADA"));
+        EtapaProduccion etapa = etapaProduccionRepository.findById(etapaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ETAPA_NO_ENCONTRADA"));
+        if (!Objects.equals(etapa.getOrdenProduccion().getId(), orden.getId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ETAPA_NO_PERTENECE_A_ORDEN");
+        }
+
+        ClasificacionMovimientoInventario clasificacionFiltro =
+                clasificacion != null ? clasificacion : ClasificacionMovimientoInventario.SALIDA_PRODUCCION;
+
+        List<MovimientoInventario> movimientos = movimientoInventarioRepository
+                .findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoDesc(
+                        ordenId,
+                        etapaId,
+                        clasificacionFiltro
+                );
+        return movimientos.stream()
+                .map(movimientoInventarioMapper::safeToResponseDTO)
+                .toList();
+    }
+
+    @Override
     @Transactional
     public OrdenProduccion cancelarOrden(Long ordenProduccionId, @Nullable String motivo) {
         OrdenProduccion orden = repository.findByIdForUpdate(ordenProduccionId)

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -8,6 +8,7 @@ import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.model.enums.*;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
@@ -419,6 +420,9 @@ class MovimientoInventarioServiceSolicitudOpTest {
                 .build();
         solicitud.setUsuarioResponsable(usuario);
 
+        EtapaProduccion etapaProduccion = new EtapaProduccion();
+        etapaProduccion.setId(77L);
+
         MovimientoInventario movimientoEntidad = new MovimientoInventario();
         movimientoEntidad.setFechaIngreso(LocalDateTime.now());
 
@@ -440,7 +444,7 @@ class MovimientoInventarioServiceSolicitudOpTest {
                 solicitud.getId(),
                 usuario.getId(),
                 ordenProduccion.getId(),
-                null,
+                etapaProduccion.getId(),
                 null,
                 lote.getCodigoLote(),
                 null,
@@ -456,6 +460,7 @@ class MovimientoInventarioServiceSolicitudOpTest {
         given(solicitudMovimientoRepository.findByIdWithLock(solicitud.getId())).willReturn(Optional.of(solicitud));
         given(usuarioService.obtenerUsuarioAutenticado()).willReturn(usuario);
         given(entityManager.getReference(eq(OrdenProduccion.class), eq(ordenProduccion.getId()))).willReturn(ordenProduccion);
+        given(entityManager.getReference(eq(EtapaProduccion.class), eq(etapaProduccion.getId()))).willReturn(etapaProduccion);
         given(entityManager.getReference(eq(Almacen.class), any())).willAnswer(invocation -> {
             Object id = invocation.getArgument(1);
             return new Almacen(id instanceof Integer ? (Integer) id : ((Long) id).intValue());
@@ -483,6 +488,8 @@ class MovimientoInventarioServiceSolicitudOpTest {
         assertThat(solicitud.getEstado()).isEqualTo(EstadoSolicitudMovimiento.CERRADA);
         assertThat(lote.getStockReservado()).isEqualByComparingTo(BigDecimal.ZERO.setScale(2));
         assertThat(lote.getStockLote()).isEqualByComparingTo(new BigDecimal("1400.00"));
+        verify(movimientoInventarioRepository).save(argThat(mov -> mov.getOrdenProduccionEtapa() != null
+                && mov.getOrdenProduccionEtapa().getId().equals(etapaProduccion.getId())));
 
         verify(reservaLoteService, times(1))
                 .consumirReserva(eq(solicitud), eq(detalle), eq(lote), eq(new BigDecimal("3600.000000")));

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
@@ -21,6 +21,7 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.doThrow;
@@ -123,7 +125,7 @@ class MovimientoInventarioServiceTransferenciaTest {
                 null,
                 null,
                 null,
-                null,
+                99L,
                 null,
                 lote.getCodigoLote(),
                 null,
@@ -155,6 +157,9 @@ class MovimientoInventarioServiceTransferenciaTest {
         assertThat(respuesta).isNotNull();
         assertThat(respuesta.getId()).isEqualTo(200L);
         assertThat(lote.getStockLote()).isEqualByComparingTo(new BigDecimal("3000.00"));
+        ArgumentCaptor<MovimientoInventario> movimientoCaptor = ArgumentCaptor.forClass(MovimientoInventario.class);
+        verify(movimientoInventarioRepository).save(movimientoCaptor.capture());
+        assertThat(movimientoCaptor.getValue().getOrdenProduccionEtapa()).isNull();
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -203,4 +203,17 @@ class OrdenProduccionControllerTest {
 
         verify(ordenProduccionService).listarConsumosPorEtapa(5L, 7L, null);
     }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/movimientos responde 200 con lista vacía")
+    void listarMovimientosPorEtapa_retornaListaVacia() throws Exception {
+        when(ordenProduccionService.listarMovimientosPorEtapa(8L, 9L, null)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/movimientos", 8L, 9L))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        verify(ordenProduccionService).listarMovimientosPorEtapa(8L, 9L, null);
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated endpoint to list inventory movements by production order stage with optional classification filtering
- ensure automatic consumption movements persist the stage identifier while transfers to Pre-Bodega do not
- extend repository queries and unit tests to cover stage-aware consumption and endpoint responses

## Testing
- mvn -q test -Dtest=MovimientoInventarioServiceSolicitudOpTest,MovimientoInventarioServiceTransferenciaTest,OrdenProduccionControllerTest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500c0c36248333915f8f4ea3dcc820)