### PR TITLE
Expose production stage name in movement responses

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioResponseDTO.java
@@ -37,6 +37,7 @@ public class MovimientoInventarioResponseDTO {
     private String unidad;
     private Long ordenProduccionId;
     private Long ordenProduccionEtapaId;
+    private String nombreEtapaProduccion;
     private String codigoOrdenProduccion;
     private Long solicitudId;
     private EstadoSolicitudMovimiento estadoSolicitud;

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/MovimientoInventarioMapper.java
@@ -85,7 +85,9 @@ public interface MovimientoInventarioMapper {
         dto.setNombreUsuarioRegistrador(u != null ? u.getNombreCompleto() : null);
         dto.setOrdenProduccionId(m.getOrdenProduccion() != null ? m.getOrdenProduccion().getId() : null);
         dto.setCodigoOrdenProduccion(m.getOrdenProduccion() != null ? m.getOrdenProduccion().getCodigoOrden() : null);
-        dto.setOrdenProduccionEtapaId(m.getOrdenProduccionEtapa() != null ? m.getOrdenProduccionEtapa().getId() : null);
+        var etapa = m.getOrdenProduccionEtapa();
+        dto.setOrdenProduccionEtapaId(etapa != null ? etapa.getId() : null);
+        dto.setNombreEtapaProduccion(etapa != null ? etapa.getNombre() : null);
         dto.setUnidad(m.getProducto() != null && m.getProducto().getUnidadMedida() != null
                 ? m.getProducto().getUnidadMedida().getNombre()
                 : null);

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 public interface MovimientoInventarioRepository extends JpaRepository<MovimientoInventario, Long> {
 
     @EntityGraph(attributePaths = {
-            "producto", "lote", "almacenOrigen", "almacenDestino", "registradoPor"
+            "producto", "lote", "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
     })
     @Query("""
     select m
@@ -43,7 +43,7 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
     );
 
     @EntityGraph(attributePaths = {
-            "producto", "lote", "almacenOrigen", "almacenDestino", "registradoPor"
+            "producto", "lote", "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
     })
     @Query("""
     select m
@@ -154,7 +154,7 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
             ClasificacionMovimientoInventario clasificacion);
 
     @EntityGraph(attributePaths = {
-            "producto", "lote", "almacenOrigen", "almacenDestino", "registradoPor"
+            "producto", "lote", "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
     })
     @Query("""
             select m

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -792,6 +792,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                             ? solicitud.getOrdenProduccion().getCodigoOrden()
                             : null)
                     .ordenProduccionEtapaId(dto.ordenProduccionEtapaId())
+                    .nombreEtapaProduccion(resolverNombreEtapaProduccion(dto.ordenProduccionEtapaId()))
                     .detallesSolicitud(detallesRespuesta == null ? List.of() : List.copyOf(detallesRespuesta))
                     .build();
         }
@@ -3384,6 +3385,15 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                 det.setEstado(com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle.ATENDIDO);
             }
         }
+    }
+
+    private String resolverNombreEtapaProduccion(Long etapaId) {
+        if (etapaId == null) {
+            return null;
+        }
+        return etapaProduccionRepository.findById(etapaId)
+                .map(EtapaProduccion::getNombre)
+                .orElse(null);
     }
 
     private Long resolverEtapaConsumo(Long ordenProduccionId, Long etapaId) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionMovimientosControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionMovimientosControllerTest.java
@@ -9,8 +9,10 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
@@ -73,6 +75,9 @@ class OrdenProduccionMovimientosControllerTest {
     @Autowired
     private OrdenProduccionRepository ordenProduccionRepository;
 
+    @Autowired
+    private EtapaProduccionRepository etapaProduccionRepository;
+
     @MockBean
     private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
 
@@ -82,6 +87,7 @@ class OrdenProduccionMovimientosControllerTest {
     @BeforeEach
     void setup() {
         movimientoInventarioRepository.deleteAll();
+        etapaProduccionRepository.deleteAll();
         loteProductoRepository.deleteAll();
         ordenProduccionRepository.deleteAll();
         productoRepository.deleteAll();
@@ -193,5 +199,111 @@ class OrdenProduccionMovimientosControllerTest {
                 .andExpect(jsonPath("$.content[0].loteId").value(lote.getId()))
                 .andExpect(jsonPath("$.content[0].codigoLote").value(lote.getCodigoLote()))
                 .andExpect(jsonPath("$.content[0].nombreProducto").value(producto.getNombre()));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void listarMovimientosIncluyeNombreDeEtapaCuandoExiste() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("tester-etapa")
+                .clave("clave")
+                .nombreCompleto("Usuario Tester Etapa")
+                .correo("tester+etapa@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidadMedida = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .nombrePlural("Unidades")
+                .simbolo("u")
+                .codigo("UND")
+                .simboloImpresion("u")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("PT")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-ETAPA")
+                .nombre("Producto con Etapa")
+                .stockMinimo(BigDecimal.ZERO)
+                .activo(true)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidadMedida)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+
+        OrdenProduccion ordenProduccion = ordenProduccionRepository.save(OrdenProduccion.builder()
+                .codigoOrden("OP-200")
+                .loteProduccion("LOTE-OP-200")
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(new BigDecimal("20"))
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .producto(producto)
+                .unidadMedida(unidadMedida)
+                .responsable(usuario)
+                .build());
+
+        EtapaProduccion etapa = etapaProduccionRepository.save(EtapaProduccion.builder()
+                .nombre("Acondicionado")
+                .secuencia(1)
+                .ordenProduccion(ordenProduccion)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Principal")
+                .ubicacion("Bodega Central")
+                .categoria(TipoCategoria.PRODUCTO_TERMINADO)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        LoteProducto lote = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LOTE-456")
+                .stockLote(new BigDecimal("25"))
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(producto)
+                .almacen(almacen)
+                .build());
+
+        MotivoMovimiento motivo = motivoMovimientoRepository.save(MotivoMovimiento.builder()
+                .descripcion("Consumo etapa")
+                .motivo(ClasificacionMovimientoInventario.SALIDA_PRODUCCION)
+                .build());
+
+        TipoMovimientoDetalle tipoDetalle = tipoMovimientoDetalleRepository.save(
+                TipoMovimientoDetalle.builder()
+                        .descripcion("Consumo etapa")
+                        .build()
+        );
+
+        movimientoInventarioRepository.save(MovimientoInventario.builder()
+                .cantidad(new BigDecimal("7"))
+                .tipoMovimiento(TipoMovimiento.SALIDA)
+                .clasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION)
+                .registradoPor(usuario)
+                .producto(producto)
+                .lote(lote)
+                .almacenOrigen(almacen)
+                .motivoMovimiento(motivo)
+                .tipoMovimientoDetalle(tipoDetalle)
+                .ordenProduccion(ordenProduccion)
+                .ordenProduccionEtapa(etapa)
+                .build());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}/movimientos", ordenProduccion.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].ordenProduccionEtapaId").value(etapa.getId()))
+                .andExpect(jsonPath("$.content[0].nombreEtapaProduccion").value(etapa.getNombre()));
     }
 }


### PR DESCRIPTION
### Motivation
- The production traceability UI shows raw stage IDs that are not user friendly, so the response must include the stage name while remaining backward compatible.
- The new field must be nullable and not change existing endpoint signatures or fields.
- Avoid N+1 queries when resolving stage names for paged results by ensuring necessary associations are fetched.

### Description
- Added a nullable `nombreEtapaProduccion` field to `MovimientoInventarioResponseDTO` and kept all existing fields unchanged.
- Mapped the new field in `MovimientoInventarioMapper.safeToResponseDTO` by reading `m.getOrdenProduccionEtapa().getNombre()` when present.
- Extended `@EntityGraph` attributePaths on relevant `MovimientoInventarioRepository` queries to include `ordenProduccion` and `ordenProduccionEtapa` to prevent extra queries.
- Populated the stage name in the idempotent response branch of `MovimientoInventarioServiceImpl` via a small helper `resolverNombreEtapaProduccion`, and added an integration test that asserts the field is present when an etapa exists.

### Testing
- Ran the integration test class with `mvn -q -Dtest=OrdenProduccionMovimientosControllerTest test` which executed the updated tests.
- The targeted test suite completed successfully (no failing tests observed for the executed test class).
- Existing movements listing behavior remains unchanged for callers that ignore the new nullable field.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c7a45f9448333b1518a989db8514d)