### PR TITLE
Prioritize loteId resolution for /api/inventario/kardex

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/KardexController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/KardexController.java
@@ -39,6 +39,7 @@ public class KardexController {
             @RequestParam(required = false) Long productoId,
             @RequestParam(required = false) String codigoSku,
             @RequestParam(required = false) Long loteId,
+            @RequestParam(name = "loteProductoId", required = false) Long loteProductoId,
             @RequestParam(required = false) String codigoLote,
             @RequestParam(required = false) String fechaDesde,
             @RequestParam(required = false) String fechaHasta,
@@ -56,7 +57,7 @@ public class KardexController {
         KardexFiltro filtro = KardexFiltro.builder()
                 .productoId(productoId)
                 .codigoSku(codigoSku)
-                .loteId(loteId)
+                .loteId(loteId != null ? loteId : loteProductoId)
                 .codigoLote(codigoLote)
                 .fechaDesde(inicio)
                 .fechaHasta(fin)

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/KardexServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/KardexServiceImpl.java
@@ -101,9 +101,33 @@ public class KardexServiceImpl implements KardexService {
                                       Long almacenId,
                                       Long ordenProduccionId) {
         if (loteId != null) {
-            Optional<LoteProducto> lote = loteProductoRepository.findById(loteId);
-            return lote.filter(lp -> Objects.equals(lp.getProducto() != null ? lp.getProducto().getId().longValue() : null, productoId))
-                    .orElseThrow(() -> new IllegalArgumentException("Lote no pertenece al producto"));
+            LoteProducto lote = loteProductoRepository.findById(loteId)
+                    .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.KARDEX_PARAM_INVALIDO,
+                            "Lote no encontrado; verifique loteId",
+                            detallesLoteId(loteId, codigoLote, productoId)));
+
+            Long loteProductoId = lote.getProducto() != null ? lote.getProducto().getId().longValue() : null;
+            if (productoId != null && !Objects.equals(loteProductoId, productoId)) {
+                throw new CustomBusinessException(ApiErrorCode.KARDEX_PARAM_INVALIDO,
+                        "El lote indicado no pertenece al producto solicitado",
+                        detallesLoteId(loteId, codigoLote, productoId));
+            }
+            if (StringUtils.hasText(codigoLote) && !codigoLote.equals(lote.getCodigoLote())) {
+                throw new CustomBusinessException(ApiErrorCode.KARDEX_PARAM_INVALIDO,
+                        "El codigoLote no coincide con el loteId proporcionado",
+                        detallesLoteId(loteId, codigoLote, productoId));
+            }
+            if (almacenId != null && (lote.getAlmacen() == null || !Objects.equals(lote.getAlmacen().getId().longValue(), almacenId))) {
+                throw new CustomBusinessException(ApiErrorCode.KARDEX_PARAM_INVALIDO,
+                        "El lote indicado no pertenece al almacén solicitado",
+                        detallesLoteId(loteId, codigoLote, productoId));
+            }
+            if (ordenProduccionId != null && (lote.getOrdenProduccion() == null || !Objects.equals(lote.getOrdenProduccion().getId(), ordenProduccionId))) {
+                throw new CustomBusinessException(ApiErrorCode.KARDEX_PARAM_INVALIDO,
+                        "El lote indicado no pertenece a la orden de producción solicitada",
+                        detallesLoteId(loteId, codigoLote, productoId));
+            }
+            return lote;
         }
         if (StringUtils.hasText(codigoLote)) {
             List<LoteProducto> lotes = loteProductoRepository.findAllByCodigoLoteAndProductoId(codigoLote, productoId);
@@ -139,13 +163,21 @@ public class KardexServiceImpl implements KardexService {
                         detallesLote(codigoLote, productoId, almacenId, ordenProduccionId, lotes));
             }
 
-            log.warn("Kardex: múltiples lotes con código {}, productoId {}, sin criterios suficientes para desambiguar (almacenId={}, ordenProduccionId={})",
+            log.warn("Kardex: múltiples lotes con código {}, productoId {}, sin criterios suficientes para desambiguar (almacenId={}, ordenProduccionId={}). Solicite loteId.",
                     codigoLote, productoId, almacenId, ordenProduccionId);
             throw new CustomBusinessException(ApiErrorCode.KARDEX_PARAM_INVALIDO,
-                    "Existen múltiples lotes con el mismo código; envíe loteId, almacenId u ordenProduccionId para desambiguar",
+                    "Existen múltiples lotes con el mismo código; envíe loteId para desambiguar (opcionalmente almacenId u ordenProduccionId)",
                     detallesLote(codigoLote, productoId, almacenId, ordenProduccionId, lotes));
         }
         return null;
+    }
+
+    private Object detallesLoteId(Long loteId, String codigoLote, Long productoId) {
+        java.util.Map<String, Object> detalles = new java.util.LinkedHashMap<>();
+        detalles.put("loteId", loteId);
+        detalles.put("codigoLote", codigoLote);
+        detalles.put("productoId", productoId);
+        return detalles;
     }
 
     private Object detallesLote(String codigoLote,

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/KardexControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/KardexControllerSecurityTest.java
@@ -113,11 +113,14 @@ class KardexControllerSecurityTest {
 
         mockMvc.perform(get("/api/inventario/kardex")
                         .param("productoId", "9")
+                        .param("loteProductoId", "123")
                         .with(SecurityMockMvcRequestPostProcessors.user("superadmin")
                                 .authorities(() -> "ROL_SUPER_ADMIN")))
                 .andExpect(status().isOk());
 
-        verify(kardexService).obtenerKardex(any());
+        ArgumentCaptor<KardexFiltro> captor = ArgumentCaptor.forClass(KardexFiltro.class);
+        verify(kardexService).obtenerKardex(captor.capture());
+        assertThat(captor.getValue().getLoteId()).isEqualTo(123L);
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/KardexServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/KardexServiceImplTest.java
@@ -12,6 +12,7 @@ import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -245,6 +246,80 @@ class KardexServiceImplTest {
         assertThat(resultado).hasSize(1);
         assertThat(resultado.get(0).getCodigoSku()).isEqualTo("SKU-03");
         verify(movimientoInventarioRepository).buscarParaKardex(null, null, 3L, null, null, 10L, null);
+    }
+
+    @Test
+    void priorizaLoteIdYValidaConsistencia() {
+        Producto producto = crearProducto(32, "ME0493", "Producto con lote");
+        LoteProducto lote = new LoteProducto();
+        lote.setId(94L);
+        lote.setCodigoLote("655412GSG");
+        lote.setProducto(producto);
+
+        when(productoRepository.findById(32L)).thenReturn(Optional.of(producto));
+        when(loteProductoRepository.findById(94L)).thenReturn(Optional.of(lote));
+        when(movimientoInventarioRepository.buscarParaKardex(any(), any(), eq(32L), eq(94L), any(), any(), any()))
+                .thenReturn(List.of());
+
+        KardexFiltro filtro = KardexFiltro.builder()
+                .productoId(32L)
+                .codigoLote("655412GSG")
+                .loteId(94L)
+                .build();
+
+        List<KardexItemDTO> resultado = kardexService.obtenerKardex(filtro);
+
+        assertThat(resultado).isEmpty();
+        verify(movimientoInventarioRepository).buscarParaKardex(null, null, 32L, 94L, null, null, null);
+    }
+
+    @Test
+    void rechazaLoteIdQueNoPerteneceAlProducto() {
+        Producto producto = crearProducto(10, "SKU-10", "Producto X");
+        Producto otroProducto = crearProducto(99, "SKU-99", "Otro");
+        LoteProducto lote = new LoteProducto();
+        lote.setId(500L);
+        lote.setCodigoLote("COD-500");
+        lote.setProducto(otroProducto);
+
+        when(productoRepository.findById(10L)).thenReturn(Optional.of(producto));
+        when(loteProductoRepository.findById(500L)).thenReturn(Optional.of(lote));
+
+        KardexFiltro filtro = KardexFiltro.builder()
+                .productoId(10L)
+                .loteId(500L)
+                .codigoLote("COD-500")
+                .build();
+
+        Assertions.assertThatThrownBy(() -> kardexService.obtenerKardex(filtro))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("no pertenece al producto");
+    }
+
+    @Test
+    void mantieneMensajeClaroParaAmbiguedadSinLoteId() {
+        Producto producto = crearProducto(12, "SKU-12", "Producto Ambiguo");
+        when(productoRepository.findByCodigoSku("SKU-12")).thenReturn(Optional.of(producto));
+
+        LoteProducto loteUno = new LoteProducto();
+        loteUno.setId(700L);
+        loteUno.setProducto(producto);
+
+        LoteProducto loteDos = new LoteProducto();
+        loteDos.setId(701L);
+        loteDos.setProducto(producto);
+
+        when(loteProductoRepository.findAllByCodigoLoteAndProductoId("AMB-01", 12L))
+                .thenReturn(List.of(loteUno, loteDos));
+
+        KardexFiltro filtro = KardexFiltro.builder()
+                .codigoSku("SKU-12")
+                .codigoLote("AMB-01")
+                .build();
+
+        Assertions.assertThatThrownBy(() -> kardexService.obtenerKardex(filtro))
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("loteId");
     }
 
     private Producto crearProducto(Integer id, String sku, String nombre) {


### PR DESCRIPTION
### Motivation
- Fix ambiguous/422 responses when frontend already sends a numeric `loteId` but backend resolves by `codigoLote` causing “Lote no encontrado” or ambiguity errors. 
- Ensure the API accepts the common alias used by clients and remains backward compatible with `codigoLote`-based lookup. 
- Provide deterministic behavior: prefer explicit `loteId` and validate consistency with other filters to avoid returning misleading results. 

### Description
- `KardexController`: added support for the alias `loteProductoId` and build `KardexFiltro` so `loteId` is `loteId != null ? loteId : loteProductoId` to preserve backward compatibility. 
- `KardexServiceImpl`: when `loteId` is provided resolve via `findById`, validate it matches `productoId`, `codigoLote`, `almacenId` and `ordenProduccionId`, and throw `CustomBusinessException(ApiErrorCode.KARDEX_PARAM_INVALIDO)` with a detailed map when inconsistent. 
- Kept existing fallback behavior to lookup by `codigoLote` using `findAllByCodigoLoteAndProductoId(...)` and improved ambiguity/error messages to clearly instruct clients to provide `loteId`. 
- Added a small helper `detallesLoteId(...)` to include `loteId` context in error details. 

### Testing
- Added unit tests in `KardexServiceImplTest` covering: prioritization of `loteId`, rejection when `loteId` belongs to another product, and preserved ambiguity error message when `loteId` is not provided. 
- Updated `KardexControllerSecurityTest` to assert `loteProductoId` is accepted as an alias and propagated to the service. 
- Ran `mvn -Dtest=KardexServiceImplTest,KardexControllerSecurityTest test` and all tests passed (`BUILD SUCCESS`). 
- No security changes were made beyond existing controller test wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c72c6f6e08333bf4e3d7cc25c3196)