### PR TITLE
Expose product and lot data for production movement traceability

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.inventario.mapper;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import org.mapstruct.*;
 
@@ -62,7 +63,10 @@ public interface MovimientoInventarioMapper {
 
         dto.setCantidad(m.getCantidad());
 
-        var p = m.getProducto();
+        Producto p = m.getProducto();
+        if (p == null && m.getLote() != null) {
+            p = m.getLote().getProducto();
+        }
         dto.setProductoId(p != null ? (p.getId() == null ? null : Long.valueOf(p.getId())) : null);
         dto.setNombreProducto(p != null ? p.getNombre() : null);
         dto.setSku(p != null ? p.getCodigoSku() : null);

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -95,31 +95,59 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     boolean existsBySolicitudMovimientoId(Long solicitudMovimientoId);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "lote.producto",
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+    })
     Page<MovimientoInventario> findByOrdenProduccionId(Long ordenProduccionId, Pageable pageable);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "lote.producto",
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+    })
     Page<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaId(Long ordenProduccionId,
                                                                                Long ordenProduccionEtapaId,
                                                                                Pageable pageable);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "lote.producto",
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+    })
     Page<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacion(
             Long ordenProduccionId,
             Long ordenProduccionEtapaId,
             ClasificacionMovimientoInventario clasificacion,
             Pageable pageable);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "lote.producto",
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+    })
     List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdOrderByFechaIngresoAsc(
             Long ordenProduccionId,
             Long ordenProduccionEtapaId);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "lote.producto",
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+    })
     List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(
             Long ordenProduccionId,
             Long ordenProduccionEtapaId,
             ClasificacionMovimientoInventario clasificacion);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "lote.producto",
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+    })
     List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdOrderByFechaIngresoDesc(
             Long ordenProduccionId,
             Long ordenProduccionEtapaId);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "lote.producto",
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+    })
     List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoDesc(
             Long ordenProduccionId,
             Long ordenProduccionEtapaId,
@@ -138,6 +166,10 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
                                                                          @Nullable TipoMovimiento tipoMovimiento,
                                                                          Pageable pageable);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "lote.producto",
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+    })
     Page<MovimientoInventario> findByOrdenProduccionIdAndClasificacion(Long ordenProduccionId,
                                                                        ClasificacionMovimientoInventario clasificacion,
                                                                        Pageable pageable);
@@ -303,6 +335,10 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
                                                 @Param("ordenProduccionId") Long ordenProduccionId,
                                                 @Param("etapaProduccionId") Long etapaProduccionId);
 
