### PR TITLE
Add checklist templates and granular item actions for production stages

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -242,6 +242,34 @@ public class OrdenProduccionController {
         return ResponseEntity.ok(checklistEtapaService.actualizarEnOrden(ordenId, etapaId, items));
     }
 
+    @PostMapping("/{ordenId}/etapas/{etapaId}/checklist/{itemId}/completar")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ChecklistItemDTO> completarChecklistItem(@PathVariable Long ordenId,
+                                                                   @PathVariable Long etapaId,
+                                                                   @PathVariable Long itemId,
+                                                                   @RequestBody(required = false) ChecklistAccionRequestDTO request) {
+        String observacion = request != null ? request.getObservacion() : null;
+        return ResponseEntity.ok(checklistEtapaService.completarItem(ordenId, etapaId, itemId, observacion));
+    }
+
+    @PostMapping("/{ordenId}/etapas/{etapaId}/checklist/{itemId}/no-aplica")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ChecklistItemDTO> marcarNoAplicaChecklistItem(@PathVariable Long ordenId,
+                                                                        @PathVariable Long etapaId,
+                                                                        @PathVariable Long itemId,
+                                                                        @RequestBody(required = false) ChecklistAccionRequestDTO request) {
+        String observacion = request != null ? request.getObservacion() : null;
+        return ResponseEntity.ok(checklistEtapaService.marcarNoAplica(ordenId, etapaId, itemId, observacion));
+    }
+
+    @PostMapping("/{ordenId}/etapas/{etapaId}/checklist/{itemId}/reabrir")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ChecklistItemDTO> reabrirChecklistItem(@PathVariable Long ordenId,
+                                                                 @PathVariable Long etapaId,
+                                                                 @PathVariable Long itemId) {
+        return ResponseEntity.ok(checklistEtapaService.reabrirItem(ordenId, etapaId, itemId));
+    }
+
     @GetMapping("/{id}/lote")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<LoteProductoResponse> obtenerLote(@PathVariable Long id) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDTO.java
