### PR TITLE
Registrar consumo real en cierre total

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -179,6 +179,16 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
                                                                  @Param("clasificacion") ClasificacionMovimientoInventario clasificacion,
                                                                  @Param("tipoMovimiento") TipoMovimiento tipoMovimiento);
 
+    @Query("select coalesce(sum(m.cantidad),0) from MovimientoInventario m " +
+            "where m.ordenProduccion.id = :ordenId " +
+            "and m.producto.id = :productoId " +
+            "and m.tipoMovimiento = :tipoMovimiento " +
+            "and m.tipoMovimientoDetalle.id = :tipoDetalleId")
+    BigDecimal sumaCantidadPorOrdenProductoTipoDetalle(@Param("ordenId") Long ordenId,
+                                                       @Param("productoId") Long productoId,
+                                                       @Param("tipoMovimiento") TipoMovimiento tipoMovimiento,
+                                                       @Param("tipoDetalleId") Long tipoDetalleId);
+
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "almacenOrigen", "almacenDestino",
             "proveedor", "ordenCompra", "motivoMovimiento", "tipoMovimientoDetalle", "registradoPor"

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -86,6 +86,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -603,6 +604,33 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "OP_SIN_ETAPA_ACTIVA"));
     }
 
+    private EtapaProduccion obtenerUltimaEtapaFinalizada(List<EtapaProduccion> etapas, Long ordenProduccionId) {
+        List<EtapaProduccion> existentes = Optional.ofNullable(etapas)
+                .orElseGet(() -> etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(ordenProduccionId));
+        return existentes.stream()
+                .filter(e -> e.getFechaInicio() != null
+                        && (e.getFechaFin() != null || e.getEstado() == EstadoEtapa.FINALIZADA))
+                .max(Comparator
+                        .comparing(EtapaProduccion::getFechaFin, Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(EtapaProduccion::getId, Comparator.nullsLast(Comparator.naturalOrder())))
+                .orElse(null);
+    }
+
+    private Long resolverTipoDetalleSalidaProduccionId() {
+        Long id = catalogResolver.getTipoDetalleSalidaProduccionId();
+        if (id == null) {
+            id = catalogResolver.getTipoDetalleSalidaId();
+        }
+        if (id == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "TIPO_DETALLE_SALIDA_PRODUCCION_INEXISTENTE");
+        }
+        return id;
+    }
+
+    private BigDecimal safeCantidad(BigDecimal valor) {
+        return valor != null ? valor : BigDecimal.ZERO;
+    }
+
     private void registrarConsumoDeInsumos(Long ordenProduccionId, Long etapaId, Long usuarioId) {
         boolean consumoRegistrado = !movimientoInventarioRepository
                 .findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(
@@ -615,6 +643,202 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             return;
         }
         movimientoInventarioService.consumirInsumosPorOrden(ordenProduccionId, etapaId, usuarioId);
+    }
+
+    private void registrarConsumoRealPorCierreTotal(OrdenProduccion orden,
+                                                    List<EtapaProduccion> etapas,
+                                                    EtapaProduccion etapaConsumo,
+                                                    Usuario usuario) {
+        if (orden == null || orden.getId() == null || orden.getProducto() == null) {
+            return;
+        }
+        FormulaProducto formula = formulaProductoRepository
+                .findByProductoIdAndEstadoAndActivoTrue(orden.getProducto().getId().longValue(), EstadoFormula.APROBADA)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "FORMULA_NO_ENCONTRADA"));
+
+        Long detalleSalidaId = resolverTipoDetalleSalidaProduccionId();
+        TipoMovimientoDetalle detalleSalida = tipoMovimientoDetalleRepository.findById(detalleSalidaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "TIPO_DETALLE_SALIDA_PRODUCCION_INEXISTENTE"));
+
+        Long motivoSalidaId = catalogResolver.getMotivoSalidaProduccionId();
+        if (motivoSalidaId == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MOTIVO_SALIDA_PRODUCCION_INEXISTENTE");
+        }
+        MotivoMovimiento motivoSalida = motivoMovimientoRepository.findById(motivoSalidaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MOTIVO_SALIDA_PRODUCCION_INEXISTENTE"));
+
+        Long preBodegaId = catalogResolver.getAlmacenPreBodegaProduccionId();
+        if (preBodegaId == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_PRE_BODEGA_INEXISTENTE");
+        }
+
+        Map<Long, BigDecimal> requeridoPorProducto = new LinkedHashMap<>();
+        for (DetalleFormula det : obtenerDetallesFormulaSeguro(formula)) {
+            if (det == null || det.getInsumo() == null || det.getInsumo().getId() == null) {
+                continue;
+            }
+            BigDecimal requerido = safeCantidad(det.getCantidadNecesaria())
+                    .multiply(orden.getCantidadProgramada())
+                    .setScale(6, RoundingMode.HALF_UP);
+            if (requerido.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+            requeridoPorProducto.merge(det.getInsumo().getId().longValue(), requerido, BigDecimal::add);
+        }
+        if (requeridoPorProducto.isEmpty()) {
+            log.debug("OP-cierre total sin insumos calculados op={}", orden.getId());
+            return;
+        }
+
+        List<MovimientoInventario> alistados = movimientoInventarioRepository
+                .findByOrdenProduccionIdAndClasificacion(
+                        orden.getId(),
+                        ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
+                        Pageable.unpaged()
+                ).getContent();
+        List<MovimientoInventario> consumosPrevios = movimientoInventarioRepository
+                .findByOrdenProduccionIdAndClasificacion(
+                        orden.getId(),
+                        ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                        Pageable.unpaged()
+                ).getContent();
+
+        Map<Long, BigDecimal> disponiblePorLote = new LinkedHashMap<>();
+        Map<Long, Long> productoPorLote = new HashMap<>();
+        Map<Long, LocalDateTime> fechaPorLote = new HashMap<>();
+
+        for (MovimientoInventario mov : alistados) {
+            if (mov == null || mov.getLote() == null || mov.getProducto() == null) {
+                continue;
+            }
+            if (mov.getTipoMovimiento() != TipoMovimiento.TRANSFERENCIA) {
+                continue;
+            }
+            if (mov.getAlmacenDestino() != null
+                    && !Objects.equals(Long.valueOf(mov.getAlmacenDestino().getId().longValue()), preBodegaId)) {
+                continue;
+            }
+            Long loteId = mov.getLote().getId();
+            if (loteId == null) {
+                continue;
+            }
+            BigDecimal cantidad = safeCantidad(mov.getCantidad());
+            disponiblePorLote.merge(loteId, cantidad, BigDecimal::add);
+            productoPorLote.put(loteId, mov.getProducto().getId().longValue());
+            if (mov.getFechaIngreso() != null) {
+                fechaPorLote.merge(loteId, mov.getFechaIngreso(), (previa, nueva) -> {
+                    if (previa == null) return nueva;
+                    return previa.isBefore(nueva) ? previa : nueva;
+                });
+            }
+        }
+
+        for (MovimientoInventario mov : consumosPrevios) {
+            if (mov == null || mov.getLote() == null) {
+                continue;
+            }
+            if (mov.getTipoMovimiento() != TipoMovimiento.SALIDA) {
+                continue;
+            }
+            if (mov.getTipoMovimientoDetalle() == null
+                    || !Objects.equals(mov.getTipoMovimientoDetalle().getId(), detalleSalidaId)) {
+                continue;
+            }
+            Long loteId = mov.getLote().getId();
+            BigDecimal saldoActual = disponiblePorLote.get(loteId);
+            if (saldoActual != null) {
+                BigDecimal nuevoSaldo = saldoActual.subtract(safeCantidad(mov.getCantidad()));
+                if (nuevoSaldo.compareTo(BigDecimal.ZERO) < 0) {
+                    nuevoSaldo = BigDecimal.ZERO;
+                }
+                disponiblePorLote.put(loteId, nuevoSaldo);
+            }
+        }
+
+        Long etapaDestinoId = Optional.ofNullable(etapaConsumo)
+                .map(EtapaProduccion::getId)
+                .orElseGet(() -> Optional.ofNullable(obtenerUltimaEtapaFinalizada(etapas, orden.getId()))
+                        .map(EtapaProduccion::getId)
+                        .orElse(null));
+
+        for (Map.Entry<Long, BigDecimal> entry : requeridoPorProducto.entrySet()) {
+            Long productoId = entry.getKey();
+            BigDecimal requerido = entry.getValue();
+            BigDecimal consumido = Optional.ofNullable(
+                    movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
+                            orden.getId(),
+                            productoId,
+                            TipoMovimiento.SALIDA,
+                            detalleSalidaId
+                    )
+            ).orElse(BigDecimal.ZERO);
+
+            BigDecimal faltante = requerido.subtract(consumido);
+            if (faltante.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+
+            List<Long> lotesProducto = disponiblePorLote.entrySet().stream()
+                    .filter(e -> e.getValue().compareTo(BigDecimal.ZERO) > 0)
+                    .filter(e -> Objects.equals(productoPorLote.get(e.getKey()), productoId))
+                    .sorted(Comparator.comparing(
+                                    (Map.Entry<Long, BigDecimal> e) -> fechaPorLote.getOrDefault(e.getKey(), LocalDateTime.MIN))
+                            .thenComparing(Map.Entry::getKey))
+                    .map(Map.Entry::getKey)
+                    .toList();
+
+            BigDecimal pendiente = faltante;
+            for (Long loteId : lotesProducto) {
+                BigDecimal disponible = disponiblePorLote.getOrDefault(loteId, BigDecimal.ZERO);
+                if (disponible.compareTo(BigDecimal.ZERO) <= 0) {
+                    continue;
+                }
+                BigDecimal consumir = pendiente.min(disponible).setScale(6, RoundingMode.HALF_UP);
+                if (consumir.compareTo(BigDecimal.ZERO) <= 0) {
+                    continue;
+                }
+
+                MovimientoInventarioDTO salida = new MovimientoInventarioDTO(
+                        null,
+                        consumir,
+                        TipoMovimiento.SALIDA,
+                        ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                        orden.getCodigoOrden(),
+                        null,
+                        productoId.intValue(),
+                        loteId,
+                        preBodegaId.intValue(),
+                        null,
+                        null,
+                        null,
+                        motivoSalida.getId(),
+                        detalleSalida.getId(),
+                        null,
+                        usuario.getId(),
+                        orden.getId(),
+                        etapaDestinoId,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                );
+                movimientoInventarioService.registrarMovimiento(salida);
+
+                pendiente = pendiente.subtract(consumir);
+                disponiblePorLote.put(loteId, disponible.subtract(consumir));
+                if (pendiente.compareTo(BigDecimal.ZERO) <= 0) {
+                    break;
+                }
+            }
+
+            if (pendiente.compareTo(BigDecimal.ZERO) > 0) {
+                log.warn("OP-cierre total con alistado insuficiente para consumo real op={}, productoId={}, faltante={}",
+                        orden.getId(), productoId, pendiente);
+            }
+        }
     }
 
     public void eliminar(Long id) {
@@ -646,12 +870,14 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             boolean todasFinalizadas = !etapas.isEmpty()
                     && etapas.stream().allMatch(e -> e.getFechaFin() != null || e.getEstado() == EstadoEtapa.FINALIZADA);
 
-            if (!algunaEtapaIniciada) {
+            boolean permitirCierreSinActiva = dto.getTipo() == TipoCierre.TOTAL
+                    && orden.getEstado() == EstadoProduccion.EN_PROCESO
+                    && todasFinalizadas;
+
+            if (!algunaEtapaIniciada && !permitirCierreSinActiva) {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "OP_SIN_ETAPA_ACTIVA");
             }
-            if (dto.getTipo() == TipoCierre.TOTAL
-                    && orden.getEstado() == EstadoProduccion.EN_PROCESO
-                    && todasFinalizadas) {
+            if (permitirCierreSinActiva) {
                 log.debug("OP-cierre total sin etapa activa permitida op={}", orden.getId());
             }
 
@@ -732,6 +958,9 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
             EtapaProduccion etapaConsumo = seleccionarEtapaParaConsumo(etapas, orden.getId());
             registrarConsumoDeInsumos(orden.getId(), etapaConsumo.getId(), usuario.getId());
+            if (dto.getTipo() == TipoCierre.TOTAL) {
+                registrarConsumoRealPorCierreTotal(orden, etapas, etapaConsumo, usuario);
+            }
 
             List<EstadoSolicitudMovimiento> estadosPendientes = parseEstados(estadosSolicitudPendientesConf);
             parseEstados(estadosSolicitudConcluyentesConf);
@@ -1604,22 +1833,24 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 .findByProductoIdAndEstadoAndActivoTrue(orden.getProducto().getId().longValue(), EstadoFormula.APROBADA)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "FORMULA_NO_ENCONTRADA"));
         List<InsumoOPDTO> lista = new ArrayList<>();
+        Long detalleSalidaId = resolverTipoDetalleSalidaProduccionId();
         for (DetalleFormula det : obtenerDetallesFormulaSeguro(formula)) {
             if (det == null || det.getInsumo() == null) {
                 continue;
             }
             BigDecimal requerida = det.getCantidadNecesaria().multiply(orden.getCantidadProgramada());
             Long insumoId = det.getInsumo().getId().longValue();
-            // Consumido real: solo salidas de producción ligadas a una etapa (activa o finalizada).
+            // Consumido real: salidas de producción registradas para la OP (independiente de etapa).
             BigDecimal consumida = Optional.ofNullable(
-                    movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionConEtapa(
+                    movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
                             id,
                             insumoId,
-                            ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
-                            TipoMovimiento.SALIDA
+                            TipoMovimiento.SALIDA,
+                            detalleSalidaId
                     )
             ).orElse(BigDecimal.ZERO);
-            // Alistado/reservado: traslados internos a Pre-Bodega sin etapa (pre-arranque).
+            // Alistado/reservado: traslados internos a Pre-Bodega sin etapa (pre-arranque). El alistado no debe
+            // contabilizar las salidas de producción.
             BigDecimal alistadoTransferencias = Optional.ofNullable(
                     movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
                             id,
@@ -1628,15 +1859,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                             TipoMovimiento.TRANSFERENCIA
                     )
             ).orElse(BigDecimal.ZERO);
-            BigDecimal alistadoSalidasSinEtapa = Optional.ofNullable(
-                    movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
-                            id,
-                            insumoId,
-                            ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
-                            TipoMovimiento.SALIDA
-                    )
-            ).orElse(BigDecimal.ZERO);
-            BigDecimal alistado = alistadoTransferencias.add(alistadoSalidasSinEtapa);
+            BigDecimal alistado = alistadoTransferencias;
             BigDecimal faltante = requerida.subtract(consumida);
             if (faltante.compareTo(BigDecimal.ZERO) < 0) {
                 faltante = BigDecimal.ZERO;

--- a/src/main/resources/db/migration/V20251225__ensure_salida_produccion_detalle.sql
+++ b/src/main/resources/db/migration/V20251225__ensure_salida_produccion_detalle.sql
@@ -1,0 +1,6 @@
+-- Garantiza que el tipo de detalle SALIDA_PRODUCCION exista para registrar consumos reales.
+INSERT INTO tipos_movimiento_detalle (descripcion)
+SELECT 'SALIDA_PRODUCCION'
+WHERE NOT EXISTS (
+    SELECT 1 FROM tipos_movimiento_detalle WHERE descripcion = 'SALIDA_PRODUCCION'
+);

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -17,6 +17,7 @@ import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
@@ -51,6 +52,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.ErrorResponseException;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -93,6 +96,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -156,6 +160,18 @@ class OrdenProduccionServiceImplTest {
                 .thenAnswer(invocation -> ((BigDecimal) invocation.getArgument(0)).setScale(2, RoundingMode.HALF_UP));
         lenient().when(umValidator.getRoundingMode()).thenReturn(RoundingMode.HALF_UP);
         lenient().when(catalogResolver.decimals(any())).thenReturn(2);
+        lenient().when(catalogResolver.getTipoDetalleSalidaProduccionId()).thenReturn(11L);
+        lenient().when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(11L);
+        lenient().when(catalogResolver.getMotivoSalidaProduccionId()).thenReturn(11L);
+        lenient().when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(6L);
+        TipoMovimientoDetalle tipoSalida = new TipoMovimientoDetalle();
+        tipoSalida.setId(11L);
+        lenient().when(tipoMovimientoDetalleRepository.findById(11L)).thenReturn(Optional.of(tipoSalida));
+        MotivoMovimiento motivoSalida = new MotivoMovimiento();
+        motivoSalida.setId(11L);
+        lenient().when(motivoMovimientoRepository.findById(11L)).thenReturn(Optional.of(motivoSalida));
+        lenient().when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(anyLong(), anyLong(), any(), anyLong()))
+                .thenReturn(BigDecimal.ZERO);
     }
 
     @Test
