### PR TITLE
Registrar consumo real en cierres de producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -18,6 +18,7 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimient
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import org.springframework.util.StringUtils;
@@ -3345,6 +3346,12 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                             "OP_SIN_ETAPA_ACTIVA",
                             Map.of("ordenProduccionId", ordenProduccionId, "etapaId", etapaId)
                     ));
+            boolean finalizada = etapa.getFechaInicio() != null
+                    && (etapa.getFechaFin() != null || etapa.getEstado() == EstadoEtapa.FINALIZADA);
+            if (finalizada && etapa.getOrdenProduccion() != null
+                    && Objects.equals(etapa.getOrdenProduccion().getId(), ordenProduccionId)) {
+                return etapa;
+            }
             return validarEtapaActiva(etapa, ordenProduccionId, false);
         }
         long activas = etapaProduccionRepository.countByOrdenProduccionIdAndFechaInicioIsNotNullAndFechaFinIsNull(ordenProduccionId);

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -92,6 +92,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Comparator;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.LocalDate;
@@ -584,6 +585,38 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                         "ETAPA_PRODUCCION_NO_CONFIGURADA"));
     }
 
+    private EtapaProduccion seleccionarEtapaParaConsumo(List<EtapaProduccion> etapas, Long ordenProduccionId) {
+        List<EtapaProduccion> existentes = Optional.ofNullable(etapas)
+                .orElseGet(() -> etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(ordenProduccionId));
+        Optional<EtapaProduccion> activa = existentes.stream()
+                .filter(e -> e.getFechaInicio() != null && e.getFechaFin() == null)
+                .findFirst();
+        if (activa.isPresent()) {
+            return activa.get();
+        }
+        return existentes.stream()
+                .filter(e -> e.getFechaInicio() != null
+                        && (e.getFechaFin() != null || e.getEstado() == EstadoEtapa.FINALIZADA))
+                .max(Comparator
+                        .comparing(EtapaProduccion::getFechaFin, Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(EtapaProduccion::getId, Comparator.nullsLast(Comparator.naturalOrder())))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "OP_SIN_ETAPA_ACTIVA"));
+    }
+
+    private void registrarConsumoDeInsumos(Long ordenProduccionId, Long etapaId, Long usuarioId) {
+        boolean consumoRegistrado = !movimientoInventarioRepository
+                .findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(
+                        ordenProduccionId,
+                        etapaId,
+                        ClasificacionMovimientoInventario.SALIDA_PRODUCCION
+                ).isEmpty();
+        if (consumoRegistrado) {
+            log.debug("OP-consumo ya registrado, omitiendo duplicados op={}, etapa={}", ordenProduccionId, etapaId);
+            return;
+        }
+        movimientoInventarioService.consumirInsumosPorOrden(ordenProduccionId, etapaId, usuarioId);
+    }
+
     public void eliminar(Long id) {
         repository.deleteById(id);
     }
@@ -606,6 +639,21 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
             BigDecimal cantidad = validarCantidad(dto.getCantidad(), orden.getProducto());
             dto.setCantidad(cantidad);
+
+            List<EtapaProduccion> etapas = etapaProduccionRepository
+                    .findByOrdenProduccionIdOrderBySecuenciaAsc(orden.getId());
+            boolean algunaEtapaIniciada = etapas.stream().anyMatch(e -> e.getFechaInicio() != null);
+            boolean todasFinalizadas = !etapas.isEmpty()
+                    && etapas.stream().allMatch(e -> e.getFechaFin() != null || e.getEstado() == EstadoEtapa.FINALIZADA);
+
+            if (!algunaEtapaIniciada) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "OP_SIN_ETAPA_ACTIVA");
+            }
+            if (dto.getTipo() == TipoCierre.TOTAL
+                    && orden.getEstado() == EstadoProduccion.EN_PROCESO
+                    && todasFinalizadas) {
+                log.debug("OP-cierre total sin etapa activa permitida op={}", orden.getId());
+            }
 
             LoteProducto lote = loteProductoRepository
                     .findByOrdenProduccionIdAndProductoId(orden.getId(), orden.getProducto().getId().longValue())
@@ -682,8 +730,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
             Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
 
-            Long etapaConsumoId = resolverEtapaPrincipal(orden.getId());
-            movimientoInventarioService.consumirInsumosPorOrden(orden.getId(), etapaConsumoId, usuario.getId());
+            EtapaProduccion etapaConsumo = seleccionarEtapaParaConsumo(etapas, orden.getId());
+            registrarConsumoDeInsumos(orden.getId(), etapaConsumo.getId(), usuario.getId());
 
             List<EstadoSolicitudMovimiento> estadosPendientes = parseEstados(estadosSolicitudPendientesConf);
             parseEstados(estadosSolicitudConcluyentesConf);

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
@@ -447,6 +447,23 @@ class MovimientoInventarioServiceConsumoEtapaTest {
         verify(etapaProduccionRepository, never()).countByOrdenProduccionIdAndFechaInicioIsNotNullAndFechaFinIsNull(anyLong());
     }
 
