### PR TITLE
Corregir filtro de búsqueda de productos: respetar `term` y `activo`, buscar por nombre/sku/etiqueta

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -44,8 +44,11 @@ public class ProductoController {
             "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD')")
     public ResponseEntity<Page<ProductoOptionDTO>> buscarProductos(
             @RequestParam(name = "q", required = false) String q,
+            @RequestParam(name = "term", required = false) String term,
+            @RequestParam(name = "activo", required = false) Boolean activo,
             @PageableDefault(size = 10, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {
-        Page<ProductoOptionDTO> page = productoService.buscarOpciones(q, pageable);
+        String criterio = (term != null && !term.isBlank()) ? term : q;
+        Page<ProductoOptionDTO> page = productoService.buscarOpciones(criterio, activo, pageable);
         return ResponseEntity.ok(page);
     }
 
@@ -260,4 +263,3 @@ public class ProductoController {
     }
 
 }
-

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -47,11 +47,15 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
     @Query("""
     select p
     from Producto p
-    where (:q is null or :q = ''
-           or lower(p.nombre) like lower(concat('%', :q, '%'))
-           or lower(p.codigoSku) like lower(concat('%', :q, '%')))
+    where (:activo is null or p.activo = :activo)
+      and (
+            :q is null or :q = ''
+         or lower(p.nombre) like lower(concat('%', :q, '%'))
+         or lower(p.codigoSku) like lower(concat('%', :q, '%'))
+         or lower(concat(p.nombre, ' (', p.codigoSku, ')')) like lower(concat('%', :q, '%'))
+      )
     """)
-    Page<Producto> buscarPorTexto(@Param("q") String q, Pageable pageable);
+    Page<Producto> buscarPorTexto(@Param("q") String q, @Param("activo") Boolean activo, Pageable pageable);
 
     /**
      * Busca insumos (MP, ME, suministros y semielaborados) por nombre.
@@ -134,4 +138,3 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
             Pageable pageable
     );
 }
-

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -34,7 +34,7 @@ public interface ProductoService {
      */
     Producto findById(Long id);
 
-    Page<ProductoOptionDTO> buscarOpciones(String q, Pageable pageable);
+    Page<ProductoOptionDTO> buscarOpciones(String q, Boolean activo, Pageable pageable);
 
     Page<ProductoResumenDTO> buscarInsumos(String term, Pageable pageable);
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -367,7 +367,7 @@ public class ProductoServiceImpl implements ProductoService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ProductoOptionDTO> buscarOpciones(String q, Pageable pageable) {
+    public Page<ProductoOptionDTO> buscarOpciones(String q, Boolean activo, Pageable pageable) {
         // Mantén tu “safe sort”
         Sort sort = pageable.getSort();
         Sort safe = Sort.by(sort.stream()
@@ -378,7 +378,8 @@ public class ProductoServiceImpl implements ProductoService {
                 }).toList());
         Pageable safePage = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), safe);
 
-        Page<Producto> page = productoRepository.buscarPorTexto(q, safePage);
+        String term = q == null ? null : q.trim();
+        Page<Producto> page = productoRepository.buscarPorTexto(term, activo, safePage);
 
         // ✅ Ahora mapeamos también la unidad
         return page.map(p -> {
@@ -634,4 +635,3 @@ public class ProductoServiceImpl implements ProductoService {
     }
 
 }
-

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.dto.ProductoOptionDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.ProductoMapper;
@@ -31,6 +32,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -46,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -295,6 +298,38 @@ class ProductoServiceImplTest {
                         TipoCategoria.PRODUCTO_SEMI_ELABORADO
                 );
         assertThat(termCaptor.getValue()).isEqualTo("ps");
+    }
+
+    @Test
+    @DisplayName("buscarOpciones debe normalizar el término y respetar filtro activo")
+    void buscarOpciones_normalizaTerminoYFiltraActivos() {
+        Pageable pageable = PageRequest.of(0, 5, Sort.by("nombre").ascending());
+        Producto producto = new Producto();
+        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
+        when(productoRepository.buscarPorTexto(anyString(), any(Boolean.class), any(Pageable.class)))
+                .thenReturn(page);
+
+        Page<ProductoOptionDTO> resultado = service.buscarOpciones("  RVC ", true, pageable);
+
+        assertThat(resultado.getTotalElements()).isEqualTo(1);
+        ArgumentCaptor<String> termCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> activoCaptor = ArgumentCaptor.forClass(Boolean.class);
+        verify(productoRepository).buscarPorTexto(termCaptor.capture(), activoCaptor.capture(), any(Pageable.class));
+        assertThat(termCaptor.getValue()).isEqualTo("RVC");
+        assertThat(activoCaptor.getValue()).isTrue();
+    }
+
+    @Test
+    @DisplayName("buscarOpciones debe permitir consultas sin término y sin filtro de estado")
+    void buscarOpciones_sinTerminoNoFiltraEstado() {
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("codigoSku"));
+        when(productoRepository.buscarPorTexto(null, null, pageable))
+                .thenReturn(Page.empty(pageable));
+
+        Page<ProductoOptionDTO> resultado = service.buscarOpciones(null, null, pageable);
+
+        assertThat(resultado).isEmpty();
+        verify(productoRepository).buscarPorTexto(null, null, pageable);
     }
 
     private CategoriaProducto categoria(TipoCategoria tipo) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.willyes.clemenintegra.inventario.controller.ProductoController;
