### PR TITLE
Enforce etapa activa for SALIDA_PRODUCCION

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -575,18 +575,17 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         if (ordenProduccionIdContexto == null && ordenProduccion != null) {
             ordenProduccionIdContexto = ordenProduccion.getId();
         }
+        if (ordenProduccionIdContexto == null
+                && solicitud != null
+                && solicitud.getOrdenProduccion() != null
+                && solicitud.getOrdenProduccion().getId() != null) {
+            ordenProduccionIdContexto = solicitud.getOrdenProduccion().getId();
+        }
 
         boolean esConsumoEtapa = clasificacion == ClasificacionMovimientoInventario.SALIDA_PRODUCCION;
-        if (dto.ordenProduccionEtapaId() != null) {
-            etapaProduccion = entityManager.getReference(EtapaProduccion.class, dto.ordenProduccionEtapaId());
-        } else if (esConsumoEtapa && ordenProduccionIdContexto != null) {
-            Long etapaId = resolverEtapaConsumo(ordenProduccionIdContexto, null);
-            etapaProduccion = entityManager.getReference(EtapaProduccion.class, etapaId);
-        } else if (esConsumoEtapa && ordenProduccion != null && ordenProduccion.getId() != null) {
-            Long etapaId = resolverEtapaConsumo(ordenProduccion.getId(), null);
-            etapaProduccion = entityManager.getReference(EtapaProduccion.class, etapaId);
-        } else {
-            etapaProduccion = null;
+        if (esConsumoEtapa) {
+            EtapaProduccion etapaActiva = resolverEtapaActiva(ordenProduccionIdContexto, dto.ordenProduccionEtapaId());
+            etapaProduccion = etapaActiva;
         }
 
         // Detección automática de devolución interna
@@ -3200,17 +3199,58 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     }
 
     private Long resolverEtapaConsumo(Long ordenProduccionId, Long etapaId) {
+        EtapaProduccion etapaActiva = resolverEtapaActiva(ordenProduccionId, etapaId);
+        return etapaActiva.getId();
+    }
+
+    private EtapaProduccion resolverEtapaActiva(Long ordenProduccionId, Long etapaId) {
+        if (ordenProduccionId == null) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.OP_SIN_ETAPA_ACTIVA,
+                    "OP_SIN_ETAPA_ACTIVA",
+                    Map.of("ordenProduccionId", (Object) null)
+            );
+        }
         if (etapaId != null) {
-            return etapaId;
+            EtapaProduccion etapa = etapaProduccionRepository.findById(etapaId)
+                    .orElseThrow(() -> new CustomBusinessException(
+                            ApiErrorCode.OP_SIN_ETAPA_ACTIVA,
+                            "OP_SIN_ETAPA_ACTIVA",
+                            Map.of("ordenProduccionId", ordenProduccionId, "etapaId", etapaId)
+                    ));
+            return validarEtapaActiva(etapa, ordenProduccionId);
         }
         EtapaProduccion etapaActiva = etapaProduccionRepository
-                .findTopByOrdenProduccionIdAndFechaFinIsNullOrderByFechaInicioDesc(ordenProduccionId)
+                .findEtapaActivaByOrdenProduccionId(ordenProduccionId)
+                .map(e -> validarEtapaActiva(e, ordenProduccionId))
                 .orElseThrow(() -> new CustomBusinessException(
                         ApiErrorCode.OP_SIN_ETAPA_ACTIVA,
                         "OP_SIN_ETAPA_ACTIVA",
                         Map.of("ordenProduccionId", ordenProduccionId)
                 ));
