### PR TITLE
Excluir tests con Testcontainers por defecto y habilitarlos con -DrunDockerTests=true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.19.7</testcontainers.version>
+    <junit.excludeTags>docker</junit.excludeTags>
   </properties>
 
   <dependencies>
@@ -264,6 +265,15 @@
           <useTestClasspath>false</useTestClasspath>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <properties>
+            <excludeTags>${junit.excludeTags}</excludeTags>
+          </properties>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -298,6 +308,18 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>docker-tests</id>
+      <activation>
+        <property>
+          <name>runDockerTests</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <junit.excludeTags></junit.excludeTags>
+      </properties>
     </profile>
   </profiles>
 

--- a/src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java
+++ b/src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java
@@ -3,11 +3,13 @@ package com.willyes.clemenintegra.support;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
+import org.junit.jupiter.api.Tag;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 // Activa TestcontainersExtension para los tests que necesitan Docker (vía @Testcontainers).
 @Testcontainers
+@Tag("docker")
 public abstract class IntegrationTestMySqlContainer {
 
     // La presencia del @Container registra y arranca el GenericContainer.


### PR DESCRIPTION
### Motivation
- Evitar que los tests que requieren Docker se ejecuten por defecto durante `mvn test` cuando no hay Docker disponible. 
- Permitir ejecutar esos tests explícitamente mediante una propiedad Maven (`-DrunDockerTests=true`).
- Mantener la lógica y el comportamiento actual de los tests Docker cuando sí se ejecutan (sin cambios funcionales en los tests).

### Description
- Se añadió `@Tag("docker")` a la clase abstracta `IntegrationTestMySqlContainer` para marcar todos los tests que usan Testcontainers. (`src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java`).
- Se añadió la propiedad Maven por defecto `junit.excludeTags=docker` en `pom.xml` para excluir dichos tests en Surefire.
- Se configuró `maven-surefire-plugin` para pasar `excludeTags` desde la propiedad `${junit.excludeTags}` a la ejecución de pruebas.
- Se añadió el perfil `docker-tests` activado por la propiedad `runDockerTests=true` que vacía `junit.excludeTags`, permitiendo ejecutar los tests etiquetados como `docker` (compatible con PowerShell). (`pom.xml`).

### Testing
- No se ejecutaron tests automatizados durante la modificación (ninguna ejecución de `mvn test` automática en este cambio).
- Para validar manualmente en la máquina/local CI se pueden usar los comandos siguientes, que no se ejecutaron aquí: `mvn -q test` y `mvn -q test -DrunDockerTests=true -Dtest=*IntegrationTest`.
- Ninguna prueba automática falló porque no se realizaron ejecuciones automáticas en este PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696433f7407c8333bab4d2e4a1255783)