### PR TITLE
Handle etapa defaults and preserve movement stage data

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -2573,6 +2573,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         copia.setOrdenCompra(base.getOrdenCompra());
         copia.setMotivoMovimiento(base.getMotivoMovimiento());
         copia.setOrdenProduccion(base.getOrdenProduccion());
+        copia.setOrdenProduccionEtapa(base.getOrdenProduccionEtapa());
         copia.setTipoMovimientoDetalle(base.getTipoMovimientoDetalle());
         copia.setOrdenCompraDetalle(base.getOrdenCompraDetalle());
         copia.setSolicitudMovimiento(base.getSolicitudMovimiento());

--- a/src/main/java/com/willyes/clemenintegra/produccion/config/ProduccionEndpointLogger.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/config/ProduccionEndpointLogger.java
@@ -1,0 +1,43 @@
+package com.willyes.clemenintegra.produccion.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.util.Set;
+
+@Component
+@Slf4j
+public class ProduccionEndpointLogger implements ApplicationListener<ApplicationReadyEvent> {
+
+    private static final String MOVIMIENTOS_ETAPA_PATH = "/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/movimientos";
+    @Qualifier("requestMappingHandlerMapping")
+    private final RequestMappingHandlerMapping handlerMapping;
+
+    public ProduccionEndpointLogger(
+            @Qualifier("requestMappingHandlerMapping") RequestMappingHandlerMapping handlerMapping
+    ) {
+        this.handlerMapping = handlerMapping;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        Set<RequestMappingInfo> coincidencias = handlerMapping.getHandlerMethods()
+                .keySet()
+                .stream()
+                .filter(info -> info.getPatternValues() != null
+                        && info.getPatternValues().stream()
+                        .anyMatch(pattern -> pattern.equals(MOVIMIENTOS_ETAPA_PATH)))
+                .collect(java.util.stream.Collectors.toSet());
+
+        if (coincidencias.isEmpty()) {
+            log.warn("Producción: mapping NO encontrado para {}", MOVIMIENTOS_ETAPA_PATH);
+        } else {
+            log.info("Producción: mapping activo para {} ({} coincidencias)", MOVIMIENTOS_ETAPA_PATH, coincidencias.size());
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaController.java
@@ -1,14 +1,16 @@
 package com.willyes.clemenintegra.produccion.controller;
 
-import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.produccion.mapper.ProduccionMapper;
 import com.willyes.clemenintegra.produccion.service.*;
 import com.willyes.clemenintegra.produccion.model.*;
 import com.willyes.clemenintegra.produccion.dto.*;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 public class DetalleEtapaController {
 
     private final DetalleEtapaService service;
+    private final com.willyes.clemenintegra.shared.service.UsuarioService usuarioService;
 
     @GetMapping
     public List<DetalleEtapaResponse> listarTodas() {
@@ -37,6 +40,7 @@ public class DetalleEtapaController {
 
     @PostMapping
     public ResponseEntity<DetalleEtapaResponse> crear(@Valid @RequestBody DetalleEtapaRequest request) {
+        normalizarRequest(request);
         EtapaProduccion etapa = new EtapaProduccion(); etapa.setId(request.etapaProduccionId);
         OrdenProduccion orden = new OrdenProduccion(); orden.setId(request.ordenProduccionId);
         Usuario operario = new Usuario(); operario.setId(request.operarioId);
@@ -48,6 +52,7 @@ public class DetalleEtapaController {
     public ResponseEntity<DetalleEtapaResponse> actualizar(@PathVariable Long id, @Valid @RequestBody DetalleEtapaRequest request) {
         return service.buscarPorId(id)
                 .map(existente -> {
+                    normalizarRequest(request);
                     EtapaProduccion etapa = new EtapaProduccion(); etapa.setId(request.etapaProduccionId);
                     OrdenProduccion orden = new OrdenProduccion(); orden.setId(request.ordenProduccionId);
                     Usuario operario = new Usuario(); operario.setId(request.operarioId);
@@ -62,5 +67,24 @@ public class DetalleEtapaController {
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {
         service.eliminar(id);
         return ResponseEntity.noContent().build();
+    }
+
+    private void normalizarRequest(DetalleEtapaRequest request) {
+        if (request == null) {
+            return;
+        }
+        if (request.fechaInicio == null) {
+            request.fechaInicio = LocalDateTime.now();
+        }
+        if (request.operarioId == null) {
+            Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+            request.operarioId = usuario != null ? usuario.getId() : null;
+        }
+        if (StringUtils.hasText(request.operarioNombre)) {
+            String prefijo = "Operario: " + request.operarioNombre;
+            request.observaciones = StringUtils.hasText(request.observaciones)
+                    ? request.observaciones + " | " + prefijo
+                    : prefijo;
+        }
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/DetalleEtapaRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/DetalleEtapaRequest.java
@@ -1,10 +1,10 @@
 package com.willyes.clemenintegra.produccion.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import java.time.LocalDateTime;
 import jakarta.validation.constraints.*;
 
 public class DetalleEtapaRequest {
-    @NotNull
     @PastOrPresent
     public LocalDateTime fechaInicio;
 
@@ -15,11 +15,17 @@ public class DetalleEtapaRequest {
     public String observaciones;
 
     @NotNull
+    @JsonAlias("ordenProduccionEtapaId")
     public Long etapaProduccionId;
 
     @NotNull
     public Long ordenProduccionId;
 
-    @NotNull
     public Long operarioId;
+
+    /**
+     * Campo opcional que puede llegar desde el frontend pero no se usa para guardar.
+     */
+    @JsonAlias("operario")
+    public String operarioNombre;
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDuplicarMovimientoBaseTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDuplicarMovimientoBaseTest.java
@@ -1,0 +1,69 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class MovimientoInventarioServiceDuplicarMovimientoBaseTest {
+
+    @Mock private AlmacenRepository almacenRepository;
+    @Mock private ProductoRepository productoRepository;
+    @Mock private ProveedorRepository proveedorRepository;
+    @Mock private OrdenCompraRepository ordenCompraRepository;
+    @Mock private OrdenCompraService ordenCompraService;
+    @Mock private LoteProductoRepository loteProductoRepository;
+    @Mock private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock private MovimientoInventarioRepository repository;
+    @Mock private MovimientoInventarioMapper mapper;
+    @Mock private UsuarioService usuarioService;
+    @Mock private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    @Mock private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock private InventoryCatalogResolver catalogResolver;
+    @Mock private ReservaLoteService reservaLoteService;
+    @Mock private ReservaLoteRepository reservaLoteRepository;
+    @Mock private RecepcionOCService recepcionOCService;
+    @Mock private LoteCalidadValidator loteCalidadValidator;
+    @Mock private UbicacionFisicaRepository ubicacionFisicaRepository;
+    @Mock private EtapaProduccionRepository etapaProduccionRepository;
+    @Mock private EntityManager entityManager;
+
+    @InjectMocks
+    private MovimientoInventarioServiceImpl service;
+
+    @Test
+    void duplicarMovimientoBase_preservaEtapaProduccion() {
+        EtapaProduccion etapa = new EtapaProduccion();
+        etapa.setId(99L);
+
+        MovimientoInventario base = new MovimientoInventario();
+        base.setOrdenProduccionEtapa(etapa);
+
+        MovimientoInventario copia = ReflectionTestUtils.invokeMethod(
+                service,
+                "duplicarMovimientoBase",
+                base,
+                new LoteProducto(),
+                new BigDecimal("1.0")
+        );
+
+        assertThat(copia).isNotNull();
+        assertThat(copia.getOrdenProduccionEtapa()).isEqualTo(etapa);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a startup logger to surface the movimientos-por-etapa mapping for producción endpoints.
- Normalize DetalleEtapa requests to accept FE aliases, auto-fill fechaInicio and operarioId, and tolerate optional operario text.
- Preserve ordenProduccionEtapa when duplicating SPLIT movements and add a regression test to cover it.

## Testing
- mvn test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950267724c08333babed77ca0079b0d)