### PR TITLE
Corrige inicio de etapas y consumo real de insumos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -157,6 +157,28 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
                                                          @Param("clasificacion") ClasificacionMovimientoInventario clasificacion,
                                                          @Param("tipoMovimiento") TipoMovimiento tipoMovimiento);
 
+    @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m " +
+            "where m.ordenProduccion.id = :ordenId " +
+            "and m.producto.id = :productoId " +
+            "and m.clasificacion = :clasificacion " +
+            "and m.tipoMovimiento = :tipoMovimiento " +
+            "and m.ordenProduccionEtapa is not null")
+    BigDecimal sumaCantidadPorOrdenProductoClasificacionConEtapa(@Param("ordenId") Long ordenId,
+                                                                 @Param("productoId") Long productoId,
+                                                                 @Param("clasificacion") ClasificacionMovimientoInventario clasificacion,
+                                                                 @Param("tipoMovimiento") TipoMovimiento tipoMovimiento);
+
+    @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m " +
+            "where m.ordenProduccion.id = :ordenId " +
+            "and m.producto.id = :productoId " +
+            "and m.clasificacion = :clasificacion " +
+            "and m.tipoMovimiento = :tipoMovimiento " +
+            "and m.ordenProduccionEtapa is null")
+    BigDecimal sumaCantidadPorOrdenProductoClasificacionSinEtapa(@Param("ordenId") Long ordenId,
+                                                                 @Param("productoId") Long productoId,
+                                                                 @Param("clasificacion") ClasificacionMovimientoInventario clasificacion,
+                                                                 @Param("tipoMovimiento") TipoMovimiento tipoMovimiento);
+
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "almacenOrigen", "almacenDestino",
             "proveedor", "ordenCompra", "motivoMovimiento", "tipoMovimientoDetalle", "registradoPor"

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -625,6 +625,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
 
         boolean esConsumoEtapa = clasificacion == ClasificacionMovimientoInventario.SALIDA_PRODUCCION;
+        boolean bloquearEtapaPorTraslado = esTrasladoAPreBodega;
         boolean requiereEtapaActiva = !esTrasladoAPreBodega && requiereEtapaActiva(
                 clasificacion,
                 resolvedTipoDetalleId,
@@ -815,7 +816,9 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         movimiento.setAlmacenOrigen(almacenOrigen);
         movimiento.setAlmacenDestino(almacenDestino);
         movimiento.setOrdenProduccion(ordenProduccion);
-        movimiento.setOrdenProduccionEtapa(etapaProduccion);
+        if (!bloquearEtapaPorTraslado) {
+            movimiento.setOrdenProduccionEtapa(etapaProduccion);
+        }
         if (esConsumoEtapa && movimiento.getOrdenProduccionEtapa() == null && ordenProduccionIdContexto != null) {
             Long etapaId = resolverEtapaConsumo(ordenProduccionIdContexto, null);
             movimiento.setOrdenProduccionEtapa(entityManager.getReference(EtapaProduccion.class, etapaId));

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/InsumoOPDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/InsumoOPDTO.java
@@ -16,4 +16,5 @@ public class InsumoOPDTO {
     private BigDecimal cantidadRequerida;
     private BigDecimal cantidadConsumida;
     private BigDecimal faltante;
+    private BigDecimal cantidadAlistada;
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -50,7 +50,6 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
-import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.calidad.service.VidaUtilProductoService;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
@@ -1329,6 +1328,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         if (!etapa.getOrdenProduccion().getId().equals(ordenId)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ETAPA_NO_PERTENECE_A_ORDEN");
         }
+        boolean etapaYaActiva = etapa.getEstado() == EstadoEtapa.EN_PROCESO
+                && etapa.getFechaInicio() != null
+                && etapa.getFechaFin() == null;
+        if (etapaYaActiva) {
+            return etapa;
+        }
         if (etapa.getEstado() != EstadoEtapa.PENDIENTE) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ETAPA_NO_INICIABLE");
         }
@@ -1432,16 +1437,18 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             repository.save(orden);
         }
 
+        etapa.setEstado(EstadoEtapa.EN_PROCESO);
+        etapa.setFechaInicio(LocalDateTime.now());
+        etapa.setUsuarioId(usuario.getId());
+        etapa.setUsuarioNombre(usuario.getNombreCompleto());
+        EtapaProduccion guardada = etapaProduccionRepository.save(etapa);
+
         // Consumo etapa 1: generar SALIDA_PRODUCCION desde Pre-Bodega (idempotente)
         if (etapa.getSecuencia() != null && etapa.getSecuencia() == 1) {
             movimientoInventarioService.consumirInsumosPorOrden(ordenId, etapaId, usuario.getId());
         }
 
-        etapa.setEstado(EstadoEtapa.EN_PROCESO);
-        etapa.setFechaInicio(LocalDateTime.now());
-        etapa.setUsuarioId(usuario.getId());
-        etapa.setUsuarioNombre(usuario.getNombreCompleto());
-        return etapaProduccionRepository.save(etapa);
+        return guardada;
     }
 
     private void recalcularEstadoOrden(OrdenProduccion orden) {
@@ -1555,19 +1562,33 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             }
             BigDecimal requerida = det.getCantidadNecesaria().multiply(orden.getCantidadProgramada());
             Long insumoId = det.getInsumo().getId().longValue();
