### PR TITLE
Ensure transfers split lot stock into Pre-Bodega

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/model/LoteProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/LoteProducto.java
@@ -108,6 +108,11 @@ public class LoteProducto {
     @JoinColumn(name = "lote_ps_origen_id")
     private LoteProducto lotePsOrigen;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lote_origen_id",
+            foreignKey = @ForeignKey(name = "fk_lotes_productos_lote_origen"))
+    private LoteProducto loteOrigen;
+
     public LoteProducto(Long id) {
         this.id = id;
     }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -2181,8 +2181,13 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
         if (tipo == TipoMovimiento.TRANSFERENCIA) {
             if (detalleOpGestionado) {
-                LoteProducto loteRespuesta = loteProcesadoOp != null ? loteProcesadoOp : loteOrigen;
-                return List.of(new MovimientoLoteDetalle(loteRespuesta, cantidad));
+                if (destino == null) {
+                    log.warn("TRANSFERENCIA_DESTINO_REQUERIDO_OP loteId={} productoId={} cantidad={}",
+                            loteOrigen.getId(), producto.getId(), cantidad);
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ALMACEN_DESTINO_REQUERIDO");
+                }
+                LoteProducto loteDestino = acreditarTransferenciaEnDestino(loteOrigen, destino, producto, cantidad);
+                return List.of(new MovimientoLoteDetalle(loteDestino, cantidad));
             }
             // Se rechaza la transferencia solo si el lote está agotado/sin disponible, en otro almacén de origen
             // o su estado no es transferible (calidad ya se valida en LoteCalidadValidator).
@@ -2419,6 +2424,26 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         return new MovimientoLoteDetalle(guardadoDestino, cantidadDetalle);
     }
 
+    private LoteProducto acreditarTransferenciaEnDestino(LoteProducto loteOrigen,
+                                                         Almacen destino,
+                                                         Producto producto,
+                                                         BigDecimal cantidadTransferida) {
+        LoteProducto loteDestino = ensureDestinoLote(producto, loteOrigen.getCodigoLote(), loteOrigen, destino);
+        int escala = resolverEscalaProducto(producto);
+        BigDecimal stockDestino = Optional.ofNullable(loteDestino.getStockLote()).orElse(BigDecimal.ZERO)
+                .setScale(escala, RoundingMode.HALF_UP);
+        BigDecimal nuevoStockDestino = stockDestino.add(cantidadTransferida.setScale(escala, RoundingMode.HALF_UP));
+        loteDestino.setStockLote(nuevoStockDestino);
+        if (loteDestino.getStockReservado() == null) {
+            loteDestino.setStockReservado(BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP));
+        }
+        if (loteDestino.getLoteOrigen() == null) {
+            loteDestino.setLoteOrigen(loteOrigen);
+        }
+        recalcularAgotadoSegunDisponibilidad(loteDestino);
+        return loteProductoRepository.save(loteDestino);
+    }
+
     private LoteProducto ensureDestinoLote(
             Producto producto,
             String codigoLote,
@@ -2433,7 +2458,12 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                 .findByCodigoLoteAndProductoIdAndAlmacenId(codigoLote, prodId, destinoId);
 
         if (exacto.isPresent()) {
-            return exacto.get();
+            LoteProducto existente = exacto.get();
+            if (existente.getLoteOrigen() == null && loteOrigen != null) {
+                existente.setLoteOrigen(loteOrigen);
+                loteProductoRepository.save(existente);
+            }
+            return existente;
         }
 
         // 2) Si NO existe en el destino, lo creamos en destino (clonando metadatos relevantes)
@@ -2447,12 +2477,13 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             nuevo.setFechaFabricacion(loteOrigen.getFechaFabricacion());
             nuevo.setFechaVencimiento(loteOrigen.getFechaVencimiento());
             nuevo.setTemperaturaAlmacenamiento(loteOrigen.getTemperaturaAlmacenamiento());
+            nuevo.setLoteOrigen(loteOrigen);
             // NO copiar stock: se ajustará por el movimiento
             nuevo.setStockLote(BigDecimal.ZERO);
-            nuevo.setStockReservado(BigDecimal.ZERO);
+            nuevo.setStockReservado(BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP));
         } else {
-            nuevo.setStockLote(BigDecimal.ZERO);
-            nuevo.setStockReservado(BigDecimal.ZERO);
+            nuevo.setStockLote(BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP));
+            nuevo.setStockReservado(BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP));
         }
 
         LoteProducto guardado = loteProductoRepository.save(nuevo);

