### PR TITLE
Add migration for etapa checklist items

### DIFF
--- a/src/main/resources/db/migration/inventario/V20251231__create_etapa_checklist_item.sql
+++ b/src/main/resources/db/migration/inventario/V20251231__create_etapa_checklist_item.sql
@@ -1,0 +1,33 @@
+-- V20251231 - Crear tabla etapa_checklist_item para checklist por etapa de producción
+SET @sql := (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM information_schema.tables
+      WHERE table_schema = DATABASE()
+        AND table_name = 'etapa_checklist_item'
+    ),
+    'SELECT "OK: tabla etapa_checklist_item ya existe" AS info;',
+    'CREATE TABLE etapa_checklist_item (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        etapa_produccion_id BIGINT NOT NULL,
+        nombre_paso VARCHAR(255) NOT NULL,
+        obligatorio BIT NOT NULL DEFAULT b''0'',
+        completado BIT NOT NULL DEFAULT b''0'',
+        observacion TEXT,
+        completed_at DATETIME(6),
+        completed_by_id BIGINT,
+        created_at DATETIME(6) NOT NULL,
+        created_by_id BIGINT,
+        updated_at DATETIME(6),
+        updated_by_id BIGINT,
+        PRIMARY KEY (id),
+        KEY idx_checklist_etapa_id (etapa_produccion_id),
+        CONSTRAINT fk_eci_etapa FOREIGN KEY (etapa_produccion_id) REFERENCES etapa_produccion (id),
+        CONSTRAINT fk_eci_completed_by FOREIGN KEY (completed_by_id) REFERENCES usuarios (id),
+        CONSTRAINT fk_eci_created_by FOREIGN KEY (created_by_id) REFERENCES usuarios (id),
+        CONSTRAINT fk_eci_updated_by FOREIGN KEY (updated_by_id) REFERENCES usuarios (id)
+     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;'
+  )
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## Summary
- add Flyway migration to create the etapa_checklist_item table with audit and foreign keys aligned to the ChecklistEtapaItem entity
- ensure idx_checklist_etapa_id index and InnoDB/utf8mb4 configuration for checklist retrieval ordering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598fe012f0833397f3b8bfbeb84f82)