### PR TITLE
Ensure checklist schema migration runs and add coverage

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -230,6 +230,7 @@ public class OrdenProduccionController {
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistEtapaDTO> obtenerChecklistPorEtapa(@PathVariable Long ordenId,
                                                                       @PathVariable Long etapaId) {
+        log.info("ChecklistEtapa - GET ordenId={}, etapaId={}", ordenId, etapaId);
         return ResponseEntity.ok(checklistEtapaService.obtenerPorOrdenYEtapa(ordenId, etapaId));
     }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
@@ -45,8 +45,10 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     @Override
     @Transactional(readOnly = true)
     public ChecklistEtapaDTO obtenerPorOrdenYEtapa(Long ordenId, Long etapaId) {
+        log.info("ChecklistEtapa - obtenerPorOrdenYEtapa ordenId={}, etapaId={}", ordenId, etapaId);
         EtapaProduccion etapa = obtenerEtapaValidada(ordenId, etapaId);
         List<ChecklistEtapaItem> items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
+        log.debug("ChecklistEtapa - items recuperados: {}", items.size());
         return buildDto(etapa, items);
     }
 
@@ -134,10 +136,12 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     private EtapaProduccion obtenerEtapaValidada(Long ordenId, Long etapaId) {
         EtapaProduccion etapa = obtenerEtapa(etapaId);
         if (etapa.getOrdenProduccion() == null || !Objects.equals(etapa.getOrdenProduccion().getId(), ordenId)) {
+            log.warn("ChecklistEtapa - etapa {} no pertenece a la orden {}", etapaId, ordenId);
             throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
                     "ETAPA_NO_PERTENECE_A_ORDEN",
                     Map.of("ordenId", ordenId, "etapaId", etapaId));
         }
+        log.debug("ChecklistEtapa - etapa {} validada para orden {}", etapaId, ordenId);
         return etapa;
     }
 

