### PR TITLE
Evitar etapa activa en traslados hacia Pre-Bodega

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -89,6 +89,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
     private static final Logger log = LoggerFactory.getLogger(MovimientoInventarioServiceImpl.class);
     private static final ZoneId ZONA_BOGOTA = ZoneId.of("America/Bogota");
+    private static final long PREBODEGA_PRODUCCION_ID_FALLBACK = 6L;
     /** Nombre normalizado del almacén Pre-Bodega Producción */
     private static final String PRE_BODEGA_PRODUCCION_NORMALIZADO =
             java.text.Normalizer.normalize("Pre-Bodega Producción", java.text.Normalizer.Form.NFD)
@@ -157,6 +158,8 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     private Integer preBodegaId;
     @Value("${inventory.tipoDetalle.transferenciaId}")
     private Integer tipoDetalleTransferenciaId;
+    private Long preBodegaProduccionIdCache;
+    private boolean preBodegaProduccionIdCacheLoaded;
 
     @Transactional(rollbackFor = Exception.class)
     @Override
@@ -582,8 +585,46 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             ordenProduccionIdContexto = solicitud.getOrdenProduccion().getId();
         }
 
+        Long preBodegaProduccionId = resolverAlmacenPreBodegaId();
+        boolean esTrasladoAPreBodega = esTrasladoManualAPreBodega(
+                tipoMovimiento,
+                clasificacion,
+                almacenDestinoIdNormalizado,
+                almacenDestino,
+                ordenProduccionIdContexto,
+                preBodegaProduccionId,
+                dto.ordenProduccionEtapaId(),
+                solicitud != null
+        );
+        if (esTrasladoAPreBodega) {
+            if (preBodegaProduccionId != null
+                    && (almacenDestino == null
+                    || !Objects.equals(almacenDestino.getId().longValue(), preBodegaProduccionId))) {
+                almacenDestino = entityManager.getReference(Almacen.class, Math.toIntExact(preBodegaProduccionId));
+                almacenDestinoIdNormalizado = almacenDestino.getId();
+            }
+            if (tipoMovimiento != TipoMovimiento.TRANSFERENCIA) {
+                tipoMovimiento = TipoMovimiento.TRANSFERENCIA;
+                movimiento.setTipoMovimiento(TipoMovimiento.TRANSFERENCIA);
+            }
+            if (clasificacion != ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION) {
+                clasificacion = ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION;
+                movimiento.setClasificacion(clasificacion);
+            }
+            if (tipoDetalleTransferenciaId != null
+                    && (tipoMovimientoDetalle == null
+                    || !Objects.equals(tipoMovimientoDetalle.getId(), tipoDetalleTransferenciaId.longValue()))) {
+                tipoMovimientoDetalle = tipoMovimientoDetalleRepository
+                        .findById(tipoDetalleTransferenciaId.longValue())
+                        .orElse(tipoMovimientoDetalle);
+                movimiento.setTipoMovimientoDetalle(tipoMovimientoDetalle);
+            }
+            log.info("TRASLADO_PREBODEGA_DETECTADO: opId={} destinoId={} tipoNormalizado={} clasificacion={}",
+                    ordenProduccionIdContexto, almacenDestinoIdNormalizado, tipoMovimiento, clasificacion);
+        }
+
         boolean esConsumoEtapa = clasificacion == ClasificacionMovimientoInventario.SALIDA_PRODUCCION;
