### PR TITLE
Add Flyway migration to convert documentos.tipo and estado to ENUMs

### DIFF
--- a/src/main/resources/db/migration/inventario/V20251236__documentos_tipo_estado_enum.sql
+++ b/src/main/resources/db/migration/inventario/V20251236__documentos_tipo_estado_enum.sql
@@ -1,0 +1,21 @@
+-- V20251236 - Normalizar documentos.tipo y documentos.estado a ENUM mayúscula
+-- Objetivo: alinear ddl-auto=validate con enums de la entidad (TipoDocumento y EstadoDocumento)
+
+-- 1) Normalizar datos existentes (UPPER)
+UPDATE documentos
+SET tipo = UPPER(tipo),
+    estado = UPPER(estado);
+
+-- 2) Backfill/fallback de valores nulos o inválidos
+UPDATE documentos
+SET tipo = 'OTRO'
+WHERE tipo IS NULL OR tipo NOT IN ('PROCEDIMIENTO','FORMATO','REGISTRO','BITACORA_SANITIZACION','BITACORA_CALIBRACION','OTRO');
+
+UPDATE documentos
+SET estado = 'EN_ELABORACION'
+WHERE estado IS NULL OR estado NOT IN ('EN_ELABORACION','VIGENTE','OBSOLETO');
+
+-- 3) Convertir columnas a ENUM con valores exactos de los enums Java
+ALTER TABLE documentos
+    MODIFY COLUMN tipo ENUM('PROCEDIMIENTO','FORMATO','REGISTRO','BITACORA_SANITIZACION','BITACORA_CALIBRACION','OTRO') NOT NULL,
+    MODIFY COLUMN estado ENUM('EN_ELABORACION','VIGENTE','OBSOLETO') NOT NULL;


### PR DESCRIPTION
### Motivation
- Align the MySQL schema with the JPA entities so `ddl-auto=validate` no longer fails for `documentos.tipo` and `documentos.estado`.
- Ensure stored values match the Java enums (uppercase exact identifiers) used by the application.
- Normalize existing mixed-case data to uppercase to avoid enum mismatches at runtime.
- Provide safe fallbacks for NULL or invalid values so the ALTER will succeed.

### Description
- Added new Flyway migration `src/main/resources/db/migration/inventario/V20251236__documentos_tipo_estado_enum.sql` that performs normalization and conversion to ENUMs.
- The migration uppercases existing `tipo` and `estado` values and backfills invalid or NULL `tipo` to `OTRO` and `estado` to `EN_ELABORACION`.
- It converts `documentos.tipo` to `ENUM('PROCEDIMIENTO','FORMATO','REGISTRO','BITACORA_SANITIZACION','BITACORA_CALIBRACION','OTRO') NOT NULL` using the exact `TipoDocumento` values from code.
- It converts `documentos.estado` to `ENUM('EN_ELABORACION','VIGENTE','OBSOLETO') NOT NULL` using the exact `EstadoDocumento` values from code.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d80a43e248333bf4c546cddb622cb)