-            // Solo se consideran consumos reales de producción (SALIDA_PRODUCCION). Traslados o preparaciones no suman aquí.
-            BigDecimal consumidaMov = Optional.ofNullable(
-                    movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacion(
+            // Consumido real: solo salidas de producción ligadas a una etapa (activa o finalizada).
+            BigDecimal consumida = Optional.ofNullable(
+                    movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionConEtapa(
                             id,
                             insumoId,
                             ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
                             TipoMovimiento.SALIDA
                     )
             ).orElse(BigDecimal.ZERO);
-            BigDecimal consumidaReservas = Optional.ofNullable(
-                    reservaLoteRepository.sumConsumidaByOrdenAndProducto(id, insumoId, EstadoReservaLote.CONSUMIDA)
+            // Alistado/reservado: traslados internos a Pre-Bodega sin etapa (pre-arranque).
+            BigDecimal alistadoTransferencias = Optional.ofNullable(
+                    movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
+                            id,
+                            insumoId,
+                            ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
+                            TipoMovimiento.TRANSFERENCIA
+                    )
             ).orElse(BigDecimal.ZERO);
-            BigDecimal consumida = consumidaMov.max(consumidaReservas);
+            BigDecimal alistadoSalidasSinEtapa = Optional.ofNullable(
+                    movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
+                            id,
+                            insumoId,
+                            ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                            TipoMovimiento.SALIDA
+                    )
+            ).orElse(BigDecimal.ZERO);
+            BigDecimal alistado = alistadoTransferencias.add(alistadoSalidasSinEtapa);
             BigDecimal faltante = requerida.subtract(consumida);
             if (faltante.compareTo(BigDecimal.ZERO) < 0) {
                 faltante = BigDecimal.ZERO;
@@ -1578,7 +1599,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     det.getInsumo().getUnidadMedida() != null ? det.getInsumo().getUnidadMedida().getNombre() : null,
                     requerida,
                     consumida,
-                    faltante
+                    faltante,
+                    alistado
             ));
         }
         return lista;

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -577,6 +577,33 @@ class OrdenProduccionServiceImplTest {
     }
 
     @Test
