### PR TITLE
Add request-id logging and preload relations to fix 500s (lazy loading)

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -13,11 +13,20 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FormulaProductoRepository extends JpaRepository<FormulaProducto, Long> {
-    @EntityGraph(attributePaths = "detalles")
+    @EntityGraph(attributePaths = {
+            "producto",
+            "producto.unidadMedida",
+            "detalles",
+            "detalles.insumo",
+            "detalles.unidadMedida",
+            "actualizadoPor",
+            "creadoPor"
+    })
     Optional<FormulaProducto> findByProductoId(Long productoId);
 
     @EntityGraph(attributePaths = {
             "producto",
+            "producto.unidadMedida",
             "detalles",
             "detalles.insumo",
             "detalles.unidadMedida",

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -220,11 +220,16 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public FormulaProductoResponse obtenerFormulaActivaPorProducto(Long productoId, BigDecimal cantidad) {
         FormulaProducto formula = formulaRepository
                 .findByProductoIdAndEstadoAndActivoTrue(productoId, EstadoFormula.APROBADA)
                 .orElseThrow(() -> new IllegalArgumentException(
                         "No existe fórmula activa aprobada para este producto."));
+
+        if (formula.getDocumentos() != null) {
+            formula.getDocumentos().size();
+        }
 
         FormulaProductoResponse response = bomMapper.toResponseDTO(formula);
         response.unidadBaseFormula = formula.getProducto() != null && formula.getProducto().getUnidadMedida() != null
@@ -362,4 +367,3 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
         return bomMapper.toFormulaActivaProduccionDTO(formula);
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.TipoIncidente;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -16,24 +17,37 @@ public interface NoConformidadRepository extends JpaRepository<NoConformidad, Lo
 
     Optional<NoConformidad> findFirstByCodigoStartingWithOrderByCodigoDesc(String codigoPrefix);
 
+    @EntityGraph(attributePaths = {"lote", "producto", "evaluacion"})
+    Page<NoConformidad> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"lote", "producto", "evaluacion"})
+    Optional<NoConformidad> findById(Long id);
+
+    @EntityGraph(attributePaths = {"lote", "producto", "evaluacion"})
     Page<NoConformidad> findBySeveridad(SeveridadNoConformidad severidad, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"lote", "producto", "evaluacion"})
     Page<NoConformidad> findByOrigen(OrigenNoConformidad origen, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"lote", "producto", "evaluacion"})
     Page<NoConformidad> findBySeveridadAndOrigen(SeveridadNoConformidad severidad,
                                                  OrigenNoConformidad origen,
                                                  Pageable pageable);
 
+    @EntityGraph(attributePaths = {"lote", "producto", "evaluacion"})
     Page<NoConformidad> findByTipoIncidente(TipoIncidente tipoIncidente, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"lote", "producto", "evaluacion"})
     Page<NoConformidad> findBySeveridadAndTipoIncidente(SeveridadNoConformidad severidad,
-                                                         TipoIncidente tipoIncidente,
-                                                         Pageable pageable);
+                                                        TipoIncidente tipoIncidente,
+                                                        Pageable pageable);
 
+    @EntityGraph(attributePaths = {"lote", "producto", "evaluacion"})
     Page<NoConformidad> findByOrigenAndTipoIncidente(OrigenNoConformidad origen,
                                                      TipoIncidente tipoIncidente,
                                                      Pageable pageable);
 
+    @EntityGraph(attributePaths = {"lote", "producto", "evaluacion"})
     Page<NoConformidad> findBySeveridadAndOrigenAndTipoIncidente(SeveridadNoConformidad severidad,
                                                                  OrigenNoConformidad origen,
                                                                  TipoIncidente tipoIncidente,

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.data.jpa.domain.Specification;
 
 @Repository
 public interface LoteProductoRepository extends JpaRepository<LoteProducto, Long>, JpaSpecificationExecutor<LoteProducto> {
@@ -152,6 +154,17 @@ WHERE lp.codigoLote = :codigoLote
     })
     org.springframework.data.domain.Page<LoteProducto> findAll(org.springframework.data.jpa.domain.Specification<LoteProducto> spec,
                                                               org.springframework.data.domain.Pageable pageable);
