### PR TITLE
Fix salida_produccion origin validation and add trace logging

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -56,6 +56,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -263,7 +264,8 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
 
         Integer almacenOrigenIdNormalizadoInt = dto.almacenOrigenId();
-        boolean salidaPt = isSalidaPt(tipoMovimiento, resolvedTipoDetalleId);
+        boolean salidaPt = clasificacion != ClasificacionMovimientoInventario.SALIDA_PRODUCCION
+                && isSalidaPt(tipoMovimiento, resolvedTipoDetalleId);
 
         Long almacenPtId = null;
         if (salidaPt) {
@@ -1802,7 +1804,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
         List<MovimientoLoteDetalle> detalles = new ArrayList<>();
         for (ParLoteCantidad par : plan) {
-            MovimientoLoteDetalle detalle = consumirLoteSalidaPt(par, producto, almacenPtId, estadosElegibles);
+            MovimientoLoteDetalle detalle = consumirLoteSalidaPt(par, producto, almacenPtId, estadosElegibles, dto);
             log.info("SALIDA_PT producto={} lote={} cantidad={} autosplit={} destino={} doc={}",
                     producto != null ? producto.getId() : null,
                     detalle.lote() != null ? detalle.lote().getId() : null,
@@ -1822,7 +1824,8 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     private MovimientoLoteDetalle consumirLoteSalidaPt(ParLoteCantidad consumo,
                                                        Producto producto,
                                                        Long almacenPtId,
-                                                       EnumSet<EstadoLote> estadosElegibles) {
+                                                       EnumSet<EstadoLote> estadosElegibles,
+                                                       MovimientoInventarioDTO dto) {
         if (consumo == null || consumo.loteId() == null) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_ID_REQUERIDO");
         }
@@ -1834,6 +1837,10 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
         Long almacenActualLoteId = obtenerAlmacenActualLoteId(lote);
         if (almacenActualLoteId == null || !Objects.equals(almacenActualLoteId, almacenPtId)) {
+            logLoteOrigenInvalido("salida_pt", dto, lote, almacenPtId, almacenActualLoteId,
+                    dto != null ? dto.clasificacionMovimientoInventario() : null,
+                    dto != null ? dto.tipoMovimiento() : null,
+                    dto != null ? dto.tipoMovimientoDetalleId() : null);
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_PERTENECE_ALMACEN_ORIGEN");
         }
         loteCalidadValidator.validarLoteUtilizable(lote);
@@ -1911,6 +1918,8 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                 || !Objects.equals(almacenActualLoteId, almacenOrigen.getId().longValue()))) {
             log.debug("[INVENTARIO] almacén origen no coincide: loteId={} almacenLoteId={} almacenOrigenId={}",
                     loteOrigen.getId(), almacenActualLoteId, almacenOrigen.getId());
+            logLoteOrigenInvalido("procesar_con_lote_existente", dto, loteOrigen,
+                    almacenOrigen.getId().longValue(), almacenActualLoteId, clasificacion, tipo, dto.tipoMovimientoDetalleId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_PERTENECE_ALMACEN_ORIGEN");
         }
 
@@ -2281,6 +2290,8 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                             || !Objects.equals(almacenActualLoteAdicionalId, almacenOrigenId.longValue())) {
                         log.warn("AUTO_SPLIT_ALMACEN_INCONSISTENTE loteId={} almacenEsperado={} almacenEncontrado={}",
                                 loteAdicional.getId(), almacenOrigenId, almacenActualLoteAdicionalId);
+                        logLoteOrigenInvalido("auto_split", dto, loteAdicional, almacenOrigenId.longValue(),
+                                almacenActualLoteAdicionalId, clasificacion, tipo, dto.tipoMovimientoDetalleId());
                         throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_PERTENECE_ALMACEN_ORIGEN");
                     }
 
@@ -2637,6 +2648,34 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
         Long salidaId = catalogResolver.getTipoDetalleSalidaId();
         return salidaId != null && Objects.equals(tipoDetalleId, salidaId);
+    }
+
+    private void logLoteOrigenInvalido(String origenLog,
+                                       MovimientoInventarioDTO dto,
+                                       LoteProducto lote,
+                                       Long almacenEsperadoId,
+                                       Long almacenActualLoteId,
+                                       ClasificacionMovimientoInventario clasificacion,
+                                       TipoMovimiento tipoMovimiento,
+                                       Long tipoDetalleId) {
+        log.warn("LOTE_NO_PERTENECE_ALMACEN_ORIGEN traceId={} origen={} opId={} etapaId={} productoId={} loteId={} codigoLote={} dtoAlmacenOrigenId={} dtoAlmacenDestinoId={} almacenEsperadoId={} loteAlmacenActualId={} loteOrigenId={} loteOrigenAlmacenId={} clasificacion={} tipoMovimiento={} tipoDetalleId={}",
+                MDC.get("opTraceId"),
+                origenLog,
+                dto != null ? dto.ordenProduccionId() : null,
+                dto != null ? dto.ordenProduccionEtapaId() : null,
+                dto != null ? dto.productoId() : (lote != null && lote.getProducto() != null ? lote.getProducto().getId() : null),
+                lote != null ? lote.getId() : null,
+                lote != null ? lote.getCodigoLote() : null,
+                dto != null ? dto.almacenOrigenId() : null,
+                dto != null ? dto.almacenDestinoId() : null,
+                almacenEsperadoId,
+                almacenActualLoteId,
+                lote != null && lote.getLoteOrigen() != null ? lote.getLoteOrigen().getId() : null,
+                lote != null && lote.getLoteOrigen() != null && lote.getLoteOrigen().getAlmacen() != null ? lote.getLoteOrigen().getAlmacen().getId() : null,
+                clasificacion,
+                tipoMovimiento,
+                tipoDetalleId
+        );
     }
 
     private MotivoMovimiento resolverMotivoMovimientoPorClasificacion(

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -56,6 +56,7 @@ import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.inventario.model.VidaUtilProducto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
@@ -92,6 +93,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.Arrays;
+import java.util.UUID;
 import java.util.Objects;
 import java.util.Comparator;
 import java.math.RoundingMode;
@@ -648,7 +650,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     private void registrarConsumoRealPorCierreTotal(OrdenProduccion orden,
                                                     List<EtapaProduccion> etapas,
                                                     EtapaProduccion etapaConsumo,
-                                                    Usuario usuario) {
+                                                    Usuario usuario,
+                                                    String traceId) {
         if (orden == null || orden.getId() == null || orden.getProducto() == null) {
             return;
         }
@@ -846,6 +849,19 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                         null,
                         null
                 );
+                log.info("OP-cierre total movDTO traceId={} opId={} etapaId={} productoId={} loteId={} tipo={} clasificacion={} almacenOrigenId={} almacenDestinoId={} tipoDetalleId={} motivoId={} cantidad={}",
+                        traceId,
+                        orden.getId(),
+                        etapaDestinoId,
+                        productoId,
+                        loteId,
+                        salida.tipoMovimiento(),
+                        salida.clasificacionMovimientoInventario(),
+                        salida.almacenOrigenId(),
+                        salida.almacenDestinoId(),
+                        salida.tipoMovimientoDetalleId(),
+                        salida.motivoMovimientoId(),
+                        salida.cantidad());
                 movimientoInventarioService.registrarMovimiento(salida);
 
                 pendiente = pendiente.subtract(consumir);
@@ -866,41 +882,63 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         repository.deleteById(id);
     }
 