+    @DisplayName("iniciarEtapa es idempotente cuando la etapa ya está activa")
+    void iniciarEtapa_idempotenteMismaEtapaActiva() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(2L);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+
+        EtapaProduccion etapaActiva = EtapaProduccion.builder()
+                .id(20L)
+                .ordenProduccion(orden)
+                .estado(EstadoEtapa.EN_PROCESO)
+                .fechaInicio(LocalDateTime.now().minusMinutes(30))
+                .build();
+
+        when(ordenProduccionRepository.findById(2L)).thenReturn(Optional.of(orden));
+        when(etapaProduccionRepository.findById(20L)).thenReturn(Optional.of(etapaActiva));
+        when(etapaProduccionRepository.countByOrdenProduccionIdAndFechaInicioIsNotNullAndFechaFinIsNull(2L))
+                .thenReturn(1L);
+        when(etapaProduccionRepository.findByOrdenProduccionIdAndFechaInicioIsNotNullAndFechaFinIsNull(2L))
+                .thenReturn(List.of(etapaActiva));
+
+        EtapaProduccion resultado = service.iniciarEtapa(2L, 20L);
+
+        assertThat(resultado).isSameAs(etapaActiva);
+        verify(movimientoInventarioService, never()).consumirInsumosPorOrden(any(), any(), any());
+    }
+
+    @Test
     @DisplayName("iniciarEtapa devuelve conflicto cuando existen múltiples etapas activas")
     void iniciarEtapa_multiplesActivas() {
         OrdenProduccion orden = new OrdenProduccion();
@@ -1190,13 +1217,23 @@ class OrdenProduccionServiceImplTest {
         when(ordenProduccionRepository.findById(200L)).thenReturn(Optional.of(orden));
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
                 .thenReturn(Optional.of(formula));
-        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacion(
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionConEtapa(
                 200L,
                 300L,
                 ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
                 TipoMovimiento.SALIDA))
                 .thenReturn(BigDecimal.ZERO);
-        when(reservaLoteRepository.sumConsumidaByOrdenAndProducto(200L, 300L, EstadoReservaLote.CONSUMIDA))
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
+                200L,
+                300L,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
+                TipoMovimiento.TRANSFERENCIA))
+                .thenReturn(new BigDecimal("1.25"));
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
+                200L,
+                300L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                TipoMovimiento.SALIDA))
                 .thenReturn(BigDecimal.ZERO);
 
         List<com.willyes.clemenintegra.produccion.dto.InsumoOPDTO> lista = service.listarInsumos(200L);
@@ -1206,6 +1243,7 @@ class OrdenProduccionServiceImplTest {
         assertThat(dto.getCantidadRequerida()).isEqualByComparingTo(new BigDecimal("10"));
         assertThat(dto.getCantidadConsumida()).isEqualByComparingTo(BigDecimal.ZERO);
         assertThat(dto.getFaltante()).isEqualByComparingTo(new BigDecimal("10"));
+        assertThat(dto.getCantidadAlistada()).isEqualByComparingTo(new BigDecimal("1.25"));
     }
 
     @Test
@@ -1235,14 +1273,24 @@ class OrdenProduccionServiceImplTest {
         when(ordenProduccionRepository.findById(201L)).thenReturn(Optional.of(orden));
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
                 .thenReturn(Optional.of(formula));
-        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacion(
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionConEtapa(
                 201L,
                 301L,
                 ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
                 TipoMovimiento.SALIDA))
-                .thenReturn(BigDecimal.ONE);
-        when(reservaLoteRepository.sumConsumidaByOrdenAndProducto(201L, 301L, EstadoReservaLote.CONSUMIDA))
                 .thenReturn(new BigDecimal("3"));
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
+                201L,
+                301L,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
+                TipoMovimiento.TRANSFERENCIA))
+                .thenReturn(new BigDecimal("2.5"));
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
+                201L,
+                301L,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                TipoMovimiento.SALIDA))
+                .thenReturn(BigDecimal.ZERO);
 
         List<com.willyes.clemenintegra.produccion.dto.InsumoOPDTO> lista = service.listarInsumos(201L);
 
@@ -1251,6 +1299,7 @@ class OrdenProduccionServiceImplTest {
         assertThat(dto.getCantidadRequerida()).isEqualByComparingTo(new BigDecimal("10"));
         assertThat(dto.getCantidadConsumida()).isEqualByComparingTo(new BigDecimal("3"));
         assertThat(dto.getFaltante()).isEqualByComparingTo(new BigDecimal("7"));
+        assertThat(dto.getCantidadAlistada()).isEqualByComparingTo(new BigDecimal("2.5"));
     }
 
     private OrdenProduccion crearOrdenBase(Long id, BigDecimal programada, BigDecimal producida, EstadoProduccion estado) {


### PR DESCRIPTION
## Summary
- Hacer que iniciarEtapa cree/active la etapa cuando no hay una activa, manteniendo conflicto solo si otra etapa está en curso y evitando setear etapa en traslados a Pre-Bodega.
- Separar el cálculo de consumido real (solo SALIDA_PRODUCCION con etapa) del alistado hacia Pre-Bodega en listarInsumos e InsumoOPDTO.
- Agregar coberturas para idempotencia de inicio de etapa y para el nuevo desglose de consumido/alistado de insumos.

## Testing
- mvn -q -DskipITs -Dtest=OrdenProduccionServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953009ca7208333ab6816ae8f0da230)