@@ -1177,6 +1193,156 @@ class OrdenProduccionServiceImplTest {
     }
 
     @Test
+    @DisplayName("registrarCierre total crea salidas de consumo real desde el alistado")
+    void registrarCierre_totalGeneraSalidas() {
+        OrdenProduccion orden = crearOrdenBase(400L, new BigDecimal("2"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Producto insumo = new Producto();
+        insumo.setId(910);
+        UnidadMedida um = new UnidadMedida();
+        um.setNombre("kg");
+        insumo.setUnidadMedida(um);
+        DetalleFormula det = new DetalleFormula();
+        det.setInsumo(insumo);
+        det.setCantidadNecesaria(new BigDecimal("1.5"));
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(det));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(orden.getProducto().getId().longValue(), EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(77L);
+        MovimientoInventario alistado = new MovimientoInventario();
+        alistado.setTipoMovimiento(TipoMovimiento.TRANSFERENCIA);
+        alistado.setClasificacion(ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION);
+        alistado.setProducto(insumo);
+        alistado.setLote(lote);
+        alistado.setCantidad(new BigDecimal("3.0"));
+        Almacen preBodega = new Almacen();
+        preBodega.setId(6);
+        alistado.setAlmacenDestino(preBodega);
+
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()),
+                eq(ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION),
+                any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(alistado)));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()),
+                eq(ClasificacionMovimientoInventario.SALIDA_PRODUCCION),
+                any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of()));
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
+                eq(orden.getId()),
+                eq(insumo.getId().longValue()),
+                eq(TipoMovimiento.SALIDA),
+                eq(11L)
+        )).thenReturn(BigDecimal.ZERO);
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("2"))
+                .tipo(TipoCierre.TOTAL)
+                .build();
+
+        ArgumentCaptor<MovimientoInventarioDTO> captor = ArgumentCaptor.forClass(MovimientoInventarioDTO.class);
+
+        service.registrarCierre(400L, dto);
+
+        verify(movimientoInventarioService, atLeast(2)).registrarMovimiento(captor.capture());
+        long salidas = captor.getAllValues().stream()
+                .filter(m -> m.tipoMovimiento() == TipoMovimiento.SALIDA)
+                .count();
+        MovimientoInventarioDTO consumo = captor.getAllValues().stream()
+                .filter(m -> m.tipoMovimiento() == TipoMovimiento.SALIDA)
+                .findFirst()
+                .orElseThrow();
+        assertThat(salidas).isEqualTo(1);
+        assertThat(consumo.cantidad()).isEqualByComparingTo(new BigDecimal("3.000000"));
+        assertThat(consumo.tipoMovimientoDetalleId()).isEqualTo(11L);
+        assertThat(consumo.almacenOrigenId()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("registrarCierre total no duplica salidas ya registradas")
+    void registrarCierre_totalIdempotenteEnSalidas() {
+        OrdenProduccion orden = crearOrdenBase(401L, new BigDecimal("2"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Producto insumo = new Producto();
+        insumo.setId(911);
+        UnidadMedida um = new UnidadMedida();
+        um.setNombre("kg");
+        insumo.setUnidadMedida(um);
+        DetalleFormula det = new DetalleFormula();
+        det.setInsumo(insumo);
+        det.setCantidadNecesaria(new BigDecimal("1.5"));
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(det));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(orden.getProducto().getId().longValue(), EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+
+        LoteProducto lote = new LoteProducto();
+        lote.setId(78L);
+        MovimientoInventario alistado = new MovimientoInventario();
+        alistado.setTipoMovimiento(TipoMovimiento.TRANSFERENCIA);
+        alistado.setClasificacion(ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION);
+        alistado.setProducto(insumo);
+        alistado.setLote(lote);
+        alistado.setCantidad(new BigDecimal("3.0"));
+        Almacen preBodega = new Almacen();
+        preBodega.setId(6);
+        alistado.setAlmacenDestino(preBodega);
+
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()),
+                eq(ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION),
+                any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(alistado)));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()),
+                eq(ClasificacionMovimientoInventario.SALIDA_PRODUCCION),
+                any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of()));
+
+        AtomicInteger consultas = new AtomicInteger(0);
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
+                eq(orden.getId()),
+                eq(insumo.getId().longValue()),
+                eq(TipoMovimiento.SALIDA),
+                eq(11L)
+        )).thenAnswer(inv -> consultas.getAndIncrement() == 0 ? BigDecimal.ZERO : new BigDecimal("3.0"));
+
+        ArgumentCaptor<MovimientoInventarioDTO> captor = ArgumentCaptor.forClass(MovimientoInventarioDTO.class);
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("2"))
+                .tipo(TipoCierre.TOTAL)
+                .build();
+
+        service.registrarCierre(401L, dto);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+        orden.setCantidadProducida(BigDecimal.ZERO);
+        orden.setCantidadProducidaAcumulada(BigDecimal.ZERO);
+        orden.setTipoCierre(null);
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
+                eq(orden.getId()),
+                eq(insumo.getId().longValue()),
+                eq(TipoMovimiento.SALIDA),
+                eq(11L)
+        )).thenReturn(new BigDecimal("3.0"));
+        service.registrarCierre(401L, dto);
+
+        verify(movimientoInventarioService, atLeast(3)).registrarMovimiento(captor.capture());
+        long salidas = captor.getAllValues().stream()
+                .filter(m -> m.tipoMovimiento() == TipoMovimiento.SALIDA)
+                .count();
+        assertThat(salidas).isEqualTo(1);
+    }
+
+    @Test
     @DisplayName("registrarCierre total usa la última etapa finalizada cuando no hay activa")
     void registrarCierre_totalSinEtapaActiva() {
         OrdenProduccion orden = crearOrdenBase(350L, new BigDecimal("80"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
@@ -1227,11 +1393,11 @@ class OrdenProduccionServiceImplTest {
             consumoEjecutado.set(true);
             return null;
         }).when(movimientoInventarioService).consumirInsumosPorOrden(eq(360L), anyLong(), anyLong());
-        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionConEtapa(
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
                 eq(360L),
                 eq(600L),
-                eq(ClasificacionMovimientoInventario.SALIDA_PRODUCCION),
-                eq(TipoMovimiento.SALIDA)
+                eq(TipoMovimiento.SALIDA),
+                eq(11L)
         )).thenAnswer(inv -> consumoEjecutado.get() ? new BigDecimal("6") : BigDecimal.ZERO);
         when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -1322,11 +1488,11 @@ class OrdenProduccionServiceImplTest {
         when(ordenProduccionRepository.findById(200L)).thenReturn(Optional.of(orden));
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
                 .thenReturn(Optional.of(formula));
-        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionConEtapa(
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
                 200L,
                 300L,
-                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
-                TipoMovimiento.SALIDA))
+                TipoMovimiento.SALIDA,
+                11L))
                 .thenReturn(BigDecimal.ZERO);
         when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
                 200L,
