### PR TITLE
Fix etapa consumption mapping and validate detalle etapa

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -19,6 +19,7 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import org.springframework.util.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
@@ -145,6 +146,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     private final RecepcionOCService recepcionOCService;
     private final LoteCalidadValidator loteCalidadValidator;
     private final UbicacionFisicaRepository ubicacionFisicaRepository;
+    private final EtapaProduccionRepository etapaProduccionRepository;
     //private final Long motivoSalidaProdId = catalogResolver.getMotivoSalidaProduccionId();
     //private final Long tipoDetSalidaProdId = catalogResolver.getTipoDetalleSalidaProduccionId();
 
@@ -3019,6 +3021,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         final Long preBodegaId = Objects.requireNonNull(
                 catalogResolver.getAlmacenPreBodegaProduccionId(),
                 "CONFIG_FALTANTE: inventory.almacenPreBodegaProduccionId");
+        Long etapaDestinoId = resolverEtapaConsumo(ordenProduccionId, ordenProduccionEtapaId);
 
         // 1) Traer TODAS las solicitudes de la OP (cualquier estado) con sus partidas + lote
         List<SolicitudMovimiento> solicitudes = entityManager.createQuery(
@@ -3153,7 +3156,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                         sol.getId(),                        // solicitudMovimientoId  <-- clave para idempotencia
                         usuarioId,                          // usuarioId
                         ordenProduccionId,                  // ordenProduccionId
-                        ordenProduccionEtapaId,             // ordenProduccionEtapaId
+                        etapaDestinoId,                     // ordenProduccionEtapaId
                         null,                               // ordenCompraDetalleId
                         null,                               // codigoLote
                         null,                               // fechaVencimiento
@@ -3170,6 +3173,21 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                 det.setEstado(com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle.ATENDIDO);
             }
         }
+    }
+
+    private Long resolverEtapaConsumo(Long ordenProduccionId, Long etapaId) {
+        if (etapaId != null) {
+            return etapaId;
+        }
+        return etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(ordenProduccionId)
+                .stream()
+                .findFirst()
+                .map(EtapaProduccion::getId)
+                .orElseThrow(() -> new CustomBusinessException(
+                        ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "ETAPA_PRODUCCION_NO_ENCONTRADA",
+                        Map.of("ordenProduccionId", ordenProduccionId)
+                ));
     }
 
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaController.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.produccion.model.*;
 import com.willyes.clemenintegra.produccion.dto.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -35,7 +36,7 @@ public class DetalleEtapaController {
     }
 
     @PostMapping