+
+    @EntityGraph(attributePaths = {
+            "almacen",
+            "producto",
+            "producto.plantillaAnalisisMicrobiologico",
+            "usuarioLiberador",
+            "lotePsOrigen",
+            "ubicacionFisica",
+            "ordenProduccion"
+    })
+    List<LoteProducto> findAll(Specification<LoteProducto> spec, Sort sort);
 
     @Query("""
       select l

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
@@ -2,11 +2,13 @@ package com.willyes.clemenintegra.produccion.repository;
 
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.domain.Specification;
 
 import jakarta.persistence.LockModeType;
 
@@ -14,8 +16,17 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 public interface OrdenProduccionRepository extends JpaRepository<OrdenProduccion, Long>, JpaSpecificationExecutor<OrdenProduccion> {
+
+    @EntityGraph(attributePaths = {"producto", "producto.categoriaProducto", "unidadMedida", "responsable"})
+    Page<OrdenProduccion> findAll(Specification<OrdenProduccion> spec, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"producto", "producto.categoriaProducto", "unidadMedida", "responsable"})
+    List<OrdenProduccion> findAll(Specification<OrdenProduccion> spec, Sort sort);
 
     Optional<OrdenProduccion> findByLoteProduccion(String loteProduccion);
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -533,6 +533,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
 
     @Override
+    @Transactional(readOnly = true)
     public Page<OrdenProduccionResponseDTO> listarPaginado(String codigo,
                                                            EstadoProduccion estado,
                                                            String responsable,
@@ -549,6 +550,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<OrdenProduccion> listar(String codigo,
                                         EstadoProduccion estado,
                                         String responsable,

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -11,6 +11,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -24,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 
 /**
  * Manejador global de excepciones para toda la aplicación.
@@ -179,10 +183,45 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponseDTO> handleRuntime(RuntimeException ex,
                                                           HttpServletRequest request) {
-        log.error("Error inesperado procesando la solicitud {}", request != null ? request.getRequestURI() : "", ex);
+        logInternalError(ex, request);
         return buildResponse(ApiErrorCode.ERROR_INTERNO,
                 "Ocurrió un error inesperado. Intente nuevamente o contacte soporte.",
                 null);
+    }
+
+    private void logInternalError(Exception ex, HttpServletRequest request) {
+        Throwable root = getRootCause(ex);
+        String requestId = MDC.get("requestId");
+        String method = request != null ? request.getMethod() : null;
+        String uri = request != null ? request.getRequestURI() : null;
+        String query = request != null ? request.getQueryString() : null;
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String usuario = auth != null ? auth.getName() : null;
+        String roles = auth != null
+                ? auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","))
+                : null;
+
+        log.error("Error inesperado requestId={} method={} uri={} query={} usuario={} roles={} rootType={} rootMessage={}",
+                requestId,
+                method,
+                uri,
+                query,
+                usuario,
+                roles,
+                root != null ? root.getClass().getSimpleName() : null,
+                root != null ? root.getMessage() : null,
+                ex);
+    }
+
+    private Throwable getRootCause(Throwable ex) {
+        Throwable current = ex;
+        while (current != null && current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current;
     }
 
     private ResponseEntity<ErrorResponseDTO> buildResponse(ApiErrorCode code, String message, Object details) {

--- a/src/main/java/com/willyes/clemenintegra/shared/logging/RequestIdFilter.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/logging/RequestIdFilter.java
@@ -1,0 +1,39 @@
+package com.willyes.clemenintegra.shared.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Slf4j
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    public static final String HEADER_NAME = "X-Request-Id";
+    public static final String MDC_KEY = "requestId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String requestId = Optional.ofNullable(request.getHeader(HEADER_NAME))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .orElseGet(() -> UUID.randomUUID().toString());
+
+        MDC.put(MDC_KEY, requestId);
+        response.setHeader(HEADER_NAME, requestId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_KEY);
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.shared.security;
 
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
 import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.model.UsuarioPrincipal;
@@ -39,6 +40,7 @@ public class SecurityConfig {
 
     private final UsuarioInactivoFilter usuarioInactivoFilter;
     private final RequestTimingFilter requestTimingFilter;
+    private final RequestIdFilter requestIdFilter;
     private final ObjectProvider<JwtAuthenticationProvider> jwtAuthenticationProviderProvider;
 
     // Orígenes permitidos por perfil (lista separada por comas)
@@ -292,6 +294,8 @@ public class SecurityConfig {
                                     response.getWriter().write("{\"error\":\"No autorizado\"}");
                                 }
                 ));
+
+        http.addFilterBefore(requestIdFilter, UsernamePasswordAuthenticationFilter.class);
 
         JwtAuthenticationProvider jwtAuthenticationProvider = jwtAuthenticationProviderProvider.getIfAvailable();
         if (jwtAuthenticationProvider != null) {

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoActivaIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoActivaIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.willyes.clemenintegra.bom.controller;
+
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class FormulaProductoActivaIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private FormulaProductoRepository formulaProductoRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void obtenerFormulaActiva_porProducto_precargaRelaciones() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("bom-user")
+                .clave("secret")
+                .nombreCompleto("Usuario BOM")
+                .correo("bom-user@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Kilogramo BOM")
+                .simbolo("KBO")
+                .codigo("KBO")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria BOM")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-FORM")
+                .nombre("Producto Formula")
+                .descripcionProducto("Producto formula")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        Producto insumo = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-INS")
+                .nombre("Insumo Formula")
+                .descripcionProducto("Insumo")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        FormulaProducto formula = FormulaProducto.builder()
+                .producto(producto)
+                .version("V1")
+                .estado(EstadoFormula.APROBADA)
+                .fechaCreacion(LocalDateTime.now())
+                .activo(true)
+                .creadoPor(usuario)
+                .detalles(List.of())
+                .documentos(List.of())
+                .build();
+
+        DetalleFormula detalle = DetalleFormula.builder()
+                .formula(formula)
+                .insumo(insumo)
+                .unidadMedida(unidad)
+                .cantidadNecesaria(BigDecimal.ONE)
+                .obligatorio(true)
+                .build();
+
+        formula.setDetalles(List.of(detalle));
+        formulaProductoRepository.save(formula);
+
+        mockMvc.perform(get("/api/bom/formulas/activa")
+                        .param("productoId", formula.getProducto().getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.productoNombre").value("Producto Formula"))
+                .andExpect(jsonPath("$.detalles[0].insumoNombre").value("Insumo Formula"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/LoteProductoPorEvaluarIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/LoteProductoPorEvaluarIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class LoteProductoPorEvaluarIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private AlmacenRepository almacenRepository;
+
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void listarLotesPorEvaluar_paginado_precargaRelaciones() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("calidad-user")
+                .clave("secret")
+                .nombreCompleto("Usuario Calidad")
+                .correo("calidad-user@example.com")
+                .rol(RolUsuario.ROL_JEFE_CALIDAD)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad QA")
+                .simbolo("UQA")
+                .codigo("UQA")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria Lote")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-LOTE-EVAL")
+                .nombre("Producto Lote Eval")
+                .descripcionProducto("Producto para evaluación")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.FISICO)
+                .requiereAnalisisFisico(true)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Almacen Calidad")
+                .ubicacion("Zona QA")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LP-EVAL-1")
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
+                .stockLote(BigDecimal.TEN)
+                .estado(EstadoLote.EN_CUARENTENA)
+                .producto(producto)
+                .almacen(almacen)
+                .usuarioLiberador(usuario)
+                .build());
+
+        mockMvc.perform(get("/api/lotes/por-evaluar")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].codigoLote").value("LP-EVAL-1"))
+                .andExpect(jsonPath("$.content[0].nombreProducto").value("Producto Lote Eval"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionListadoIntegrationTest.java
@@ -1,0 +1,121 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class OrdenProduccionListadoIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private OrdenProduccionRepository ordenProduccionRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void listarOrdenesPaginadas_precargaRelaciones() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("responsable-op")
+                .clave("secret")
+                .nombreCompleto("Responsable OP")
+                .correo("responsable-op@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad OP")
+                .simbolo("UOP")
+                .codigo("UOP")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria OP")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-OP")
+                .nombre("Producto OP")
+                .descripcionProducto("Producto para orden")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        ordenProduccionRepository.save(OrdenProduccion.builder()
+                .codigoOrden("OP-001")
+                .fechaInicio(LocalDateTime.now().minusHours(1))
+                .cantidadProgramada(BigDecimal.TEN)
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .producto(producto)
+                .unidadMedida(unidad)
+                .responsable(usuario)
+                .build());
+
+        mockMvc.perform(get("/api/produccion/ordenes")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].nombreProducto").value("Producto OP"))
+                .andExpect(jsonPath("$.content[0].nombreResponsable").value("Responsable OP"));
+    }
+}


### PR DESCRIPTION
### Motivation

- Multiple 500 errors in production were traced to LazyInitializationException and incomplete error context when handling unexpected exceptions.  
- Improve observability by correlating requests with a generated request id so individual 500s can be triaged.  
- Apply minimal safe fixes to endpoints that fetch lazy relations used by mappers to avoid runtime 500s.  
- Add small smoke tests to prevent regressions for the affected endpoint families.

### Description

- Added a `RequestIdFilter` (OncePerRequestFilter) that reuses `X-Request-Id` or generates a UUID, stores it in `MDC` and returns it in the response header `X-Request-Id`.  
- Enhanced `GlobalExceptionHandler` to log `requestId`, HTTP method, URI, query string, authenticated user and roles, plus the exception root cause for unexpected runtime errors.  
- Registered the `RequestIdFilter` in the security filter chain so every request gets correlated and logged.  
- Prevented lazy-loading errors by preloading required relations with `@EntityGraph` on repositories and marking list methods `@Transactional(readOnly=true)`, plus an explicit initialization for documents in the BOM service where needed.  
- Added three Spring Boot integration smoke tests (one per affected family) that exercise: paginated production orders, active formula lookup by product, and paginated "por-evaluar" lotes.

### Testing

- Added and executed three SpringBootTest smoke tests: `OrdenProduccionListadoIntegrationTest`, `FormulaProductoActivaIntegrationTest`, and `LoteProductoPorEvaluarIntegrationTest`.  
- The tests were used iteratively to reveal lazy-loading and mapping issues and those issues were fixed in this PR.  
- Run command used locally: `mvn -q -Dtest=OrdenProduccionListadoIntegrationTest,FormulaProductoActivaIntegrationTest,LoteProductoPorEvaluarIntegrationTest test`.  
- Smoke tests were exercised during development and the assertions were adapted to match the safe DTO mappings added by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963079b9a88833392079a54ca0c374c)