--- a/src/main/resources/db/migration/V20251226__inventario_lote_origen_transferencia.sql
+++ b/src/main/resources/db/migration/V20251226__inventario_lote_origen_transferencia.sql
@@ -1,0 +1,6 @@
+ALTER TABLE lotes_productos
+    ADD COLUMN lote_origen_id BIGINT NULL;
+
+ALTER TABLE lotes_productos
+    ADD CONSTRAINT fk_lotes_productos_lote_origen
+        FOREIGN KEY (lote_origen_id) REFERENCES lotes_productos (id);

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
@@ -152,6 +152,14 @@ class MovimientoInventarioServiceTransferenciaTest {
             mov.setId(200L);
             return mov;
         });
+        ArgumentCaptor<LoteProducto> lotesGuardados = ArgumentCaptor.forClass(LoteProducto.class);
+        given(loteProductoRepository.save(lotesGuardados.capture())).willAnswer(invocation -> {
+            LoteProducto loteArg = invocation.getArgument(0);
+            if (loteArg.getId() == null) {
+                loteArg.setId(900L);
+            }
+            return loteArg;
+        });
         given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
                 .willReturn(MovimientoInventarioResponseDTO.builder().id(200L).build());
 
@@ -163,6 +171,14 @@ class MovimientoInventarioServiceTransferenciaTest {
         ArgumentCaptor<MovimientoInventario> movimientoCaptor = ArgumentCaptor.forClass(MovimientoInventario.class);
         verify(movimientoInventarioRepository).save(movimientoCaptor.capture());
         assertThat(movimientoCaptor.getValue().getOrdenProduccionEtapa()).isNull();
+        LoteProducto loteDestinoPersistido = lotesGuardados.getAllValues().stream()
+                .filter(lp -> lp.getAlmacen() != null && lp.getAlmacen().getId().equals(dto.almacenDestinoId()))
+                .reduce((first, second) -> second)
+                .orElse(null);
+        assertThat(loteDestinoPersistido).isNotNull();
+        assertThat(loteDestinoPersistido.getStockLote()).isEqualByComparingTo(new BigDecimal("1000.00"));
+        assertThat(loteDestinoPersistido.getLoteOrigen()).isEqualTo(lote);
+        assertThat(movimientoCaptor.getValue().getLote()).isSameAs(loteDestinoPersistido);
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCierreTotalTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCierreTotalTest.java
@@ -1,0 +1,276 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.inventario.service.*;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.TipoCierre;
+import com.willyes.clemenintegra.produccion.repository.CierreProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class OrdenProduccionServiceCierreTotalTest {
+
+    private FormulaProductoRepository formulaProductoRepository;
+    private ProductoRepository productoRepository;
+    private UsuarioRepository usuarioRepository;
+    private SolicitudMovimientoService solicitudMovimientoService;
+    private OrdenProduccionRepository repository;
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    private CierreProduccionRepository cierreProduccionRepository;
+    private MovimientoInventarioService movimientoInventarioService;
+    private LoteProductoRepository loteProductoRepository;
+    private AlmacenRepository almacenRepository;
+    private UnidadConversionService unidadConversionService;
+    private EtapaProduccionRepository etapaProduccionRepository;
+    private EtapaPlantillaRepository etapaPlantillaRepository;
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    private MovimientoInventarioMapper movimientoInventarioMapper;
+    private com.willyes.clemenintegra.shared.service.UsuarioService usuarioService;
+    private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    private InventoryCatalogResolver catalogResolver;
+    private UmValidator umValidator;
+    private com.willyes.clemenintegra.calidad.service.VidaUtilProductoService vidaUtilProductoService;
+    private ReservaLoteService reservaLoteService;
+    private ReservaLoteRepository reservaLoteRepository;
+    private DisponibilidadInsumoService disponibilidadInsumoService;
+
+    private OrdenProduccionServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        formulaProductoRepository = mock(FormulaProductoRepository.class);
+        productoRepository = mock(ProductoRepository.class);
+        usuarioRepository = mock(UsuarioRepository.class);
+        solicitudMovimientoService = mock(SolicitudMovimientoService.class);
+        repository = mock(OrdenProduccionRepository.class);
+        motivoMovimientoRepository = mock(MotivoMovimientoRepository.class);
+        tipoMovimientoDetalleRepository = mock(TipoMovimientoDetalleRepository.class);
+        cierreProduccionRepository = mock(CierreProduccionRepository.class);
+        movimientoInventarioService = mock(MovimientoInventarioService.class);
+        loteProductoRepository = mock(LoteProductoRepository.class);
+        almacenRepository = mock(AlmacenRepository.class);
+        unidadConversionService = mock(UnidadConversionService.class);
+        etapaProduccionRepository = mock(EtapaProduccionRepository.class);
+        etapaPlantillaRepository = mock(EtapaPlantillaRepository.class);
+        movimientoInventarioRepository = mock(MovimientoInventarioRepository.class);
+        movimientoInventarioMapper = mock(MovimientoInventarioMapper.class);
+        usuarioService = mock(com.willyes.clemenintegra.shared.service.UsuarioService.class);
+        solicitudMovimientoRepository = mock(SolicitudMovimientoRepository.class);
+        catalogResolver = mock(InventoryCatalogResolver.class);
+        umValidator = mock(UmValidator.class);
+        vidaUtilProductoService = mock(com.willyes.clemenintegra.calidad.service.VidaUtilProductoService.class);
+        reservaLoteService = mock(ReservaLoteService.class);
+        reservaLoteRepository = mock(ReservaLoteRepository.class);
+        disponibilidadInsumoService = mock(DisponibilidadInsumoService.class);
+
+        service = new OrdenProduccionServiceImpl(
+                formulaProductoRepository,
+                productoRepository,
+                usuarioRepository,
+                solicitudMovimientoService,
+                repository,
+                motivoMovimientoRepository,
+                tipoMovimientoDetalleRepository,
+                cierreProduccionRepository,
+                movimientoInventarioService,
+                loteProductoRepository,
+                almacenRepository,
+                unidadConversionService,
+                etapaProduccionRepository,
+                etapaPlantillaRepository,
+                movimientoInventarioRepository,
+                movimientoInventarioMapper,
+                usuarioService,
+                solicitudMovimientoRepository,
+                catalogResolver,
+                umValidator,
+                vidaUtilProductoService,
+                reservaLoteService,
+                reservaLoteRepository,
+                disponibilidadInsumoService
+        );
+        ReflectionTestUtils.setField(service, "estadosSolicitudPendientesConf", "PENDIENTE");
+        ReflectionTestUtils.setField(service, "estadosSolicitudConcluyentesConf", "ATENDIDO");
+    }
+
+    @Test
+    void registrarConsumoRealPorCierreTotal_generaSalidaDesdePrebodega() {
+        OrdenProduccion orden = ordenProduccion(new BigDecimal("5"));
+        Usuario usuario = usuario(50L);
+        EtapaProduccion etapa = new EtapaProduccion();
+        etapa.setId(99L);
+        List<EtapaProduccion> etapas = List.of(etapa);
+
+        Producto insumo = producto(200);
+        FormulaProducto formula = formula(insumo, new BigDecimal("2.0"));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(
+                orden.getProducto().getId().longValue(), EstadoFormula.APROBADA)).thenReturn(Optional.of(formula));
+
+        when(catalogResolver.getTipoDetalleSalidaProduccionId()).thenReturn(10L);
+        when(tipoMovimientoDetalleRepository.findById(10L)).thenReturn(Optional.of(tipoMovimientoDetalle(10L)));
+        when(catalogResolver.getMotivoSalidaProduccionId()).thenReturn(11L);
+        when(motivoMovimientoRepository.findById(11L)).thenReturn(Optional.of(motivoMovimiento(11L)));
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(6L);
+
+        MovimientoInventario alistado = transferenciaPrebodega(insumo, 6, new BigDecimal("12"));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()), eq(ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION), any()))
+                .thenReturn(new PageImpl<>(List.of(alistado)));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()), eq(ClasificacionMovimientoInventario.SALIDA_PRODUCCION), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
+                eq(orden.getId()), eq(insumo.getId().longValue()), eq(TipoMovimiento.SALIDA), eq(10L)))
+                .thenReturn(BigDecimal.ZERO);
+        when(movimientoInventarioService.registrarMovimiento(any()))
+                .thenReturn(MovimientoInventarioResponseDTO.builder().id(999L).build());
+
+        ReflectionTestUtils.invokeMethod(
+                service,
+                "registrarConsumoRealPorCierreTotal",
+                orden,
+                etapas,
+                etapa,
+                usuario
+        );
+
+        ArgumentCaptor<MovimientoInventarioDTO> dtoCaptor = ArgumentCaptor.forClass(MovimientoInventarioDTO.class);
+        verify(movimientoInventarioService).registrarMovimiento(dtoCaptor.capture());
+        MovimientoInventarioDTO dto = dtoCaptor.getValue();
+        assertThat(dto.tipoMovimiento()).isEqualTo(TipoMovimiento.SALIDA);
+        assertThat(dto.clasificacionMovimientoInventario()).isEqualTo(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+        assertThat(dto.almacenOrigenId()).isEqualTo(6);
+        assertThat(dto.cantidad()).isEqualByComparingTo(new BigDecimal("10.0"));
+    }
+
+    @Test
+    void registrarConsumoRealPorCierreTotal_idempotenteCuandoYaConsumido() {
+        OrdenProduccion orden = ordenProduccion(new BigDecimal("3"));
+        Usuario usuario = usuario(51L);
+        Producto insumo = producto(201);
+        FormulaProducto formula = formula(insumo, new BigDecimal("1.5"));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(
+                orden.getProducto().getId().longValue(), EstadoFormula.APROBADA)).thenReturn(Optional.of(formula));
+
+        when(catalogResolver.getTipoDetalleSalidaProduccionId()).thenReturn(10L);
+        when(tipoMovimientoDetalleRepository.findById(10L)).thenReturn(Optional.of(tipoMovimientoDetalle(10L)));
+        when(catalogResolver.getMotivoSalidaProduccionId()).thenReturn(11L);
+        when(motivoMovimientoRepository.findById(11L)).thenReturn(Optional.of(motivoMovimiento(11L)));
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(6L);
+
+        MovimientoInventario alistado = transferenciaPrebodega(insumo, 6, new BigDecimal("9"));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()), eq(ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION), any()))
+                .thenReturn(new PageImpl<>(List.of(alistado)));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()), eq(ClasificacionMovimientoInventario.SALIDA_PRODUCCION), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+        when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
+                eq(orden.getId()), eq(insumo.getId().longValue()), eq(TipoMovimiento.SALIDA), eq(10L)))
+                .thenReturn(new BigDecimal("4.5"));
+
+        ReflectionTestUtils.invokeMethod(
+                service,
+                "registrarConsumoRealPorCierreTotal",
+                orden,
+                List.of(),
+                null,
+                usuario
+        );
+
+        verify(movimientoInventarioService, never()).registrarMovimiento(any());
+    }
+
+    private OrdenProduccion ordenProduccion(BigDecimal cantidadProgramada) {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(1L);
+        orden.setProducto(producto(100));
+        orden.setCantidadProgramada(cantidadProgramada);
+        orden.setEstado(EstadoProduccion.EN_PROCESO);
+        orden.setTipoCierre(TipoCierre.TOTAL);
+        return orden;
+    }
+
+    private Usuario usuario(Long id) {
+        Usuario usuario = new Usuario();
+        usuario.setId(id);
+        usuario.setNombreCompleto("Tester");
+        return usuario;
+    }
+
+    private Producto producto(Integer id) {
+        Producto producto = new Producto();
+        producto.setId(id);
+        producto.setCategoriaProducto(new CategoriaProducto());
+        return producto;
+    }
+
+    private FormulaProducto formula(Producto insumo, BigDecimal cantidad) {
+        FormulaProducto formula = new FormulaProducto();
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(insumo);
+        detalle.setCantidadNecesaria(cantidad);
+        formula.setDetalles(List.of(detalle));
+        return formula;
+    }
+
+    private MovimientoInventario transferenciaPrebodega(Producto producto, int almacenDestino, BigDecimal cantidad) {
+        MovimientoInventario mov = new MovimientoInventario();
+        mov.setTipoMovimiento(TipoMovimiento.TRANSFERENCIA);
+        mov.setClasificacion(ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION);
+        mov.setCantidad(cantidad);
+        mov.setProducto(producto);
+        LoteProducto lote = new LoteProducto();
+        lote.setId(700L);
+        lote.setCodigoLote("LOTE-X");
+        lote.setProducto(producto);
+        lote.setAlmacen(new Almacen(almacenDestino));
+        mov.setLote(lote);
+        mov.setFechaIngreso(LocalDateTime.now());
+        return mov;
+    }
+
+    private TipoMovimientoDetalle tipoMovimientoDetalle(Long id) {
+        TipoMovimientoDetalle detalle = new TipoMovimientoDetalle();
+        detalle.setId(id);
+        return detalle;
+    }
+
+    private MotivoMovimiento motivoMovimiento(Long id) {
+        MotivoMovimiento motivo = new MotivoMovimiento();
+        motivo.setId(id);
+        motivo.setMotivo(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+        return motivo;
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -60,6 +60,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
@@ -165,11 +166,16 @@ class OrdenProduccionServiceReservaTest {
         when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
         MotivoMovimiento motivo = new MotivoMovimiento();
         motivo.setId(11L);
+        when(catalogResolver.getMotivoSalidaProduccionId()).thenReturn(11L);
         when(motivoMovimientoRepository.findByMotivo(ClasificacionMovimientoInventario.SALIDA_PRODUCCION))
                 .thenReturn(Optional.of(motivo));
+        when(motivoMovimientoRepository.findById(11L)).thenReturn(Optional.of(motivo));
         TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
         tipoDetalle.setId(33L);
+        when(catalogResolver.getTipoDetalleSalidaProduccionId()).thenReturn(33L);
         when(tipoMovimientoDetalleRepository.findById(anyLong())).thenReturn(Optional.of(tipoDetalle));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(anyLong(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
         lenient().when(solicitudMovimientoRepository.findById(100L)).thenReturn(Optional.of(crearSolicitudBase()));
         lenient().when(solicitudMovimientoRepository.saveAndFlush(any(SolicitudMovimiento.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));


### PR DESCRIPTION
## Summary
- add `lote_origen_id` to `lotes_productos` and map it in the entity
- update transfer processing to always materialize destination lots (linking them to their origin) and consume Pre-Bodega stock during closures
- cover transfers and closure consumption with new unit tests

## Testing
- mvn -q -DskipITs test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ac35300083339e123361430eb865)