### PR TITLE
Add admin REST endpoints for checklist templates

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaTemplateController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaTemplateController.java
@@ -1,0 +1,56 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaTemplateCopyRequest;
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaTemplateRequest;
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaTemplateResponse;
+import com.willyes.clemenintegra.produccion.service.ChecklistEtapaTemplateAdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/produccion")
+@RequiredArgsConstructor
+public class ChecklistEtapaTemplateController {
+
+    private final ChecklistEtapaTemplateAdminService service;
+
+    @GetMapping("/plantillas-etapas/{etapaPlantillaId}/checklist")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    public List<ChecklistEtapaTemplateResponse> listar(@PathVariable Long etapaPlantillaId) {
+        return service.listar(etapaPlantillaId);
+    }
+
+    @PostMapping("/plantillas-etapas/{etapaPlantillaId}/checklist")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ChecklistEtapaTemplateResponse> crear(@PathVariable Long etapaPlantillaId,
+                                                                @RequestBody ChecklistEtapaTemplateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.crear(etapaPlantillaId, request));
+    }
+
+    @PutMapping("/checklist-template/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ChecklistEtapaTemplateResponse> actualizar(@PathVariable Long id,
+                                                                     @RequestBody ChecklistEtapaTemplateRequest request) {
+        return ResponseEntity.ok(service.actualizar(id, request));
+    }
+
+    @DeleteMapping("/checklist-template/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        service.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/plantillas-etapas/{etapaPlantillaId}/checklist/copiar-desde")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    public ResponseEntity<List<ChecklistEtapaTemplateResponse>> copiar(@PathVariable Long etapaPlantillaId,
+                                                                       @RequestBody ChecklistEtapaTemplateCopyRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(service.copiarDesde(etapaPlantillaId, request.getOrigenEtapaPlantillaId()));
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistEtapaTemplateCopyRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistEtapaTemplateCopyRequest.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Data;
+
+@Data
+public class ChecklistEtapaTemplateCopyRequest {
+    private Long origenEtapaPlantillaId;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistEtapaTemplateRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistEtapaTemplateRequest.java
@@ -1,0 +1,12 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Data;
+
+@Data
+public class ChecklistEtapaTemplateRequest {
+    public String nombreItem;
+    public Boolean obligatorio;
+    public Boolean permitirNoAplica;
+    public Integer orden;
+    public Boolean activo;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistEtapaTemplateResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ChecklistEtapaTemplateResponse.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class ChecklistEtapaTemplateResponse {
+    private Long id;
+    private Long etapaPlantillaId;
+    private String nombreItem;
+    private Boolean obligatorio;
+    private Boolean permitirNoAplica;
+    private Integer orden;
+    private Boolean activo;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/ChecklistEtapaTemplateRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/ChecklistEtapaTemplateRepository.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface ChecklistEtapaTemplateRepository extends JpaRepository<ChecklistEtapaTemplate, Long> {
     List<ChecklistEtapaTemplate> findByEtapaPlantillaIdAndActivoTrueOrderByOrdenAsc(Long etapaPlantillaId);
 
+    List<ChecklistEtapaTemplate> findByEtapaPlantillaIdOrderByOrdenAsc(Long etapaPlantillaId);
+
     @Query("select c from ChecklistEtapaTemplate c " +
             "where c.etapaPlantilla.id = :etapaPlantillaId and c.activo = true order by c.orden asc")
     List<ChecklistEtapaTemplate> findActiveByEtapaPlantillaIdOrderByOrdenAsc(Long etapaPlantillaId);
@@ -16,4 +18,13 @@ public interface ChecklistEtapaTemplateRepository extends JpaRepository<Checklis
     boolean existsByEtapaPlantillaIdAndActivoTrue(Long etapaPlantillaId);
 
     List<ChecklistEtapaTemplate> findByEtapaPlantillaId(Long etapaPlantillaId);
+
+    @Query("select case when count(c) > 0 then true else false end from ChecklistEtapaTemplate c " +
+            "where c.etapaPlantilla.id = :etapaPlantillaId and c.activo = true and c.nombreItem <> :placeholder")
+    boolean existsOperativosActivosByEtapaPlantillaId(Long etapaPlantillaId, String placeholder);
+
+    @Query("select c from ChecklistEtapaTemplate c " +
+            "where c.etapaPlantilla.id = :etapaPlantillaId and c.activo = true and c.nombreItem <> :placeholder " +
+            "order by c.orden asc")
+    List<ChecklistEtapaTemplate> findOperativosActivosByEtapaPlantillaId(Long etapaPlantillaId, String placeholder);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateAdminService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateAdminService.java
@@ -1,0 +1,18 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaTemplateRequest;
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaTemplateResponse;
+
+import java.util.List;
+
+public interface ChecklistEtapaTemplateAdminService {
+    List<ChecklistEtapaTemplateResponse> listar(Long etapaPlantillaId);
+
+    ChecklistEtapaTemplateResponse crear(Long etapaPlantillaId, ChecklistEtapaTemplateRequest request);
+
+    ChecklistEtapaTemplateResponse actualizar(Long id, ChecklistEtapaTemplateRequest request);
+
+    void eliminar(Long id);
+
+    List<ChecklistEtapaTemplateResponse> copiarDesde(Long etapaPlantillaId, Long origenEtapaPlantillaId);
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateAdminServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateAdminServiceImpl.java
@@ -1,0 +1,144 @@
+package com.willyes.clemenintegra.produccion.service;
+
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaTemplateRequest;
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaTemplateResponse;
+import com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate;
+import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
+import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaTemplateRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChecklistEtapaTemplateAdminServiceImpl implements ChecklistEtapaTemplateAdminService {
+
+    private final ChecklistEtapaTemplateRepository repository;
+    private final EtapaPlantillaRepository etapaPlantillaRepository;
+
+    @Override
+    public List<ChecklistEtapaTemplateResponse> listar(Long etapaPlantillaId) {
+        EtapaPlantilla etapa = obtenerEtapa(etapaPlantillaId);
+        return repository.findByEtapaPlantillaIdOrderByOrdenAsc(etapa.getId()).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Override
+    public ChecklistEtapaTemplateResponse crear(Long etapaPlantillaId, ChecklistEtapaTemplateRequest request) {
+        EtapaPlantilla etapa = obtenerEtapa(etapaPlantillaId);
+        validarRequest(request);
+        ChecklistEtapaTemplate entidad = ChecklistEtapaTemplate.builder()
+                .etapaPlantilla(etapa)
+                .nombreItem(request.getNombreItem().trim())
+                .obligatorio(Boolean.TRUE.equals(request.getObligatorio()))
+                .permitirNoAplica(Boolean.TRUE.equals(request.getPermitirNoAplica()))
+                .orden(request.getOrden())
+                .activo(request.getActivo() == null || Boolean.TRUE.equals(request.getActivo()))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+        return toResponse(repository.save(entidad));
+    }
+
+    @Override
+    public ChecklistEtapaTemplateResponse actualizar(Long id, ChecklistEtapaTemplateRequest request) {
+        validarRequest(request);
+        ChecklistEtapaTemplate existente = obtenerTemplate(id);
+        existente.setNombreItem(request.getNombreItem().trim());
+        existente.setObligatorio(Boolean.TRUE.equals(request.getObligatorio()));
+        existente.setPermitirNoAplica(Boolean.TRUE.equals(request.getPermitirNoAplica()));
+        existente.setOrden(request.getOrden());
+        existente.setActivo(request.getActivo() == null || Boolean.TRUE.equals(request.getActivo()));
+        return toResponse(repository.save(existente));
+    }
+
+    @Override
+    public void eliminar(Long id) {
+        ChecklistEtapaTemplate existente = obtenerTemplate(id);
+        existente.setActivo(false);
+        existente.setUpdatedAt(LocalDateTime.now());
+        repository.save(existente);
+    }
+
+    @Override
+    public List<ChecklistEtapaTemplateResponse> copiarDesde(Long etapaPlantillaId, Long origenEtapaPlantillaId) {
+        if (origenEtapaPlantillaId == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Etapa plantilla origen requerida");
+        }
+        EtapaPlantilla destino = obtenerEtapa(etapaPlantillaId);
+        EtapaPlantilla origen = obtenerEtapa(origenEtapaPlantillaId);
+
+        boolean destinoTieneChecklist = repository.existsOperativosActivosByEtapaPlantillaId(
+                destino.getId(), ChecklistEtapaTemplateService.PLACEHOLDER_NOMBRE);
+        if (destinoTieneChecklist) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "CHECKLIST_YA_EXISTE");
+        }
+
+        List<ChecklistEtapaTemplate> origenItems = repository.findOperativosActivosByEtapaPlantillaId(
+                origen.getId(), ChecklistEtapaTemplateService.PLACEHOLDER_NOMBRE);
+        if (origenItems.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Checklist origen vacío");
+        }
+
+        LocalDateTime ahora = LocalDateTime.now();
+        List<ChecklistEtapaTemplate> copias = origenItems.stream()
+                .map(item -> ChecklistEtapaTemplate.builder()
+                        .etapaPlantilla(destino)
+                        .nombreItem(item.getNombreItem())
+                        .obligatorio(Boolean.TRUE.equals(item.getObligatorio()))
+                        .permitirNoAplica(Boolean.TRUE.equals(item.getPermitirNoAplica()))
+                        .orden(item.getOrden())
+                        .activo(true)
+                        .createdAt(ahora)
+                        .updatedAt(ahora)
+                        .build())
+                .toList();
+        repository.saveAll(copias);
+        return repository.findByEtapaPlantillaIdOrderByOrdenAsc(destino.getId()).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private ChecklistEtapaTemplateResponse toResponse(ChecklistEtapaTemplate template) {
+        return ChecklistEtapaTemplateResponse.builder()
+                .id(template.getId())
+                .etapaPlantillaId(template.getEtapaPlantilla().getId())
+                .nombreItem(template.getNombreItem())
+                .obligatorio(template.getObligatorio())
+                .permitirNoAplica(template.getPermitirNoAplica())
+                .orden(template.getOrden())
+                .activo(template.getActivo())
+                .createdAt(template.getCreatedAt())
+                .updatedAt(template.getUpdatedAt())
+                .build();
+    }
+
+    private void validarRequest(ChecklistEtapaTemplateRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Request inválido");
+        }
+        if (!StringUtils.hasText(request.getNombreItem())) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Nombre de item requerido");
+        }
+        if (request.getOrden() == null || request.getOrden() < 1) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Orden debe ser mayor o igual a 1");
+        }
+    }
+
+    private EtapaPlantilla obtenerEtapa(Long etapaPlantillaId) {
+        return etapaPlantillaRepository.findById(etapaPlantillaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Etapa plantilla no encontrada"));
+    }
+
+    private ChecklistEtapaTemplate obtenerTemplate(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Checklist template no encontrado"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaTemplateControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaTemplateControllerIntegrationTest.java
@@ -1,0 +1,273 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaTemplateCopyRequest;
+import com.willyes.clemenintegra.produccion.dto.ChecklistEtapaTemplateRequest;
+import com.willyes.clemenintegra.produccion.model.ChecklistEtapaTemplate;
+import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
+import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaTemplateRepository;
+import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class ChecklistEtapaTemplateControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private EtapaPlantillaRepository etapaPlantillaRepository;
+
+    @Autowired
+    private ChecklistEtapaTemplateRepository checklistEtapaTemplateRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    private EtapaPlantilla etapaDestino;
+    private EtapaPlantilla etapaOrigen;
+
+    @BeforeEach
+    void setUp() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("jefe")
+                .clave("secret")
+                .nombreCompleto("Jefe Produccion")
+                .correo("jefe@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .sessionVersion(0L)
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("PT")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("KILOGRAMO")
+                .simbolo("KG")
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-1")
+                .nombre("Producto 1")
+                .stockMinimo(BigDecimal.ZERO)
+                .stockMinimoProveedor(BigDecimal.ZERO)
+                .activo(true)
+                .fechaCreacion(LocalDateTime.now())
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+
+        etapaDestino = etapaPlantillaRepository.save(EtapaPlantilla.builder()
+                .producto(producto)
+                .nombre("Etapa Destino")
+                .secuencia(1)
+                .activo(true)
+                .build());
+
+        etapaOrigen = etapaPlantillaRepository.save(EtapaPlantilla.builder()
+                .producto(producto)
+                .nombre("Etapa Origen")
+                .secuencia(2)
+                .activo(true)
+                .build());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void crearYListarChecklistTemplate() throws Exception {
+        ChecklistEtapaTemplateRequest request = new ChecklistEtapaTemplateRequest();
+        request.setNombreItem("Verificar insumos");
+        request.setObligatorio(true);
+        request.setPermitirNoAplica(false);
+        request.setOrden(1);
+        request.setActivo(true);
+
+        mockMvc.perform(post("/api/produccion/plantillas-etapas/{id}/checklist", etapaDestino.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.nombreItem").value("Verificar insumos"))
+                .andExpect(jsonPath("$.etapaPlantillaId").value(etapaDestino.getId()));
+
+        mockMvc.perform(get("/api/produccion/plantillas-etapas/{id}/checklist", etapaDestino.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].nombreItem").value("Verificar insumos"))
+                .andExpect(jsonPath("$[0].orden").value(1));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void actualizarChecklistTemplate() throws Exception {
+        ChecklistEtapaTemplate existente = checklistEtapaTemplateRepository.save(ChecklistEtapaTemplate.builder()
+                .etapaPlantilla(etapaDestino)
+                .nombreItem("Paso previo")
+                .obligatorio(true)
+                .permitirNoAplica(false)
+                .orden(1)
+                .activo(true)
+                .build());
+
+        ChecklistEtapaTemplateRequest request = new ChecklistEtapaTemplateRequest();
+        request.setNombreItem("Paso actualizado");
+        request.setObligatorio(false);
+        request.setPermitirNoAplica(true);
+        request.setOrden(2);
+        request.setActivo(true);
+
+        mockMvc.perform(put("/api/produccion/checklist-template/{id}", existente.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nombreItem").value("Paso actualizado"))
+                .andExpect(jsonPath("$.obligatorio").value(false))
+                .andExpect(jsonPath("$.permitirNoAplica").value(true))
+                .andExpect(jsonPath("$.orden").value(2));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void eliminarChecklistTemplate_softDelete() throws Exception {
+        ChecklistEtapaTemplate existente = checklistEtapaTemplateRepository.save(ChecklistEtapaTemplate.builder()
+                .etapaPlantilla(etapaDestino)
+                .nombreItem("Paso a eliminar")
+                .obligatorio(true)
+                .permitirNoAplica(false)
+                .orden(1)
+                .activo(true)
+                .build());
+
+        mockMvc.perform(delete("/api/produccion/checklist-template/{id}", existente.getId()))
+                .andExpect(status().isNoContent());
+
+        ChecklistEtapaTemplate eliminado = checklistEtapaTemplateRepository.findById(existente.getId()).orElseThrow();
+        assertThat(eliminado.getActivo()).isFalse();
+        assertThat(eliminado.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void copiarChecklistTemplate_conflictoCuandoDestinoTieneChecklist() throws Exception {
+        checklistEtapaTemplateRepository.save(ChecklistEtapaTemplate.builder()
+                .etapaPlantilla(etapaDestino)
+                .nombreItem("Paso existente")
+                .obligatorio(true)
+                .permitirNoAplica(false)
+                .orden(1)
+                .activo(true)
+                .build());
+
+        checklistEtapaTemplateRepository.save(ChecklistEtapaTemplate.builder()
+                .etapaPlantilla(etapaOrigen)
+                .nombreItem("Paso origen")
+                .obligatorio(true)
+                .permitirNoAplica(false)
+                .orden(1)
+                .activo(true)
+                .build());
+
+        ChecklistEtapaTemplateCopyRequest request = new ChecklistEtapaTemplateCopyRequest();
+        request.setOrigenEtapaPlantillaId(etapaOrigen.getId());
+
+        mockMvc.perform(post("/api/produccion/plantillas-etapas/{id}/checklist/copiar-desde", etapaDestino.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void copiarChecklistTemplate_exitoso() throws Exception {
+        checklistEtapaTemplateRepository.save(ChecklistEtapaTemplate.builder()
+                .etapaPlantilla(etapaOrigen)
+                .nombreItem("Paso origen 1")
+                .obligatorio(true)
+                .permitirNoAplica(false)
+                .orden(1)
+                .activo(true)
+                .build());
+        checklistEtapaTemplateRepository.save(ChecklistEtapaTemplate.builder()
+                .etapaPlantilla(etapaOrigen)
+                .nombreItem("Definir checklist operativo")
+                .obligatorio(true)
+                .permitirNoAplica(false)
+                .orden(2)
+                .activo(true)
+                .build());
+
+        ChecklistEtapaTemplateCopyRequest request = new ChecklistEtapaTemplateCopyRequest();
+        request.setOrigenEtapaPlantillaId(etapaOrigen.getId());
+
+        mockMvc.perform(post("/api/produccion/plantillas-etapas/{id}/checklist/copiar-desde", etapaDestino.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$[0].nombreItem").value("Paso origen 1"))
+                .andExpect(jsonPath("$[0].orden").value(1))
+                .andExpect(jsonPath("$[0].etapaPlantillaId").value(etapaDestino.getId()));
+    }
+}


### PR DESCRIPTION
## Summary
- add REST endpoints, DTOs, and service layer to manage checklist templates for etapas plantilla with validation and security annotations
- extend repository queries to support ordered fetches and active-operational existence checks
- add integration coverage for creating, updating, deleting, and copying checklist templates

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aed99dad8833398ad9696e951b173)