### PR TITLE
Return summary DTO for conteo listing to avoid LazyInitializationException

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResumenResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoUpdateRequestDTO;
 import com.willyes.clemenintegra.inventario.service.ConteoCiclicoService;
 import com.willyes.clemenintegra.shared.util.PaginationUtil;
@@ -28,7 +29,7 @@ public class ConteoCiclicoController {
 
     @GetMapping
     @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
-    public ResponseEntity<Page<ConteoCiclicoResponseDTO>> listar(
+    public ResponseEntity<Page<ConteoCiclicoResumenResponseDTO>> listar(
             @RequestParam(required = false) Integer almacenId,
             @RequestParam(required = false) String estado,
             @PageableDefault(size = 10, sort = "fechaCreacion", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -36,7 +37,7 @@ public class ConteoCiclicoController {
             return ResponseEntity.badRequest().build();
         }
         Pageable sanitized = PaginationUtil.sanitize(pageable, List.of("fechaCreacion", "id"), "fechaCreacion");
-        Page<ConteoCiclicoResponseDTO> respuesta = conteoCiclicoService.listar(almacenId, estado, sanitized);
+        Page<ConteoCiclicoResumenResponseDTO> respuesta = conteoCiclicoService.listar(almacenId, estado, sanitized);
         return ResponseEntity.ok(respuesta);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoResumenResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoResumenResponseDTO.java
@@ -1,0 +1,19 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+
+@Value
+@Builder
+public class ConteoCiclicoResumenResponseDTO {
+    Long id;
+    Integer almacenId;
+    EstadoConteoCiclico estado;
+    LocalDateTime fechaCreacion;
+    LocalDateTime aplicadoEn;
+    Long creadoPorId;
+    Long aplicadoPorId;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/ConteoCiclicoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/ConteoCiclicoMapper.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.mapper;
 
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResumenResponseDTO;
 import com.willyes.clemenintegra.inventario.model.ConteoCiclico;
 import com.willyes.clemenintegra.inventario.model.ConteoCiclicoDetalle;
 import org.springframework.stereotype.Component;
@@ -14,7 +15,22 @@ import java.util.stream.Collectors;
 @Component
 public class ConteoCiclicoMapper {
 
-    public ConteoCiclicoResponseDTO toResponse(ConteoCiclico conteo) {
+    public ConteoCiclicoResumenResponseDTO toResumen(ConteoCiclico conteo) {
+        if (conteo == null) {
+            return null;
+        }
+        return ConteoCiclicoResumenResponseDTO.builder()
+                .id(conteo.getId())
+                .almacenId(conteo.getAlmacen() != null ? conteo.getAlmacen().getId() : null)
+                .estado(conteo.getEstado())
+                .fechaCreacion(conteo.getFechaCreacion())
+                .aplicadoEn(conteo.getAplicadoEn())
+                .creadoPorId(conteo.getCreadoPor() != null ? conteo.getCreadoPor().getId() : null)
+                .aplicadoPorId(conteo.getAplicadoPor() != null ? conteo.getAplicadoPor().getId() : null)
+                .build();
+    }
+
+    public ConteoCiclicoResponseDTO toResponseCompleto(ConteoCiclico conteo) {
         if (conteo == null) {
             return null;
         }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoDetalleRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResumenResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.mapper.ConteoCiclicoMapper;
 import com.willyes.clemenintegra.inventario.model.*;
@@ -53,17 +54,17 @@ public class ConteoCiclicoService {
     private final UsuarioService usuarioService;
     private final ConteoCiclicoMapper mapper;
 
-    public Page<ConteoCiclicoResponseDTO> listar(Integer almacenId, String estado, Pageable pageable) {
+    public Page<ConteoCiclicoResumenResponseDTO> listar(Integer almacenId, String estado, Pageable pageable) {
         EstadoConteoCiclico estadoEnum = parseEstado(estado);
         Page<ConteoCiclico> conteos = conteoRepository.buscar(almacenId, estadoEnum, pageable);
-        return conteos.map(mapper::toResponse);
+        return conteos.map(mapper::toResumen);
     }
 
     public ConteoCiclicoResponseDTO obtenerPorId(Long conteoId) {
         ConteoCiclico conteo = conteoRepository.findByIdWithDetalles(conteoId)
                 .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
                         "Conteo no encontrado"));
-        return mapper.toResponse(conteo);
+        return mapper.toResponseCompleto(conteo);
     }
 
     public List<ConteoCiclicoLoteResponseDTO> listarLotesParaConteo(Long conteoId,
@@ -147,7 +148,7 @@ public class ConteoCiclicoService {
                 .build();
 
         ConteoCiclico guardado = conteoRepository.save(conteo);
-        return mapper.toResponse(guardado);
+        return mapper.toResponseCompleto(guardado);
     }
 
     @Transactional
@@ -172,7 +173,7 @@ public class ConteoCiclicoService {
         }
 
         ConteoCiclico actualizado = conteoRepository.save(conteo);
-        return mapper.toResponse(actualizado);
+        return mapper.toResponseCompleto(actualizado);
     }
 
     @Transactional
@@ -199,19 +200,19 @@ public class ConteoCiclicoService {
         }
 
         ConteoCiclico actualizado = conteoRepository.save(conteo);
-        return mapper.toResponse(actualizado);
+        return mapper.toResponseCompleto(actualizado);
     }
 
     @Transactional
     public ConteoCiclicoResponseDTO marcarEnConteo(Long conteoId) {
         ConteoCiclico conteo = cambiarEstado(conteoId, EstadoConteoCiclico.EN_CONTEO);
-        return mapper.toResponse(conteo);
+        return mapper.toResponseCompleto(conteo);
     }
 
     @Transactional
     public ConteoCiclicoResponseDTO cerrar(Long conteoId) {
         ConteoCiclico conteo = cambiarEstado(conteoId, EstadoConteoCiclico.CERRADO);
-        return mapper.toResponse(conteo);
+        return mapper.toResponseCompleto(conteo);
     }
 
     @Transactional
@@ -262,7 +263,7 @@ public class ConteoCiclicoService {
         conteo.setAplicadoEn(LocalDateTime.now());
         conteo.setAplicadoPor(usuario);
         ConteoCiclico aplicado = conteoRepository.save(conteo);
-        return mapper.toResponse(aplicado);
+        return mapper.toResponseCompleto(aplicado);
     }
 
     private ConteoCiclico cambiarEstado(Long conteoId, EstadoConteoCiclico destino) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.ConteoCiclico;
+import com.willyes.clemenintegra.inventario.model.ConteoCiclicoDetalle;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ConteoCiclicoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+class ConteoCiclicoControllerIntegrationTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private AlmacenRepository almacenRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private ConteoCiclicoRepository conteoCiclicoRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    private ConteoCiclico conteo;
+    private Producto producto;
+
+    @BeforeEach
+    void setUp() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("contador")
+                .clave("secret")
+                .nombreCompleto("Usuario Contador")
+                .correo("contador@example.com")
+                .rol(RolUsuario.ROL_CONTADOR)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Almacen Conteo")
+                .ubicacion("Zona Conteo")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("UND")
+                .codigo("UND")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria Conteo")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-CONTEO-1")
+                .nombre("Producto Conteo")
+                .descripcionProducto("Producto para conteo")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        ConteoCiclicoDetalle detalle = ConteoCiclicoDetalle.builder()
+                .producto(producto)
+                .stockSistema(new BigDecimal("5.00"))
+                .conteoFisico(new BigDecimal("7.00"))
+                .diferencia(new BigDecimal("2.00"))
+                .build();
+
+        conteo = ConteoCiclico.builder()
+                .almacen(almacen)
+                .creadoPor(usuario)
+                .estado(EstadoConteoCiclico.BORRADOR)
+                .detalles(new ArrayList<>(List.of(detalle)))
+                .build();
+        detalle.setConteo(conteo);
+
+        conteo = conteoCiclicoRepository.save(conteo);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    void listarConteosConDetallesDevuelve200() throws Exception {
+        mockMvc.perform(get("/api/inventario/conteos")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(conteo.getId()))
+                .andExpect(jsonPath("$.content[0].detalles").doesNotExist());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_CONTADOR")
+    void obtenerPorIdConDetallesDevuelve200() throws Exception {
+        mockMvc.perform(get("/api/inventario/conteos/{id}", conteo.getId())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.detalles[0].productoId").value(producto.getId()));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
@@ -1,9 +1,10 @@
 package com.willyes.clemenintegra.inventario.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
-import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResumenResponseDTO;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
 import com.willyes.clemenintegra.inventario.service.ConteoCiclicoService;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
@@ -62,12 +63,12 @@ class ConteoCiclicoControllerTest {
     @Test
     @WithMockUser(authorities = "ROL_ALMACENISTA")
     void listarConteosDevuelve200() throws Exception {
-        ConteoCiclicoResponseDTO response = ConteoCiclicoResponseDTO.builder()
+        ConteoCiclicoResumenResponseDTO response = ConteoCiclicoResumenResponseDTO.builder()
                 .id(5L)
                 .almacenId(1)
                 .estado(EstadoConteoCiclico.BORRADOR)
                 .build();
-        Page<ConteoCiclicoResponseDTO> page = new PageImpl<>(List.of(response));
+        Page<ConteoCiclicoResumenResponseDTO> page = new PageImpl<>(List.of(response));
         when(conteoCiclicoService.listar(ArgumentMatchers.isNull(), ArgumentMatchers.isNull(), ArgumentMatchers.any(Pageable.class)))
                 .thenReturn(page);
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
@@ -527,7 +527,7 @@ class ConteoCiclicoServiceTest {
                 .build();
         detalle.setConteo(conteo);
 
-        ConteoCiclicoResponseDTO response = mapper.toResponse(conteo);
+        ConteoCiclicoResponseDTO response = mapper.toResponseCompleto(conteo);
 
         assertThat(response.getDetalles()).hasSize(1);
         assertThat(response.getDetalles().getFirst().getLoteCodigo()).isEqualTo("L-0401");


### PR DESCRIPTION
### Motivation
- Avoid `LazyInitializationException` when listing `ConteoCiclico` entities caused by accessing the LAZY `detalles` collection during pagination mapping.
- Provide a lightweight response for the listing endpoint that does not touch `detalles` while keeping full details available on the detalle endpoint.
- Ensure details are still eagerly fetched for the detail endpoint using existing repository methods with `@EntityGraph` (`findByIdWithDetalles` / `findByIdWithDetallesForUpdate`).
- Respect constraints: no change to `detalles` fetch type and no use of OpenEntityManagerInView.

### Description
- Added a new DTO `ConteoCiclicoResumenResponseDTO` for list responses that excludes `detalles`.
- Split mapping in `ConteoCiclicoMapper` into `toResumen(ConteoCiclico)` (no access to `detalles`) and `toResponseCompleto(ConteoCiclico)` (includes `detalles`).
- Changed `ConteoCiclicoService.listar` to return `Page<ConteoCiclicoResumenResponseDTO>` and map with `mapper::toResumen`, and kept detail endpoints using `findByIdWithDetalles` and `mapper.toResponseCompleto`.
- Updated controller signatures and unit tests to use the resumen DTO and added an integration test `ConteoCiclicoControllerIntegrationTest` asserting listing omits `detalles` and detalle returns `detalles` when present.

### Testing
- Ran unit/controller tests with `mvn -q -Dtest=ConteoCiclicoControllerTest,ConteoCiclicoServiceTest test` and they passed.
- Added `ConteoCiclicoControllerIntegrationTest` (integration with Testcontainers/Docker) to cover listing vs detail behavior with persisted `detalles` (test is included in the repo).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696444a1f4a08333b71fec3426e610f7)