-    public ResponseEntity<DetalleEtapaResponse> crear(@RequestBody DetalleEtapaRequest request) {
+    public ResponseEntity<DetalleEtapaResponse> crear(@Valid @RequestBody DetalleEtapaRequest request) {
         EtapaProduccion etapa = new EtapaProduccion(); etapa.setId(request.etapaProduccionId);
         OrdenProduccion orden = new OrdenProduccion(); orden.setId(request.ordenProduccionId);
         Usuario operario = new Usuario(); operario.setId(request.operarioId);
@@ -44,7 +45,7 @@ public class DetalleEtapaController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<DetalleEtapaResponse> actualizar(@PathVariable Long id, @RequestBody DetalleEtapaRequest request) {
+    public ResponseEntity<DetalleEtapaResponse> actualizar(@PathVariable Long id, @Valid @RequestBody DetalleEtapaRequest request) {
         return service.buscarPorId(id)
                 .map(existente -> {
                     EtapaProduccion etapa = new EtapaProduccion(); etapa.setId(request.etapaProduccionId);

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/DetalleEtapaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/DetalleEtapaServiceImpl.java
@@ -1,18 +1,33 @@
 package com.willyes.clemenintegra.produccion.service;
 
 import com.willyes.clemenintegra.produccion.model.DetalleEtapa;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.repository.DetalleEtapaRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.dao.DataIntegrityViolationException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DetalleEtapaServiceImpl implements DetalleEtapaService {
 
     private final DetalleEtapaRepository repository;
+    private final EtapaProduccionRepository etapaProduccionRepository;
+    private final OrdenProduccionRepository ordenProduccionRepository;
+    private final UsuarioRepository usuarioRepository;
 
     public List<DetalleEtapa> listarTodas() {
         return repository.findAll();
@@ -22,12 +37,56 @@ public class DetalleEtapaServiceImpl implements DetalleEtapaService {
         return repository.findById(id);
     }
 
+    @Transactional
     public DetalleEtapa guardar(DetalleEtapa detalle) {
-        return repository.save(detalle);
+        try {
+            if (detalle == null) {
+                throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "DETALLE_OBLIGATORIO");
+            }
+            Long etapaId = detalle.getEtapaProduccion() != null ? detalle.getEtapaProduccion().getId() : null;
+            Long ordenId = detalle.getOrdenProduccion() != null ? detalle.getOrdenProduccion().getId() : null;
+            Long operarioId = detalle.getOperario() != null ? detalle.getOperario().getId() : null;
+
+            if (etapaId == null || ordenId == null || operarioId == null) {
+                throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                        "FALTAN_REFERENCIAS_REQUERIDAS");
+            }
+
+            EtapaProduccion etapa = etapaProduccionRepository.findById(etapaId)
+                    .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                            "ETAPA_NO_ENCONTRADA"));
+            OrdenProduccion orden = ordenProduccionRepository.findById(ordenId)
+                    .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                            "ORDEN_NO_ENCONTRADA"));
+            Usuario operario = usuarioRepository.findById(operarioId)
+                    .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                            "OPERARIO_NO_ENCONTRADO"));
+
+            if (etapa.getOrdenProduccion() == null
+                    || !etapa.getOrdenProduccion().getId().equals(orden.getId())) {
+                throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "ETAPA_NO_PERTENECE_A_ORDEN");
+            }
+
+            detalle.setEtapaProduccion(etapa);
+            detalle.setOrdenProduccion(orden);
+            detalle.setOperario(operario);
+
+            return repository.save(detalle);
+        } catch (DataIntegrityViolationException ex) {
+            log.error("Error de integridad al guardar detalle de etapa opId={} etapaId={} operarioId={}",
+                    detalle != null && detalle.getOrdenProduccion() != null ? detalle.getOrdenProduccion().getId() : null,
+                    detalle != null && detalle.getEtapaProduccion() != null ? detalle.getEtapaProduccion().getId() : null,
+                    detalle != null && detalle.getOperario() != null ? detalle.getOperario().getId() : null,
+                    ex);
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "DETALLE_ETAPA_DATOS_INVALIDOS");
+        } catch (RuntimeException ex) {
+            log.error("Error inesperado al guardar detalle de etapa", ex);
+            throw ex;
+        }
     }
 
     public void eliminar(Long id) {
         repository.deleteById(id);
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -575,6 +575,16 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         return orden;
     }
 
+    private Long resolverEtapaPrincipal(Long ordenProduccionId) {
+        return etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(ordenProduccionId)
+                .stream()
+                .findFirst()
+                .map(EtapaProduccion::getId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNPROCESSABLE_ENTITY,
+                        "ETAPA_PRODUCCION_NO_CONFIGURADA"));
+    }
+
     public void eliminar(Long id) {
         repository.deleteById(id);
     }
@@ -673,7 +683,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
             Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
 
-            movimientoInventarioService.consumirInsumosPorOrden(orden.getId(), null, usuario.getId());
+            Long etapaConsumoId = resolverEtapaPrincipal(orden.getId());
+            movimientoInventarioService.consumirInsumosPorOrden(orden.getId(), etapaConsumoId, usuario.getId());
 
             List<EstadoSolicitudMovimiento> estadosPendientes = parseEstados(estadosSolicitudPendientesConf);
             parseEstados(estadosSolicitudConcluyentesConf);
@@ -1718,7 +1729,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
         Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
 
