### PR TITLE
Prevent etapa validation for pre-bodega transfers

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -582,14 +582,25 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             ordenProduccionIdContexto = solicitud.getOrdenProduccion().getId();
         }
 
-        boolean esConsumoEtapa = clasificacion == ClasificacionMovimientoInventario.SALIDA_PRODUCCION;
-        boolean requiereEtapaActiva = requiereEtapaActiva(
+        boolean esConsumoEtapa = esMovimientoConsumoEnEtapa(
                 clasificacion,
+                tipoMovimiento,
                 resolvedTipoDetalleId,
-                dto.ordenProduccionEtapaId(),
+                almacenDestinoIdNormalizado);
+        Long etapaIdContextual = esConsumoEtapa ? dto.ordenProduccionEtapaId() : null;
+
+        boolean requiereEtapaActiva = requiereEtapaActiva(
+                esConsumoEtapa,
+                etapaIdContextual,
                 ordenProduccionIdContexto);
+        log.debug("OP_ETAPA requiere? tipoMovimiento={} clasificacion={} motivoId={} tipoDetalleId={} opId={} etapaId={} requiere={}",
+                tipoMovimiento, clasificacion, dto.motivoMovimientoId(), resolvedTipoDetalleId, ordenProduccionIdContexto,
+                etapaIdContextual, requiereEtapaActiva);
         if (requiereEtapaActiva) {
-            EtapaProduccion etapaActiva = resolverEtapaActiva(ordenProduccionIdContexto, dto.ordenProduccionEtapaId());
+            log.debug("OP_ETAPA resolverEtapaActiva opId={} etapaId={}", ordenProduccionIdContexto, etapaIdContextual);
+            EtapaProduccion etapaActiva = resolverEtapaActiva(ordenProduccionIdContexto, etapaIdContextual);
+            log.debug("OP_ETAPA etapaActiva id={} estado={}", etapaActiva != null ? etapaActiva.getId() : null,
+                    etapaActiva != null ? etapaActiva.getEstado() : null);
             etapaProduccion = etapaActiva;
         }
 
@@ -745,7 +756,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                     .codigoOrdenProduccion(solicitud.getOrdenProduccion() != null
                             ? solicitud.getOrdenProduccion().getCodigoOrden()
                             : null)
-                    .ordenProduccionEtapaId(dto.ordenProduccionEtapaId())
+                    .ordenProduccionEtapaId(etapaIdContextual)
                     .detallesSolicitud(detallesRespuesta == null ? List.of() : List.copyOf(detallesRespuesta))
                     .build();
         }
@@ -3208,23 +3219,33 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         return etapaActiva.getId();
     }
 