@@ -1378,11 +1544,11 @@ class OrdenProduccionServiceImplTest {
         when(ordenProduccionRepository.findById(201L)).thenReturn(Optional.of(orden));
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
                 .thenReturn(Optional.of(formula));
-        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionConEtapa(
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
                 201L,
                 301L,
-                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
-                TipoMovimiento.SALIDA))
+                TipoMovimiento.SALIDA,
+                11L))
                 .thenReturn(new BigDecimal("3"));
         when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoClasificacionSinEtapa(
                 201L,
@@ -1448,6 +1614,10 @@ class OrdenProduccionServiceImplTest {
         when(ordenProduccionRepository.findById(orden.getId())).thenReturn(Optional.of(orden));
         when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(
                 orden.getId(), orden.getProducto().getId().longValue())).thenReturn(Optional.empty());
+        FormulaProducto formulaVacia = new FormulaProducto();
+        formulaVacia.setDetalles(List.of());
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(orden.getProducto().getId().longValue(), EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaVacia));
 
         EtapaProduccion etapa = EtapaProduccion.builder()
                 .id(1L)
@@ -1462,6 +1632,7 @@ class OrdenProduccionServiceImplTest {
         when(vidaUtilProductoService.buscarPorProductoId(orden.getProducto().getId()))
                 .thenReturn(Optional.of(vidaUtil));
 
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(6L);
         when(catalogResolver.getMotivoIdDevolucionDesdeProduccion()).thenReturn(10L);
         MotivoMovimiento motivoDev = new MotivoMovimiento();
         motivoDev.setId(10L);
@@ -1472,9 +1643,12 @@ class OrdenProduccionServiceImplTest {
         when(solicitudMovimientoRepository.findWithDetalles(eq(orden.getId()), isNull(), isNull(), isNull(), eq(false), any()))
                 .thenReturn(List.of());
         when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(11L);
+        when(catalogResolver.getTipoDetalleSalidaProduccionId()).thenReturn(11L);
         when(catalogResolver.getTipoDetalleTransferenciaId()).thenReturn(null);
         when(movimientoInventarioRepository.sumaPorSolicitudYTipo(any(), any(), any(), any(), any(), any()))
                 .thenReturn(BigDecimal.ZERO);
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(anyLong(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
 
         when(catalogResolver.getMotivoIdEntradaProductoTerminado()).thenReturn(20L);
         MotivoMovimiento motivoEntrada = new MotivoMovimiento();
@@ -1496,6 +1670,9 @@ class OrdenProduccionServiceImplTest {
         almacenCuarentena.setId(31);
         when(almacenRepository.findById(30L)).thenReturn(Optional.of(almacenPt));
         when(almacenRepository.findById(31L)).thenReturn(Optional.of(almacenCuarentena));
+        Almacen preBodega = new Almacen();
+        preBodega.setId(6);
+        when(almacenRepository.findById(6L)).thenReturn(Optional.of(preBodega));
 
         when(loteProductoRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuarioBasico());


### PR DESCRIPTION
## Summary
- ensure tipos_movimiento_detalle includes SALIDA_PRODUCCION for production consumption movements
- register SALIDA_PRODUCCION consumption on total order closures using pre-bodega transfers and allow closing when all stages are finished
- update consumption calculations and tests to reflect the new SALIDA detail handling and idempotency

## Testing
- mvn -q -Dtest=OrdenProduccionServiceImplTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695336c609c483338a804b2721cf10e2)