### PR TITLE
Add POST compatibility for finalizar etapa endpoint

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -187,7 +187,8 @@ public class OrdenProduccionController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @PatchMapping("/{ordenId}/etapas/{etapaId}/finalizar")
+    // Compatibilidad POST agregada porque el frontend usa POST
+    @RequestMapping(value = "/{ordenId}/etapas/{etapaId}/finalizar", method = {RequestMethod.PATCH, RequestMethod.POST})
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaProduccionResponse> finalizarEtapa(@PathVariable Long ordenId, @PathVariable Long etapaId) {
         Usuario usuario = usuarioService.obtenerUsuarioAutenticado();

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -15,9 +15,11 @@ import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +47,7 @@ import java.util.Optional;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -294,5 +297,43 @@ class OrdenProduccionControllerTest {
         mockMvc.perform(post("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/iniciar", 77L, 88L))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value(ApiErrorCode.PRODUCCION_OTRA_ETAPA_ACTIVA.name()));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("POST /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/finalizar responde 200")
+    void finalizarEtapa_postRespondeOk() throws Exception {
+        Usuario usuario = Usuario.builder().id(10L).nombreCompleto("Operador").build();
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(22L)
+                .estado(EstadoEtapa.EN_PROCESO)
+                .ordenProduccion(OrdenProduccion.builder().id(11L).build())
+                .build();
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(ordenProduccionService.finalizarEtapa(11L, 22L, 10L)).thenReturn(etapa);
+
+        mockMvc.perform(post("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/finalizar", 11L, 22L))
+                .andExpect(status().isOk());
+
+        verify(ordenProduccionService).finalizarEtapa(11L, 22L, 10L);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("PATCH /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/finalizar responde 200")
+    void finalizarEtapa_patchRespondeOk() throws Exception {
+        Usuario usuario = Usuario.builder().id(20L).nombreCompleto("Operador Patch").build();
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(33L)
+                .estado(EstadoEtapa.EN_PROCESO)
+                .ordenProduccion(OrdenProduccion.builder().id(44L).build())
+                .build();
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(ordenProduccionService.finalizarEtapa(44L, 33L, 20L)).thenReturn(etapa);
+
+        mockMvc.perform(patch("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/finalizar", 44L, 33L))
+                .andExpect(status().isOk());
+
+        verify(ordenProduccionService).finalizarEtapa(44L, 33L, 20L);
     }
 }


### PR DESCRIPTION
## Summary
- allow finalizar etapa endpoint to accept both PATCH and POST so the frontend call succeeds
- add MockMvc coverage for finalizar etapa via POST and PATCH to ensure compatibility

## Testing
- mvn -q -DskipITs -Dtest=OrdenProduccionControllerTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530b1378108333ab31638f0f1a7aff)