### PR TITLE
feat: agregar trazabilidad de producción y filtros de Kardex

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/KardexController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/KardexController.java
@@ -34,7 +34,9 @@ public class KardexController {
             @RequestParam(required = false) String codigoLote,
             @RequestParam(required = false) String fechaDesde,
             @RequestParam(required = false) String fechaHasta,
-            @RequestParam(required = false) Long almacenId
+            @RequestParam(required = false) Long almacenId,
+            @RequestParam(required = false) Long ordenProduccionId,
+            @RequestParam(required = false) Long etapaProduccionId
     ) {
         if (productoId == null && !StringUtils.hasText(codigoSku)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Se requiere productoId o codigoSku");
@@ -51,6 +53,8 @@ public class KardexController {
                 .fechaDesde(inicio)
                 .fechaHasta(fin)
                 .almacenId(almacenId)
+                .ordenProduccionId(ordenProduccionId)
+                .etapaProduccionId(etapaProduccionId)
                 .build();
 
         try {

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/KardexFiltro.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/KardexFiltro.java
@@ -19,4 +19,6 @@ public class KardexFiltro {
     private LocalDateTime fechaDesde;
     private LocalDateTime fechaHasta;
     private Long almacenId;
+    private Long ordenProduccionId;
+    private Long etapaProduccionId;
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -291,12 +291,18 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
            and (:inicio is null or m.fechaIngreso >= :inicio)
            and (:fin is null or m.fechaIngreso <= :fin)
            and (:almacenId is null or m.almacenOrigen.id = :almacenId or m.almacenDestino.id = :almacenId)
+           and (:ordenProduccionId is null or m.ordenProduccion.id = :ordenProduccionId)
+           and (:etapaProduccionId is null or m.ordenProduccionEtapa.id = :etapaProduccionId)
          order by m.fechaIngreso asc, m.id asc
     """)
     List<MovimientoInventario> buscarParaKardex(@Param("inicio") LocalDateTime inicio,
                                                 @Param("fin") LocalDateTime fin,
                                                 @Param("productoId") Long productoId,
                                                 @Param("loteId") Long loteId,
-                                                @Param("almacenId") Long almacenId);
+                                                @Param("almacenId") Long almacenId,
+                                                @Param("ordenProduccionId") Long ordenProduccionId,
+                                                @Param("etapaProduccionId") Long etapaProduccionId);
+
+    List<MovimientoInventario> findByOrdenProduccionIdOrderByFechaIngresoAsc(Long ordenProduccionId);
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/KardexServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/KardexServiceImpl.java
@@ -69,7 +69,9 @@ public class KardexServiceImpl implements KardexService {
                 filtro.getFechaHasta(),
                 productoId,
                 lote != null ? lote.getId() : null,
-                filtro.getAlmacenId()
+                filtro.getAlmacenId(),
+                filtro.getOrdenProduccionId(),
+                filtro.getEtapaProduccionId()
         );
 
         return calcularSaldo(movimientos, producto, lote, filtro.getAlmacenId());

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -98,6 +98,12 @@ public class OrdenProduccionController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @GetMapping("/{id}/trazabilidad")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ProduccionTrazabilidadResponseDTO> obtenerTrazabilidad(@PathVariable Long id) {
+        return ResponseEntity.ok(service.obtenerTrazabilidad(id));
+    }
+
     @PostMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<ResultadoValidacionOrdenDTO> crear(@RequestBody OrdenProduccionRequestDTO request) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/BatchRecordDTO.java
@@ -55,6 +55,8 @@ public class BatchRecordDTO {
     }
 
     public static class ConsumoDTO {
+        public Long movimientoId;
+        public Long etapaId;
         public String tipoMovimiento;
         public String clasificacionMovimiento;
         public Long productoId;

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/ProduccionTrazabilidadResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/ProduccionTrazabilidadResponseDTO.java
@@ -1,0 +1,131 @@
+package com.willyes.clemenintegra.produccion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProduccionTrazabilidadResponseDTO {
+
+    private OpDTO op;
+    private List<EtapaDTO> etapas;
+    private List<ConsumoDTO> consumos;
+    private List<MovimientoDTO> movimientos;
+    private List<LoteResultanteDTO> lotesResultantes;
+    private List<CierreDTO> cierres;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OpDTO {
+        private Long id;
+        private String codigoOrden;
+        private Long productoId;
+        private String nombreProducto;
+        private String codigoSku;
+        private String loteProduccion;
+        private String estado;
+        private LocalDateTime fechaInicio;
+        private LocalDateTime fechaFin;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EtapaDTO {
+        private Long id;
+        private Integer secuencia;
+        private String nombreEtapa;
+        private String estado;
+        private LocalDateTime fechaInicio;
+        private LocalDateTime fechaFin;
+        private Long usuarioId;
+        private String usuarioNombre;
+        private ChecklistResumenDTO checklist;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChecklistResumenDTO {
+        private Integer total;
+        private Integer obligatoriosPendientes;
+        private Boolean completo;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ConsumoDTO {
+        private Long movimientoId;
+        private Long etapaId;
+        private String tipoMovimiento;
+        private String clasificacion;
+        private Long productoId;
+        private String codigoSku;
+        private String nombreProducto;
+        private Long loteId;
+        private String codigoLote;
+        private Long almacenOrigenId;
+        private String almacenOrigenNombre;
+        private BigDecimal cantidad;
+        private LocalDateTime fechaMovimiento;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MovimientoDTO {
+        private Long movimientoId;
+        private Long etapaId;
+        private String tipoMovimiento;
+        private String clasificacion;
+        private Long loteId;
+        private String codigoLote;
+        private String almacenOrigen;
+        private String almacenDestino;
+        private BigDecimal cantidad;
+        private LocalDateTime fechaMovimiento;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoteResultanteDTO {
+        private Long loteId;
+        private String codigoLote;
+        private String estado;
+        private Long almacenId;
+        private String almacenNombre;
+        private LocalDateTime fechaFabricacion;
+        private LocalDateTime fechaVencimiento;
+        private Long lotePsOrigenId;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CierreDTO {
+        private Long id;
+        private String tipoCierre;
+        private LocalDateTime fecha;
+        private Long usuarioId;
+        private String usuarioNombre;
+        private String observacion;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/BatchRecordServiceImpl.java
@@ -345,6 +345,8 @@ public class BatchRecordServiceImpl implements BatchRecordService {
 
     private BatchRecordDTO.ConsumoDTO crearConsumoDtoDesdeMovimiento(MovimientoInventario movimiento) {
         BatchRecordDTO.ConsumoDTO consumoDTO = new BatchRecordDTO.ConsumoDTO();
+        consumoDTO.movimientoId = movimiento.getId();
+        consumoDTO.etapaId = movimiento.getOrdenProduccionEtapa() != null ? movimiento.getOrdenProduccionEtapa().getId() : null;
         consumoDTO.tipoMovimiento = movimiento.getTipoMovimiento() != null ? movimiento.getTipoMovimiento().name() : null;
         consumoDTO.clasificacionMovimiento = movimiento.getClasificacion() != null ? movimiento.getClasificacion().name() : null;
         consumoDTO.productoId = movimiento.getProducto() != null ? movimiento.getProducto().getId().longValue() : null;
@@ -365,6 +367,8 @@ public class BatchRecordServiceImpl implements BatchRecordService {
                                                                  MovimientoInventario movimientoPs,
                                                                  BigDecimal cantidadTeorica) {
         BatchRecordDTO.ConsumoDTO consumoDTO = new BatchRecordDTO.ConsumoDTO();
+        consumoDTO.movimientoId = movimientoPs.getId();
+        consumoDTO.etapaId = movimientoPs.getOrdenProduccionEtapa() != null ? movimientoPs.getOrdenProduccionEtapa().getId() : null;
         consumoDTO.tipoMovimiento = movimientoPs.getTipoMovimiento() != null ? movimientoPs.getTipoMovimiento().name() : null;
         consumoDTO.clasificacionMovimiento = movimientoPs.getClasificacion() != null ? movimientoPs.getClasificacion().name() : null;
         consumoDTO.productoId = detalle.getInsumo() != null ? detalle.getInsumo().getId().longValue() : null;

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -71,4 +71,6 @@ public interface OrdenProduccionService {
                                  LocalDateTime fechaFin);
 
     OrdenProduccion cancelarOrden(Long ordenProduccionId, @Nullable String motivo);
+
+    com.willyes.clemenintegra.produccion.dto.ProduccionTrazabilidadResponseDTO obtenerTrazabilidad(Long ordenProduccionId);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -17,6 +17,7 @@ import com.willyes.clemenintegra.produccion.dto.CierreProduccionRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.CierreProduccionResponseDTO;
 import com.willyes.clemenintegra.produccion.dto.EtapaProduccionResponse;
 import com.willyes.clemenintegra.produccion.dto.InsumoOPDTO;
+import com.willyes.clemenintegra.produccion.dto.ProduccionTrazabilidadResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.produccion.mapper.ProduccionMapper;
 import com.willyes.clemenintegra.produccion.service.UnidadConversionService;
@@ -28,6 +29,7 @@ import com.willyes.clemenintegra.produccion.repository.CierreProduccionRepositor
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.TipoCierre;
 import com.willyes.clemenintegra.produccion.service.spec.OrdenProduccionSpecifications;
+import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository;
 import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoResponseDTO;
@@ -64,6 +66,7 @@ import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
 import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoChecklistItem;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
@@ -137,6 +140,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     private final ReservaLoteRepository reservaLoteRepository;
     private final DisponibilidadInsumoService disponibilidadInsumoService;
     private final ChecklistEtapaService checklistEtapaService;
+    private final ChecklistEtapaItemRepository checklistEtapaItemRepository;
 
     @Value("${inventory.solicitud.estados.pendientes}")
     private String estadosSolicitudPendientesConf;
@@ -2130,6 +2134,145 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
         return repository.save(orden);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProduccionTrazabilidadResponseDTO obtenerTrazabilidad(Long ordenProduccionId) {
+        OrdenProduccion orden = repository.findById(ordenProduccionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ORDEN_NO_ENCONTRADA"));
+
+        ProduccionTrazabilidadResponseDTO.OpDTO opDTO = ProduccionTrazabilidadResponseDTO.OpDTO.builder()
+                .id(orden.getId())
+                .codigoOrden(orden.getCodigoOrden())
+                .productoId(orden.getProducto() != null ? orden.getProducto().getId().longValue() : null)
+                .nombreProducto(orden.getProducto() != null ? orden.getProducto().getNombre() : null)
+                .codigoSku(orden.getProducto() != null ? orden.getProducto().getCodigoSku() : null)
+                .loteProduccion(orden.getLoteProduccion())
+                .estado(orden.getEstado() != null ? orden.getEstado().name() : null)
+                .fechaInicio(orden.getFechaInicio())
+                .fechaFin(orden.getFechaFin())
+                .build();
+
+        List<ProduccionTrazabilidadResponseDTO.EtapaDTO> etapasDto = etapaProduccionRepository
+                .findByOrdenProduccionIdOrderBySecuenciaAsc(ordenProduccionId).stream()
+                .map(this::mapEtapaTrazabilidad)
+                .toList();
+
+        List<ProduccionTrazabilidadResponseDTO.ConsumoDTO> consumosDto = movimientoInventarioRepository
+                .findByOrdenProduccionIdAndClasificacion(
+                        ordenProduccionId,
+                        ClasificacionMovimientoInventario.SALIDA_PRODUCCION,
+                        Pageable.unpaged())
+                .getContent()
+                .stream()
+                .map(this::mapConsumoTrazabilidad)
+                .toList();
+
+        List<ProduccionTrazabilidadResponseDTO.MovimientoDTO> movimientosDto = movimientoInventarioRepository
+                .findByOrdenProduccionIdOrderByFechaIngresoAsc(ordenProduccionId).stream()
+                .map(this::mapMovimientoTrazabilidad)
+                .toList();
+
+        List<ProduccionTrazabilidadResponseDTO.LoteResultanteDTO> lotesDto = loteProductoRepository
+                .findByOrdenProduccionId(ordenProduccionId).stream()
+                .map(lote -> ProduccionTrazabilidadResponseDTO.LoteResultanteDTO.builder()
+                        .loteId(lote.getId())
+                        .codigoLote(lote.getCodigoLote())
+                        .estado(lote.getEstado() != null ? lote.getEstado().name() : null)
+                        .almacenId(lote.getAlmacen() != null ? lote.getAlmacen().getId().longValue() : null)
+                        .almacenNombre(lote.getAlmacen() != null ? lote.getAlmacen().getNombre() : null)
+                        .fechaFabricacion(lote.getFechaFabricacion())
+                        .fechaVencimiento(lote.getFechaVencimiento())
+                        .lotePsOrigenId(lote.getLotePsOrigen() != null ? lote.getLotePsOrigen().getId() : null)
+                        .build())
+                .toList();
+
+        List<ProduccionTrazabilidadResponseDTO.CierreDTO> cierresDto = cierreProduccionRepository
+                .findByOrdenProduccionId(ordenProduccionId, Pageable.unpaged())
+                .getContent()
+                .stream()
+                .map(cierre -> ProduccionTrazabilidadResponseDTO.CierreDTO.builder()
+                        .id(cierre.getId())
+                        .tipoCierre(cierre.getTipo() != null ? cierre.getTipo().name() : null)
+                        .fecha(cierre.getFechaCierre())
+                        .usuarioId(cierre.getUsuarioId())
+                        .usuarioNombre(cierre.getUsuarioNombre())
+                        .observacion(cierre.getObservacion())
+                        .build())
+                .toList();
+
+        return ProduccionTrazabilidadResponseDTO.builder()
+                .op(opDTO)
+                .etapas(etapasDto)
+                .consumos(consumosDto)
+                .movimientos(movimientosDto)
+                .lotesResultantes(lotesDto)
+                .cierres(cierresDto)
+                .build();
+    }
+
+    private ProduccionTrazabilidadResponseDTO.EtapaDTO mapEtapaTrazabilidad(EtapaProduccion etapa) {
+        List<com.willyes.clemenintegra.produccion.model.ChecklistEtapaItem> items =
+                checklistEtapaItemRepository.findByEtapaProduccionIdOrderByIdAsc(etapa.getId());
+        int total = items.size();
+        int obligPendientes = (int) items.stream()
+                .filter(i -> Boolean.TRUE.equals(i.getObligatorio()))
+                .filter(i -> !(EstadoChecklistItem.COMPLETADO.equals(i.getEstado())
+                        || (EstadoChecklistItem.NO_APLICA.equals(i.getEstado())
+                        && Boolean.TRUE.equals(i.getPermitirNoAplica()))))
+                .count();
+        boolean completo = total > 0 && obligPendientes == 0;
+
+        ProduccionTrazabilidadResponseDTO.ChecklistResumenDTO resumenChecklist =
+                ProduccionTrazabilidadResponseDTO.ChecklistResumenDTO.builder()
+                        .total(total)
+                        .obligatoriosPendientes(obligPendientes)
+                        .completo(completo)
+                        .build();
+
+        return ProduccionTrazabilidadResponseDTO.EtapaDTO.builder()
+                .id(etapa.getId())
+                .secuencia(etapa.getSecuencia())
+                .nombreEtapa(etapa.getNombre())
+                .estado(etapa.getEstado() != null ? etapa.getEstado().name() : null)
+                .fechaInicio(etapa.getFechaInicio())
+                .fechaFin(etapa.getFechaFin())
+                .usuarioId(etapa.getUsuarioId())
+                .usuarioNombre(etapa.getUsuarioNombre())
+                .checklist(resumenChecklist)
+                .build();
+    }
+
+    private ProduccionTrazabilidadResponseDTO.ConsumoDTO mapConsumoTrazabilidad(MovimientoInventario movimiento) {
+        return ProduccionTrazabilidadResponseDTO.ConsumoDTO.builder()
+                .movimientoId(movimiento.getId())
+                .etapaId(movimiento.getOrdenProduccionEtapa() != null ? movimiento.getOrdenProduccionEtapa().getId() : null)
+                .tipoMovimiento(movimiento.getTipoMovimiento() != null ? movimiento.getTipoMovimiento().name() : null)
+                .clasificacion(movimiento.getClasificacion() != null ? movimiento.getClasificacion().name() : null)
+                .productoId(movimiento.getProducto() != null ? movimiento.getProducto().getId().longValue() : null)
+                .codigoSku(movimiento.getProducto() != null ? movimiento.getProducto().getCodigoSku() : null)
+                .nombreProducto(movimiento.getProducto() != null ? movimiento.getProducto().getNombre() : null)
+                .loteId(movimiento.getLote() != null ? movimiento.getLote().getId() : null)
+                .codigoLote(movimiento.getLote() != null ? movimiento.getLote().getCodigoLote() : null)
+                .almacenOrigenId(movimiento.getAlmacenOrigen() != null ? movimiento.getAlmacenOrigen().getId().longValue() : null)
+                .almacenOrigenNombre(movimiento.getAlmacenOrigen() != null ? movimiento.getAlmacenOrigen().getNombre() : null)
+                .cantidad(movimiento.getCantidad())
+                .fechaMovimiento(movimiento.getFechaIngreso())
+                .build();
+    }
+
+    private ProduccionTrazabilidadResponseDTO.MovimientoDTO mapMovimientoTrazabilidad(MovimientoInventario movimiento) {
+        return ProduccionTrazabilidadResponseDTO.MovimientoDTO.builder()
+                .movimientoId(movimiento.getId())
+                .etapaId(movimiento.getOrdenProduccionEtapa() != null ? movimiento.getOrdenProduccionEtapa().getId() : null)
+                .tipoMovimiento(movimiento.getTipoMovimiento() != null ? movimiento.getTipoMovimiento().name() : null)
+                .clasificacion(movimiento.getClasificacion() != null ? movimiento.getClasificacion().name() : null)
+                .loteId(movimiento.getLote() != null ? movimiento.getLote().getId() : null)
+                .codigoLote(movimiento.getLote() != null ? movimiento.getLote().getCodigoLote() : null)
+                .almacenOrigen(movimiento.getAlmacenOrigen() != null ? movimiento.getAlmacenOrigen().getNombre() : null)
+                .almacenDestino(movimiento.getAlmacenDestino() != null ? movimiento.getAlmacenDestino().getNombre() : null)
+                .cantidad(movimiento.getCantidad())
+                .fechaMovimiento(movimiento.getFechaIngreso())
+                .build();
+    }
 }
-
-

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/KardexServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/KardexServiceImplTest.java
@@ -51,7 +51,7 @@ class KardexServiceImplTest {
         MovimientoInventario salida = movimiento(LocalDateTime.now().minusDays(1), new BigDecimal("3"),
                 TipoMovimiento.SALIDA, ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
 
-        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(1L), any(), any()))
+        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(1L), any(), any(), any(), any()))
                 .thenReturn(List.of(entrada, salida));
 
         KardexFiltro filtro = KardexFiltro.builder().productoId(1L).build();
@@ -73,7 +73,7 @@ class KardexServiceImplTest {
         when(productoRepository.findByCodigoSku("SKU-05")).thenReturn(Optional.of(producto));
         when(loteProductoRepository.findByCodigoLoteAndProductoId("L-001", 5L)).thenReturn(Optional.of(lote));
 
-        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(5L), eq(9L), any()))
+        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(5L), eq(9L), any(), any(), any()))
                 .thenReturn(List.of());
 
         KardexFiltro filtro = KardexFiltro.builder()
@@ -84,7 +84,7 @@ class KardexServiceImplTest {
         List<KardexItemDTO> resultado = kardexService.obtenerKardex(filtro);
 
         assertThat(resultado).isEmpty();
-        verify(movimientoInventarioRepository).buscarParaKardex(null, null, 5L, 9L, null);
+        verify(movimientoInventarioRepository).buscarParaKardex(null, null, 5L, 9L, null, null, null);
     }
 
     @Test
@@ -102,7 +102,7 @@ class KardexServiceImplTest {
         transferencia.setAlmacenOrigen(origen);
         transferencia.setAlmacenDestino(destino);
 
-        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(2L), any(), eq(2L)))
+        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(2L), any(), eq(2L), any(), any()))
                 .thenReturn(List.of(transferencia));
 
         KardexFiltro filtro = KardexFiltro.builder()
@@ -115,6 +115,32 @@ class KardexServiceImplTest {
         assertThat(resultado).hasSize(1);
         assertThat(resultado.get(0).getCantidadEntrada()).isEqualByComparingTo("5");
         assertThat(resultado.get(0).getSaldo()).isEqualByComparingTo("5");
+    }
+
+    @Test
+    void filtraPorOrdenProduccion() {
+        Producto producto = crearProducto(3, "SKU-03", "Producto C");
+        when(productoRepository.findById(3L)).thenReturn(Optional.of(producto));
+
+        MovimientoInventario movOp = movimiento(LocalDateTime.now(), new BigDecimal("4"),
+                TipoMovimiento.SALIDA, ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+        com.willyes.clemenintegra.produccion.model.OrdenProduccion op = new com.willyes.clemenintegra.produccion.model.OrdenProduccion();
+        op.setId(10L);
+        movOp.setOrdenProduccion(op);
+
+        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(3L), any(), any(), eq(10L), any()))
+                .thenReturn(List.of(movOp));
+
+        KardexFiltro filtro = KardexFiltro.builder()
+                .productoId(3L)
+                .ordenProduccionId(10L)
+                .build();
+
+        List<KardexItemDTO> resultado = kardexService.obtenerKardex(filtro);
+
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getCodigoSku()).isEqualTo("SKU-03");
+        verify(movimientoInventarioRepository).buscarParaKardex(null, null, 3L, null, null, 10L, null);
     }
 
     private Producto crearProducto(Integer id, String sku, String nombre) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/ProduccionTrazabilidadControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/ProduccionTrazabilidadControllerIntegrationTest.java
@@ -1,0 +1,217 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoEtapa;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class ProduccionTrazabilidadControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Autowired
+    private EtapaProduccionRepository etapaProduccionRepository;
+    @Autowired
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private AlmacenRepository almacenRepository;
+    @Autowired
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Autowired
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    private Usuario usuario;
+    private Producto producto;
+    private Almacen almacen;
+    private LoteProducto loteMp;
+    private MotivoMovimiento motivoMovimiento;
+    private TipoMovimientoDetalle tipoMovimientoDetalle;
+
+    @BeforeEach
+    void setUp() {
+        usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("tester")
+                .clave("secret")
+                .nombreCompleto("Tester")
+                .correo("tester@example.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .codigo("U")
+                .simbolo("U")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("MP")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-TZ-1")
+                .nombre("Insumo Trazabilidad")
+                .stockMinimo(BigDecimal.ONE)
+                .activo(true)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+
+        almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Principal")
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .ubicacion("Bodega Central")
+                .build());
+
+        loteMp = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("L-TZ-MP-1")
+                .producto(producto)
+                .almacen(almacen)
+                .estado(com.willyes.clemenintegra.inventario.model.enums.EstadoLote.DISPONIBLE)
+                .stockLote(new BigDecimal("50"))
+                .stockReservado(BigDecimal.ZERO)
+                .build());
+
+        motivoMovimiento = motivoMovimientoRepository.save(MotivoMovimiento.builder()
+                .descripcion("Consumo")
+                .motivo(ClasificacionMovimientoInventario.SALIDA_PRODUCCION)
+                .build());
+
+        tipoMovimientoDetalle = tipoMovimientoDetalleRepository.save(TipoMovimientoDetalle.builder()
+                .descripcion("Consumo Prod")
+                .build());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void retornaMatrizDeTrazabilidadConConsumosYLotes() throws Exception {
+        OrdenProduccion orden = ordenProduccionRepository.save(OrdenProduccion.builder()
+                .codigoOrden("OP-TZ-1")
+                .producto(producto)
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(new BigDecimal("10"))
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .build());
+
+        EtapaProduccion etapa = etapaProduccionRepository.save(EtapaProduccion.builder()
+                .nombre("Mezclado")
+                .secuencia(1)
+                .estado(EstadoEtapa.EN_PROCESO)
+                .ordenProduccion(orden)
+                .build());
+
+        LoteProducto lotePt = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("L-TZ-PT-1")
+                .producto(producto)
+                .almacen(almacen)
+                .estado(com.willyes.clemenintegra.inventario.model.enums.EstadoLote.DISPONIBLE)
+                .stockLote(BigDecimal.ZERO)
+                .ordenProduccion(orden)
+                .build());
+
+        MovimientoInventario movSalida = movimientoInventarioRepository.save(MovimientoInventario.builder()
+                .cantidad(new BigDecimal("5"))
+                .tipoMovimiento(TipoMovimiento.SALIDA)
+                .clasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION)
+                .fechaIngreso(LocalDateTime.now().minusHours(1))
+                .registradoPor(usuario)
+                .producto(producto)
+                .lote(loteMp)
+                .almacenOrigen(almacen)
+                .motivoMovimiento(motivoMovimiento)
+                .tipoMovimientoDetalle(tipoMovimientoDetalle)
+                .ordenProduccion(orden)
+                .ordenProduccionEtapa(etapa)
+                .build());
+
+        MovimientoInventario movTransfer = movimientoInventarioRepository.save(MovimientoInventario.builder()
+                .cantidad(new BigDecimal("3"))
+                .tipoMovimiento(TipoMovimiento.TRANSFERENCIA)
+                .clasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION)
+                .fechaIngreso(LocalDateTime.now())
+                .registradoPor(usuario)
+                .producto(producto)
+                .lote(loteMp)
+                .almacenOrigen(almacen)
+                .motivoMovimiento(motivoMovimiento)
+                .tipoMovimientoDetalle(tipoMovimientoDetalle)
+                .ordenProduccion(orden)
+                .ordenProduccionEtapa(etapa)
+                .build());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}/trazabilidad", orden.getId())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.consumos").isArray())
+                .andExpect(jsonPath("$.consumos[0].movimientoId").value(movSalida.getId()))
+                .andExpect(jsonPath("$.consumos[0].etapaId").value(etapa.getId()))
+                .andExpect(jsonPath("$.lotesResultantes[0].loteId").value(lotePt.getId()))
+                .andExpect(jsonPath("$.movimientos").isArray())
+                .andExpect(jsonPath("$.movimientos.length()").value(2));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceChecklistTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceChecklistTest.java
@@ -58,6 +58,8 @@ class OrdenProduccionServiceChecklistTest {
         ReservaLoteRepository reservaLoteRepository = mock(ReservaLoteRepository.class);
         DisponibilidadInsumoService disponibilidadInsumoService = mock(DisponibilidadInsumoService.class);
         checklistEtapaService = mock(ChecklistEtapaService.class);
+        com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository checklistEtapaItemRepository =
+                mock(com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository.class);
 
         service = new OrdenProduccionServiceImpl(
                 formulaProductoRepository,
@@ -84,7 +86,8 @@ class OrdenProduccionServiceChecklistTest {
                 reservaLoteService,
                 reservaLoteRepository,
                 disponibilidadInsumoService,
-                checklistEtapaService
+                checklistEtapaService,
+                checklistEtapaItemRepository
         );
 
         OrdenProduccion orden = OrdenProduccion.builder()

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCierreTotalTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCierreTotalTest.java
@@ -97,6 +97,8 @@ class OrdenProduccionServiceCierreTotalTest {
         reservaLoteRepository = mock(ReservaLoteRepository.class);
         disponibilidadInsumoService = mock(DisponibilidadInsumoService.class);
         ChecklistEtapaService checklistEtapaService = mock(ChecklistEtapaService.class);
+        com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository checklistEtapaItemRepository =
+                mock(com.willyes.clemenintegra.produccion.repository.ChecklistEtapaItemRepository.class);
 
         service = new OrdenProduccionServiceImpl(
                 formulaProductoRepository,
@@ -123,7 +125,8 @@ class OrdenProduccionServiceCierreTotalTest {
                 reservaLoteService,
                 reservaLoteRepository,
                 disponibilidadInsumoService,
-                checklistEtapaService
+                checklistEtapaService,
+                checklistEtapaItemRepository
         );
         ReflectionTestUtils.setField(service, "estadosSolicitudPendientesConf", "PENDIENTE");
         ReflectionTestUtils.setField(service, "estadosSolicitudConcluyentesConf", "ATENDIDO");


### PR DESCRIPTION
## Summary
- add ProduccionTrazabilidadResponseDTO and secure endpoint /api/produccion/ordenes/{id}/trazabilidad to expose OP, etapas, consumos, movimientos y lotes resultantes
- expand consumos reales (Batch Record y consumo teórico vs real) para incluir SALIDA_PRODUCCION independientemente del tipo de movimiento y exponer movimientoId/etapaId
- habilitate filtros opcionales por ordenProduccionId y etapaProduccionId en Kardex y actualizar pruebas

## Testing
- mvn test -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bdb3441cc8333978af3b16a3ecebf)