+    /*
+     * Auditoría rápida (opcional, para ejecución manual) para seguir movimientos de la OP:
+     * 1) Movimientos del producto fabricado (818) por orden:
+     *    SELECT mi.id, mi.tipo_mov, mi.cantidad, mi.almacen_origen_id, mi.almacen_destino_id, mi.productos_id,
+     *           lp.id lote_id, lp.codigo_lote, lp.almacenes_id lote_almacen_actual
+     *    FROM movimientos_inventario mi
+     *    JOIN lotes_productos lp ON lp.id = mi.lotes_productos_id
+     *    WHERE mi.orden_produccion_id = :opId AND mi.productos_id = 818
+     *    ORDER BY mi.id DESC;
+     * 2) Todas las SALIDAS por orden:
+     *    SELECT mi.id, mi.tipo_mov, mi.cantidad, mi.almacen_origen_id, mi.almacen_destino_id, mi.productos_id,
+     *           mi.tipos_movimiento_detalle_id, mi.clasificacion,
+     *           lp.id lote_id, lp.codigo_lote, lp.almacenes_id lote_almacen_actual
+     *    FROM movimientos_inventario mi
+     *    JOIN lotes_productos lp ON lp.id = mi.lotes_productos_id
+     *    WHERE mi.orden_produccion_id = :opId AND mi.tipo_mov='SALIDA'
+     *    ORDER BY mi.id DESC;
+     */
     @Transactional
     public OrdenProduccion registrarCierre(Long id, CierreProduccionRequestDTO dto) {
-        try {
+        String traceId = UUID.randomUUID().toString();
+        try (MDC.MDCCloseable ignored = MDC.putCloseable("opTraceId", traceId)) {
             OrdenProduccion orden = repository.findById(id)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ORDEN_NO_ENCONTRADA"));
 
-            if (orden.getEstado() == EstadoProduccion.FINALIZADA ||
-                    orden.getEstado() == EstadoProduccion.CANCELADA ||
-                    orden.getEstado() == EstadoProduccion.CERRADA_INCOMPLETA) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ORDEN_NO_CERRABLE");
-            }
+                if (orden.getEstado() == EstadoProduccion.FINALIZADA ||
+                        orden.getEstado() == EstadoProduccion.CANCELADA ||
+                        orden.getEstado() == EstadoProduccion.CERRADA_INCOMPLETA) {
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ORDEN_NO_CERRABLE");
+                }
 
-            if (dto.getCantidad() == null) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CANTIDAD_INVALIDA");
-            }
+                if (dto.getCantidad() == null) {
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CANTIDAD_INVALIDA");
+                }
 
-            BigDecimal cantidad = validarCantidad(dto.getCantidad(), orden.getProducto());
-            dto.setCantidad(cantidad);
+                Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+                BigDecimal cantidad = validarCantidad(dto.getCantidad(), orden.getProducto());
+                dto.setCantidad(cantidad);
+                log.info("OP-cierre request traceId={} opId={} tipo={} cantidad={} usuarioId={}", traceId, orden.getId(),
+                        dto.getTipo(), cantidad, usuario.getId());
 
-            List<EtapaProduccion> etapas = etapaProduccionRepository
-                    .findByOrdenProduccionIdOrderBySecuenciaAsc(orden.getId());
-            boolean algunaEtapaIniciada = etapas.stream().anyMatch(e -> e.getFechaInicio() != null);
-            boolean todasFinalizadas = !etapas.isEmpty()
-                    && etapas.stream().allMatch(e -> e.getFechaFin() != null || e.getEstado() == EstadoEtapa.FINALIZADA);
+                List<EtapaProduccion> etapas = etapaProduccionRepository
+                        .findByOrdenProduccionIdOrderBySecuenciaAsc(orden.getId());
+                boolean algunaEtapaIniciada = etapas.stream().anyMatch(e -> e.getFechaInicio() != null);
+                boolean todasFinalizadas = !etapas.isEmpty()
+                        && etapas.stream().allMatch(e -> e.getFechaFin() != null || e.getEstado() == EstadoEtapa.FINALIZADA);
 
-            boolean permitirCierreSinActiva = dto.getTipo() == TipoCierre.TOTAL
-                    && orden.getEstado() == EstadoProduccion.EN_PROCESO
-                    && todasFinalizadas;
+                boolean permitirCierreSinActiva = dto.getTipo() == TipoCierre.TOTAL
+                        && orden.getEstado() == EstadoProduccion.EN_PROCESO
+                        && todasFinalizadas;
 
-            if (!algunaEtapaIniciada && !permitirCierreSinActiva) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "OP_SIN_ETAPA_ACTIVA");
-            }
-            if (permitirCierreSinActiva) {
-                log.debug("OP-cierre total sin etapa activa permitida op={}", orden.getId());
-            }
+                if (!algunaEtapaIniciada && !permitirCierreSinActiva) {
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "OP_SIN_ETAPA_ACTIVA");
+                }
+                if (permitirCierreSinActiva) {
+                    log.debug("OP-cierre total sin etapa activa permitida op={}", orden.getId());
+                }
 
             LoteProducto lote = loteProductoRepository
                     .findByOrdenProduccionIdAndProductoId(orden.getId(), orden.getProducto().getId().longValue())