-        boolean requiereEtapaActiva = requiereEtapaActiva(
+        boolean requiereEtapaActiva = !esTrasladoAPreBodega && requiereEtapaActiva(
                 clasificacion,
                 resolvedTipoDetalleId,
                 dto.ordenProduccionEtapaId(),
@@ -2032,7 +2073,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         boolean hayContextoSolicitud = solicitudContexto != null || detalleContexto != null;
 
         boolean esTransferenciaInternaProduccion = tipo == TipoMovimiento.TRANSFERENCIA
-                && dto.clasificacionMovimientoInventario() == ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION;
+                && clasificacion == ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION;
         boolean autoSplitSolicitado = Boolean.TRUE.equals(dto.autoSplit());
         boolean requiereAutoSplit = tipo == TipoMovimiento.TRANSFERENCIA
                 && esTransferenciaInternaProduccion
@@ -2669,6 +2710,51 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
         String nfd = java.text.Normalizer.normalize(nombre, java.text.Normalizer.Form.NFD);
         return nfd.replaceAll("\\p{M}", "").toLowerCase();
+    }
+
+    private Long resolverAlmacenPreBodegaId() {
+        if (preBodegaProduccionIdCacheLoaded) {
+            return preBodegaProduccionIdCache;
+        }
+        preBodegaProduccionIdCacheLoaded = true;
+        if (preBodegaId != null) {
+            preBodegaProduccionIdCache = preBodegaId.longValue();
+            return preBodegaProduccionIdCache;
+        }
+        Optional<Almacen> preBodega = almacenRepository.findByNombre("Pre-Bodega Producción");
+        if (preBodega.isPresent() && preBodega.get().getId() != null) {
+            preBodegaProduccionIdCache = preBodega.get().getId().longValue();
+            return preBodegaProduccionIdCache;
+        }
+        preBodegaProduccionIdCache = PREBODEGA_PRODUCCION_ID_FALLBACK;
+        log.warn("PREBODEGA_ID_NO_CONFIGURADA_USANDO_FALLBACK: {}", PREBODEGA_PRODUCCION_ID_FALLBACK);
+        return preBodegaProduccionIdCache;
+    }
+
+    private boolean esTrasladoManualAPreBodega(TipoMovimiento tipoMovimiento,
+                                               ClasificacionMovimientoInventario clasificacion,
+                                               Integer almacenDestinoId,
+                                               Almacen almacenDestino,
+                                               Long ordenProduccionId,
+                                               Long preBodegaProduccionId,
+                                               Long etapaProduccionId,
+                                               boolean tieneSolicitud) {
+        if (ordenProduccionId == null || etapaProduccionId != null || tieneSolicitud) {
+            return false;
+        }
+        boolean destinoCoincide = (almacenDestinoId != null && preBodegaProduccionId != null
+                && Objects.equals(almacenDestinoId.longValue(), preBodegaProduccionId));
+        if (!destinoCoincide && almacenDestino != null) {
+            destinoCoincide = PRE_BODEGA_PRODUCCION_NORMALIZADO.equals(normalizar(almacenDestino.getNombre()));
+        }
+        if (!destinoCoincide) {
+            return false;
+        }
+        boolean esEnvioProduccion = clasificacion == ClasificacionMovimientoInventario.SALIDA_PRODUCCION
+                || clasificacion == ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION
+                || tipoMovimiento == TipoMovimiento.TRANSFERENCIA
+                || tipoMovimiento == TipoMovimiento.SALIDA;
+        return esEnvioProduccion;
     }
 
     private boolean requiereSolicitudMovimientoId(TipoMovimientoDetalle tipoMovimientoDetalle) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -35,6 +35,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1280,6 +1281,105 @@ class MovimientoInventarioServiceSolicitudOpTest {
     }
 
     @Test
+    void registrarMovimiento_trasladoPrebodegaNoExigeEtapaActiva() {
+        ReflectionTestUtils.setField(service, "preBodegaId", 6);
+        ReflectionTestUtils.setField(service, "tipoDetalleTransferenciaId", 2);
+
+        Producto producto = new Producto();
+        producto.setId(1);
+        producto.setUnidadMedida(new UnidadMedida());
+
+        Almacen origen = new Almacen(5);
+        origen.setNombre("Principal Empaque");
+
+        Almacen destino = new Almacen(6);
+        destino.setNombre("Pre-Bodega Producción");
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(301L);
+        lote.setProducto(producto);
+        lote.setAlmacen(origen);
+        lote.setStockLote(new BigDecimal("10"));
+        lote.setStockReservado(BigDecimal.ZERO);
+        lote.setEstado(EstadoLote.DISPONIBLE);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("3"),
+                TipoMovimiento.SALIDA,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                "DOC-SAL",
+                null,
+                producto.getId(),
+                lote.getId(),
+                origen.getId(),
+                destino.getId(),
+                null,
+                null,
+                null,
+                2L,
+                null,
+                null,
+                24L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.FALSE,
+                List.<AtencionDTO>of(),
+                null
+        );
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(TipoMovimiento.SALIDA);
+        movimientoEntidad.setClasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
+        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
+        tipoDetalle.setId(2L);
+        given(tipoMovimientoDetalleRepository.findById(2L)).willReturn(Optional.of(tipoDetalle));
+        given(entityManager.getReference(eq(Almacen.class), any())).willAnswer(invocation -> {
+            Number id = invocation.getArgument(1);
+            if (Objects.equals(id.longValue(), destino.getId().longValue())) {
+                return destino;
+            }
+            Almacen almacen = new Almacen(id.intValue());
+            almacen.setNombre("Principal Empaque");
+            return almacen;
+        });
+        OrdenProduccion opReferencia = new OrdenProduccion();
+        opReferencia.setId(24L);
+        given(entityManager.getReference(eq(OrdenProduccion.class), eq(24L))).willReturn(opReferencia);
+        given(loteProductoRepository.findByIdForUpdate(lote.getId())).willReturn(Optional.of(lote));
+        given(loteProductoRepository.save(any(LoteProducto.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(usuarioService.obtenerUsuarioAutenticado()).willReturn(usuarioOperativo());
+        lenient().when(catalogResolver.decimals(any())).thenReturn(2);
+        lenient().doNothing().when(loteCalidadValidator).validarLoteUtilizable(any());
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(902L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willReturn(MovimientoInventarioResponseDTO.builder().id(902L).build());
+
+        MovimientoInventarioResponseDTO respuesta = service.registrarMovimiento(dto);
+
+        ArgumentCaptor<MovimientoInventario> movimientoCaptor = ArgumentCaptor.forClass(MovimientoInventario.class);
+        verify(movimientoInventarioRepository).save(movimientoCaptor.capture());
+
+        MovimientoInventario guardado = movimientoCaptor.getValue();
+        assertThat(respuesta.getId()).isEqualTo(902L);
+        assertThat(guardado.getTipoMovimiento()).isEqualTo(TipoMovimiento.TRANSFERENCIA);
+        assertThat(guardado.getClasificacion()).isEqualTo(ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION);
+        assertThat(guardado.getOrdenProduccionEtapa()).isNull();
+        verifyNoInteractions(etapaProduccionRepository);
+    }
+
+    @Test
     void registrarMovimiento_descartaEtapaCorruptaSinFechaInicio() {
         Producto producto = new Producto();
         producto.setId(1);
@@ -1456,6 +1556,19 @@ class MovimientoInventarioServiceSolicitudOpTest {
                 .clave("secret")
                 .nombreCompleto("Tester")
                 .correo("tester@example.com")
+                .activo(true)
+                .bloqueado(false)
+                .build();
+    }
+
+    private Usuario usuarioOperativo() {
+        return Usuario.builder()
+                .id(77L)
+                .rol(RolUsuario.ROL_ALMACENISTA)
+                .nombreUsuario("operativo")
+                .clave("secret")
+                .nombreCompleto("Operativo")
+                .correo("operativo@example.com")
                 .activo(true)
                 .bloqueado(false)
                 .build();


### PR DESCRIPTION
## Summary
- Detect and normalize manual OP transfers to Pre-Bodega as production transfers without requiring an active stage.
- Cache Pre-Bodega lookup with a safe fallback while keeping stage validation for consumption flows with solicitudes.
- Add regression coverage for transfers from almacén 5 to Pre-Bodega when no etapa is provided.

## Testing
- mvn -q -Dtest=MovimientoInventarioServiceSolicitudOpTest,MovimientoInventarioServiceConsumoEtapaTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952decb97608333b78670d64e27a4af)