### PR TITLE
Expose production checklist endpoints for ordenes

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -41,6 +41,7 @@ public class OrdenProduccionController {
     private final ReporteOrdenProduccionService reporteOrdenProduccionService;
     private final UsuarioService usuarioService;
     private final com.willyes.clemenintegra.inventario.service.MovimientoInventarioService movimientoInventarioService;
+    private final ChecklistEtapaService checklistEtapaService;
     //private final UsuarioService usuarioService;
 
 
@@ -223,6 +224,21 @@ public class OrdenProduccionController {
                                                                                            @PathVariable Long etapaId,
                                                                                            @RequestParam(name = "clasificacion", required = false) ClasificacionMovimientoInventario clasificacion) {
         return ResponseEntity.ok(service.listarMovimientosPorEtapa(ordenId, etapaId, clasificacion));
+    }
+
+    @GetMapping("/{ordenId}/etapas/{etapaId}/checklist")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ChecklistEtapaDTO> obtenerChecklistPorEtapa(@PathVariable Long ordenId,
+                                                                      @PathVariable Long etapaId) {
+        return ResponseEntity.ok(checklistEtapaService.obtenerPorOrdenYEtapa(ordenId, etapaId));
+    }
+
+    @PostMapping("/{ordenId}/etapas/{etapaId}/checklist")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ChecklistEtapaDTO> actualizarChecklistPorEtapa(@PathVariable Long ordenId,
+                                                                         @PathVariable Long etapaId,
+                                                                         @RequestBody List<ChecklistItemDTO> items) {
+        return ResponseEntity.ok(checklistEtapaService.actualizarEnOrden(ordenId, etapaId, items));
     }
 
     @GetMapping("/{id}/lote")

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaService.java
@@ -7,7 +7,9 @@ import java.util.List;
 
 public interface ChecklistEtapaService {
     ChecklistEtapaDTO obtenerPorEtapa(Long etapaId);
+    ChecklistEtapaDTO obtenerPorOrdenYEtapa(Long ordenId, Long etapaId);
     ChecklistEtapaDTO actualizar(Long etapaId, List<ChecklistItemDTO> items);
+    ChecklistEtapaDTO actualizarEnOrden(Long ordenId, Long etapaId, List<ChecklistItemDTO> items);
     byte[] exportCsvPorOrden(Long ordenId);
     void validarChecklistCompleto(Long etapaId);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,8 +37,15 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     @Override
     @Transactional(readOnly = true)
     public ChecklistEtapaDTO obtenerPorEtapa(Long etapaId) {
-        EtapaProduccion etapa = etapaProduccionRepository.findById(etapaId)
-                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "ETAPA_NO_ENCONTRADA"));
+        EtapaProduccion etapa = obtenerEtapa(etapaId);
+        List<ChecklistEtapaItem> items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
+        return buildDto(etapa, items);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ChecklistEtapaDTO obtenerPorOrdenYEtapa(Long ordenId, Long etapaId) {
+        EtapaProduccion etapa = obtenerEtapaValidada(ordenId, etapaId);
         List<ChecklistEtapaItem> items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
         return buildDto(etapa, items);
     }
@@ -45,16 +53,19 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     @Override
     @Transactional
     public ChecklistEtapaDTO actualizar(Long etapaId, List<ChecklistItemDTO> itemsDto) {
-        EtapaProduccion etapa = etapaProduccionRepository.findById(etapaId)
-                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "ETAPA_NO_ENCONTRADA"));
+        EtapaProduccion etapa = obtenerEtapa(etapaId);
         Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
 
-        repository.deleteByEtapaProduccionId(etapaId);
-        List<ChecklistEtapaItem> items = (itemsDto != null ? itemsDto : List.<ChecklistItemDTO>of()).stream()
-                .map(dto -> toEntity(dto, etapa, usuario))
-                .sorted(Comparator.comparing(ChecklistEtapaItem::getId, Comparator.nullsLast(Long::compareTo)))
-                .collect(Collectors.toList());
-        List<ChecklistEtapaItem> guardados = repository.saveAll(items);
+        List<ChecklistEtapaItem> guardados = guardarItems(etapa, usuario, itemsDto);
+        return buildDto(etapa, guardados);
+    }
+
+    @Override
+    @Transactional
+    public ChecklistEtapaDTO actualizarEnOrden(Long ordenId, Long etapaId, List<ChecklistItemDTO> itemsDto) {
+        EtapaProduccion etapa = obtenerEtapaValidada(ordenId, etapaId);
+        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+        List<ChecklistEtapaItem> guardados = guardarItems(etapa, usuario, itemsDto);
         return buildDto(etapa, guardados);
     }
 