@@ -975,12 +1013,10 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 throw new ErrorResponseException(HttpStatus.CONFLICT, problem, null);
             }
 
-            Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
-
             EtapaProduccion etapaConsumo = seleccionarEtapaParaConsumo(etapas, orden.getId());
             registrarConsumoDeInsumos(orden.getId(), etapaConsumo.getId(), usuario.getId());
             if (dto.getTipo() == TipoCierre.TOTAL) {
-                registrarConsumoRealPorCierreTotal(orden, etapas, etapaConsumo, usuario);
+                registrarConsumoRealPorCierreTotal(orden, etapas, etapaConsumo, usuario, traceId);
             }
 
             List<EstadoSolicitudMovimiento> estadosPendientes = parseEstados(estadosSolicitudPendientesConf);
@@ -1229,6 +1265,19 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     null,
                     null,
                     null);
+            log.info("OP-cierre entrada DTO traceId={} opId={} etapaId={} productoId={} loteId={} tipo={} clasificacion={} almacenOrigenId={} almacenDestinoId={} tipoDetalleId={} motivoId={} cantidad={}",
+                    traceId,
+                    orden.getId(),
+                    null,
+                    orden.getProducto().getId(),
+                    lote.getId(),
+                    movDto.tipoMovimiento(),
+                    movDto.clasificacionMovimientoInventario(),
+                    movDto.almacenOrigenId(),
+                    movDto.almacenDestinoId(),
+                    movDto.tipoMovimientoDetalleId(),
+                    movDto.motivoMovimientoId(),
+                    movDto.cantidad());
             movimientoInventarioService.registrarMovimiento(movDto);
             log.info("OP-cierre entrada PT op={}, producto={}, lote={}, cantidad={}, usuario={}, destino={}, motivoId={}, tipoDetalleId={}",
                     orden.getId(), orden.getProducto().getId(), lote.getId(), cantidad, usuario.getId(), destino.getId(), motivoEntrada.getId(), tipoDetalleEntrada.getId());

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceAlmacenOrigenTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceAlmacenOrigenTest.java
@@ -169,6 +169,65 @@ class MovimientoInventarioServiceAlmacenOrigenTest {
         verify(movimientoInventarioRepository).save(any(MovimientoInventario.class));
     }
 