+import com.willyes.clemenintegra.inventario.dto.ProductoOptionDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.UnidadMedidaResponseDTO;
@@ -34,7 +35,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -154,6 +157,33 @@ class ProductoControllerSmokeTest {
                 .andExpect(jsonPath("$.content[0].sku").value("SKU-010"))
                 .andExpect(jsonPath("$.totalElements").value(1))
                 .andExpect(jsonPath("$.totalPages").value(1));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    @DisplayName("GET /api/productos/buscar utiliza term/activo y devuelve opciones")
+    void buscarProductos_conTerminoYActivo() throws Exception {
+        ProductoOptionDTO option = ProductoOptionDTO.builder()
+                .id(5L)
+                .nombre("Producto RVC")
+                .sku("RVC001")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ProductoOptionDTO> page = new PageImpl<>(List.of(option), pageable, 1);
+        when(productoService.buscarOpciones(anyString(), any(Boolean.class), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/productos/buscar")
+                        .param("term", "RVC")
+                        .param("activo", "true")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(5))
+                .andExpect(jsonPath("$.content[0].sku").value("RVC001"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+
+        verify(productoService).buscarOpciones(eq("RVC"), eq(true), any(Pageable.class));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- El endpoint de autocomplete estaba ignorando el parámetro de búsqueda y devolvía resultados genéricos porque el `term`/`q` no se aplicaba correctamente en la consulta.
- Se necesitaba que la búsqueda devuelva coincidencias por `nombre`, `codigoSku` o la `etiqueta` (ej. `Nombre (SKU)`) y que respete el filtro `activo` cuando se solicita.

### Description
- El controlador `GET /api/productos/buscar` ahora acepta `term` y `activo` y prioriza `term` sobre `q`, pasando ambos al servicio mediante `productoService.buscarOpciones(criterio, activo, pageable)`.
- Se actualizó la firma del servicio `buscarOpciones` a `buscarOpciones(String q, Boolean activo, Pageable pageable)` y la implementación normaliza el término con `trim()` antes de llamar al repositorio.
- La consulta JPA en `ProductoRepository.buscarPorTexto` se modificó para aplicar `activo` cuando se recibe y para buscar case-insensitive en `nombre`, `codigoSku` y en la etiqueta generada `concat(nombre, ' (', codigoSku, ')')` usando `lower(...) like lower(concat('%', :q, '%'))`.
- Añadí pruebas unitarias y de controlador (`ProductoServiceImplTest` y `ProductoControllerSmokeTest`) que validan normalización del término, el respeto al filtro `activo` y la integración del nuevo contrato del endpoint.

### Testing
- Ejecutado: `mvn -Dtest=ProductoServiceImplTest,ProductoControllerSmokeTest test`.
- Resultado: las pruebas seleccionadas pasaron correctamente (`Tests run: 15, Failures: 0, Errors: 0, Skipped: 0`) y el `mvn` finalizó con `BUILD SUCCESS`.
- También compilación del módulo verificada durante la ejecución de los tests y correcciones aplicadas hasta resolver errores de imports en tests.  
- Cambios verificados localmente mediante las pruebas añadidas que cubren consultas con y sin término y con/ sin `activo`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c549505648333ae877abe1bb54efc)