-        movimientoInventarioService.consumirInsumosPorOrden(orden.getId(), null, usuario.getId());
+        Long etapaConsumoId = resolverEtapaPrincipal(orden.getId());
+        movimientoInventarioService.consumirInsumosPorOrden(orden.getId(), etapaConsumoId, usuario.getId());
 
         orden.setCantidadProducida(cantidadProducida);
         orden.setEstado(EstadoProduccion.FINALIZADA);

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -23,11 +23,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Manejador global de excepciones para toda la aplicación.
  */
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -177,6 +179,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponseDTO> handleRuntime(RuntimeException ex,
                                                           HttpServletRequest request) {
+        log.error("Error inesperado procesando la solicitud {}", request != null ? request.getRequestURI() : "", ex);
         return buildResponse(ApiErrorCode.ERROR_INTERNO,
                 "Ocurrió un error inesperado. Intente nuevamente o contacte soporte.",
                 null);

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
@@ -12,6 +12,8 @@ import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import org.junit.jupiter.api.Test;
@@ -74,6 +76,8 @@ class MovimientoInventarioServiceConsumoEtapaTest {
     private EntityManager entityManager;
     @Mock
     private UbicacionFisicaRepository ubicacionFisicaRepository;
+    @Mock
+    private EtapaProduccionRepository etapaProduccionRepository;
 
     @Spy
     @InjectMocks
@@ -145,6 +149,54 @@ class MovimientoInventarioServiceConsumoEtapaTest {
         assertThatThrownBy(() -> service.consumirInsumosPorOrden(10L, 20L, 5L))
                 .isInstanceOf(CustomBusinessException.class)
                 .hasFieldOrPropertyWithValue("code", ApiErrorCode.CONSUMO_PREBODEGA_INSUFICIENTE);
+    }
+
+    @Test
+    void consumirInsumosPorOrden_resuelveEtapaCuandoNoSeEnvio() {
+        SolicitudMovimiento solicitud = solicitudConDetalle();
+        SolicitudMovimientoDetalle detalle = solicitud.getDetalles().get(0);
+        Producto producto = solicitud.getProducto();
+
+        TypedQuery<SolicitudMovimiento> query = mock(TypedQuery.class);
+        when(entityManager.createQuery(anyString(), eq(SolicitudMovimiento.class))).thenReturn(query);
+        when(query.setParameter(eq("opId"), any())).thenReturn(query);
+        when(query.getResultList()).thenReturn(List.of(solicitud));
+
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(30L);
+        when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(70L);
+        when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(10L))
+                .thenReturn(List.of(EtapaProduccion.builder().id(22L).build()));
+
+        LoteProducto lotePrebodega = new LoteProducto();
+        lotePrebodega.setId(300L);
+        lotePrebodega.setCodigoLote(detalle.getLote().getCodigoLote());
+        lotePrebodega.setProducto(producto);
+        lotePrebodega.setAlmacen(new Almacen(30));
+        lotePrebodega.setEstado(EstadoLote.DISPONIBLE);
+        lotePrebodega.setStockLote(new BigDecimal("50"));
+        lotePrebodega.setStockReservado(BigDecimal.ZERO);
+
+        when(loteProductoRepository.findByCodigoLoteAndProductoIdAndAlmacenId(
+                detalle.getLote().getCodigoLote(), producto.getId(), 30))
+                .thenReturn(Optional.of(lotePrebodega));
+        when(movimientoInventarioRepository.sumaPorSolicitudYTipo(
+                eq(solicitud.getId()),
+                eq(producto.getId().longValue()),
+                eq(lotePrebodega.getId()),
+                eq(TipoMovimiento.SALIDA),
+                eq(70L),
+                isNull())).thenReturn(BigDecimal.ZERO);
+
+        doReturn(MovimientoInventarioResponseDTO.builder().id(999L).build())
+                .when(service).registrarMovimiento(any(MovimientoInventarioDTO.class));
+
+        service.consumirInsumosPorOrden(10L, null, 5L);
+
+        ArgumentCaptor<MovimientoInventarioDTO> dtoCaptor = ArgumentCaptor.forClass(MovimientoInventarioDTO.class);
+        verify(service).registrarMovimiento(dtoCaptor.capture());
+
+        MovimientoInventarioDTO dtoSalida = dtoCaptor.getValue();
+        assertThat(dtoSalida.ordenProduccionEtapaId()).isEqualTo(22L);
     }
 
     private SolicitudMovimiento solicitudConDetalle() {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceFefoTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceFefoTest.java
@@ -9,6 +9,7 @@ import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,6 +70,8 @@ class MovimientoInventarioServiceFefoTest {
     private LoteCalidadValidator loteCalidadValidator;
     @Mock
     private EntityManager entityManager;
+    @Mock
+    private EtapaProduccionRepository etapaProduccionRepository;
     @Mock
     private UbicacionFisicaRepository ubicacionFisicaRepository;
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSalidaPtTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSalidaPtTest.java
@@ -19,6 +19,7 @@ import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,6 +91,8 @@ class MovimientoInventarioServiceSalidaPtTest {
     private EntityManager entityManager;
     @Mock
     private UbicacionFisicaRepository ubicacionFisicaRepository;
+    @Mock
+    private EtapaProduccionRepository etapaProduccionRepository;
 
     @InjectMocks
     private MovimientoInventarioServiceImpl service;

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -9,6 +9,7 @@ import com.willyes.clemenintegra.inventario.model.enums.*;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
@@ -79,6 +80,8 @@ class MovimientoInventarioServiceSolicitudOpTest {
     private LoteCalidadValidator loteCalidadValidator;
     @Mock
     private EntityManager entityManager;
+    @Mock
+    private EtapaProduccionRepository etapaProduccionRepository;
     @Mock
     private UbicacionFisicaRepository ubicacionFisicaRepository;
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
@@ -17,6 +17,7 @@ import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +90,8 @@ class MovimientoInventarioServiceTransferenciaTest {
     private EntityManager entityManager;
     @Mock
     private UbicacionFisicaRepository ubicacionFisicaRepository;
+    @Mock
+    private EtapaProduccionRepository etapaProduccionRepository;
 
     @InjectMocks
     private MovimientoInventarioServiceImpl service;

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -11,6 +11,8 @@ import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
 import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -215,5 +217,27 @@ class OrdenProduccionControllerTest {
                 .andExpect(content().json("[]"));
 
         verify(ordenProduccionService).listarMovimientosPorEtapa(8L, 9L, null);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/movimientos responde con movimientos")
+    void listarMovimientosPorEtapa_retornaMovimientos() throws Exception {
+        MovimientoInventarioResponseDTO movimiento = MovimientoInventarioResponseDTO.builder()
+                .id(77L)
+                .ordenProduccionId(8L)
+                .ordenProduccionEtapaId(9L)
+                .clasificacion("SALIDA_PRODUCCION")
+                .build();
+        when(ordenProduccionService.listarMovimientosPorEtapa(8L, 9L, ClasificacionMovimientoInventario.SALIDA_PRODUCCION))
+                .thenReturn(List.of(movimiento));
+
+        mockMvc.perform(get("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/movimientos", 8L, 9L)
+                        .param("clasificacion", "SALIDA_PRODUCCION"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(77L))
+                .andExpect(jsonPath("$[0].ordenProduccionEtapaId").value(9L));
+
+        verify(ordenProduccionService).listarMovimientosPorEtapa(8L, 9L, ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/DetalleEtapaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/DetalleEtapaServiceImplTest.java
@@ -1,0 +1,109 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.model.DetalleEtapa;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.repository.DetalleEtapaRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DetalleEtapaServiceImplTest {
+
+    @Mock
+    private DetalleEtapaRepository detalleEtapaRepository;
+    @Mock
+    private EtapaProduccionRepository etapaProduccionRepository;
+    @Mock
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @InjectMocks
+    private DetalleEtapaServiceImpl service;
+
+    @Test
+    void guardar_asociaReferenciasValidadas() {
+        OrdenProduccion orden = OrdenProduccion.builder().id(5L).build();
+        EtapaProduccion etapa = EtapaProduccion.builder().id(7L).ordenProduccion(orden).build();
+        Usuario operario = new Usuario(); operario.setId(11L);
+
+        DetalleEtapa detalle = DetalleEtapa.builder()
+                .ordenProduccion(OrdenProduccion.builder().id(orden.getId()).build())
+                .etapaProduccion(EtapaProduccion.builder().id(etapa.getId()).build())
+                .operario(operario)
+                .build();
+
+        when(etapaProduccionRepository.findById(etapa.getId())).thenReturn(Optional.of(etapa));
+        when(ordenProduccionRepository.findById(orden.getId())).thenReturn(Optional.of(orden));
+        when(usuarioRepository.findById(operario.getId())).thenReturn(Optional.of(operario));
+        when(detalleEtapaRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DetalleEtapa guardado = service.guardar(detalle);
+
+        assertThat(guardado.getOrdenProduccion()).isSameAs(orden);
+        assertThat(guardado.getEtapaProduccion()).isSameAs(etapa);
+        assertThat(guardado.getOperario()).isSameAs(operario);
+    }
+
+    @Test
+    void guardar_conEtapaDeOtraOrdenLanzaErrorDeNegocio() {
+        OrdenProduccion orden = OrdenProduccion.builder().id(5L).build();
+        OrdenProduccion otraOrden = OrdenProduccion.builder().id(8L).build();
+        EtapaProduccion etapa = EtapaProduccion.builder().id(7L).ordenProduccion(otraOrden).build();
+        Usuario operario = new Usuario(); operario.setId(11L);
+
+        DetalleEtapa detalle = DetalleEtapa.builder()
+                .ordenProduccion(orden)
+                .etapaProduccion(EtapaProduccion.builder().id(etapa.getId()).build())
+                .operario(operario)
+                .build();
+
+        when(etapaProduccionRepository.findById(etapa.getId())).thenReturn(Optional.of(etapa));
+        when(ordenProduccionRepository.findById(orden.getId())).thenReturn(Optional.of(orden));
+        when(usuarioRepository.findById(operario.getId())).thenReturn(Optional.of(operario));
+
+        assertThatThrownBy(() -> service.guardar(detalle))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasFieldOrPropertyWithValue("code", ApiErrorCode.SOLICITUD_INVALIDA);
+    }
+
+    @Test
+    void guardar_errorDeIntegridadSeMapeaComoSolicitudInvalida() {
+        OrdenProduccion orden = OrdenProduccion.builder().id(5L).build();
+        EtapaProduccion etapa = EtapaProduccion.builder().id(7L).ordenProduccion(orden).build();
+        Usuario operario = new Usuario(); operario.setId(11L);
+
+        DetalleEtapa detalle = DetalleEtapa.builder()
+                .ordenProduccion(orden)
+                .etapaProduccion(etapa)
+                .operario(operario)
+                .build();
+
+        when(etapaProduccionRepository.findById(etapa.getId())).thenReturn(Optional.of(etapa));
+        when(ordenProduccionRepository.findById(orden.getId())).thenReturn(Optional.of(orden));
+        when(usuarioRepository.findById(operario.getId())).thenReturn(Optional.of(operario));
+        when(detalleEtapaRepository.save(any())).thenThrow(new DataIntegrityViolationException("fk error"));
+
+        assertThatThrownBy(() -> service.guardar(detalle))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasFieldOrPropertyWithValue("code", ApiErrorCode.SOLICITUD_INVALIDA);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -950,7 +950,7 @@ class OrdenProduccionServiceImplTest {
 
         service.registrarCierre(250L, dto);
 
-        verify(movimientoInventarioService).consumirInsumosPorOrden(250L, null, usuarioBasico().getId());
+        verify(movimientoInventarioService).consumirInsumosPorOrden(250L, 1L, usuarioBasico().getId());
         verify(movimientoInventarioService).registrarMovimiento(any());
     }
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -467,6 +467,7 @@ class OrdenProduccionServiceReservaTest {
         tipoDetalleEntrada.setId(90L);
         when(tipoMovimientoDetalleRepository.findById(90L)).thenReturn(Optional.of(tipoDetalleEntrada));
         EtapaProduccion etapa = new EtapaProduccion();
+        etapa.setId(3L);
         etapa.setEstado(EstadoEtapa.FINALIZADA);
         etapa.setFechaInicio(LocalDateTime.now().minusDays(2));
         when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(1L))


### PR DESCRIPTION
## Summary
- ensure automatic consumo SALIDA_PRODUCCION links movimientos to the correspondiente etapa and cover the movimientos por etapa endpoint
- validate DetalleEtapa requests, mapping missing or inconsistent references to business errors instead of 500 responses
- extend unit coverage for etapa consumption, movimientos retrieval, and DetalleEtapa persistence validations

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695012ff26c48333a0b50a4300a119d6)