### PR TITLE
Refetch MRP corrida with full entity graph to avoid lazy loading in response

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
@@ -20,9 +20,22 @@ public interface CorridaMrpRepository extends JpaRepository<CorridaMrp, Long> {
             "detalles.producto.categoriaProducto",
             "detalles.sugerencia",
             "detalles.sugerencia.detalleCorrida",
-            "detalles.sugerencia.detalleCorrida.producto"
+            "detalles.sugerencia.detalleCorrida.producto",
+            "detalles.sugerencia.detalleCorrida.producto.categoriaProducto"
     })
     Optional<CorridaMrp> findWithDetallesById(Long id);
+
+    @EntityGraph(attributePaths = {
+            "planProduccionSemanal",
+            "detalles",
+            "detalles.producto",
+            "detalles.producto.categoriaProducto",
+            "detalles.sugerencia",
+            "detalles.sugerencia.detalleCorrida",
+            "detalles.sugerencia.detalleCorrida.producto",
+            "detalles.sugerencia.detalleCorrida.producto.categoriaProducto"
+    })
+    Optional<CorridaMrp> findByIdWithGraph(Long id);
 
     Optional<CorridaMrp> findTopByPlanProduccionSemanalAndEstadoOrderByFechaEjecucionDesc(
             PlanProduccionSemanal plan, EstadoCorridaMrp estado

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
@@ -92,7 +92,7 @@ public class MrpServiceImpl implements MrpService {
         corrida.setEstado(EstadoCorridaMrp.COMPLETADA);
 
         CorridaMrp guardada = corridaMrpRepository.save(corrida);
-        CorridaMrp corridaCargada = corridaMrpRepository.findWithDetallesById(guardada.getId())
+        CorridaMrp corridaCargada = corridaMrpRepository.findByIdWithGraph(guardada.getId())
                 .orElse(guardada);
         enriquecerCorrida(corridaCargada);
         log.info("Corrida MRP semanal {} finalizada. Insumos evaluados: {}", guardada.getId(), requerimientosNetos.size());
@@ -194,7 +194,7 @@ public class MrpServiceImpl implements MrpService {
     @Override
     @Transactional(readOnly = true)
     public CorridaMrp obtenerCorrida(Long id) {
-        CorridaMrp corrida = corridaMrpRepository.findWithDetallesById(id)
+        CorridaMrp corrida = corridaMrpRepository.findByIdWithGraph(id)
                 .orElseThrow(() -> new NoSuchElementException("Corrida MRP no encontrada"));
         // Las métricas de cobertura y criticidad son transitorias; al cargar desde BD deben recalcularse
         // para que el GET entregue el mismo DTO enriquecido que el POST.

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerIntegrationTest.java
@@ -177,6 +177,7 @@ class MrpControllerIntegrationTest extends IntegrationTestMySqlContainer {
                         .content("{\"planSemanalId\":" + plan.getId() + "}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.detalles[0].productoNombre").value(insumo.getNombre()))
+                .andExpect(jsonPath("$.detalles[0].categoriaInsumo").value("MP"))
                 .andExpect(jsonPath("$.sugerencias[0].productoNombre").value(insumo.getNombre()));
     }
 }


### PR DESCRIPTION
### Motivation
- The controller DTO mapping accesses lazy associations such as `detalle.producto.categoriaProducto` and the sugerencia path (`detalles.sugerencia.detalleCorrida.producto`) which can raise `LazyInitializationException` when the entity leaves the transactional context. 
- The service saved the `CorridaMrp` and returned the in-memory entity which did not have all transitive associations initialized for the response mapping. 
- The objective is to guarantee the response-mapped associations are fully loaded with a minimal, consistent change. 

### Description
- Added a repository method `findByIdWithGraph(Long id)` on `CorridaMrpRepository` annotated with `@EntityGraph` that preloads `planProduccionSemanal`, `detalles`, `detalles.producto`, `detalles.producto.categoriaProducto`, `detalles.sugerencia`, `detalles.sugerencia.detalleCorrida` and the transitive `producto.categoriaProducto`. 
- After persisting a corrida the service now re-fetches the persisted entity via `corridaMrpRepository.findByIdWithGraph(...)` before mapping to DTO, and `obtenerCorrida` was updated to use the same fetch method. 
- Adjusted the integration test `MrpControllerIntegrationTest#ejecutarCorridaMrpDevuelveDetalles` to assert the `categoriaInsumo` JSON field is present and correct. 

### Testing
- Ran `mvn -Dtest=MrpControllerIntegrationTest#ejecutarCorridaMrpDevuelveDetalles test` to exercise the integration test. 
- The test run did not execute integration tests because Testcontainers/Docker was not available in the environment (tests were skipped), and the build finished successfully. 
- The modified integration test now asserts `$.detalles[0].categoriaInsumo` and the other existing assertions for product names. 
- No unit tests were broken by these changes during the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696536d2a40083339e9cc0704d9fdabe)