+    @Test
+    void salidaProduccionNoSeNormalizaComoSalidaPt() {
+        Producto producto = crearProducto(818, 2);
+        LoteProducto lotePreBodega = crearLote(300L, producto, 6, EstadoLote.LIBERADO,
+                new BigDecimal("5"), BigDecimal.ZERO, false);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("2"),
+                TipoMovimiento.SALIDA,
+                ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                null,
+                null,
+                producto.getId(),
+                lotePreBodega.getId(),
+                6,
+                null,
+                null,
+                null,
+                null,
+                TIPO_DETALLE_SALIDA_PRODUCCION_ID,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        configurarMocksBasicos(producto, lotePreBodega);
+        lenient().when(catalogResolver.isSalidaPtEnabled()).thenReturn(true);
+        lenient().when(catalogResolver.getTipoDetalleSalidaPtId()).thenReturn(TIPO_DETALLE_SALIDA_PRODUCCION_ID);
+        lenient().when(catalogResolver.getAlmacenPtId()).thenReturn(2L);
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(dto.tipoMovimiento());
+        movimientoEntidad.setClasificacion(dto.clasificacionMovimientoInventario());
+        movimientoEntidad.setCantidad(dto.cantidad());
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(501L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willReturn(MovimientoInventarioResponseDTO.builder().id(501L).build());
+
+        assertThatNoException().isThrownBy(() -> service.registrarMovimiento(dto));
+
+        assertThat(lotePreBodega.getStockLote()).isEqualByComparingTo(new BigDecimal("3.00"));
+        verify(movimientoInventarioRepository).save(any(MovimientoInventario.class));
+    }
+
     private void configurarMocksBasicos(Producto producto, LoteProducto lotePreBodega) {
         given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
         TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCierreTotalTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCierreTotalTest.java
@@ -165,7 +165,8 @@ class OrdenProduccionServiceCierreTotalTest {
                 orden,
                 etapas,
                 etapa,
-                usuario
+                usuario,
+                "trace-test"
         );
 
         ArgumentCaptor<MovimientoInventarioDTO> dtoCaptor = ArgumentCaptor.forClass(MovimientoInventarioDTO.class);
@@ -209,7 +210,8 @@ class OrdenProduccionServiceCierreTotalTest {
                 orden,
                 List.of(),
                 null,
-                usuario
+                usuario,
+                "trace-test"
         );
 
         verify(movimientoInventarioService, never()).registrarMovimiento(any());
@@ -261,7 +263,8 @@ class OrdenProduccionServiceCierreTotalTest {
                 orden,
                 etapas,
                 etapa,
-                usuario
+                usuario,
+                "trace-test"
         )).doesNotThrowAnyException();
 
         verify(movimientoInventarioService, times(1)).registrarMovimiento(argThat(dto ->


### PR DESCRIPTION
## Summary
- Add trace-aware logging during order production closures and around inventory origin validation, including SQL audit references for movement review.
- Prevent SALIDA_PRODUCCION movements from being normalized as product-terminated exits and log detailed context before rejecting invalid origin warehouses.
- Cover regression scenarios for closing orders with product 818 and ensure reflection-based tests account for new trace identifiers.

## Testing
- mvn -q -DskipITs test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953feadcbd48333a42b0ef1b8054320)