-    private boolean requiereEtapaActiva(ClasificacionMovimientoInventario clasificacion,
-                                        Long tipoMovimientoDetalleId,
+    private boolean requiereEtapaActiva(boolean esConsumoEtapa,
                                         Long etapaId,
                                         Long ordenProduccionId) {
-        if (ordenProduccionId == null) {
+        if (!esConsumoEtapa || ordenProduccionId == null) {
             return false;
         }
-        if (etapaId != null) {
-            return true;
+        return true;
+    }
+
+    private boolean esMovimientoConsumoEnEtapa(ClasificacionMovimientoInventario clasificacion,
+                                               TipoMovimiento tipoMovimiento,
+                                               Long tipoMovimientoDetalleId,
+                                               Integer almacenDestinoId) {
+        if (clasificacion != ClasificacionMovimientoInventario.SALIDA_PRODUCCION
+                || tipoMovimiento != TipoMovimiento.SALIDA) {
+            return false;
         }
-        if (clasificacion != null) {
-            return clasificacion == ClasificacionMovimientoInventario.SALIDA_PRODUCCION;
-        }
-        Long tipoDetalleSalidaProduccionId = catalogResolver.getTipoDetalleSalidaProduccionId();
-        return tipoDetalleSalidaProduccionId != null
+        boolean detalleEsTransferencia = tipoDetalleTransferenciaId != null
                 && tipoMovimientoDetalleId != null
-                && Objects.equals(tipoMovimientoDetalleId, tipoDetalleSalidaProduccionId);
+                && Objects.equals(tipoMovimientoDetalleId, tipoDetalleTransferenciaId.longValue());
+        if (detalleEsTransferencia) {
+            return false;
+        }
+        boolean destinoEsPrebodega = preBodegaId != null
+                && almacenDestinoId != null
+                && Objects.equals(preBodegaId.longValue(), almacenDestinoId.longValue());
+        return !destinoEsPrebodega;
     }
 
     private EtapaProduccion resolverEtapaActiva(Long ordenProduccionId, Long etapaId) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
@@ -395,10 +395,9 @@ class MovimientoInventarioServiceConsumoEtapaTest {
         boolean requiere = ReflectionTestUtils.invokeMethod(
                 service,
                 "requiereEtapaActiva",
-                ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
-                100L,
+                false,
                 null,
-                null
+                10L
         );
 
         assertThat(requiere).isFalse();
@@ -409,8 +408,7 @@ class MovimientoInventarioServiceConsumoEtapaTest {
         boolean requiere = ReflectionTestUtils.invokeMethod(
                 service,
                 "requiereEtapaActiva",
-                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
-                200L,
+                true,
                 null,
                 10L
         );
@@ -423,8 +421,7 @@ class MovimientoInventarioServiceConsumoEtapaTest {
         boolean requiere = ReflectionTestUtils.invokeMethod(
                 service,
                 "requiereEtapaActiva",
-                ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
-                200L,
+                true,
                 55L,
                 10L
         );

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
@@ -31,6 +31,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -40,11 +41,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -389,9 +392,69 @@ class MovimientoInventarioServiceTransferenciaTest {
                 });
     }
 
+    @Test
+    void salidaProduccionAHaciaPrebodegaNoResuelveEtapa() {
+        ReflectionTestUtils.setField(service, "preBodegaId", 6);
+        ReflectionTestUtils.setField(service, "tipoDetalleTransferenciaId", 12);
+
+        Producto producto = crearProducto(11, 2);
+        LoteProducto lote = crearLote(410L, producto, 5, EstadoLote.DISPONIBLE,
+                new BigDecimal("1000"), BigDecimal.ZERO, false);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("100"),
+                TipoMovimiento.SALIDA,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                null,
+                null,
+                producto.getId(),
+                lote.getId(),
+                5,
+                6,
+                null,
+                null,
+                null,
+                11L,
+                null,
+                24L,
+                1L,
+                null,
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                null,
+                null
+        );
+
+        configurarMocksBasicos(producto, lote);
+        given(mapper.toEntity(dto)).willReturn(new MovimientoInventario());
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class)))
+                .willAnswer(invocation -> {
+                    MovimientoInventario mov = invocation.getArgument(0);
+                    mov.setId(901L);
+                    return mov;
+                });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willAnswer(invocation -> {
+                    MovimientoInventario mov = invocation.getArgument(0);
+                    return MovimientoInventarioResponseDTO.builder().id(mov.getId()).build();
+                });
+        lenient().doNothing().when(loteCalidadValidator).validarLoteUtilizable(any());
+
+        MovimientoInventarioResponseDTO respuesta = service.registrarMovimiento(dto);
+
+        assertThat(respuesta).isNotNull();
+        assertThat(respuesta.getId()).isEqualTo(901L);
+        verifyNoInteractions(etapaProduccionRepository);
+    }
+
     private void configurarMocksBasicos(Producto producto, LoteProducto lote) {
         given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
-        given(tipoMovimientoDetalleRepository.findById(5L)).willReturn(Optional.of(new TipoMovimientoDetalle()));
+        lenient().when(tipoMovimientoDetalleRepository.findById(anyLong()))
+                .thenReturn(Optional.of(new TipoMovimientoDetalle()));
         given(loteProductoRepository.findByIdForUpdate(lote.getId())).willReturn(Optional.of(lote));
         lenient().when(loteProductoRepository.findByCodigoLoteAndProductoIdAndAlmacenId(
                 lote.getCodigoLote(), producto.getId(), 6)).thenReturn(Optional.empty());


### PR DESCRIPTION
## Summary
- add debug logs around etapa resolution and gate etapa validation to true consumptions only
- treat SALIDA_PRODUCCION hacia Pre-Bodega as pre-arranque, skipping etapa resolution even if etapaId is provided
- cover prebodega transfer scenario and updated etapa requirement helpers with unit tests

## Testing
- mvn -q -Dtest=MovimientoInventarioServiceConsumoEtapaTest,MovimientoInventarioServiceTransferenciaTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d9801fa883338c902d9216149baa)