### PR TITLE
Evitar validación de lote origen en cierre total

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -652,6 +652,10 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         if (orden == null || orden.getId() == null || orden.getProducto() == null) {
             return;
         }
+        Long productoFabricadoId = Optional.ofNullable(orden.getProducto())
+                .map(Producto::getId)
+                .map(Integer::longValue)
+                .orElse(null);
         FormulaProducto formula = formulaProductoRepository
                 .findByProductoIdAndEstadoAndActivoTrue(orden.getProducto().getId().longValue(), EstadoFormula.APROBADA)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "FORMULA_NO_ENCONTRADA"));
@@ -677,13 +681,19 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             if (det == null || det.getInsumo() == null || det.getInsumo().getId() == null) {
                 continue;
             }
+            Long productoId = det.getInsumo().getId().longValue();
+            if (productoFabricadoId != null && Objects.equals(productoId, productoFabricadoId)) {
+                log.debug("OP-cierre total omitiendo producto fabricado como insumo op={}, productoId={}",
+                        orden.getId(), productoFabricadoId);
+                continue;
+            }
             BigDecimal requerido = safeCantidad(det.getCantidadNecesaria())
                     .multiply(orden.getCantidadProgramada())
                     .setScale(6, RoundingMode.HALF_UP);
             if (requerido.compareTo(BigDecimal.ZERO) <= 0) {
                 continue;
             }
