### PR TITLE
Fix LoteProducto listing lazy loading with EntityGraph

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -141,6 +141,18 @@ WHERE lp.codigoLote = :codigoLote
     @EntityGraph(attributePaths = {"producto", "almacen"})
     List<LoteProducto> findByOrdenProduccionId(Long ordenProduccionId);
 
+    @EntityGraph(attributePaths = {
+            "almacen",
+            "producto",
+            "producto.plantillaAnalisisMicrobiologico",
+            "usuarioLiberador",
+            "lotePsOrigen",
+            "ubicacionFisica",
+            "ordenProduccion"
+    })
+    org.springframework.data.domain.Page<LoteProducto> findAll(org.springframework.data.jpa.domain.Specification<LoteProducto> spec,
+                                                              org.springframework.data.domain.Pageable pageable);
+
     @Query("""
       select l
       from LoteProducto l

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceImpl.java
@@ -388,6 +388,7 @@ public class LoteProductoServiceImpl implements LoteProductoService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<LoteProductoResponseDTO> listarTodos(String producto, EstadoLote estado, String almacen,
                                                      Boolean vencidos, LocalDateTime fechaInicio,
                                                      LocalDateTime fechaFin, Pageable pageable) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceLazyLoadingTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/LoteProductoServiceLazyLoadingTest.java
@@ -1,0 +1,169 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.LoteProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UbicacionFisica;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UbicacionFisicaRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class LoteProductoServiceLazyLoadingTest {
+
+    @Autowired
+    private LoteProductoService loteProductoService;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private AlmacenRepository almacenRepository;
+    @Autowired
+    private UbicacionFisicaRepository ubicacionFisicaRepository;
+    @Autowired
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @Test
+    void listarTodosPrecargaRelacionesParaMapper() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("liberador")
+                .clave("secret")
+                .nombreCompleto("Usuario Liberador")
+                .correo("liberador@example.com")
+                .rol(RolUsuario.ROL_JEFE_CALIDAD)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("UND")
+                .codigo("UND")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria Lote")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-LOTE")
+                .nombre("Producto Lote")
+                .descripcionProducto("Producto para lote")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Almacen Lote")
+                .ubicacion("Zona Lote")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        UbicacionFisica ubicacion = ubicacionFisicaRepository.save(UbicacionFisica.builder()
+                .almacen(almacen)
+                .codigo("UB-001")
+                .descripcion("Ubicacion principal")
+                .activo(true)
+                .build());
+
+        OrdenProduccion ordenProduccion = ordenProduccionRepository.save(OrdenProduccion.builder()
+                .codigoOrden("OP-001")
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(BigDecimal.ONE)
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .producto(producto)
+                .unidadMedida(unidad)
+                .responsable(usuario)
+                .build());
+
+        LoteProducto lotePsOrigen = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LP-ORIGEN")
+                .stockLote(BigDecimal.TEN)
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(producto)
+                .almacen(almacen)
+                .build());
+
+        loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LP-001")
+                .stockLote(BigDecimal.ONE)
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(producto)
+                .almacen(almacen)
+                .usuarioLiberador(usuario)
+                .lotePsOrigen(lotePsOrigen)
+                .ubicacionFisica(ubicacion)
+                .ordenProduccion(ordenProduccion)
+                .build());
+
+        Page<LoteProductoResponseDTO> result = loteProductoService.listarTodos(
+                null,
+                null,
+                null,
+                false,
+                null,
+                null,
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        LoteProductoResponseDTO dto = result.getContent().stream()
+                .filter(item -> "LP-001".equals(item.getCodigoLote()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(dto.getNombreAlmacen()).isEqualTo("Almacen Lote");
+        assertThat(dto.getNombreProducto()).isEqualTo("Producto Lote");
+        assertThat(dto.getCodigoOrdenProduccion()).isEqualTo("OP-001");
+    }
+}


### PR DESCRIPTION
### Motivation

- The `LoteProducto` listing flow triggers `LazyInitializationException` when `open-in-view=false` because `LoteProductoMapper` accesses multiple LAZY relations during mapping.
- The goal is to preload the relations the mapper needs in the repository query instead of enabling Open Session In View. 

### Description

- Added a repository paged `findAll` signature annotated with `@EntityGraph` to preload relations: `almacen`, `producto`, `producto.plantillaAnalisisMicrobiologico`, `usuarioLiberador`, `lotePsOrigen`, `ubicacionFisica` and `ordenProduccion` using `@EntityGraph(attributePaths={...})` on `LoteProductoRepository#findAll(Specification, Pageable)`.
- Marked the service listing method `listarTodos` with `@Transactional(readOnly = true)` so mapping with `LoteProductoMapper` runs inside an active transaction/session.
- Added a Spring Boot integration-style test `LoteProductoServiceLazyLoadingTest` that prepares related entities and asserts DTO fields returned by `loteProductoService.listarTodos`, validating the relations are populated for the mapper.
- Did not modify the generated mapper (`LoteProductoMapper`) or its mappings; instead the query was adapted to satisfy its LAZY accesses.

### Testing

- Added automated test `src/test/java/.../LoteProductoServiceLazyLoadingTest.java` that inserts `Producto`, `Almacen`, `Usuario`, `OrdenProduccion`, `UbicacionFisica` and `LoteProducto` records and asserts mapped DTO fields are populated.
- No test suite was executed as part of this change in the rollout (no automated test run was performed).
- The change is limited to repository/service/test code and should be safe to run under the existing test profile (`test`) which uses an in-memory H2 database.
- Runtime behavior: listing continues to use `loteProductoRepository.findAll(spec, pageable)` and mapping remains unchanged but now executes with required associations pre-fetched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e9d599988333b70fe19995f65fc3)