-        return etapaActiva.getId();
+        return etapaActiva;
+    }
+
+    private EtapaProduccion validarEtapaActiva(EtapaProduccion etapa, Long ordenProduccionId) {
+        if (etapa == null || etapa.getFechaInicio() == null || etapa.getFechaFin() != null) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.OP_SIN_ETAPA_ACTIVA,
+                    "OP_SIN_ETAPA_ACTIVA",
+                    Map.of("ordenProduccionId", ordenProduccionId,
+                            "etapaId", etapa != null ? etapa.getId() : null)
+            );
+        }
+        if (etapa.getOrdenProduccion() != null
+                && etapa.getOrdenProduccion().getId() != null
+                && !Objects.equals(etapa.getOrdenProduccion().getId(), ordenProduccionId)) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.OP_SIN_ETAPA_ACTIVA,
+                    "OP_SIN_ETAPA_ACTIVA",
+                    Map.of("ordenProduccionId", ordenProduccionId,
+                            "etapaId", etapa.getId())
+            );
+        }
+        return etapa;
     }
 
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/EtapaProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/EtapaProduccion.java
@@ -6,6 +6,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
+import jakarta.persistence.PrePersist;
 
 @Entity
 @Table(name = "etapa_produccion",
@@ -48,4 +49,13 @@ public class EtapaProduccion {
 
     @Column(name = "usuario_nombre", length = 100)
     private String usuarioNombre;
+
+    @PrePersist
+    public void prePersist() {
+        if (fechaInicio == null) {
+            fechaInicio = LocalDateTime.now();
+        }
+        // Las etapas nuevas nunca deberían nacer cerradas
+        fechaFin = null;
+    }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaProduccionRepository.java
@@ -2,11 +2,20 @@ package com.willyes.clemenintegra.produccion.repository;
 
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
 public interface EtapaProduccionRepository extends JpaRepository<EtapaProduccion, Long> {
     List<EtapaProduccion> findByOrdenProduccionIdOrderBySecuenciaAsc(Long ordenProduccionId);
 
-    Optional<EtapaProduccion> findTopByOrdenProduccionIdAndFechaFinIsNullOrderByFechaInicioDesc(Long ordenProduccionId);
+    @Query("""
+            select e from EtapaProduccion e
+            where e.ordenProduccion.id = :ordenId
+              and e.fechaInicio is not null
+              and e.fechaFin is null
+            order by e.fechaInicio desc
+            """)
+    Optional<EtapaProduccion> findEtapaActivaByOrdenProduccionId(@Param("ordenId") Long ordenProduccionId);
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
@@ -25,6 +25,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,6 +97,12 @@ class MovimientoInventarioServiceConsumoEtapaTest {
 
         when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(30L);
         when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(70L);
+        EtapaProduccion etapaActiva = EtapaProduccion.builder()
+                .id(20L)
+                .fechaInicio(LocalDateTime.now())
+                .ordenProduccion(OrdenProduccion.builder().id(10L).build())
+                .build();
+        when(etapaProduccionRepository.findById(anyLong())).thenReturn(Optional.of(etapaActiva));
 
         LoteProducto lotePrebodega = new LoteProducto();
         lotePrebodega.setId(300L);
@@ -146,6 +153,12 @@ class MovimientoInventarioServiceConsumoEtapaTest {
 
         when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(30L);
         when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(70L);
+        EtapaProduccion etapaActiva = EtapaProduccion.builder()
+                .id(20L)
+                .fechaInicio(LocalDateTime.now())
+                .ordenProduccion(OrdenProduccion.builder().id(10L).build())
+                .build();
+        when(etapaProduccionRepository.findById(anyLong())).thenReturn(Optional.of(etapaActiva));
 
         LoteProducto lotePrebodega1 = loteEnPrebodega(detalle1.getLote(), producto, 30);
         LoteProducto lotePrebodega2 = loteEnPrebodega(detalle2.getLote(), producto, 30);
@@ -191,6 +204,12 @@ class MovimientoInventarioServiceConsumoEtapaTest {
 
         when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(30L);
         when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(70L);
+        EtapaProduccion etapaActivaError = EtapaProduccion.builder()
+                .id(20L)
+                .fechaInicio(LocalDateTime.now())
+                .ordenProduccion(OrdenProduccion.builder().id(10L).build())
+                .build();
+        when(etapaProduccionRepository.findById(anyLong())).thenReturn(Optional.of(etapaActivaError));
         when(loteProductoRepository.findByCodigoLoteAndProductoIdAndAlmacenId(any(), anyInt(), anyInt()))
                 .thenReturn(Optional.empty());
 
@@ -212,8 +231,8 @@ class MovimientoInventarioServiceConsumoEtapaTest {
 
         when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(30L);
         when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(70L);
-        when(etapaProduccionRepository.findTopByOrdenProduccionIdAndFechaFinIsNullOrderByFechaInicioDesc(10L))
-                .thenReturn(Optional.of(EtapaProduccion.builder().id(22L).build()));
+        when(etapaProduccionRepository.findEtapaActivaByOrdenProduccionId(10L))
+                .thenReturn(Optional.of(EtapaProduccion.builder().id(22L).fechaInicio(LocalDateTime.now()).build()));
 
         LoteProducto lotePrebodega = new LoteProducto();
         lotePrebodega.setId(300L);
@@ -260,8 +279,8 @@ class MovimientoInventarioServiceConsumoEtapaTest {
 
         when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(30L);
         when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(70L);
-        when(etapaProduccionRepository.findTopByOrdenProduccionIdAndFechaFinIsNullOrderByFechaInicioDesc(10L))
-                .thenReturn(Optional.of(EtapaProduccion.builder().id(30L).build()));
+        when(etapaProduccionRepository.findEtapaActivaByOrdenProduccionId(10L))
+                .thenReturn(Optional.of(EtapaProduccion.builder().id(30L).fechaInicio(LocalDateTime.now()).build()));
 
         LoteProducto lotePrebodega = new LoteProducto();
         lotePrebodega.setId(300L);
@@ -298,7 +317,7 @@ class MovimientoInventarioServiceConsumoEtapaTest {
     @Test
     void consumirInsumosPorOrden_sinEtapaActivaLanzaError() {
         when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(30L);
-        when(etapaProduccionRepository.findTopByOrdenProduccionIdAndFechaFinIsNullOrderByFechaInicioDesc(10L))
+        when(etapaProduccionRepository.findEtapaActivaByOrdenProduccionId(10L))
                 .thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.consumirInsumosPorOrden(10L, null, 5L))

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -427,6 +427,8 @@ class MovimientoInventarioServiceSolicitudOpTest {
 
         EtapaProduccion etapaProduccion = new EtapaProduccion();
         etapaProduccion.setId(77L);
+        etapaProduccion.setFechaInicio(LocalDateTime.now());
+        etapaProduccion.setFechaFin(null);
 
         MovimientoInventario movimientoEntidad = new MovimientoInventario();
         movimientoEntidad.setFechaIngreso(LocalDateTime.now());
@@ -465,7 +467,7 @@ class MovimientoInventarioServiceSolicitudOpTest {
         given(solicitudMovimientoRepository.findByIdWithLock(solicitud.getId())).willReturn(Optional.of(solicitud));
         given(usuarioService.obtenerUsuarioAutenticado()).willReturn(usuario);
         given(entityManager.getReference(eq(OrdenProduccion.class), eq(ordenProduccion.getId()))).willReturn(ordenProduccion);
-        given(entityManager.getReference(eq(EtapaProduccion.class), eq(etapaProduccion.getId()))).willReturn(etapaProduccion);
+        given(etapaProduccionRepository.findById(etapaProduccion.getId())).willReturn(Optional.of(etapaProduccion));
         given(entityManager.getReference(eq(Almacen.class), any())).willAnswer(invocation -> {
             Object id = invocation.getArgument(1);
             return new Almacen(id instanceof Integer ? (Integer) id : ((Long) id).intValue());
@@ -555,6 +557,8 @@ class MovimientoInventarioServiceSolicitudOpTest {
         EtapaProduccion etapaProduccion = new EtapaProduccion();
         etapaProduccion.setId(77L);
         etapaProduccion.setOrdenProduccion(ordenProduccion);
+        etapaProduccion.setFechaInicio(LocalDateTime.now());
+        etapaProduccion.setFechaFin(null);
 
         MovimientoInventario movimientoEntidad = new MovimientoInventario();
         movimientoEntidad.setFechaIngreso(LocalDateTime.now());
@@ -603,10 +607,8 @@ class MovimientoInventarioServiceSolicitudOpTest {
         given(solicitudMovimientoRepository.saveAndFlush(solicitud)).willReturn(solicitud);
         lenient().when(reservaLoteRepository.sumPendienteActivaByLoteId(anyLong(), eq(EstadoReservaLote.ACTIVA)))
                 .thenReturn(BigDecimal.ZERO);
-        given(etapaProduccionRepository.findTopByOrdenProduccionIdAndFechaFinIsNullOrderByFechaInicioDesc(
-                ordenProduccion.getId()))
+        given(etapaProduccionRepository.findEtapaActivaByOrdenProduccionId(ordenProduccion.getId()))
                 .willReturn(Optional.of(etapaProduccion));
-        given(entityManager.getReference(eq(EtapaProduccion.class), eq(etapaProduccion.getId()))).willReturn(etapaProduccion);
         given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
             MovimientoInventario mov = invocation.getArgument(0);
             mov.setId(902L);
@@ -1024,6 +1026,12 @@ class MovimientoInventarioServiceSolicitudOpTest {
         Producto producto = productoSemiElaborado();
         LoteProducto lote = loteEnEstado(producto, EstadoLote.EN_CUARENTENA, new BigDecimal("10"), 60);
 
+        EtapaProduccion etapaActiva = EtapaProduccion.builder()
+                .id(300L)
+                .fechaInicio(LocalDateTime.now())
+                .ordenProduccion(OrdenProduccion.builder().id(30L).build())
+                .build();
+
         MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
                 null,
                 new BigDecimal("2"),
@@ -1041,7 +1049,7 @@ class MovimientoInventarioServiceSolicitudOpTest {
                 2L,
                 null,
                 null,
-                null,
+                30L,
                 null,
                 null,
                 null,
@@ -1068,6 +1076,11 @@ class MovimientoInventarioServiceSolicitudOpTest {
             Number id = invocation.getArgument(1);
             return new Almacen(id.intValue());
         });
+        given(entityManager.getReference(eq(OrdenProduccion.class), eq(30L))).willAnswer(invocation -> {
+            OrdenProduccion op = new OrdenProduccion();
+            op.setId(30L);
+            return op;
+        });
         given(usuarioService.obtenerUsuarioAutenticado()).willReturn(usuarioBasico());
         given(loteProductoRepository.findByIdForUpdate(lote.getId())).willReturn(Optional.of(lote));
         doThrow(new CustomBusinessException(ApiErrorCode.CALIDAD_LOTE_NO_LIBERADO, "BLOQUEO"))
@@ -1075,11 +1088,260 @@ class MovimientoInventarioServiceSolicitudOpTest {
         lenient().when(catalogResolver.decimals(any())).thenReturn(2);
         lenient().when(reservaLoteRepository.sumPendienteActivaByLoteId(anyLong(), eq(EstadoReservaLote.ACTIVA)))
                 .thenReturn(BigDecimal.ZERO);
+        given(etapaProduccionRepository.findEtapaActivaByOrdenProduccionId(30L)).willReturn(Optional.of(etapaActiva));
 
         assertThatThrownBy(() -> service.registrarMovimiento(dto))
                 .isInstanceOf(CustomBusinessException.class)
                 .extracting("code")
                 .isEqualTo(ApiErrorCode.CALIDAD_LOTE_NO_LIBERADO);
+    }
+
+    @Test
+    void registrarMovimiento_salidaProduccionAsociaEtapaActiva() {
+        Producto producto = new Producto();
+        producto.setId(1);
+        UnidadMedida unidad = new UnidadMedida();
+        unidad.setId(5L);
+        producto.setUnidadMedida(unidad);
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(200L);
+        lote.setProducto(producto);
+        lote.setAlmacen(new Almacen(10));
+        lote.setStockLote(new BigDecimal("50"));
+        lote.setStockReservado(BigDecimal.ZERO);
+        lote.setEstado(EstadoLote.DISPONIBLE);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("5"),
+                TipoMovimiento.SALIDA,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                "DOC-SAL",
+                null,
+                producto.getId(),
+                lote.getId(),
+                lote.getAlmacen().getId(),
+                null,
+                null,
+                null,
+                null,
+                2L,
+                null,
+                null,
+                20L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.FALSE,
+                List.<AtencionDTO>of(),
+                null
+        );
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(TipoMovimiento.SALIDA);
+        movimientoEntidad.setClasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+
+        EtapaProduccion etapaActiva = EtapaProduccion.builder()
+                .id(55L)
+                .fechaInicio(LocalDateTime.now())
+                .ordenProduccion(OrdenProduccion.builder().id(20L).build())
+                .build();
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
+        TipoMovimientoDetalle detalle = new TipoMovimientoDetalle();
+        detalle.setId(2L);
+        detalle.setDescripcion("SALIDA OP");
+        given(tipoMovimientoDetalleRepository.findById(2L)).willReturn(Optional.of(detalle));
+        given(etapaProduccionRepository.findEtapaActivaByOrdenProduccionId(20L)).willReturn(Optional.of(etapaActiva));
+        given(entityManager.getReference(eq(OrdenProduccion.class), eq(20L))).willAnswer(invocation -> {
+            OrdenProduccion op = new OrdenProduccion();
+            op.setId(20L);
+            return op;
+        });
+        given(entityManager.getReference(eq(Almacen.class), any())).willAnswer(invocation -> {
+            Number id = invocation.getArgument(1);
+            return new Almacen(id.intValue());
+        });
+        given(loteProductoRepository.findByIdForUpdate(lote.getId())).willReturn(Optional.of(lote));
+        lenient().when(reservaLoteRepository.sumPendienteActivaByLoteId(anyLong(), any()))
+                .thenReturn(BigDecimal.ZERO);
+        lenient().when(catalogResolver.decimals(any())).thenReturn(2);
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(901L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            return MovimientoInventarioResponseDTO.builder()
+                    .id(mov.getId())
+                    .ordenProduccionEtapaId(
+                            mov.getOrdenProduccionEtapa() != null ? mov.getOrdenProduccionEtapa().getId() : null)
+                    .build();
+        });
+        doNothing().when(loteCalidadValidator).validarLoteUtilizable(any());
+
+        MovimientoInventarioResponseDTO respuesta = service.registrarMovimiento(dto);
+
+        assertThat(respuesta.getOrdenProduccionEtapaId()).isEqualTo(55L);
+        verify(movimientoInventarioRepository).save(argThat(mov ->
+                mov.getOrdenProduccionEtapa() != null && mov.getOrdenProduccionEtapa().getId().equals(55L)));
+    }
+
+    @Test
+    void registrarMovimiento_salidaProduccionSinEtapaActivaLanzaError() {
+        Producto producto = new Producto();
+        producto.setId(1);
+        producto.setUnidadMedida(new UnidadMedida());
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(201L);
+        lote.setProducto(producto);
+        lote.setAlmacen(new Almacen(10));
+        lote.setStockLote(new BigDecimal("10"));
+        lote.setStockReservado(BigDecimal.ZERO);
+        lote.setEstado(EstadoLote.DISPONIBLE);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("1"),
+                TipoMovimiento.SALIDA,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                "DOC-SAL",
+                null,
+                producto.getId(),
+                lote.getId(),
+                lote.getAlmacen().getId(),
+                null,
+                null,
+                null,
+                null,
+                2L,
+                null,
+                null,
+                21L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.FALSE,
+                List.<AtencionDTO>of(),
+                null
+        );
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(TipoMovimiento.SALIDA);
+        movimientoEntidad.setClasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
+        given(tipoMovimientoDetalleRepository.findById(2L)).willReturn(Optional.of(new TipoMovimientoDetalle()));
+        given(etapaProduccionRepository.findEtapaActivaByOrdenProduccionId(21L)).willReturn(Optional.empty());
+        given(entityManager.getReference(eq(Almacen.class), any())).willAnswer(invocation -> {
+            Number id = invocation.getArgument(1);
+            return new Almacen(id.intValue());
+        });
+        given(entityManager.getReference(eq(OrdenProduccion.class), eq(21L))).willAnswer(invocation -> {
+            OrdenProduccion op = new OrdenProduccion();
+            op.setId(21L);
+            return op;
+        });
+        lenient().when(reservaLoteRepository.sumPendienteActivaByLoteId(anyLong(), any()))
+                .thenReturn(BigDecimal.ZERO);
+        lenient().when(catalogResolver.decimals(any())).thenReturn(2);
+
+        assertThatThrownBy(() -> service.registrarMovimiento(dto))
+                .isInstanceOf(CustomBusinessException.class)
+                .extracting("code")
+                .isEqualTo(ApiErrorCode.OP_SIN_ETAPA_ACTIVA);
+
+        verify(movimientoInventarioRepository, never()).save(any(MovimientoInventario.class));
+    }
+
+    @Test
+    void registrarMovimiento_descartaEtapaCorruptaSinFechaInicio() {
+        Producto producto = new Producto();
+        producto.setId(1);
+        producto.setUnidadMedida(new UnidadMedida());
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(202L);
+        lote.setProducto(producto);
+        lote.setAlmacen(new Almacen(10));
+        lote.setStockLote(new BigDecimal("10"));
+        lote.setStockReservado(BigDecimal.ZERO);
+        lote.setEstado(EstadoLote.DISPONIBLE);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("1"),
+                TipoMovimiento.SALIDA,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                "DOC-SAL",
+                null,
+                producto.getId(),
+                lote.getId(),
+                lote.getAlmacen().getId(),
+                null,
+                null,
+                null,
+                null,
+                2L,
+                null,
+                null,
+                22L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.FALSE,
+                List.<AtencionDTO>of(),
+                null
+        );
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(TipoMovimiento.SALIDA);
+        movimientoEntidad.setClasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+
+        EtapaProduccion corrupta = EtapaProduccion.builder()
+                .id(88L)
+                .fechaInicio(null)
+                .fechaFin(null)
+                .ordenProduccion(OrdenProduccion.builder().id(22L).build())
+                .build();
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
+        given(tipoMovimientoDetalleRepository.findById(2L)).willReturn(Optional.of(new TipoMovimientoDetalle()));
+        given(etapaProduccionRepository.findEtapaActivaByOrdenProduccionId(22L)).willReturn(Optional.of(corrupta));
+        given(entityManager.getReference(eq(Almacen.class), any())).willAnswer(invocation -> {
+            Number id = invocation.getArgument(1);
+            return new Almacen(id.intValue());
+        });
+        given(entityManager.getReference(eq(OrdenProduccion.class), eq(22L))).willAnswer(invocation -> {
+            OrdenProduccion op = new OrdenProduccion();
+            op.setId(22L);
+            return op;
+        });
+        lenient().when(reservaLoteRepository.sumPendienteActivaByLoteId(anyLong(), any()))
+                .thenReturn(BigDecimal.ZERO);
+        lenient().when(catalogResolver.decimals(any())).thenReturn(2);
+
+        assertThatThrownBy(() -> service.registrarMovimiento(dto))
+                .isInstanceOf(CustomBusinessException.class)
+                .extracting("code")
+                .isEqualTo(ApiErrorCode.OP_SIN_ETAPA_ACTIVA);
+
+        verify(movimientoInventarioRepository, never()).save(any(MovimientoInventario.class));
     }
 
     private void prepararEscenarioComun(MovimientoInventarioDTO dto,


### PR DESCRIPTION
## Summary
- require resolving a real active etapa before persisting SALIDA_PRODUCCION, attaching the etapa to the movement and raising OP_SIN_ETAPA_ACTIVA when missing or corrupt
- add repository helper to fetch the latest etapa with fecha_inicio set and fecha_fin null, and ensure new etapas default their start timestamp
- expand movement and consumo tests to cover etapa resolution success, missing etapas, and corrupted etapa records

## Testing
- mvn test -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69507f63e6648333b4b5d4f655dd455d)