### PR TITLE
Ensure checklist backfill before validating production stages

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/ChecklistEtapaTemplateRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/ChecklistEtapaTemplateRepository.java
@@ -2,11 +2,16 @@ package com.willyes.clemenintegra.produccion.repository;
 
 import com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface ChecklistEtapaTemplateRepository extends JpaRepository<ChecklistEtapaTemplate, Long> {
     List<ChecklistEtapaTemplate> findByEtapaPlantillaIdAndActivoTrueOrderByOrdenAsc(Long etapaPlantillaId);
+
+    @Query("select c from ChecklistEtapaTemplate c " +
+            "where c.etapaPlantilla.id = :etapaPlantillaId and c.activo = true order by c.orden asc")
+    List<ChecklistEtapaTemplate> findActiveByEtapaPlantillaIdOrderByOrdenAsc(Long etapaPlantillaId);
 
     boolean existsByEtapaPlantillaIdAndActivoTrue(Long etapaPlantillaId);
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaPlantillaRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaPlantillaRepository.java
@@ -10,6 +10,8 @@ public interface EtapaPlantillaRepository extends JpaRepository<EtapaPlantilla, 
 
     List<EtapaPlantilla> findByProductoIdAndActivoTrueOrderBySecuenciaAsc(Integer productoId);
 
+    Optional<EtapaPlantilla> findFirstByProductoIdAndSecuencia(Integer productoId, Integer secuencia);
+
     boolean existsByProductoIdAndSecuencia(Integer productoId, Integer secuencia);
 
     boolean existsByProductoIdAndNombreIgnoreCase(Integer productoId, String nombre);

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaService.java
@@ -11,6 +11,7 @@ public interface ChecklistEtapaService {
     ChecklistEtapaDTO actualizar(Long etapaId, List<ChecklistItemDTO> items);
     ChecklistEtapaDTO actualizarEnOrden(Long ordenId, Long etapaId, List<ChecklistItemDTO> items);
     void generarChecklistDesdeTemplateSiNoExiste(Long etapaProduccionId);
+    void ensureChecklistOperativo(Long etapaProduccionId);
     ChecklistItemDTO completarItem(Long ordenId, Long etapaId, Long itemId, String observacion);
     ChecklistItemDTO marcarNoAplica(Long ordenId, Long etapaId, Long itemId, String observacion);
     ChecklistItemDTO reabrirItem(Long ordenId, Long etapaId, Long itemId);

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
@@ -41,23 +41,23 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     private final UsuarioService usuarioService;
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public ChecklistEtapaDTO obtenerPorEtapa(Long etapaId) {
+        ensureChecklistOperativo(etapaId);
         EtapaProduccion etapa = obtenerEtapa(etapaId);
         List<ChecklistEtapaItem> items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
-        if (items.isEmpty()) {
-            generarChecklistDesdeTemplateSiNoExiste(etapaId);
-            items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
-        }
+        validarChecklistConfigurado(items, etapaId);
         return buildDto(etapa, items);
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public ChecklistEtapaDTO obtenerPorOrdenYEtapa(Long ordenId, Long etapaId) {
         log.info("ChecklistEtapa - obtenerPorOrdenYEtapa ordenId={}, etapaId={}", ordenId, etapaId);
         EtapaProduccion etapa = obtenerEtapaValidada(ordenId, etapaId);
+        ensureChecklistOperativo(etapaId);
         List<ChecklistEtapaItem> items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
+        validarChecklistConfigurado(items, etapaId);
         log.debug("ChecklistEtapa - items recuperados: {}", items.size());
         return buildDto(etapa, items);
     }
@@ -84,6 +84,12 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     @Override
     @Transactional
     public void generarChecklistDesdeTemplateSiNoExiste(Long etapaProduccionId) {
+        ensureChecklistOperativo(etapaProduccionId);
+    }
+
+    @Override
+    @Transactional
+    public void ensureChecklistOperativo(Long etapaProduccionId) {
         if (repository.countByEtapaProduccionId(etapaProduccionId) > 0) {
             return;
         }
@@ -93,8 +99,12 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
             log.warn("No se pudo resolver plantilla para etapa {}, checklist no generado", etapaProduccionId);
             return;
         }
-        List<com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate> templates =
-                templateService.listarActivosPorEtapaPlantilla(etapaPlantillaId);
+        List<com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate> templates = templateService
+                .listarActivosPorEtapaPlantilla(etapaPlantillaId).stream()
+                .filter(template -> !esPlaceholder(template))
+                .sorted(Comparator.comparing(com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate::getOrden,
+                        Comparator.nullsLast(Integer::compareTo)))
+                .toList();
         validarChecklistTemplateConfigurado(templates, etapaProduccionId);
         Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
         List<ChecklistEtapaItem> nuevos = templates.stream()
@@ -198,14 +208,11 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public void validarChecklistCompleto(Long etapaId) {
+        ensureChecklistOperativo(etapaId);
         List<ChecklistEtapaItem> items = repository.findByEtapaProduccionIdOrderByIdAsc(etapaId);
-        if (items.isEmpty() || esSoloPlaceholder(items)) {
-            throw new CustomBusinessException(ApiErrorCode.PRODUCCION_CHECKLIST_NO_CONFIGURADO,
-                    "La etapa no tiene checklist operativo configurado",
-                    Map.of("etapaId", etapaId));
-        }
+        validarChecklistConfigurado(items, etapaId);
         List<String> faltantes = items.stream()
                 .filter(i -> Boolean.TRUE.equals(i.getObligatorio()))
                 .filter(i -> !(EstadoChecklistItem.COMPLETADO.equals(i.getEstado())
@@ -222,7 +229,7 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
 
     private void validarChecklistTemplateConfigurado(List<com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate> templates,
                                                      Long etapaProduccionId) {
-        if (templates.isEmpty() || (templates.size() == 1 && esPlaceholder(templates.get(0)))) {
+        if (templates.isEmpty()) {
             throw new CustomBusinessException(ApiErrorCode.PRODUCCION_CHECKLIST_NO_CONFIGURADO,
                     "La etapa no tiene checklist operativo configurado",
                     Map.of("etapaProduccionId", etapaProduccionId));
@@ -333,14 +340,22 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
         return item;
     }
 
+    private void validarChecklistConfigurado(List<ChecklistEtapaItem> items, Long etapaId) {
+        if (items.isEmpty() || esSoloPlaceholder(items)) {
+            throw new CustomBusinessException(ApiErrorCode.PRODUCCION_CHECKLIST_NO_CONFIGURADO,
+                    "La etapa no tiene checklist operativo configurado",
+                    Map.of("etapaId", etapaId));
+        }
+    }
+
     private Long resolverEtapaPlantillaId(EtapaProduccion etapa) {
         if (etapa.getOrdenProduccion() == null || etapa.getOrdenProduccion().getProducto() == null
-                || etapa.getOrdenProduccion().getProducto().getId() == null) {
+                || etapa.getOrdenProduccion().getProducto().getId() == null || etapa.getSecuencia() == null) {
             return null;
         }
         Integer productoId = etapa.getOrdenProduccion().getProducto().getId();
         Optional<com.willyes.clemenintegra.produccion.model.EtapaPlantilla> plantillaOpt =
-                etapaPlantillaRepository.findFirstByProductoIdAndNombreIgnoreCase(productoId, etapa.getNombre());
+                etapaPlantillaRepository.findFirstByProductoIdAndSecuencia(productoId, etapa.getSecuencia());
         return plantillaOpt.map(com.willyes.clemenintegra.produccion.model.EtapaPlantilla::getId).orElse(null);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateServiceImpl.java
@@ -16,7 +16,7 @@ public class ChecklistEtapaTemplateServiceImpl implements ChecklistEtapaTemplate
 
     @Override
     public List<ChecklistEtapaTemplate> listarActivosPorEtapaPlantilla(Long etapaPlantillaId) {
-        return repository.findByEtapaPlantillaIdAndActivoTrueOrderByOrdenAsc(etapaPlantillaId);
+        return repository.findActiveByEtapaPlantillaIdOrderByOrdenAsc(etapaPlantillaId);
     }
 
     @Override

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1882,6 +1882,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             throw new CustomBusinessException(ApiErrorCode.ETAPA_NO_INICIADA, "ETAPA_NO_INICIADA",
                     Map.of("ordenProduccionId", ordenId, "etapaId", etapaId));
         }
+        checklistEtapaService.ensureChecklistOperativo(etapaId);
         checklistEtapaService.validarChecklistCompleto(etapaId);
         Usuario usuario = usuarioRepository.findById(usuarioId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "USUARIO_NO_ENCONTRADO"));
@@ -2130,6 +2131,5 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         return repository.save(orden);
     }
 }
-
 
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaControllerIntegrationTest.java
@@ -92,11 +92,7 @@ class ChecklistEtapaControllerIntegrationTest {
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     void obtenerChecklist_sinItems() throws Exception {
         mockMvc.perform(get("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist", ordenId, etapaId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.items").isArray())
-                .andExpect(jsonPath("$.items").isEmpty())
-                .andExpect(jsonPath("$.completo").value(false))
-                .andExpect(jsonPath("$.faltantesObligatorios").value(0));
+                .andExpect(status().isUnprocessableEntity());
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImplTest.java
@@ -23,6 +23,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -54,6 +55,7 @@ class ChecklistEtapaServiceImplTest {
     void obtenerChecklist_conFaltantes() {
         EtapaProduccion etapa = EtapaProduccion.builder().id(10L).build();
         when(etapaProduccionRepository.findById(10L)).thenReturn(Optional.of(etapa));
+        when(checklistRepository.countByEtapaProduccionId(10L)).thenReturn(1L);
         ChecklistEtapaItem incompleto = ChecklistEtapaItem.builder()
                 .id(1L)
                 .etapaProduccion(etapa)
@@ -102,6 +104,7 @@ class ChecklistEtapaServiceImplTest {
     @Test
     @DisplayName("Validar checklist incompleto lanza CustomBusinessException")
     void validarChecklist_incompleto() {
+        when(checklistRepository.countByEtapaProduccionId(7L)).thenReturn(1L);
         when(checklistRepository.findByEtapaProduccionIdOrderByIdAsc(7L)).thenReturn(List.of(
                 ChecklistEtapaItem.builder().obligatorio(true).completado(false).nombrePaso("Paso faltante").build()
         ));
@@ -110,20 +113,17 @@ class ChecklistEtapaServiceImplTest {
     }
 
     @Test
-    @DisplayName("Obtener checklist por orden valida pertenencia y retorna lista vacía sin plantilla")
+    @DisplayName("Obtener checklist por orden valida pertenencia y falla si no hay checklist configurado")
     void obtenerChecklistPorOrden_sinItems() {
         EtapaProduccion etapa = EtapaProduccion.builder()
                 .id(3L)
                 .ordenProduccion(OrdenProduccion.builder().id(2L).build())
                 .build();
         when(etapaProduccionRepository.findById(3L)).thenReturn(Optional.of(etapa));
+        when(checklistRepository.countByEtapaProduccionId(3L)).thenReturn(1L);
         when(checklistRepository.findByEtapaProduccionIdOrderByIdAsc(3L)).thenReturn(List.of());
 
-        var dto = service.obtenerPorOrdenYEtapa(2L, 3L);
-
-        assertThat(dto.getItems()).isEmpty();
-        assertThat(dto.getFaltantesObligatorios()).isZero();
-        assertThat(dto.getOrdenProduccionId()).isEqualTo(2L);
+        assertThrows(CustomBusinessException.class, () -> service.obtenerPorOrdenYEtapa(2L, 3L));
     }
 
     @Test
@@ -164,6 +164,7 @@ class ChecklistEtapaServiceImplTest {
         EtapaProduccion etapa = EtapaProduccion.builder()
                 .id(11L)
                 .nombre("Mezclado")
+                .secuencia(2)
                 .ordenProduccion(OrdenProduccion.builder().id(3L)
                         .producto(Producto.builder().id(5).build())
                         .build())
@@ -171,7 +172,7 @@ class ChecklistEtapaServiceImplTest {
         when(checklistRepository.countByEtapaProduccionId(11L)).thenReturn(0L);
         when(etapaProduccionRepository.findById(11L)).thenReturn(Optional.of(etapa));
         EtapaPlantilla etapaPlantilla = EtapaPlantilla.builder().id(20L).build();
-        when(etapaPlantillaRepository.findFirstByProductoIdAndNombreIgnoreCase(5, "Mezclado")).thenReturn(Optional.of(etapaPlantilla));
+        when(etapaPlantillaRepository.findFirstByProductoIdAndSecuencia(5, 2)).thenReturn(Optional.of(etapaPlantilla));
         ChecklistEtapaTemplate template = ChecklistEtapaTemplate.builder()
                 .id(30L)
                 .nombreItem("Verificar limpieza")
@@ -192,6 +193,7 @@ class ChecklistEtapaServiceImplTest {
         EtapaProduccion etapa = EtapaProduccion.builder()
                 .id(12L)
                 .nombre("Envasado")
+                .secuencia(1)
                 .ordenProduccion(OrdenProduccion.builder().id(4L)
                         .producto(Producto.builder().id(6).build())
                         .build())
@@ -199,7 +201,7 @@ class ChecklistEtapaServiceImplTest {
         when(checklistRepository.countByEtapaProduccionId(12L)).thenReturn(0L);
         when(etapaProduccionRepository.findById(12L)).thenReturn(Optional.of(etapa));
         EtapaPlantilla plantilla = EtapaPlantilla.builder().id(30L).build();
-        when(etapaPlantillaRepository.findFirstByProductoIdAndNombreIgnoreCase(6, "Envasado")).thenReturn(Optional.of(plantilla));
+        when(etapaPlantillaRepository.findFirstByProductoIdAndSecuencia(6, 1)).thenReturn(Optional.of(plantilla));
         ChecklistEtapaTemplate placeholder = ChecklistEtapaTemplate.builder()
                 .id(40L)
                 .nombreItem(ChecklistEtapaTemplateService.PLACEHOLDER_NOMBRE)
@@ -209,7 +211,74 @@ class ChecklistEtapaServiceImplTest {
         when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(new Usuario());
 
         CustomBusinessException exception = assertThrows(CustomBusinessException.class,
-                () -> service.generarChecklistDesdeTemplateSiNoExiste(12L));
+                () -> service.ensureChecklistOperativo(12L));
+
+        assertThat(exception.getCode()).isEqualTo(ApiErrorCode.PRODUCCION_CHECKLIST_NO_CONFIGURADO);
+        verify(checklistRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("Finalizar etapa con plantilla activa genera checklist y valida obligatorios pendientes")
+    void validarChecklistGeneradoDesdeTemplate() {
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(21L)
+                .secuencia(3)
+                .ordenProduccion(OrdenProduccion.builder().id(8L)
+                        .producto(Producto.builder().id(9).build())
+                        .build())
+                .build();
+        EtapaPlantilla plantilla = EtapaPlantilla.builder().id(31L).build();
+        AtomicReference<List<ChecklistEtapaItem>> almacenados = new AtomicReference<>(List.of());
+
+        when(checklistRepository.countByEtapaProduccionId(21L)).thenReturn(0L);
+        when(etapaProduccionRepository.findById(21L)).thenReturn(Optional.of(etapa));
+        when(etapaPlantillaRepository.findFirstByProductoIdAndSecuencia(9, 3)).thenReturn(Optional.of(plantilla));
+        when(templateService.listarActivosPorEtapaPlantilla(31L)).thenReturn(List.of(
+                ChecklistEtapaTemplate.builder().id(1L).nombreItem("Paso 1").obligatorio(true).build(),
+                ChecklistEtapaTemplate.builder().id(2L).nombreItem("Paso 2").obligatorio(false).build(),
+                ChecklistEtapaTemplate.builder().id(3L).nombreItem("Paso 3").obligatorio(true).build()
+        ));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(new Usuario());
+        when(checklistRepository.saveAll(anyList())).thenAnswer(invocation -> {
+            List<ChecklistEtapaItem> lista = invocation.getArgument(0);
+            almacenados.set(lista);
+            return lista;
+        });
+        when(checklistRepository.findByEtapaProduccionIdOrderByIdAsc(21L))
+                .thenAnswer(invocation -> almacenados.get());
+
+        CustomBusinessException exception = assertThrows(CustomBusinessException.class,
+                () -> service.validarChecklistCompleto(21L));
+
+        assertThat(exception.getCode()).isEqualTo(ApiErrorCode.CHECKLIST_ETAPA_INCOMPLETO);
+        assertThat(almacenados.get()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Validar checklist con plantilla solo placeholder lanza error de configuración")
+    void validarChecklistSoloPlaceholderDesdeTemplate() {
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(22L)
+                .secuencia(4)
+                .ordenProduccion(OrdenProduccion.builder().id(10L)
+                        .producto(Producto.builder().id(11).build())
+                        .build())
+                .build();
+        EtapaPlantilla plantilla = EtapaPlantilla.builder().id(32L).build();
+
+        when(checklistRepository.countByEtapaProduccionId(22L)).thenReturn(0L);
+        when(etapaProduccionRepository.findById(22L)).thenReturn(Optional.of(etapa));
+        when(etapaPlantillaRepository.findFirstByProductoIdAndSecuencia(11, 4)).thenReturn(Optional.of(plantilla));
+        when(templateService.listarActivosPorEtapaPlantilla(32L)).thenReturn(List.of(
+                ChecklistEtapaTemplate.builder()
+                        .id(90L)
+                        .nombreItem(ChecklistEtapaTemplateService.PLACEHOLDER_NOMBRE)
+                        .activo(true)
+                        .build()
+        ));
+
+        CustomBusinessException exception = assertThrows(CustomBusinessException.class,
+                () -> service.validarChecklistCompleto(22L));
 
         assertThat(exception.getCode()).isEqualTo(ApiErrorCode.PRODUCCION_CHECKLIST_NO_CONFIGURADO);
         verify(checklistRepository, never()).saveAll(anyList());
@@ -224,6 +293,7 @@ class ChecklistEtapaServiceImplTest {
                 .obligatorio(true)
                 .build();
 
+        when(checklistRepository.countByEtapaProduccionId(15L)).thenReturn(1L);
         when(checklistRepository.findByEtapaProduccionIdOrderByIdAsc(15L)).thenReturn(List.of(placeholder));
 
         assertThrows(CustomBusinessException.class, () -> service.validarChecklistCompleto(15L));


### PR DESCRIPTION
## Summary
- add `ensureChecklistOperativo` to backfill checklist items from active stage templates using producto + secuencia and excluding placeholders
- invoke checklist backfill when retrieving checklists and before finalizing stages, keeping configuration errors when no operative checklist exists
- extend repositories and tests to cover backfill, placeholder-only templates, and updated checklist retrieval expectations

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab82820a48333ac9f0faa5977fc24)