+    @Test
+    void resolverEtapaActiva_conEtapaFinalizadaPermiteConsumo() {
+        LocalDateTime fin = LocalDateTime.now();
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(12L)
+                .estado(EstadoEtapa.FINALIZADA)
+                .fechaInicio(fin.minusHours(2))
+                .fechaFin(fin.minusHours(1))
+                .ordenProduccion(OrdenProduccion.builder().id(8L).build())
+                .build();
+        when(etapaProduccionRepository.findById(12L)).thenReturn(Optional.of(etapa));
+
+        EtapaProduccion resultado = ReflectionTestUtils.invokeMethod(service, "resolverEtapaActiva", 8L, 12L);
+
+        assertThat(resultado).isSameAs(etapa);
+    }
+
     private SolicitudMovimiento solicitudConDetalle() {
         Producto producto = new Producto();
         producto.setId(1);

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -72,9 +72,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -85,6 +88,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -1173,6 +1177,106 @@ class OrdenProduccionServiceImplTest {
     }
 
     @Test
+    @DisplayName("registrarCierre total usa la última etapa finalizada cuando no hay activa")
+    void registrarCierre_totalSinEtapaActiva() {
+        OrdenProduccion orden = crearOrdenBase(350L, new BigDecimal("80"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+        LocalDateTime fin = LocalDateTime.now().minusHours(1);
+        EtapaProduccion etapaFinalizada = EtapaProduccion.builder()
+                .id(5L)
+                .estado(EstadoEtapa.FINALIZADA)
+                .fechaInicio(fin.minusHours(1))
+                .fechaFin(fin)
+                .build();
+        when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(orden.getId()))
+                .thenReturn(List.of(etapaFinalizada));
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("40"))
+                .tipo(TipoCierre.TOTAL)
+                .build();
+
+        assertThatCode(() -> service.registrarCierre(350L, dto)).doesNotThrowAnyException();
+
+        verify(movimientoInventarioService).consumirInsumosPorOrden(350L, 5L, usuarioBasico().getId());
+    }
+
+    @Test
+    @DisplayName("registrarCierre registra consumo real antes de consultar insumos")
+    void registrarCierre_actualizaConsumido() {
+        OrdenProduccion orden = crearOrdenBase(360L, new BigDecimal("3"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+        Producto insumo = new Producto();
+        insumo.setId(600);
+        insumo.setNombre("Insumo prueba");
+        UnidadMedida um = new UnidadMedida();
+        um.setNombre("kg");
+        insumo.setUnidadMedida(um);
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(insumo);
+        detalle.setCantidadNecesaria(new BigDecimal("2"));
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(detalle));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(orden.getProducto().getId().longValue(), EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+
+        AtomicBoolean consumoEjecutado = new AtomicBoolean(false);
+        doAnswer(inv -> {
+            consumoEjecutado.set(true);
+            return null;
+        }).when(movimientoInventarioService).consumirInsumosPorOrden(eq(360L), anyLong(), anyLong());
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionConEtapa(
+                eq(360L),
+                eq(600L),
+                eq(ClasificacionMovimientoInventario.SALIDA_PRODUCCION),
+                eq(TipoMovimiento.SALIDA)
+        )).thenAnswer(inv -> consumoEjecutado.get() ? new BigDecimal("6") : BigDecimal.ZERO);
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("3"))
+                .tipo(TipoCierre.PARCIAL)
+                .build();
+
+        service.registrarCierre(360L, dto);
+        List<com.willyes.clemenintegra.produccion.dto.InsumoOPDTO> insumos = service.listarInsumos(360L);
+
+        assertThat(insumos).hasSize(1);
+        assertThat(insumos.get(0).getCantidadConsumida()).isEqualByComparingTo(new BigDecimal("6"));
+    }
+
+    @Test
+    @DisplayName("registrarCierre es idempotente al registrar consumos de insumos")
+    void registrarCierre_idempotenciaConsumos() {
+        OrdenProduccion orden = crearOrdenBase(370L, new BigDecimal("10"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        AtomicInteger consumos = new AtomicInteger(0);
+        doAnswer(inv -> {
+            consumos.incrementAndGet();
+            return null;
+        }).when(movimientoInventarioService).consumirInsumosPorOrden(eq(370L), anyLong(), anyLong());
+        AtomicInteger consultasConsumo = new AtomicInteger(0);
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(
+                eq(370L),
+                anyLong(),
+                eq(ClasificacionMovimientoInventario.SALIDA_PRODUCCION)
+        )).thenAnswer(inv -> consultasConsumo.getAndIncrement() == 0 ? List.of() : List.of(new MovimientoInventario()));
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("5"))
+                .tipo(TipoCierre.PARCIAL)
+                .build();
+
+        service.registrarCierre(370L, dto);
+        service.registrarCierre(370L, dto);
+
+        assertThat(consumos.get()).isEqualTo(1);
+    }
+
+    @Test
     @DisplayName("registrarCierre definitivo rechaza cierre sin producción acumulada")
     void registrarCierre_definitivoSinProduccion() {
         OrdenProduccion orden = crearOrdenBase(304L, new BigDecimal("100"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
@@ -1379,6 +1483,9 @@ class OrdenProduccionServiceImplTest {
         TipoMovimientoDetalle tipoEntrada = new TipoMovimientoDetalle();
         tipoEntrada.setId(21L);
         when(tipoMovimientoDetalleRepository.findById(21L)).thenReturn(Optional.of(tipoEntrada));
+        when(movimientoInventarioRepository
+                .findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(anyLong(), anyLong(), any()))
+                .thenReturn(List.of());
 
         when(catalogResolver.getAlmacenPtId()).thenReturn(30L);
         when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(31L);


### PR DESCRIPTION
## Summary
- Permitir cierres totales aun sin etapa activa cuando todas las etapas están finalizadas y seleccionar la etapa más reciente para asociar el consumo.
- Registrar consumos SALIDA_PRODUCCION de forma idempotente durante el cierre de la orden y reutilizar etapas finalizadas.
- Agregar coberturas unitarias para cierres sin etapa activa, actualización de consumos y evitar duplicados.

## Testing
- `mvn -q -DskipITs test` *(falla: RecepcionOCControllerIntegrationTest no encuentra la tabla `usuarios` en H2)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69531cc6d8388333bf75c7ab289b496d)