### PR TITLE
Ensure H2 test schema is initialized via SQL scripts

### DIFF
--- a/src/test/resources/application-default.properties
+++ b/src/test/resources/application-default.properties
@@ -2,11 +2,12 @@ spring.datasource.url=jdbc:h2:mem:clemen_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CL
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
+spring.sql.init.platform=h2
 spring.sql.init.schema-locations=classpath:schema-test.sql
 spring.sql.init.data-locations=classpath:data-test.sql
 spring.sql.init.continue-on-error=true

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -2,11 +2,12 @@ spring.datasource.url=jdbc:h2:mem:clemen_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CL
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
+spring.sql.init.platform=h2
 spring.sql.init.schema-locations=classpath:schema-test.sql
 spring.sql.init.data-locations=classpath:data-test.sql
 spring.sql.init.continue-on-error=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,11 +6,12 @@ spring.datasource.url=jdbc:h2:mem:clemen_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CL
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
+spring.sql.init.platform=h2
 spring.sql.init.schema-locations=classpath:schema-test.sql
 spring.sql.init.data-locations=classpath:data-test.sql
 spring.sql.init.continue-on-error=true


### PR DESCRIPTION
### Motivation
- Fix failing integration tests caused by the in-memory H2 database missing the `usuarios` table when running under the `test` profile.
- Ensure the SQL schema in `src/test/resources/schema-test.sql` is applied before Spring Data/JPA starts using the datasource.
- Prevent Hibernate automatic DDL from conflicting with explicit SQL initialization so the test schema is authoritative.
- Limit changes to test-only configuration under `src/test/resources` to avoid impacting demo/prod environments.

### Description
- Set `spring.jpa.hibernate.ddl-auto=none` in `src/test/resources/application-test.properties`, `src/test/resources/application.properties`, and `src/test/resources/application-default.properties` so Hibernate does not override SQL scripts.
- Add `spring.sql.init.platform=h2` alongside existing `spring.sql.init.mode=always` and existing `spring.sql.init.schema-locations=classpath:schema-test.sql` / `spring.sql.init.data-locations=classpath:data-test.sql` to ensure Spring SQL init runs for H2.
- Confirmed `src/test/resources/schema-test.sql` already contains creation of `usuarios` and required dependent tables, so no DDL edits were necessary to provide the minimal schema.
- Files modified: `src/test/resources/application-test.properties`, `src/test/resources/application.properties`, and `src/test/resources/application-default.properties`.

### Testing
- No automated tests were executed as part of this change; configuration and SQL scripts were verified by inspection.
- Recommend running the full test suite with `mvn test` to confirm integration tests (e.g. `OrdenProduccionListadoIntegrationTest`) start with the H2 schema applied.
- If any lifecycle failures occur, run tests with logs to verify Spring SQL init runs and applied statements include `CREATE TABLE usuarios`.
- No test failures were observed because tests were not executed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963db1940cc8333b3204412bc892645)