### PR TITLE
Add resolver endpoint for producto por lote

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteResolverController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteResolverController.java
@@ -1,0 +1,34 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.ProductoPorLoteDTO;
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/inventario/lotes")
+@RequiredArgsConstructor
+public class LoteResolverController {
+
+    private final LoteProductoService loteProductoService;
+
+    @GetMapping("/resolver-producto")
+    @PreAuthorize("hasAnyAuthority(" +
+            "'ROL_JEFE_ALMACENES'," +
+            "'ROL_ALMACENISTA'," +
+            "'ROL_JEFE_PRODUCCION'," +
+            "'ROL_LIDER_ALIMENTOS'," +
+            "'ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD'," +
+            "'ROL_SUPER_ADMIN'" +
+            ")")
+    public ResponseEntity<ProductoPorLoteDTO> resolverProducto(@RequestParam String codigoLote) {
+        ProductoPorLoteDTO dto = loteProductoService.resolverProductoPorLote(codigoLote);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoPorLoteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoPorLoteDTO.java
@@ -1,0 +1,11 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+/**
+ * Información mínima del producto asociado a un lote.
+ */
+public record ProductoPorLoteDTO(
+        Long productoId,
+        String sku,
+        String nombreProducto
+) {
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.calidad.dto.CondicionUsoResponseDTO;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoCondicionUso;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ProductoPorLoteDTO;
 import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.ReaperturaLoteRequestDTO;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -42,5 +43,7 @@ public interface LoteProductoService {
     List<CondicionUsoResponseDTO> listarCondicionesUso(Long loteId, EstadoCondicionUso estado);
 
     LoteProductoResponseDTO reabrirParaReevaluacion(Long loteId, ReaperturaLoteRequestDTO dto, com.willyes.clemenintegra.shared.model.Usuario usuarioActual);
+
+    ProductoPorLoteDTO resolverProductoPorLote(String codigoLote);
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -9,6 +9,7 @@ import com.willyes.clemenintegra.calidad.repository.CondicionUsoRepository;
 import com.willyes.clemenintegra.inventario.dto.BitacoraCambiosInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ProductoPorLoteDTO;
 import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.ReaperturaLoteRequestDTO;
 import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
@@ -35,6 +36,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -1000,5 +1002,27 @@ public class LoteProductoServiceImpl implements LoteProductoService {
                 .condicionUsoActiva(!condiciones.isEmpty())
                 .condicionUso(condicionResumen)
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProductoPorLoteDTO resolverProductoPorLote(String codigoLote) {
+        if (!StringUtils.hasText(codigoLote)) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "CODIGO_LOTE_OBLIGATORIO");
+        }
+
+        LoteProducto lote = loteProductoRepository.findByCodigoLote(codigoLote)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "LOTE_NO_EXISTE"));
+
+        Producto producto = lote.getProducto();
+        if (producto == null || producto.getId() == null) {
+            throw new CustomBusinessException(ApiErrorCode.NEGOCIO_GENERICO, "LOTE_SIN_PRODUCTO_ASOCIADO");
+        }
+
+        return new ProductoPorLoteDTO(
+                producto.getId().longValue(),
+                producto.getCodigoSku(),
+                producto.getNombre()
+        );
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/LoteResolverControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/LoteResolverControllerTest.java
@@ -1,0 +1,72 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.ProductoPorLoteDTO;
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LoteResolverController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class LoteResolverControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LoteProductoService loteProductoService;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void retornaProductoCuandoElLoteExiste() throws Exception {
+        ProductoPorLoteDTO dto = new ProductoPorLoteDTO(1L, "SKU-123", "Producto Demo");
+        when(loteProductoService.resolverProductoPorLote(eq("L-001"))).thenReturn(dto);
+
+        mockMvc.perform(get("/api/inventario/lotes/resolver-producto")
+                        .param("codigoLote", "L-001")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.productoId").value(1))
+                .andExpect(jsonPath("$.sku").value("SKU-123"))
+                .andExpect(jsonPath("$.nombreProducto").value("Producto Demo"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void retornaErrorControladoCuandoNoExisteLote() throws Exception {
+        when(loteProductoService.resolverProductoPorLote(eq("NOPE")))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "LOTE_NO_EXISTE"));
+
+        mockMvc.perform(get("/api/inventario/lotes/resolver-producto")
+                        .param("codigoLote", "NOPE")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RECURSO_NO_ENCONTRADO"))
+                .andExpect(jsonPath("$.message").value("LOTE_NO_EXISTE"));
+
+        Mockito.verify(loteProductoService).resolverProductoPorLote("NOPE");
+    }
+}


### PR DESCRIPTION
## Summary
- add DTO and service support to resolve producto information from a codigoLote
- expose GET /api/inventario/lotes/resolver-producto to return productoId, sku y nombre del lote
- cover success and lote inexistente scenarios with a WebMvc test

## Testing
- mvn -q -Dtest=LoteResolverControllerTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1fa436a08333b1a18535fa136543)