@@ -104,6 +115,30 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
                     "CHECKLIST_ETAPA_INCOMPLETO",
                     Map.of("etapaId", etapaId, "faltantes", faltantes));
         }
+    }
+
+    private List<ChecklistEtapaItem> guardarItems(EtapaProduccion etapa, Usuario usuario, List<ChecklistItemDTO> itemsDto) {
+        repository.deleteByEtapaProduccionId(etapa.getId());
+        List<ChecklistEtapaItem> items = (itemsDto != null ? itemsDto : List.<ChecklistItemDTO>of()).stream()
+                .map(dto -> toEntity(dto, etapa, usuario))
+                .sorted(Comparator.comparing(ChecklistEtapaItem::getId, Comparator.nullsLast(Long::compareTo)))
+                .collect(Collectors.toList());
+        return repository.saveAll(items);
+    }
+
+    private EtapaProduccion obtenerEtapa(Long etapaId) {
+        return etapaProduccionRepository.findById(etapaId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "ETAPA_NO_ENCONTRADA"));
+    }
+
+    private EtapaProduccion obtenerEtapaValidada(Long ordenId, Long etapaId) {
+        EtapaProduccion etapa = obtenerEtapa(etapaId);
+        if (etapa.getOrdenProduccion() == null || !Objects.equals(etapa.getOrdenProduccion().getId(), ordenId)) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "ETAPA_NO_PERTENECE_A_ORDEN",
+                    Map.of("ordenId", ordenId, "etapaId", etapaId));
+        }
+        return etapa;
     }
 
     private ChecklistEtapaDTO buildDto(EtapaProduccion etapa, List<ChecklistEtapaItem> items) {

--- a/src/main/java/com/willyes/clemenintegra/shared/version/VersionService.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/version/VersionService.java
@@ -14,10 +14,11 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class VersionService {
 
-    private final BuildProperties buildProperties;
+    private final ObjectProvider<BuildProperties> buildPropertiesProvider;
     private final ObjectProvider<GitProperties> gitPropertiesProvider;
 
     public VersionResponse getVersionInfo() {
+        BuildProperties buildProperties = buildPropertiesProvider.getIfAvailable();
         GitProperties gitProperties = gitPropertiesProvider.getIfAvailable();
 
         String gitTag = Optional.ofNullable(gitProperties)
@@ -33,11 +34,11 @@ public class VersionService {
             gitTag = gitCommitId;
         }
 
-        Instant buildInstant = buildProperties.getTime();
+        Instant buildInstant = buildProperties != null ? buildProperties.getTime() : null;
 
         return VersionResponse.builder()
-                .appName(buildProperties.getName())
-                .version(buildProperties.getVersion())
+                .appName(buildProperties != null ? buildProperties.getName() : "unknown")
+                .version(buildProperties != null ? buildProperties.getVersion() : "unknown")
                 .buildTime(buildInstant != null ? buildInstant.toString() : null)
                 .gitTag(gitTag)
                 .gitCommitId(gitCommitId)

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -5,8 +5,10 @@ import com.willyes.clemenintegra.produccion.dto.InsumoFaltanteDTO;
 import com.willyes.clemenintegra.produccion.dto.OrdenProduccionRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.OrdenProduccionResponseDTO;
 import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaDTO;
 import com.willyes.clemenintegra.produccion.service.OrdenProduccionService;
 import com.willyes.clemenintegra.produccion.service.ReporteOrdenProduccionService;
+import com.willyes.clemenintegra.produccion.service.ChecklistEtapaService;
 import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
@@ -45,6 +47,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -81,6 +84,9 @@ class OrdenProduccionControllerTest {
 
     @MockBean
     private UsuarioService usuarioService;
+
+    @MockBean
+    private ChecklistEtapaService checklistEtapaService;
 
     @MockBean
     private MovimientoInventarioService movimientoInventarioService;
@@ -261,6 +267,48 @@ class OrdenProduccionControllerTest {
                 .andExpect(jsonPath("$[0].ordenProduccionEtapaId").value(9L));
 
         verify(ordenProduccionService).listarMovimientosPorEtapa(8L, 9L, ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist responde 200 y retorna lista vacía")
+    void obtenerChecklistPorEtapa_respondeOk() throws Exception {
+        ChecklistEtapaDTO checklist = ChecklistEtapaDTO.builder()
+                .etapaId(12L)
+                .ordenProduccionId(11L)
+                .items(List.of())
+                .faltantesObligatorios(0)
+                .completo(false)
+                .build();
+        when(checklistEtapaService.obtenerPorOrdenYEtapa(11L, 12L)).thenReturn(checklist);
+
+        mockMvc.perform(get("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist", 11L, 12L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items").isEmpty());
+
+        verify(checklistEtapaService).obtenerPorOrdenYEtapa(11L, 12L);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("POST /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist responde 200")
+    void actualizarChecklistPorEtapa_respondeOk() throws Exception {
+        ChecklistEtapaDTO checklist = ChecklistEtapaDTO.builder()
+                .etapaId(14L)
+                .ordenProduccionId(13L)
+                .items(List.of())
+                .completo(true)
+                .faltantesObligatorios(0)
+                .build();
+        when(checklistEtapaService.actualizarEnOrden(eq(13L), eq(14L), any())).thenReturn(checklist);
+
+        mockMvc.perform(post("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist", 13L, 14L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[]"))
+                .andExpect(status().isOk());
+
+        verify(checklistEtapaService).actualizarEnOrden(eq(13L), eq(14L), any());
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImplTest.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.produccion.service;
 import com.willyes.clemenintegra.produccion.dto.ChecklistItemDTO;
 import com.willyes.clemenintegra.produccion.model.ChecklistEtapaItem;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository;
 import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
@@ -93,5 +94,34 @@ class ChecklistEtapaServiceImplTest {
         ));
 
         assertThrows(CustomBusinessException.class, () -> service.validarChecklistCompleto(7L));
+    }
+
+    @Test
+    @DisplayName("Obtener checklist por orden valida pertenencia y retorna lista vacía sin plantilla")
+    void obtenerChecklistPorOrden_sinItems() {
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(3L)
+                .ordenProduccion(OrdenProduccion.builder().id(2L).build())
+                .build();
+        when(etapaProduccionRepository.findById(3L)).thenReturn(Optional.of(etapa));
+        when(checklistRepository.findByEtapaProduccionIdOrderByIdAsc(3L)).thenReturn(List.of());
+
+        var dto = service.obtenerPorOrdenYEtapa(2L, 3L);
+
+        assertThat(dto.getItems()).isEmpty();
+        assertThat(dto.getFaltantesObligatorios()).isZero();
+        assertThat(dto.getOrdenProduccionId()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("Obtener checklist por orden falla si etapa no pertenece a la orden")
+    void obtenerChecklistPorOrden_etapaNoPertenece() {
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(6L)
+                .ordenProduccion(OrdenProduccion.builder().id(99L).build())
+                .build();
+        when(etapaProduccionRepository.findById(6L)).thenReturn(Optional.of(etapa));
+
+        assertThrows(CustomBusinessException.class, () -> service.obtenerPorOrdenYEtapa(1L, 6L));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.produccion.web;
 
 import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import com.willyes.clemenintegra.produccion.controller.OrdenProduccionController;
+import com.willyes.clemenintegra.produccion.service.ChecklistEtapaService;
 import com.willyes.clemenintegra.produccion.service.OrdenProduccionService;
 import com.willyes.clemenintegra.produccion.service.ReporteOrdenProduccionService;
 import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
@@ -51,6 +52,8 @@ class OrdenProduccionControllerSecurityTest {
     private ReporteOrdenProduccionService reporteOrdenProduccionService;
     @MockBean
     private UsuarioService usuarioService;
+    @MockBean
+    private ChecklistEtapaService checklistEtapaService;
     @MockBean
     private MovimientoInventarioService movimientoInventarioService;
     @MockBean


### PR DESCRIPTION
## Summary
- add GET and POST checklist endpoints under `/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist` with the same authorization scheme as etapas and returning empty payloads when no template exists
- extend checklist service with order-aware retrieval/update helpers plus validation tests, and make VersionService tolerant when BuildProperties is unavailable for test contexts
- cover new mappings with controller MockMvc tests and ensure security slices include the checklist service

## Testing
- mvn -q -DskipITs test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695702e75b648333bb022b2b2966ce42)