### PR TITLE
Fix lote resolver using orden de produccion context

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteResolverController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteResolverController.java
@@ -27,8 +27,9 @@ public class LoteResolverController {
             "'ROL_JEFE_CALIDAD'," +
             "'ROL_SUPER_ADMIN'" +
             ")")
-    public ResponseEntity<ProductoPorLoteDTO> resolverProducto(@RequestParam String codigoLote) {
-        ProductoPorLoteDTO dto = loteProductoService.resolverProductoPorLote(codigoLote);
+    public ResponseEntity<ProductoPorLoteDTO> resolverProducto(@RequestParam String codigoLote,
+                                                               @RequestParam Long ordenProduccionId) {
+        ProductoPorLoteDTO dto = loteProductoService.resolverProductoPorLote(codigoLote, ordenProduccionId);
         return ResponseEntity.ok(dto);
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -30,7 +30,14 @@ public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long
     boolean existsByProducto(Producto producto);
     boolean existsByCodigoLote(String codigoLote);
     List<LoteProducto> findByEstado(EstadoLote estado);
-    Optional<LoteProducto> findByCodigoLote(String codigoLote);
+    @Query("""
+SELECT lp
+FROM LoteProducto lp
+WHERE lp.codigoLote = :codigoLote
+  AND lp.ordenProduccion.id = :ordenProduccionId
+""")
+    List<LoteProducto> findByCodigoLoteAndOrdenProduccion(@Param("codigoLote") String codigoLote,
+                                                          @Param("ordenProduccionId") Long ordenProduccionId);
     @Query("""
        SELECT lp
          FROM LoteProducto lp

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoService.java
@@ -44,6 +44,6 @@ public interface LoteProductoService {
 
     LoteProductoResponseDTO reabrirParaReevaluacion(Long loteId, ReaperturaLoteRequestDTO dto, com.willyes.clemenintegra.shared.model.Usuario usuarioActual);
 
-    ProductoPorLoteDTO resolverProductoPorLote(String codigoLote);
+    ProductoPorLoteDTO resolverProductoPorLote(String codigoLote, Long ordenProduccionId);
 
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -1006,14 +1006,23 @@ public class LoteProductoServiceImpl implements LoteProductoService {
 
     @Override
     @Transactional(readOnly = true)
-    public ProductoPorLoteDTO resolverProductoPorLote(String codigoLote) {
+    public ProductoPorLoteDTO resolverProductoPorLote(String codigoLote, Long ordenProduccionId) {
         if (!StringUtils.hasText(codigoLote)) {
             throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "CODIGO_LOTE_OBLIGATORIO");
         }
+        if (ordenProduccionId == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA, "ORDEN_PRODUCCION_OBLIGATORIA");
+        }
 
-        LoteProducto lote = loteProductoRepository.findByCodigoLote(codigoLote)
-                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "LOTE_NO_EXISTE"));
+        List<LoteProducto> lotes = loteProductoRepository.findByCodigoLoteAndOrdenProduccion(codigoLote, ordenProduccionId);
+        if (lotes.isEmpty()) {
+            throw new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "LOTE_NO_ENCONTRADO");
+        }
+        if (lotes.size() > 1) {
+            throw new CustomBusinessException(ApiErrorCode.NEGOCIO_GENERICO, "LOTE_AMBIGUO");
+        }
 
+        LoteProducto lote = lotes.get(0);
         Producto producto = lote.getProducto();
         if (producto == null || producto.getId() == null) {
             throw new CustomBusinessException(ApiErrorCode.NEGOCIO_GENERICO, "LOTE_SIN_PRODUCTO_ASOCIADO");

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1195,8 +1195,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             String codigoLote = dto.getCodigoLote();
             if (lote == null) {
                 if (codigoLote != null && !codigoLote.isBlank()) {
-                    Optional<LoteProducto> existente = loteProductoRepository.findByCodigoLote(codigoLote);
-                    if (existente.isPresent()) {
+                    boolean existeCodigo = loteProductoRepository.existsByCodigoLote(codigoLote);
+                    if (existeCodigo) {
                         throw new ResponseStatusException(HttpStatus.CONFLICT, "CODIGO_LOTE_DUPLICADO");
                     }
                     orden.setLoteProduccion(codigoLote);
@@ -1226,8 +1226,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     throw new ResponseStatusException(HttpStatus.CONFLICT, "LOTE_PT_INCOMPATIBLE");
                 }
                 if (codigoLote != null && lote.getCodigoLote() != null && !lote.getCodigoLote().equals(codigoLote)) {
-                    Optional<LoteProducto> existente = loteProductoRepository.findByCodigoLote(codigoLote);
-                    if (existente.isPresent() && !existente.get().getId().equals(lote.getId())) {
+                    boolean existeCodigo = loteProductoRepository.existsByCodigoLote(codigoLote);
+                    if (existeCodigo) {
                         throw new ResponseStatusException(HttpStatus.CONFLICT, "CODIGO_LOTE_DUPLICADO");
                     }
                 } else if (lote.getCodigoLote() == null && codigoLote != null) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/LoteResolverControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/LoteResolverControllerTest.java
@@ -43,10 +43,11 @@ class LoteResolverControllerTest {
     @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
     void retornaProductoCuandoElLoteExiste() throws Exception {
         ProductoPorLoteDTO dto = new ProductoPorLoteDTO(1L, "SKU-123", "Producto Demo");
-        when(loteProductoService.resolverProductoPorLote(eq("L-001"))).thenReturn(dto);
+        when(loteProductoService.resolverProductoPorLote(eq("L-001"), eq(99L))).thenReturn(dto);
 
         mockMvc.perform(get("/api/inventario/lotes/resolver-producto")
                         .param("codigoLote", "L-001")
+                        .param("ordenProduccionId", "99")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.productoId").value(1))
@@ -57,16 +58,17 @@ class LoteResolverControllerTest {
     @Test
     @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
     void retornaErrorControladoCuandoNoExisteLote() throws Exception {
-        when(loteProductoService.resolverProductoPorLote(eq("NOPE")))
-                .thenThrow(new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "LOTE_NO_EXISTE"));
+        when(loteProductoService.resolverProductoPorLote(eq("NOPE"), eq(1L)))
+                .thenThrow(new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO, "LOTE_NO_ENCONTRADO"));
 
         mockMvc.perform(get("/api/inventario/lotes/resolver-producto")
                         .param("codigoLote", "NOPE")
+                        .param("ordenProduccionId", "1")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("RECURSO_NO_ENCONTRADO"))
-                .andExpect(jsonPath("$.message").value("LOTE_NO_EXISTE"));
+                .andExpect(jsonPath("$.message").value("LOTE_NO_ENCONTRADO"));
 
-        Mockito.verify(loteProductoService).resolverProductoPorLote("NOPE");
+        Mockito.verify(loteProductoService).resolverProductoPorLote("NOPE", 1L);
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -493,7 +493,7 @@ class OrdenProduccionServiceReservaTest {
         when(almacenRepository.findById(1L)).thenReturn(Optional.of(almacenPt));
         when(almacenRepository.findById(2L)).thenReturn(Optional.of(almacenCuarentena));
         when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(1L, 10L)).thenReturn(Optional.empty());
-        when(loteProductoRepository.findByCodigoLote(any())).thenReturn(Optional.empty());
+        when(loteProductoRepository.existsByCodigoLote(any())).thenReturn(false);
         when(loteProductoRepository.save(any(LoteProducto.class))).thenAnswer(invocation -> {
             LoteProducto lote = invocation.getArgument(0);
             lote.setId(555L);


### PR DESCRIPTION
## Summary
- update lote resolver endpoint to require orden de produccion context and handle ambiguous or missing lots
- add repository query for codigo de lote plus orden de produccion and adjust service to return controlled errors
- align controller/test clients and production order service with new validations

## Testing
- mvn -q -DskipTests compile *(fails: dependency download returned 502 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c235cbc8c8333bf5674c5bda7aa21)