+    @EntityGraph(attributePaths = {
+            "producto", "producto.unidadMedida", "lote", "lote.producto",
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+    })
     List<MovimientoInventario> findByOrdenProduccionIdOrderByFechaIngresoAsc(Long ordenProduccionId);
 
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionMovimientosControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionMovimientosControllerTest.java
@@ -1,0 +1,197 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OrdenProduccionMovimientosControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private AlmacenRepository almacenRepository;
+
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+
+    @Autowired
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+
+    @Autowired
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+
+    @Autowired
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+
+    @Autowired
+    private OrdenProduccionRepository ordenProduccionRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @BeforeEach
+    void setup() {
+        movimientoInventarioRepository.deleteAll();
+        loteProductoRepository.deleteAll();
+        ordenProduccionRepository.deleteAll();
+        productoRepository.deleteAll();
+        categoriaProductoRepository.deleteAll();
+        unidadMedidaRepository.deleteAll();
+        almacenRepository.deleteAll();
+        usuarioRepository.deleteAll();
+        motivoMovimientoRepository.deleteAll();
+        tipoMovimientoDetalleRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void listarMovimientosIncluyeDatosDeProductoYLote() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("tester")
+                .clave("clave")
+                .nombreCompleto("Usuario Tester")
+                .correo("tester@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidadMedida = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .nombrePlural("Unidades")
+                .simbolo("u")
+                .codigo("UND")
+                .simboloImpresion("u")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("PT")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-ENTRADA")
+                .nombre("Producto Entrada")
+                .stockMinimo(BigDecimal.ZERO)
+                .activo(true)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidadMedida)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+
+        OrdenProduccion ordenProduccion = ordenProduccionRepository.save(OrdenProduccion.builder()
+                .codigoOrden("OP-100")
+                .loteProduccion("LOTE-OP-100")
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(new BigDecimal("10"))
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .producto(producto)
+                .unidadMedida(unidadMedida)
+                .responsable(usuario)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Principal")
+                .ubicacion("Bodega Central")
+                .categoria(TipoCategoria.PRODUCTO_TERMINADO)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        LoteProducto lote = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LOTE-123")
+                .stockLote(new BigDecimal("50"))
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(producto)
+                .almacen(almacen)
+                .build());
+
+        MotivoMovimiento motivo = motivoMovimientoRepository.save(MotivoMovimiento.builder()
+                .descripcion("Entrada producto terminado")
+                .motivo(ClasificacionMovimientoInventario.ENTRADA_PRODUCTO_TERMINADO)
+                .build());
+
+        TipoMovimientoDetalle tipoDetalle = tipoMovimientoDetalleRepository.save(
+                TipoMovimientoDetalle.builder()
+                        .descripcion("Entrada PT")
+                        .build()
+        );
+
+        movimientoInventarioRepository.save(MovimientoInventario.builder()
+                .cantidad(new BigDecimal("5"))
+                .tipoMovimiento(TipoMovimiento.ENTRADA)
+                .clasificacion(ClasificacionMovimientoInventario.ENTRADA_PRODUCTO_TERMINADO)
+                .registradoPor(usuario)
+                .producto(producto)
+                .lote(lote)
+                .almacenDestino(almacen)
+                .motivoMovimiento(motivo)
+                .tipoMovimientoDetalle(tipoDetalle)
+                .ordenProduccion(ordenProduccion)
+                .build());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}/movimientos", ordenProduccion.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].productoId").value(producto.getId()))
+                .andExpect(jsonPath("$.content[0].codigoSku").value(producto.getCodigoSku()))
+                .andExpect(jsonPath("$.content[0].loteId").value(lote.getId()))
+                .andExpect(jsonPath("$.content[0].codigoLote").value(lote.getCodigoLote()))
+                .andExpect(jsonPath("$.content[0].nombreProducto").value(producto.getNombre()));
+    }
+}


### PR DESCRIPTION
### Motivation
- Production movement rows lacked the minimal product/lote identifiers required by the frontend to open the Kardex and showed `-` in the Producto column.
- The endpoint needed to expose `productoId`/`codigoSku` and `loteId` when applicable, without introducing N+1 query problems.

### Description
- Added `@EntityGraph` to the `MovimientoInventarioRepository` production-related queries so `producto`, `lote` and related metadata (e.g. `producto.unidadMedida`) are fetched eagerly and avoid N+1 queries.
- Updated `MovimientoInventarioMapper.safeToResponseDTO` to populate `productoId`, `codigoSku` and `nombreProducto` from `movimiento.getProducto()` or, if null, from `movimiento.getLote().getProducto()` as a fallback.
- Added an integration test `OrdenProduccionMovimientosControllerTest` that creates an OP, product, lote and an ENTRADA movement and asserts the `/api/produccion/ordenes/{id}/movimientos` response includes `productoId`, `codigoSku`, `loteId`, `codigoLote` and `nombreProducto`.
- Main files changed: `MovimientoInventarioRepository`, `MovimientoInventarioMapper`, and the new test `OrdenProduccionMovimientosControllerTest`.

### Testing
- Ran the full test suite with `mvn -q test`, which initially surfaced unrelated context/setup failures during the long suite run.
- Executed the focused integration test with `mvn -q -Dtest=OrdenProduccionMovimientosControllerTest test`, and the new test passed.
- The targeted test verifies the JSON payload contains `productoId`, `codigoSku`, `loteId`, `codigoLote` and `nombreProducto` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c6c711bb083339cf96a8f1cb61bbc)