### PR TITLE
Hacer perezoso MySQLContainer y omitir tests cuando Docker no está disponible

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java
+++ b/src/test/java/com/willyes/clemenintegra/support/IntegrationTestMySqlContainer.java
@@ -1,9 +1,12 @@
 package com.willyes.clemenintegra.support;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 // Activa TestcontainersExtension para los tests que necesitan Docker (vía @Testcontainers).
@@ -11,18 +14,57 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @DockerTest
 public abstract class IntegrationTestMySqlContainer {
 
-    // La presencia del @Container registra y arranca el GenericContainer.
-    @Container
-    static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0")
-            .withDatabaseName("clemen_test")
-            .withUsername("test")
-            .withPassword("test");
+    // El contenedor se inicializa de forma perezosa para evitar fallos sin Docker.
+    private static MySQLContainer<?> mysql;
+
+    @BeforeAll
+    static void setUpMySqlContainer() {
+        Assumptions.assumeTrue(isDockerAvailable(),
+                "Docker no disponible; se omiten tests con Testcontainers");
+        startContainerIfNeeded();
+    }
 
     @DynamicPropertySource
     static void registerMySqlProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
-        registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
-        registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
-        registry.add("spring.datasource.driver-class-name", MYSQL_CONTAINER::getDriverClassName);
+        if (!isDockerAvailable()) {
+            Assumptions.assumeTrue(false,
+                    "Docker no disponible; se omiten tests con Testcontainers");
+            return;
+        }
+        startContainerIfNeeded();
+        if (mysql == null) {
+            return;
+        }
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.datasource.driver-class-name", mysql::getDriverClassName);
+    }
+
+    @AfterAll
+    static void tearDownMySqlContainer() {
+        if (mysql != null) {
+            mysql.stop();
+        }
+    }
+
+    private static synchronized void startContainerIfNeeded() {
+        if (mysql != null) {
+            return;
+        }
+        mysql = new MySQLContainer<>("mysql:8.0")
+                .withDatabaseName("clemen_test")
+                .withUsername("test")
+                .withPassword("test");
+        mysql.start();
+    }
+
+    private static boolean isDockerAvailable() {
+        try {
+            DockerClientFactory.instance().client();
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Evitar que `mvn -q test` falle con `IllegalStateException` de Testcontainers en máquinas sin Docker.
- Los tests que heredan de `IntegrationTestMySqlContainer` deben quedar SKIPPED si Docker no está disponible y ejecutarse normalmente si sí lo está.
- El `static final` anterior instanciaba el contenedor en tiempo de carga de clase, forzando a Testcontainers a buscar Docker antes de que `Assumptions`/perfiles pudieran omitir los tests.

### Description
- Reemplacé el `static final MySQLContainer` por un `private static MySQLContainer<?> mysql` inicializado de forma perezosa con `startContainerIfNeeded()`.
- Añadí un `@BeforeAll` que verifica disponibilidad de Docker usando `DockerClientFactory.instance().client()` dentro de `isDockerAvailable()` y aplica `Assumptions.assumeTrue(...)` para marcar tests como SKIPPED cuando no haya Docker.
- Moví el arranque del contenedor a `startContainerIfNeeded()` (síncrono) y añadí `@AfterAll` para detener el contenedor si fue iniciado; además el `@DynamicPropertySource` ahora lee las propiedades de `mysql` ya iniciado y está protegido contra `null`.
- Se añadieron los imports necesarios (`@BeforeAll`, `@AfterAll`, `Assumptions`, `DockerClientFactory`) sin modificar tests individuales.

### Testing
- No se ejecutaron pruebas automatizadas como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69643c6b8fd08333ab51d01c0b6aa026)