### PR TITLE
Agregar anotación heredable @DockerTest para tests Docker

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/support/DockerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/support/DockerTest.java
@@ -1,0 +1,16 @@
+package com.willyes.clemenintegra.support;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Tag("docker")
+public @interface DockerTest {}

--- a/src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java
+++ b/src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java
@@ -3,13 +3,12 @@ package com.willyes.clemenintegra.support;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
-import org.junit.jupiter.api.Tag;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 // Activa TestcontainersExtension para los tests que necesitan Docker (vía @Testcontainers).
 @Testcontainers
-@Tag("docker")
+@DockerTest
 public abstract class IntegrationTestMySqlContainer {
 
     // La presencia del @Container registra y arranca el GenericContainer.


### PR DESCRIPTION
### Motivation
- Algunos tests de integración que extienden `IntegrationTestMySqlContainer` no heredaban el tag `docker`, por lo que Surefire no los excluía por defecto.
- Las anotaciones de JUnit `@Tag` no se propagan automáticamente a subclases, lo que provocaba la ejecución inesperada de tests que requieren Docker.
- Se necesita excluir los tests Docker por defecto y permitir ejecutarlos solo con `-DrunDockerTests=true` sin cambiar la lógica del contenedor.

### Description
- Añadido `src/test/java/com/willyes/clemenintegra/support/DockerTest.java` como meta-anotación con `@Inherited` y `@Tag("docker")` para propagar el tag a subclases.
- Reemplazado `@Tag("docker")` por `@DockerTest` en `IntegrationTestMySqlContainer` y mantenido `@Testcontainers` y la lógica del `MySQLContainer` intactas.
- No se modificó la lógica del contenedor ni se tocaron tests concretos, y no se añadieron cambios al `pom.xml` porque la configuración de exclusión por defecto (`junit.excludeTags=docker`) y el perfil `docker-tests` ya existen.

### Testing
- No se ejecutaron pruebas automatizadas en este cambio (ningún `mvn test` fue corrido durante la modificación).
- Validación recomendada en local: ejecutar `mvn -q test` para comprobar que los tests Docker quedan excluidos por defecto.
- Para ejecutar tests Docker intencionalmente, usar `mvn -q test -DrunDockerTests=true` y verificar que solo entonces se intenten arrancar contenedores.
- Ejecutar `mvn -q test -Dtest=OrdenProduccionListadoIntegrationTest*` para confirmar que los tests H2 existentes siguen ejecutándose sin Docker.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696438a945608333a761799a924eb343)