### PR TITLE
Fix etapa defaults and ensure movimiento etapa linkage

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -572,7 +572,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
         // === /OP OVERRIDES ===
         boolean esConsumoEtapa = clasificacion == ClasificacionMovimientoInventario.SALIDA_PRODUCCION;
-        if (esConsumoEtapa && dto.ordenProduccionEtapaId() != null) {
+        if (dto.ordenProduccionEtapaId() != null) {
             etapaProduccion = entityManager.getReference(EtapaProduccion.class, dto.ordenProduccionEtapaId());
         } else {
             etapaProduccion = null;

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaController.java
@@ -40,7 +40,7 @@ public class DetalleEtapaController {
 
     @PostMapping
     public ResponseEntity<DetalleEtapaResponse> crear(@Valid @RequestBody DetalleEtapaRequest request) {
-        normalizarRequest(request);
+        normalizarRequest(request, null);
         EtapaProduccion etapa = new EtapaProduccion(); etapa.setId(request.etapaProduccionId);
         OrdenProduccion orden = new OrdenProduccion(); orden.setId(request.ordenProduccionId);
         Usuario operario = new Usuario(); operario.setId(request.operarioId);
@@ -52,7 +52,7 @@ public class DetalleEtapaController {
     public ResponseEntity<DetalleEtapaResponse> actualizar(@PathVariable Long id, @Valid @RequestBody DetalleEtapaRequest request) {
         return service.buscarPorId(id)
                 .map(existente -> {
-                    normalizarRequest(request);
+                    normalizarRequest(request, existente);
                     EtapaProduccion etapa = new EtapaProduccion(); etapa.setId(request.etapaProduccionId);
                     OrdenProduccion orden = new OrdenProduccion(); orden.setId(request.ordenProduccionId);
                     Usuario operario = new Usuario(); operario.setId(request.operarioId);
@@ -69,17 +69,15 @@ public class DetalleEtapaController {
         return ResponseEntity.noContent().build();
     }
 
-    private void normalizarRequest(DetalleEtapaRequest request) {
+    private void normalizarRequest(DetalleEtapaRequest request, DetalleEtapa existente) {
         if (request == null) {
             return;
         }
-        if (request.fechaInicio == null) {
-            request.fechaInicio = LocalDateTime.now();
-        }
-        if (request.operarioId == null) {
-            Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
-            request.operarioId = usuario != null ? usuario.getId() : null;
-        }
+        // La fecha de inicio y el operario se fijan en backend para evitar discrepancias
+        // de zona horaria y asegurar trazabilidad de quién inició la etapa.
+        request.fechaInicio = existente != null ? existente.getFechaInicio() : LocalDateTime.now();
+        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+        request.operarioId = usuario != null ? usuario.getId() : null;
         if (StringUtils.hasText(request.operarioNombre)) {
             String prefijo = "Operario: " + request.operarioNombre;
             request.observaciones = StringUtils.hasText(request.observaciones)

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/DetalleEtapaRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/DetalleEtapaRequest.java
@@ -5,10 +5,12 @@ import java.time.LocalDateTime;
 import jakarta.validation.constraints.*;
 
 public class DetalleEtapaRequest {
-    @PastOrPresent
+    /**
+     * La fecha de inicio se establece en backend usando la hora del servidor para evitar
+     * desfaces por zona horaria.
+     */
     public LocalDateTime fechaInicio;
 
-    @FutureOrPresent
     public LocalDateTime fechaFin;
 
     @Size(max = 255)
@@ -21,6 +23,9 @@ public class DetalleEtapaRequest {
     @NotNull
     public Long ordenProduccionId;
 
+    /**
+     * Se asigna en backend con el usuario autenticado para mantener la trazabilidad.
+     */
     public Long operarioId;
 
     /**

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -27,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -496,6 +497,38 @@ class MovimientoInventarioServiceSolicitudOpTest {
 
         verify(reservaLoteService, times(1))
                 .consumirReserva(eq(solicitud), eq(detalle), eq(lote), eq(new BigDecimal("3600.000000")));
+    }
+
+    @Test
+    void duplicarMovimientoBase_copiaEtapaYOrdenProduccion() {
+        OrdenProduccion ordenProduccion = OrdenProduccion.builder().id(10L).build();
+        EtapaProduccion etapaProduccion = EtapaProduccion.builder().id(20L).ordenProduccion(ordenProduccion).build();
+
+        MovimientoInventario base = new MovimientoInventario();
+        base.setCantidad(new BigDecimal("5.00"));
+        base.setTipoMovimiento(TipoMovimiento.SALIDA);
+        base.setClasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+        base.setOrdenProduccion(ordenProduccion);
+        base.setOrdenProduccionEtapa(etapaProduccion);
+        base.setLote(new LoteProducto());
+
+        LoteProducto nuevoLote = new LoteProducto();
+        nuevoLote.setId(55L);
+
+        MovimientoInventario duplicado = ReflectionTestUtils.invokeMethod(
+                service,
+                "duplicarMovimientoBase",
+                base,
+                nuevoLote,
+                new BigDecimal("3.50")
+        );
+
+        assertThat(duplicado).isNotNull();
+        assertThat(duplicado.getOrdenProduccion()).isSameAs(ordenProduccion);
+        assertThat(duplicado.getOrdenProduccionEtapa()).isNotNull();
+        assertThat(duplicado.getOrdenProduccionEtapa().getId()).isEqualTo(etapaProduccion.getId());
+        assertThat(duplicado.getLote()).isSameAs(nuevoLote);
+        assertThat(duplicado.getCantidad()).isEqualByComparingTo(new BigDecimal("3.50"));
     }
 
     @Disabled("Requiere entorno de integración para validar consumo doble de lote")

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaControllerTest.java
@@ -1,0 +1,76 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.dto.DetalleEtapaRequest;
+import com.willyes.clemenintegra.produccion.dto.DetalleEtapaResponse;
+import com.willyes.clemenintegra.produccion.model.DetalleEtapa;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.service.DetalleEtapaService;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DetalleEtapaControllerTest {
+
+    @Mock
+    private DetalleEtapaService detalleEtapaService;
+
+    @Mock
+    private UsuarioService usuarioService;
+
+    @InjectMocks
+    private DetalleEtapaController controller;
+
+    @Test
+    void crear_asignaFechaInicioYOperarioDelBackend() {
+        DetalleEtapaRequest request = new DetalleEtapaRequest();
+        request.etapaProduccionId = 7L;
+        request.ordenProduccionId = 11L;
+        request.fechaInicio = null;
+        request.operarioId = null;
+
+        Usuario usuario = new Usuario();
+        usuario.setId(99L);
+        usuario.setNombreCompleto("Operario Backend");
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(detalleEtapaService.guardar(any())).thenAnswer(invocation -> {
+            DetalleEtapa detalle = invocation.getArgument(0);
+            detalle.setId(1L);
+            if (detalle.getOrdenProduccion() == null) {
+                detalle.setOrdenProduccion(OrdenProduccion.builder().id(request.ordenProduccionId).build());
+            }
+            if (detalle.getEtapaProduccion() == null) {
+                detalle.setEtapaProduccion(EtapaProduccion.builder().id(request.etapaProduccionId).build());
+            }
+            return detalle;
+        });
+
+        ResponseEntity<DetalleEtapaResponse> response = controller.crear(request);
+
+        ArgumentCaptor<DetalleEtapa> detalleCaptor = ArgumentCaptor.forClass(DetalleEtapa.class);
+        verify(detalleEtapaService).guardar(detalleCaptor.capture());
+        DetalleEtapa enviado = detalleCaptor.getValue();
+
+        assertThat(enviado.getFechaInicio()).isNotNull();
+        assertThat(enviado.getFechaInicio()).isBeforeOrEqualTo(LocalDateTime.now());
+        assertThat(enviado.getOperario()).isNotNull();
+        assertThat(enviado.getOperario().getId()).isEqualTo(usuario.getId());
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -1535,6 +1535,33 @@ class OrdenProduccionServiceImplTest {
         assertThat(consumos).containsExactly(respuesta);
     }
 
+    @Test
+    void listarMovimientosPorEtapa_filtraPorOrdenEtapaYClasificacion() {
+        OrdenProduccion orden = OrdenProduccion.builder().id(10L).build();
+        EtapaProduccion etapa = EtapaProduccion.builder().id(20L).ordenProduccion(orden).build();
+        when(ordenProduccionRepository.findById(orden.getId())).thenReturn(Optional.of(orden));
+        when(etapaProduccionRepository.findById(etapa.getId())).thenReturn(Optional.of(etapa));
+
+        MovimientoInventario movimiento = new MovimientoInventario();
+        MovimientoInventarioResponseDTO dto = MovimientoInventarioResponseDTO.builder().id(77L).build();
+
+        when(movimientoInventarioRepository
+                .findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoDesc(
+                        orden.getId(),
+                        etapa.getId(),
+                        ClasificacionMovimientoInventario.SALIDA_PRODUCCION))
+                .thenReturn(List.of(movimiento));
+        when(movimientoInventarioMapper.safeToResponseDTO(movimiento)).thenReturn(dto);
+
+        List<MovimientoInventarioResponseDTO> respuesta = service.listarMovimientosPorEtapa(
+                orden.getId(),
+                etapa.getId(),
+                null
+        );
+
+        assertThat(respuesta).containsExactly(dto);
+    }
+
     private void stubDisponibilidadGenerica() {
         when(disponibilidadInsumoService.resolverAlmacenesPreferidos(any()))
                 .thenReturn(List.of(90L));


### PR DESCRIPTION
## Summary
- Set `fechaInicio` and operario for detalles de etapa on the server to avoid timezone issues and keep auditability, documenting the backend ownership of those fields.
- Guarantee SALIDA_PRODUCCION movements retain their etapa reference (including duplicated movements) and keep mapping available for movimientos por etapa.
- Add unit coverage for etapa defaults, movimientos por etapa filtering, and duplication of inventory movements with etapa linkage.

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69503199f41c833392af7b770eea0fdd)