-            requeridoPorProducto.merge(det.getInsumo().getId().longValue(), requerido, BigDecimal::add);
+            requeridoPorProducto.merge(productoId, requerido, BigDecimal::add);
         }
         if (requeridoPorProducto.isEmpty()) {
             log.debug("OP-cierre total sin insumos calculados op={}", orden.getId());
@@ -711,6 +721,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             if (mov == null || mov.getLote() == null || mov.getProducto() == null) {
                 continue;
             }
+            if (productoFabricadoId != null
+                    && Objects.equals(mov.getProducto().getId().longValue(), productoFabricadoId)) {
+                log.debug("OP-cierre total omitió movimiento del producto fabricado op={}, loteId={}",
+                        orden.getId(), mov.getLote().getId());
+                continue;
+            }
             if (mov.getTipoMovimiento() != TipoMovimiento.TRANSFERENCIA) {
                 continue;
             }
@@ -735,6 +751,11 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
         for (MovimientoInventario mov : consumosPrevios) {
             if (mov == null || mov.getLote() == null) {
+                continue;
+            }
+            if (productoFabricadoId != null
+                    && mov.getProducto() != null
+                    && Objects.equals(mov.getProducto().getId().longValue(), productoFabricadoId)) {
                 continue;
             }
             if (mov.getTipoMovimiento() != TipoMovimiento.SALIDA) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCierreTotalTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCierreTotalTest.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -35,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -212,6 +215,61 @@ class OrdenProduccionServiceCierreTotalTest {
         verify(movimientoInventarioService, never()).registrarMovimiento(any());
     }
 
+    @Test
+    void registrarConsumoRealPorCierreTotal_omiteProductoFabricadoAlValidarAlmacenOrigen() {
+        OrdenProduccion orden = ordenProduccion(new BigDecimal("5"));
+        Usuario usuario = usuario(52L);
+        EtapaProduccion etapa = new EtapaProduccion();
+        etapa.setId(88L);
+        List<EtapaProduccion> etapas = List.of(etapa);
+
+        Producto productoFabricado = orden.getProducto();
+        Producto insumo = producto(202);
+        FormulaProducto formula = formulaConProductoFabricado(productoFabricado, insumo,
+                new BigDecimal("1.0"), new BigDecimal("2.0"));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(
+                orden.getProducto().getId().longValue(), EstadoFormula.APROBADA)).thenReturn(Optional.of(formula));
+
+        when(catalogResolver.getTipoDetalleSalidaProduccionId()).thenReturn(10L);
+        when(tipoMovimientoDetalleRepository.findById(10L)).thenReturn(Optional.of(tipoMovimientoDetalle(10L)));
+        when(catalogResolver.getMotivoSalidaProduccionId()).thenReturn(11L);
+        when(motivoMovimientoRepository.findById(11L)).thenReturn(Optional.of(motivoMovimiento(11L)));
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(6L);
+
+        MovimientoInventario alistadoInsumo = transferenciaPrebodega(insumo, 6, new BigDecimal("12"));
+        MovimientoInventario alistadoProducto = transferenciaPrebodega(productoFabricado, 6, new BigDecimal("3"));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()), eq(ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION), any()))
+                .thenReturn(new PageImpl<>(List.of(alistadoProducto, alistadoInsumo)));
+        when(movimientoInventarioRepository.findByOrdenProduccionIdAndClasificacion(
+                eq(orden.getId()), eq(ClasificacionMovimientoInventario.SALIDA_PRODUCCION), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+        lenient().when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(
+                eq(orden.getId()), anyLong(), eq(TipoMovimiento.SALIDA), eq(10L)))
+                .thenReturn(BigDecimal.ZERO);
+
+        when(movimientoInventarioService.registrarMovimiento(argThat(dto ->
+                dto != null && dto.productoId().longValue() == productoFabricado.getId().longValue())))
+                .thenThrow(new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_PERTENECE_ALMACEN_ORIGEN"));
+        when(movimientoInventarioService.registrarMovimiento(argThat(dto ->
+                dto != null && dto.productoId().longValue() == insumo.getId().longValue())))
+                .thenReturn(MovimientoInventarioResponseDTO.builder().id(1001L).build());
+
+        assertThatCode(() -> ReflectionTestUtils.invokeMethod(
+                service,
+                "registrarConsumoRealPorCierreTotal",
+                orden,
+                etapas,
+                etapa,
+                usuario
+        )).doesNotThrowAnyException();
+
+        verify(movimientoInventarioService, times(1)).registrarMovimiento(argThat(dto ->
+                dto != null && dto.productoId().longValue() == insumo.getId().longValue()));
+        verify(movimientoInventarioService, never()).registrarMovimiento(argThat(dto ->
+                dto != null && dto.productoId().longValue() == productoFabricado.getId().longValue()));
+    }
+
     private OrdenProduccion ordenProduccion(BigDecimal cantidadProgramada) {
         OrdenProduccion orden = new OrdenProduccion();
         orden.setId(1L);
@@ -242,6 +300,21 @@ class OrdenProduccionServiceCierreTotalTest {
         detalle.setInsumo(insumo);
         detalle.setCantidadNecesaria(cantidad);
         formula.setDetalles(List.of(detalle));
+        return formula;
+    }
+
+    private FormulaProducto formulaConProductoFabricado(Producto productoFabricado,
+                                                        Producto insumo,
+                                                        BigDecimal requeridoFabricado,
+                                                        BigDecimal requeridoInsumo) {
+        FormulaProducto formula = new FormulaProducto();
+        DetalleFormula detProducto = new DetalleFormula();
+        detProducto.setInsumo(productoFabricado);
+        detProducto.setCantidadNecesaria(requeridoFabricado);
+        DetalleFormula detInsumo = new DetalleFormula();
+        detInsumo.setInsumo(insumo);
+        detInsumo.setCantidadNecesaria(requeridoInsumo);
+        formula.setDetalles(List.of(detProducto, detInsumo));
         return formula;
     }
 


### PR DESCRIPTION
## Summary
- evita tratar el producto fabricado como insumo al calcular consumos en cierres totales, omitiendo movimientos y lotes del propio PT/PS
- añade una prueba de cierre total que confirma que no se valida almacén origen para el producto fabricado y que solo se generan salidas para insumos

## Testing
- mvn -q -DskipITs test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953eef57af08333a84182750711ab2d)