### PR TITLE
Fix CorridaMrp repository graph lookup method

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java
@@ -35,7 +35,7 @@ public interface CorridaMrpRepository extends JpaRepository<CorridaMrp, Long> {
             "detalles.sugerencia.detalleCorrida.producto",
             "detalles.sugerencia.detalleCorrida.producto.categoriaProducto"
     })
-    Optional<CorridaMrp> findByIdWithGraph(Long id);
+    Optional<CorridaMrp> findWithGraphById(Long id);
 
     Optional<CorridaMrp> findTopByPlanProduccionSemanalAndEstadoOrderByFechaEjecucionDesc(
             PlanProduccionSemanal plan, EstadoCorridaMrp estado

--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java
@@ -92,7 +92,7 @@ public class MrpServiceImpl implements MrpService {
         corrida.setEstado(EstadoCorridaMrp.COMPLETADA);
 
         CorridaMrp guardada = corridaMrpRepository.save(corrida);
-        CorridaMrp corridaCargada = corridaMrpRepository.findByIdWithGraph(guardada.getId())
+        CorridaMrp corridaCargada = corridaMrpRepository.findWithGraphById(guardada.getId())
                 .orElse(guardada);
         enriquecerCorrida(corridaCargada);
         log.info("Corrida MRP semanal {} finalizada. Insumos evaluados: {}", guardada.getId(), requerimientosNetos.size());
@@ -194,7 +194,7 @@ public class MrpServiceImpl implements MrpService {
     @Override
     @Transactional(readOnly = true)
     public CorridaMrp obtenerCorrida(Long id) {
-        CorridaMrp corrida = corridaMrpRepository.findByIdWithGraph(id)
+        CorridaMrp corrida = corridaMrpRepository.findWithGraphById(id)
                 .orElseThrow(() -> new NoSuchElementException("Corrida MRP no encontrada"));
         // Las métricas de cobertura y criticidad son transitorias; al cargar desde BD deben recalcularse
         // para que el GET entregue el mismo DTO enriquecido que el POST.


### PR DESCRIPTION
### Motivation
- Spring Data interpreted `findByIdWithGraph(Long)` as a derived property (`id.withGraph`) causing repository resolution issues at startup.
- The intent is to keep the `@EntityGraph` eager-loading behavior while using a method name that Spring Data can parse.
- Make a minimal change to repository and service wiring to avoid larger refactors.
- Preserve existing entity graph attribute paths and behavior.

### Description
- Renamed `CorridaMrpRepository.findByIdWithGraph(Long)` to `findWithGraphById(Long)` in `src/main/java/com/willyes/clemenintegra/planeacion/repository/CorridaMrpRepository.java` and kept the `@EntityGraph` configuration intact.
- Updated service usages in `src/main/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImpl.java` to call `corridaMrpRepository.findWithGraphById(...)` where the old method was used.
- No other behavioral changes were introduced; changes are limited to the method rename and call sites.
- Changes committed include the two modified files mentioned above.

### Testing
- No automated tests were executed as part of this change.
- A code search showed there were no test references to the old method name, so test sources required no updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69653a226cf4833382693e0fd843b1e7)