### PR TITLE
Ajustar OrdenProduccionListadoIntegrationTest para H2 sin Testcontainers

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionListadoIntegrationTest.java
@@ -26,16 +26,17 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
-import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import com.willyes.clemenintegra.support.IntegrationTestH2;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+// Se usa base H2 para evitar Testcontainers/Docker en este test.
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
-class OrdenProduccionListadoIntegrationTest extends IntegrationTestMySqlContainer {
+class OrdenProduccionListadoIntegrationTest extends IntegrationTestH2 {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/willyes/clemenintegra/support/IntegrationTestH2.java
+++ b/src/test/java/com/willyes/clemenintegra/support/IntegrationTestH2.java
@@ -1,0 +1,16 @@
+package com.willyes.clemenintegra.support;
+
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Base para pruebas de integración sin Docker: usa el datasource H2 definido en application-test.properties.
+ */
+@TestPropertySource(properties = {
+        // Limita migraciones a versiones compatibles con H2 para estas pruebas.
+        "spring.flyway.target=20251009",
+        // Completa columnas faltantes sin tocar migraciones productivas.
+        "spring.jpa.hibernate.ddl-auto=update"
+})
+public abstract class IntegrationTestH2 {
+    // Sin anotaciones de Testcontainers para evitar el TestcontainersExtension.
+}

--- a/src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java
+++ b/src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java
@@ -6,9 +6,11 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+// Activa TestcontainersExtension para los tests que necesitan Docker (vía @Testcontainers).
 @Testcontainers
 public abstract class IntegrationTestMySqlContainer {
 
+    // La presencia del @Container registra y arranca el GenericContainer.
     @Container
     static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0")
             .withDatabaseName("clemen_test")


### PR DESCRIPTION
### Motivation

- El test `OrdenProduccionListadoIntegrationTest` estaba heredando de una base que activa Testcontainers y por eso fallaba en entornos sin Docker.
- Se detectó la activación de Testcontainers en `src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java` en la anotación `@Testcontainers` (línea ~10) y el `@Container` `MYSQL_CONTAINER` (línea ~14). 
- La intención es ejecutar ese test con H2 + Flyway en memoria sin requerir Docker y sin tocar código productivo.

### Description

- Se agregó `src/test/java/com/willyes/clemenintegra/support/IntegrationTestH2.java` con `@TestPropertySource` que fija `spring.flyway.target=20251009` y `spring.jpa.hibernate.ddl-auto=update` para limitar migraciones aplicadas en H2 y permitir completar columnas faltantes en el esquema solo en tests. 
- `OrdenProduccionListadoIntegrationTest` ahora extiende `IntegrationTestH2` en lugar de `IntegrationTestMySqlContainer` y se añadió un comentario explicando que usa H2 para evitar Testcontainers/Docker. 
- Se dejaron comentarios en `IntegrationTestMySqlContainer` señalando la presencia de `@Testcontainers` y `@Container` para clarificar qué activa Docker/Testcontainers y mantener esa base para tests que sí necesiten contenedores.

### Testing

- Se ejecutó `mvn -q test -Dtest=OrdenProduccionListadoIntegrationTest*` inicialmente y la ejecución falló antes del cambio porque el test heredaba `IntegrationTestMySqlContainer` y Testcontainers intentó arrancar Docker (excepción por entorno Docker no disponible). 
- Tras los cambios se volvió a ejecutar `mvn -q test -Dtest=OrdenProduccionListadoIntegrationTest*` y el test se ejecutó con H2/Flyway en memoria y completó correctamente (pasó).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964306d3c8c8333be015cf52efae870)