@@ -17,6 +17,7 @@ public class BatchRecordDTO {
     public List<ControlProcesoDTO> controlesProceso;
     public List<ControlEmpaqueDTO> controlesEmpaque;
     public List<ObservacionProcesoDTO> observacionesProceso;
+    public List<ChecklistEtapaDTO> checklistEtapas;
     public EstadoBatchRecord estadoBatchRecord;
     public String revisadoPorNombre;
     public LocalDateTime fechaRevision;
@@ -157,5 +158,23 @@ public class BatchRecordDTO {
         public String descripcion;
         public String registradoPor;
         public LocalDateTime fechaRegistro;
+    }
+
+    public static class ChecklistEtapaDTO {
+        public Long etapaId;
+        public String etapaNombre;
+        public List<ChecklistItemDTO> items;
+    }
+
+    public static class ChecklistItemDTO {
+        public Long itemId;
+        public String nombrePaso;
+        public Boolean obligatorio;
+        public String estado;
+        public Boolean noAplica;
+        public Boolean permitirNoAplica;
+        public String observacion;
+        public LocalDateTime completedAt;
+        public String completedBy;
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistAccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistAccionRequestDTO.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Data;
+
+@Data
+public class ChecklistAccionRequestDTO {
+    private String observacion;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistItemDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistItemDTO.java
@@ -12,6 +12,9 @@ public class ChecklistItemDTO {
     public String nombrePaso;
     public Boolean obligatorio;
     public Boolean completado;
+    public Boolean noAplica;
+    public Boolean permitirNoAplica;
+    public String estado;
     public String observacion;
     public LocalDateTime completedAt;
     public String completedByNombre;

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/ChecklistEtapaItem.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/ChecklistEtapaItem.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.produccion.model;
 
 import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoChecklistItem;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,7 +9,10 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "etapa_checklist_item",
-        indexes = @Index(name = "idx_checklist_etapa_id", columnList = "etapa_produccion_id"))
+        indexes = {
+                @Index(name = "idx_checklist_etapa_id", columnList = "etapa_produccion_id"),
+                @Index(name = "idx_checklist_etapa_estado", columnList = "etapa_produccion_id, estado")
+        })
 @Getter
 @Setter
 @NoArgsConstructor
@@ -34,6 +38,19 @@ public class ChecklistEtapaItem {
     @Column(nullable = false)
     @Builder.Default
     private Boolean completado = Boolean.FALSE;
+
+    @Column(name = "no_aplica", nullable = false)
+    @Builder.Default
+    private Boolean noAplica = Boolean.FALSE;
+
+    @Column(name = "permitir_no_aplica", nullable = false)
+    @Builder.Default
+    private Boolean permitirNoAplica = Boolean.FALSE;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado", length = 20, nullable = false)
+    @Builder.Default
+    private EstadoChecklistItem estado = EstadoChecklistItem.PENDIENTE;
 
     @Column(columnDefinition = "TEXT")
     private String observacion;

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/ChecklistEtapaTemplate.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/ChecklistEtapaTemplate.java
@@ -1,0 +1,65 @@
+package com.willyes.clemenintegra.produccion.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "checklist_etapa_template",
+        indexes = @Index(name = "idx_cet_etapa_orden", columnList = "etapa_plantilla_id, orden"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChecklistEtapaTemplate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "etapa_plantilla_id", nullable = false)
+    private EtapaPlantilla etapaPlantilla;
+
+    @Column(name = "nombre_item", nullable = false, length = 255)
+    private String nombreItem;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean obligatorio = Boolean.FALSE;
+
+    @Column(name = "permitir_no_aplica", nullable = false)
+    @Builder.Default
+    private Boolean permitirNoAplica = Boolean.FALSE;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer orden = 0;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean activo = Boolean.TRUE;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+        if (updatedAt == null) {
+            updatedAt = createdAt;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/enums/EstadoChecklistItem.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/enums/EstadoChecklistItem.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.produccion.model.enums;
+
+public enum EstadoChecklistItem {
+    PENDIENTE,
+    COMPLETADO,
+    NO_APLICA
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/ChecklistEtapaItemRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/ChecklistEtapaItemRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ChecklistEtapaItemRepository extends JpaRepository<ChecklistEtapaItem, Long> {
     List<ChecklistEtapaItem> findByEtapaProduccionIdOrderByIdAsc(Long etapaId);
     void deleteByEtapaProduccionId(Long etapaId);
+    long countByEtapaProduccionId(Long etapaProduccionId);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/ChecklistEtapaTemplateRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/ChecklistEtapaTemplateRepository.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.produccion.repository;
+
+import com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChecklistEtapaTemplateRepository extends JpaRepository<ChecklistEtapaTemplate, Long> {
+    List<ChecklistEtapaTemplate> findByEtapaPlantillaIdAndActivoTrueOrderByOrdenAsc(Long etapaPlantillaId);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaPlantillaRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaPlantillaRepository.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.produccion.repository;
 import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.Optional;
 
 public interface EtapaPlantillaRepository extends JpaRepository<EtapaPlantilla, Long> {
     List<EtapaPlantilla> findByProductoIdOrderBySecuenciaAsc(Integer productoId);
@@ -16,4 +17,6 @@ public interface EtapaPlantillaRepository extends JpaRepository<EtapaPlantilla, 
     boolean existsByProductoIdAndSecuenciaAndIdNot(Integer productoId, Integer secuencia, Long id);
 
     boolean existsByProductoIdAndNombreIgnoreCaseAndIdNot(Integer productoId, String nombre, Long id);
+
+    Optional<EtapaPlantilla> findFirstByProductoIdAndNombreIgnoreCase(Integer productoId, String nombre);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
@@ -26,12 +26,17 @@ import com.willyes.clemenintegra.produccion.model.ControlEmpaqueLote;
 import com.willyes.clemenintegra.produccion.model.ControlProcesoProduccion;
 import com.willyes.clemenintegra.produccion.model.ObservacionProceso;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.ChecklistEtapaItem;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoChecklistItem;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoBatchRecord;
 import com.willyes.clemenintegra.produccion.repository.CierreProduccionRepository;
 import com.willyes.clemenintegra.produccion.repository.ControlEmpaqueLoteRepository;
 import com.willyes.clemenintegra.produccion.repository.ControlProcesoProduccionRepository;
 import com.willyes.clemenintegra.produccion.repository.ObservacionProcesoRepository;
 import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
@@ -66,6 +71,8 @@ public class BatchRecordServiceImpl implements BatchRecordService {
     private final ControlProcesoProduccionRepository controlProcesoProduccionRepository;
     private final ControlEmpaqueLoteRepository controlEmpaqueLoteRepository;
     private final ObservacionProcesoRepository observacionProcesoRepository;
+    private final EtapaProduccionRepository etapaProduccionRepository;
+    private final ChecklistEtapaItemRepository checklistEtapaItemRepository;
 
     @Override
     @Transactional
@@ -128,6 +135,7 @@ public class BatchRecordServiceImpl implements BatchRecordService {
         dto.controlesProceso = mapControlesProceso(ordenProduccionId);
         dto.controlesEmpaque = mapControlesEmpaque(ordenProduccionId);
         dto.observacionesProceso = mapObservaciones(ordenProduccionId);
+        dto.checklistEtapas = mapChecklistEtapas(ordenProduccionId);
         dto.estadoBatchRecord = ordenProduccion.getBatchRecordEstado();
         dto.revisadoPorNombre = ordenProduccion.getBatchRecordRevisadoPor() != null
                 ? ordenProduccion.getBatchRecordRevisadoPor().getNombreCompleto()
@@ -548,6 +556,37 @@ public class BatchRecordServiceImpl implements BatchRecordService {
             resultado.add(dto);
         }
         return resultado;
+    }
+
+    private List<BatchRecordDTO.ChecklistEtapaDTO> mapChecklistEtapas(Long ordenProduccionId) {
+        List<EtapaProduccion> etapas = etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(ordenProduccionId);
+        List<BatchRecordDTO.ChecklistEtapaDTO> resultado = new ArrayList<>();
+        for (EtapaProduccion etapa : etapas) {
+            List<ChecklistEtapaItem> items = checklistEtapaItemRepository.findByEtapaProduccionIdOrderByIdAsc(etapa.getId());
+            if (items.isEmpty()) {
+                continue;
+            }
+            BatchRecordDTO.ChecklistEtapaDTO dto = new BatchRecordDTO.ChecklistEtapaDTO();
+            dto.etapaId = etapa.getId();
+            dto.etapaNombre = etapa.getNombre();
+            dto.items = items.stream().map(this::mapChecklistItem).toList();
+            resultado.add(dto);
+        }
+        return resultado;
+    }
+
+    private BatchRecordDTO.ChecklistItemDTO mapChecklistItem(ChecklistEtapaItem item) {
+        BatchRecordDTO.ChecklistItemDTO dto = new BatchRecordDTO.ChecklistItemDTO();
+        dto.itemId = item.getId();
+        dto.nombrePaso = item.getNombrePaso();
+        dto.obligatorio = item.getObligatorio();
+        dto.estado = item.getEstado() != null ? item.getEstado().name() : null;
+        dto.noAplica = item.getNoAplica();
+        dto.permitirNoAplica = item.getPermitirNoAplica();
+        dto.observacion = item.getObservacion();
+        dto.completedAt = item.getCompletedAt();
+        dto.completedBy = item.getCompletedBy() != null ? item.getCompletedBy().getNombreCompleto() : null;
+        return dto;
     }
 
     private Usuario obtenerUsuarioDesdeAuth(Authentication auth) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaService.java
@@ -10,6 +10,10 @@ public interface ChecklistEtapaService {
     ChecklistEtapaDTO obtenerPorOrdenYEtapa(Long ordenId, Long etapaId);
     ChecklistEtapaDTO actualizar(Long etapaId, List<ChecklistItemDTO> items);
     ChecklistEtapaDTO actualizarEnOrden(Long ordenId, Long etapaId, List<ChecklistItemDTO> items);
+    void generarChecklistDesdeTemplateSiNoExiste(Long etapaProduccionId);
+    ChecklistItemDTO completarItem(Long ordenId, Long etapaId, Long itemId, String observacion);
+    ChecklistItemDTO marcarNoAplica(Long ordenId, Long etapaId, Long itemId, String observacion);
+    ChecklistItemDTO reabrirItem(Long ordenId, Long etapaId, Long itemId);
     byte[] exportCsvPorOrden(Long ordenId);
     void validarChecklistCompleto(Long etapaId);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
@@ -4,8 +4,10 @@ import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaDTO;
 import com.willyes.clemenintegra.produccion.dto.ChecklistItemDTO;
 import com.willyes.clemenintegra.produccion.model.ChecklistEtapaItem;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoChecklistItem;
 import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository;
 import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
@@ -24,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +35,8 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
 
     private final ChecklistEtapaItemRepository repository;
     private final EtapaProduccionRepository etapaProduccionRepository;
+    private final ChecklistEtapaTemplateService templateService;
+    private final EtapaPlantillaRepository etapaPlantillaRepository;
     private final UsuarioService usuarioService;
 
     @Override
@@ -39,6 +44,10 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     public ChecklistEtapaDTO obtenerPorEtapa(Long etapaId) {
         EtapaProduccion etapa = obtenerEtapa(etapaId);
         List<ChecklistEtapaItem> items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
+        if (items.isEmpty()) {
+            generarChecklistDesdeTemplateSiNoExiste(etapaId);
+            items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
+        }
         return buildDto(etapa, items);
     }
 
@@ -72,11 +81,96 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     }
 
     @Override
+    @Transactional
+    public void generarChecklistDesdeTemplateSiNoExiste(Long etapaProduccionId) {
+        if (repository.countByEtapaProduccionId(etapaProduccionId) > 0) {
+            return;
+        }
+        EtapaProduccion etapa = obtenerEtapa(etapaProduccionId);
+        Long etapaPlantillaId = resolverEtapaPlantillaId(etapa);
+        if (etapaPlantillaId == null) {
+            log.warn("No se pudo resolver plantilla para etapa {}, checklist no generado", etapaProduccionId);
+            return;
+        }
+        List<com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate> templates =
+                templateService.listarActivosPorEtapaPlantilla(etapaPlantillaId);
+        if (templates.isEmpty()) {
+            log.info("Etapa {} sin plantilla de checklist, no se generan items", etapaProduccionId);
+            return;
+        }
+        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+        List<ChecklistEtapaItem> nuevos = templates.stream()
+                .map(t -> ChecklistEtapaItem.builder()
+                        .etapaProduccion(etapa)
+                        .nombrePaso(t.getNombreItem())
+                        .obligatorio(Boolean.TRUE.equals(t.getObligatorio()))
+                        .permitirNoAplica(Boolean.TRUE.equals(t.getPermitirNoAplica()))
+                        .estado(EstadoChecklistItem.PENDIENTE)
+                        .completado(false)
+                        .noAplica(false)
+                        .createdBy(usuario)
+                        .updatedBy(usuario)
+                        .build())
+                .toList();
+        repository.saveAll(nuevos);
+        log.info("Checklist generado desde plantilla para etapa {} con {} items", etapaProduccionId, nuevos.size());
+    }
+
+    @Override
+    @Transactional
+    public ChecklistItemDTO completarItem(Long ordenId, Long etapaId, Long itemId, String observacion) {
+        ChecklistEtapaItem item = obtenerItemValidado(ordenId, etapaId, itemId);
+        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+        item.setEstado(EstadoChecklistItem.COMPLETADO);
+        item.setCompletado(true);
+        item.setNoAplica(false);
+        item.setObservacion(observacion);
+        item.setCompletedAt(LocalDateTime.now());
+        item.setCompletedBy(usuario);
+        item.setUpdatedBy(usuario);
+        return toDto(repository.save(item));
+    }
+
+    @Override
+    @Transactional
+    public ChecklistItemDTO marcarNoAplica(Long ordenId, Long etapaId, Long itemId, String observacion) {
+        ChecklistEtapaItem item = obtenerItemValidado(ordenId, etapaId, itemId);
+        if (!Boolean.TRUE.equals(item.getPermitirNoAplica())) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "CHECKLIST_ITEM_NO_APLICA_NO_PERMITIDO",
+                    Map.of("itemId", itemId));
+        }
+        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+        item.setEstado(EstadoChecklistItem.NO_APLICA);
+        item.setCompletado(false);
+        item.setNoAplica(true);
+        item.setObservacion(observacion);
+        item.setCompletedAt(LocalDateTime.now());
+        item.setCompletedBy(usuario);
+        item.setUpdatedBy(usuario);
+        return toDto(repository.save(item));
+    }
+
+    @Override
+    @Transactional
+    public ChecklistItemDTO reabrirItem(Long ordenId, Long etapaId, Long itemId) {
+        ChecklistEtapaItem item = obtenerItemValidado(ordenId, etapaId, itemId);
+        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+        item.setEstado(EstadoChecklistItem.PENDIENTE);
+        item.setCompletado(false);
+        item.setNoAplica(false);
+        item.setCompletedAt(null);
+        item.setCompletedBy(null);
+        item.setUpdatedBy(usuario);
+        return toDto(repository.save(item));
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public byte[] exportCsvPorOrden(Long ordenId) {
         List<EtapaProduccion> etapas = etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(ordenId);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        String header = "ordenId,etapaId,etapaNombre,paso,obligatorio,completado,observacion,completedAt,completedBy\n";
+        String header = "ordenId,etapaId,etapaNombre,paso,obligatorio,estado,noAplica,permitirNoAplica,observacion,completedAt,completedBy\n";
         try {
             out.write(header.getBytes(StandardCharsets.UTF_8));
             for (EtapaProduccion etapa : etapas) {
@@ -88,7 +182,9 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
                             csv(etapa.getNombre()),
                             csv(item.getNombrePaso()),
                             safeBool(item.getObligatorio()),
-                            safeBool(item.getCompletado()),
+                            item.getEstado() != null ? item.getEstado().name() : "",
+                            safeBool(item.getNoAplica()),
+                            safeBool(item.getPermitirNoAplica()),
                             csv(item.getObservacion()),
                             safe(item.getCompletedAt()),
                             csv(item.getCompletedBy() != null ? item.getCompletedBy().getNombreCompleto() : null)
@@ -109,7 +205,9 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
         List<ChecklistEtapaItem> items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
         List<String> faltantes = items.stream()
                 .filter(i -> Boolean.TRUE.equals(i.getObligatorio()))
-                .filter(i -> !Boolean.TRUE.equals(i.getCompletado()))
+                .filter(i -> !(EstadoChecklistItem.COMPLETADO.equals(i.getEstado())
+                        || (EstadoChecklistItem.NO_APLICA.equals(i.getEstado())
+                        && Boolean.TRUE.equals(i.getPermitirNoAplica()))))
                 .map(ChecklistEtapaItem::getNombrePaso)
                 .toList();
         if (!faltantes.isEmpty()) {
@@ -151,7 +249,9 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
                 .toList();
         long faltantes = items.stream()
                 .filter(i -> Boolean.TRUE.equals(i.getObligatorio()))
-                .filter(i -> !Boolean.TRUE.equals(i.getCompletado()))
+                .filter(i -> !(EstadoChecklistItem.COMPLETADO.equals(i.getEstado())
+                        || (EstadoChecklistItem.NO_APLICA.equals(i.getEstado())
+                        && Boolean.TRUE.equals(i.getPermitirNoAplica()))))
                 .count();
         boolean completo = faltantes == 0 && !items.isEmpty();
         return ChecklistEtapaDTO.builder()
@@ -164,16 +264,24 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     }
 
     private ChecklistEtapaItem toEntity(ChecklistItemDTO dto, EtapaProduccion etapa, Usuario usuario) {
-        LocalDateTime completedAt = Boolean.TRUE.equals(dto.getCompletado()) ? LocalDateTime.now() : null;
+        EstadoChecklistItem estado = Boolean.TRUE.equals(dto.getNoAplica())
+                ? EstadoChecklistItem.NO_APLICA
+                : Boolean.TRUE.equals(dto.getCompletado())
+                ? EstadoChecklistItem.COMPLETADO
+                : EstadoChecklistItem.PENDIENTE;
+        LocalDateTime completedAt = estado != EstadoChecklistItem.PENDIENTE ? LocalDateTime.now() : null;
         return ChecklistEtapaItem.builder()
                 .id(dto.getId())
                 .etapaProduccion(etapa)
                 .nombrePaso(dto.getNombrePaso())
                 .obligatorio(Boolean.TRUE.equals(dto.getObligatorio()))
                 .completado(Boolean.TRUE.equals(dto.getCompletado()))
+                .noAplica(Boolean.TRUE.equals(dto.getNoAplica()))
+                .permitirNoAplica(Boolean.TRUE.equals(dto.getPermitirNoAplica()))
+                .estado(estado)
                 .observacion(dto.getObservacion())
                 .completedAt(completedAt)
-                .completedBy(Boolean.TRUE.equals(dto.getCompletado()) ? usuario : null)
+                .completedBy(estado != EstadoChecklistItem.PENDIENTE ? usuario : null)
                 .createdBy(usuario)
                 .updatedBy(usuario)
                 .build();
@@ -185,10 +293,35 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
                 .nombrePaso(item.getNombrePaso())
                 .obligatorio(item.getObligatorio())
                 .completado(item.getCompletado())
+                .noAplica(item.getNoAplica())
+                .permitirNoAplica(item.getPermitirNoAplica())
+                .estado(item.getEstado() != null ? item.getEstado().name() : null)
                 .observacion(item.getObservacion())
                 .completedAt(item.getCompletedAt())
                 .completedByNombre(item.getCompletedBy() != null ? item.getCompletedBy().getNombreCompleto() : null)
                 .build();
+    }
+
+    private ChecklistEtapaItem obtenerItemValidado(Long ordenId, Long etapaId, Long itemId) {
+        EtapaProduccion etapa = obtenerEtapaValidada(ordenId, etapaId);
+        ChecklistEtapaItem item = repository.findById(itemId)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "CHECKLIST_ITEM_NO_ENCONTRADO"));
+        if (!Objects.equals(item.getEtapaProduccion() != null ? item.getEtapaProduccion().getId() : null, etapa.getId())) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "ITEM_NO_PERTENECE_A_ETAPA",
+                    Map.of("etapaId", etapaId, "itemId", itemId));
+        }
+        return item;
+    }
+
+    private Long resolverEtapaPlantillaId(EtapaProduccion etapa) {
+        if (etapa.getOrdenProduccion() == null || etapa.getOrdenProduccion().getProducto() == null
+                || etapa.getOrdenProduccion().getProducto().getId() == null) {
+            return null;
+        }
+        Integer productoId = etapa.getOrdenProduccion().getProducto().getId();
+        Optional<com.willyes.clemenintegra.produccion.model.EtapaPlantilla> plantillaOpt =
+                etapaPlantillaRepository.findFirstByProductoIdAndNombreIgnoreCase(productoId, etapa.getNombre());
+        return plantillaOpt.map(com.willyes.clemenintegra.produccion.model.EtapaPlantilla::getId).orElse(null);
     }
 
     private String csv(String value) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateService.java
@@ -1,0 +1,9 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate;
+
+import java.util.List;
+
+public interface ChecklistEtapaTemplateService {
+    List<ChecklistEtapaTemplate> listarActivosPorEtapaPlantilla(Long etapaPlantillaId);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateServiceImpl.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate;
+import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChecklistEtapaTemplateServiceImpl implements ChecklistEtapaTemplateService {
+
+    private final ChecklistEtapaTemplateRepository repository;
+
+    @Override
+    public List<ChecklistEtapaTemplate> listarActivosPorEtapaPlantilla(Long etapaPlantillaId) {
+        return repository.findByEtapaPlantillaIdAndActivoTrueOrderByOrdenAsc(etapaPlantillaId);
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1791,6 +1791,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         etapa.setUsuarioId(usuario.getId());
         etapa.setUsuarioNombre(usuario.getNombreCompleto());
         EtapaProduccion guardada = etapaProduccionRepository.save(etapa);
+        checklistEtapaService.generarChecklistDesdeTemplateSiNoExiste(guardada.getId());
 
         // Consumo etapa 1: generar SALIDA_PRODUCCION desde Pre-Bodega (idempotente)
         if (etapa.getSecuencia() != null && etapa.getSecuencia() == 1) {
@@ -2129,7 +2130,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         return repository.save(orden);
     }
 }
-
 
 
 

--- a/src/main/resources/db/migration/inventario/V20251232__produccion_checklist_template.sql
+++ b/src/main/resources/db/migration/inventario/V20251232__produccion_checklist_template.sql
@@ -1,0 +1,95 @@
+-- Crear tabla de plantilla de checklist por etapa de producción y columnas adicionales en instancia
+
+-- Tabla checklist_etapa_template
+SET @sql_create_template := (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = 'checklist_etapa_template'
+        ),
+        'SELECT "OK: tabla checklist_etapa_template ya existe" AS info;',
+        'CREATE TABLE checklist_etapa_template (
+            id BIGINT NOT NULL AUTO_INCREMENT,
+            etapa_plantilla_id BIGINT NOT NULL,
+            nombre_item VARCHAR(255) NOT NULL,
+            obligatorio BIT NOT NULL DEFAULT b''0'',
+            permitir_no_aplica BIT NOT NULL DEFAULT b''0'',
+            orden INT NOT NULL DEFAULT 0,
+            activo BIT NOT NULL DEFAULT b''1'',
+            created_at DATETIME(6) NOT NULL,
+            updated_at DATETIME(6),
+            PRIMARY KEY (id),
+            KEY idx_cet_etapa_orden (etapa_plantilla_id, orden),
+            CONSTRAINT fk_cet_etapa_plantilla FOREIGN KEY (etapa_plantilla_id) REFERENCES etapa_plantilla (id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;'
+    )
+);
+PREPARE stmt_ct FROM @sql_create_template; EXECUTE stmt_ct; DEALLOCATE PREPARE stmt_ct;
+
+-- Alteraciones a etapa_checklist_item
+SET @sql_estado := (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'etapa_checklist_item'
+              AND column_name = 'estado'
+        ),
+        'SELECT "OK: columna estado ya existe en etapa_checklist_item" AS info;',
+        'ALTER TABLE etapa_checklist_item
+            ADD COLUMN estado ENUM(''PENDIENTE'',''COMPLETADO'',''NO_APLICA'') NOT NULL DEFAULT ''PENDIENTE''
+                AFTER completado;'
+    )
+);
+PREPARE stmt_estado FROM @sql_estado; EXECUTE stmt_estado; DEALLOCATE PREPARE stmt_estado;
+
+SET @sql_no_aplica := (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'etapa_checklist_item'
+              AND column_name = 'no_aplica'
+        ),
+        'SELECT "OK: columna no_aplica ya existe en etapa_checklist_item" AS info;',
+        'ALTER TABLE etapa_checklist_item
+            ADD COLUMN no_aplica BIT NOT NULL DEFAULT b''0'' AFTER completado;'
+    )
+);
+PREPARE stmt_no_aplica FROM @sql_no_aplica; EXECUTE stmt_no_aplica; DEALLOCATE PREPARE stmt_no_aplica;
+
+SET @sql_permitir_no_aplica := (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'etapa_checklist_item'
+              AND column_name = 'permitir_no_aplica'
+        ),
+        'SELECT "OK: columna permitir_no_aplica ya existe en etapa_checklist_item" AS info;',
+        'ALTER TABLE etapa_checklist_item
+            ADD COLUMN permitir_no_aplica BIT NOT NULL DEFAULT b''0'' AFTER no_aplica;'
+    )
+);
+PREPARE stmt_permitir_no_aplica FROM @sql_permitir_no_aplica; EXECUTE stmt_permitir_no_aplica; DEALLOCATE PREPARE stmt_permitir_no_aplica;
+
+SET @sql_index_estado := (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.statistics
+            WHERE table_schema = DATABASE()
+              AND table_name = 'etapa_checklist_item'
+              AND index_name = 'idx_checklist_etapa_estado'
+        ),
+        'SELECT "OK: índice idx_checklist_etapa_estado ya existe" AS info;',
+        'ALTER TABLE etapa_checklist_item
+            ADD INDEX idx_checklist_etapa_estado (etapa_produccion_id, estado);'
+    )
+);
+PREPARE stmt_index_estado FROM @sql_index_estado; EXECUTE stmt_index_estado; DEALLOCATE PREPARE stmt_index_estado;

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaControllerIntegrationTest.java
@@ -98,4 +98,22 @@ class ChecklistEtapaControllerIntegrationTest {
                 .andExpect(jsonPath("$.completo").value(false))
                 .andExpect(jsonPath("$.faltantesObligatorios").value(0));
     }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void completarItemChecklist_actualizaEstado() throws Exception {
+        ChecklistEtapaItem item = checklistEtapaItemRepository.save(ChecklistEtapaItem.builder()
+                .etapaProduccion(etapaProduccionRepository.getReferenceById(etapaId))
+                .nombrePaso("Montaje equipo")
+                .obligatorio(true)
+                .completado(false)
+                .estado(com.willyes.clemenintegra.produccion.model.enums.EstadoChecklistItem.PENDIENTE)
+                .build());
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post(
+                        "/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist/{itemId}/completar",
+                        ordenId, etapaId, item.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.estado").value("COMPLETADO"));
+    }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImplTest.java
@@ -32,6 +32,8 @@ import com.willyes.clemenintegra.produccion.repository.ControlEmpaqueLoteReposit
 import com.willyes.clemenintegra.produccion.repository.ControlProcesoProduccionRepository;
 import com.willyes.clemenintegra.produccion.repository.ObservacionProcesoRepository;
 import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
@@ -87,6 +89,10 @@ class BatchRecordServiceImplTest {
     private ControlEmpaqueLoteRepository controlEmpaqueLoteRepository;
     @Mock
     private ObservacionProcesoRepository observacionProcesoRepository;
+    @Mock
+    private EtapaProduccionRepository etapaProduccionRepository;
+    @Mock
+    private ChecklistEtapaItemRepository checklistEtapaItemRepository;
 
     private BatchRecordServiceImpl service;
 
@@ -103,7 +109,9 @@ class BatchRecordServiceImplTest {
                 retencionLoteRepository,
                 controlProcesoProduccionRepository,
                 controlEmpaqueLoteRepository,
-                observacionProcesoRepository
+                observacionProcesoRepository,
+                etapaProduccionRepository,
+                checklistEtapaItemRepository
         );
     }
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImplTest.java
@@ -4,8 +4,14 @@ import com.willyes.clemenintegra.produccion.dto.ChecklistItemDTO;
 import com.willyes.clemenintegra.produccion.model.ChecklistEtapaItem;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
+import com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoChecklistItem;
+import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository;
 import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
+import com.willyes.clemenintegra.produccion.service.ChecklistEtapaTemplateService;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
@@ -26,6 +32,8 @@ class ChecklistEtapaServiceImplTest {
 
     private ChecklistEtapaItemRepository checklistRepository;
     private EtapaProduccionRepository etapaProduccionRepository;
+    private ChecklistEtapaTemplateService templateService;
+    private EtapaPlantillaRepository etapaPlantillaRepository;
     private UsuarioService usuarioService;
     private ChecklistEtapaServiceImpl service;
 
@@ -33,8 +41,10 @@ class ChecklistEtapaServiceImplTest {
     void setUp() {
         checklistRepository = mock(ChecklistEtapaItemRepository.class);
         etapaProduccionRepository = mock(EtapaProduccionRepository.class);
+        templateService = mock(ChecklistEtapaTemplateService.class);
+        etapaPlantillaRepository = mock(EtapaPlantillaRepository.class);
         usuarioService = mock(UsuarioService.class);
-        service = new ChecklistEtapaServiceImpl(checklistRepository, etapaProduccionRepository, usuarioService);
+        service = new ChecklistEtapaServiceImpl(checklistRepository, etapaProduccionRepository, templateService, etapaPlantillaRepository, usuarioService);
     }
 
     @Test
@@ -48,6 +58,7 @@ class ChecklistEtapaServiceImplTest {
                 .nombrePaso("Paso 1")
                 .obligatorio(true)
                 .completado(false)
+                .estado(EstadoChecklistItem.PENDIENTE)
                 .build();
         when(checklistRepository.findByEtapaProduccionIdOrderByIdAsc(10L)).thenReturn(List.of(incompleto));
 
@@ -123,5 +134,53 @@ class ChecklistEtapaServiceImplTest {
         when(etapaProduccionRepository.findById(6L)).thenReturn(Optional.of(etapa));
 
         assertThrows(CustomBusinessException.class, () -> service.obtenerPorOrdenYEtapa(1L, 6L));
+    }
+
+    @Test
+    @DisplayName("Marcar no aplica falla si el item no lo permite")
+    void marcarNoAplica_noPermitido() {
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(4L)
+                .ordenProduccion(OrdenProduccion.builder().id(1L).build())
+                .build();
+        when(etapaProduccionRepository.findById(4L)).thenReturn(Optional.of(etapa));
+        ChecklistEtapaItem item = ChecklistEtapaItem.builder()
+                .id(8L)
+                .etapaProduccion(etapa)
+                .obligatorio(true)
+                .permitirNoAplica(false)
+                .estado(EstadoChecklistItem.PENDIENTE)
+                .build();
+        when(checklistRepository.findById(8L)).thenReturn(Optional.of(item));
+
+        assertThrows(CustomBusinessException.class, () -> service.marcarNoAplica(1L, 4L, 8L, "N/A"));
+    }
+
+    @Test
+    @DisplayName("Genera checklist desde plantilla cuando no hay items")
+    void generarChecklistDesdeTemplate() {
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(11L)
+                .nombre("Mezclado")
+                .ordenProduccion(OrdenProduccion.builder().id(3L)
+                        .producto(Producto.builder().id(5).build())
+                        .build())
+                .build();
+        when(checklistRepository.countByEtapaProduccionId(11L)).thenReturn(0L);
+        when(etapaProduccionRepository.findById(11L)).thenReturn(Optional.of(etapa));
+        EtapaPlantilla etapaPlantilla = EtapaPlantilla.builder().id(20L).build();
+        when(etapaPlantillaRepository.findFirstByProductoIdAndNombreIgnoreCase(5, "Mezclado")).thenReturn(Optional.of(etapaPlantilla));
+        ChecklistEtapaTemplate template = ChecklistEtapaTemplate.builder()
+                .id(30L)
+                .nombreItem("Verificar limpieza")
+                .obligatorio(true)
+                .permitirNoAplica(true)
+                .build();
+        when(templateService.listarActivosPorEtapaPlantilla(20L)).thenReturn(List.of(template));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(new Usuario());
+
+        service.generarChecklistDesdeTemplateSiNoExiste(11L);
+
+        verify(checklistRepository).saveAll(anyList());
     }
 }


### PR DESCRIPTION
## Summary
- add checklist template entity and migration plus new columns/indices for runtime checklist items
- generate per-stage checklists from templates, track item states including no-aplica, and expose item-level actions with security
- surface checklist data in batch record exports and extend tests for service, controller, and batch record

## Testing
- mvn -q -DskipTests compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a915b85588333815b4014e1952c78)