--- a/src/main/java/com/willyes/clemenintegra/shared/config/FlywayBootstrap.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/config/FlywayBootstrap.java
@@ -50,24 +50,28 @@ public class FlywayBootstrap implements CommandLineRunner {
 
     private void migrateIfFirstTime(String url, String user, String pass) {
         try {
-            if (!hasFlywayHistory(url, user, pass)) {
+            boolean hasHistory = hasFlywayHistory(url, user, pass);
+            Flyway flyway = Flyway.configure()
+                    .dataSource(url, user, pass)
+                    .locations(locations)
+                    .baselineOnMigrate(baselineOnMigrate)
+                    .baselineVersion(baselineVersion)
+                    .outOfOrder(false)
+                    .load();
+
+            if (!hasHistory) {
                 log.info("Flyway[once]: SIN historial en {} → baseline+migrate (baselineVersion={})",
                         url, baselineVersion);
-                Flyway flyway = Flyway.configure()
-                        .dataSource(url, user, pass)
-                        .locations(locations)
-                        .baselineOnMigrate(baselineOnMigrate)
-                        .baselineVersion(baselineVersion)
-                        .outOfOrder(false)
-                        .load();
-                flyway.migrate();
-                var info = flyway.info();
-                log.info("Flyway[once]: OK en {} → applied={}, current={}",
-                        url, info.applied().length,
-                        info.current() == null ? "n/a" : info.current().getVersion());
             } else {
-                log.info("Flyway[once]: historial YA presente en {} → no se ejecuta nada.", url);
+                log.info("Flyway[once]: historial YA presente en {} → se ejecuta migrate para aplicar pendientes.",
+                        url);
             }
+
+            flyway.migrate();
+            var info = flyway.info();
+            log.info("Flyway[once]: OK en {} → applied={}, current={}",
+                    url, info.applied().length,
+                    info.current() == null ? "n/a" : info.current().getVersion());
         } catch (Exception e) {
             log.error("Flyway[once]: ERROR migrando {}", url, e);
             throw e;
@@ -87,5 +91,4 @@ public class FlywayBootstrap implements CommandLineRunner {
         }
     }
 }
-
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaControllerIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.model.ChecklistEtapaItem;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class ChecklistEtapaControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Autowired
+    private EtapaProduccionRepository etapaProduccionRepository;
+    @Autowired
+    private ChecklistEtapaItemRepository checklistEtapaItemRepository;
+    @MockBean
+    private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    private Long ordenId;
+    private Long etapaId;
+
+    @BeforeEach
+    void setUp() {
+        OrdenProduccion orden = ordenProduccionRepository.save(OrdenProduccion.builder()
+                .codigoOrden("OP-CL-1")
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(BigDecimal.ONE)
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.CREADA)
+                .build());
+
+        EtapaProduccion etapa = etapaProduccionRepository.save(EtapaProduccion.builder()
+                .nombre("Preparación")
+                .secuencia(1)
+                .estado(EstadoEtapa.PENDIENTE)
+                .ordenProduccion(orden)
+                .build());
+
+        this.ordenId = orden.getId();
+        this.etapaId = etapa.getId();
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void obtenerChecklist_conItems() throws Exception {
+        checklistEtapaItemRepository.save(ChecklistEtapaItem.builder()
+                .etapaProduccion(etapaProduccionRepository.getReferenceById(etapaId))
+                .nombrePaso("Verificar insumos")
+                .obligatorio(true)
+                .completado(false)
+                .build());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist", ordenId, etapaId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].nombrePaso").value("Verificar insumos"))
+                .andExpect(jsonPath("$.completo").value(false))
+                .andExpect(jsonPath("$.faltantesObligatorios").value(1));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void obtenerChecklist_sinItems() throws Exception {
+        mockMvc.perform(get("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist", ordenId, etapaId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items").isEmpty())
+                .andExpect(jsonPath("$.completo").value(false))
+                .andExpect(jsonPath("$.faltantesObligatorios").value(0));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.produccion.dto.OrdenProduccionRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.OrdenProduccionResponseDTO;
 import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
 import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaDTO;
+import com.willyes.clemenintegra.produccion.dto.ChecklistItemDTO;
 import com.willyes.clemenintegra.produccion.service.OrdenProduccionService;
 import com.willyes.clemenintegra.produccion.service.ReporteOrdenProduccionService;
 import com.willyes.clemenintegra.produccion.service.ChecklistEtapaService;
@@ -288,6 +289,48 @@ class OrdenProduccionControllerTest {
                 .andExpect(jsonPath("$.items").isEmpty());
 
         verify(checklistEtapaService).obtenerPorOrdenYEtapa(11L, 12L);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist responde 200 con checklist lleno")
+    void obtenerChecklistPorEtapa_conDatos() throws Exception {
+        ChecklistItemDTO item = ChecklistItemDTO.builder()
+                .id(21L)
+                .nombrePaso("Validar equipo")
+                .obligatorio(true)
+                .completado(true)
+                .observacion("ok")
+                .build();
+        ChecklistEtapaDTO checklist = ChecklistEtapaDTO.builder()
+                .etapaId(14L)
+                .ordenProduccionId(13L)
+                .items(List.of(item))
+                .completo(true)
+                .faltantesObligatorios(0)
+                .build();
+        when(checklistEtapaService.obtenerPorOrdenYEtapa(13L, 14L)).thenReturn(checklist);
+
+        mockMvc.perform(get("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist", 13L, 14L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].id").value(21L))
+                .andExpect(jsonPath("$.completo").value(true));
+
+        verify(checklistEtapaService).obtenerPorOrdenYEtapa(13L, 14L);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist devuelve 400 si la etapa no corresponde")
+    void obtenerChecklistPorEtapa_etapaNoPertenece() throws Exception {
+        when(checklistEtapaService.obtenerPorOrdenYEtapa(9L, 99L))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "ETAPA_NO_PERTENECE_A_ORDEN"));
+
+        mockMvc.perform(get("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist", 9L, 99L))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ApiErrorCode.SOLICITUD_INVALIDA.name()));
+
+        verify(checklistEtapaService).obtenerPorOrdenYEtapa(9L, 99L);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add focused logging around the checklist endpoints and validation warnings
- ensure Flyway bootstrap runs migrations even when schema history already exists so checklist tables are created
- expand checklist controller coverage with unit and integration tests for populated and empty responses

## Testing
- mvn -q -DskipITs test -Dtest=OrdenProduccionControllerTest,ChecklistEtapaControllerIntegrationTest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695707ae47788333b28c70a101407046)