### PR TITLE
Fix JPA equals/hashCode recursion in MRP models

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/CorridaMrp.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/CorridaMrp.java
@@ -3,7 +3,12 @@ package com.willyes.clemenintegra.planeacion.model;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoCorridaMrp;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -12,14 +17,17 @@ import java.util.List;
 
 @Entity
 @Table(name = "corridas_mrp")
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class CorridaMrp {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/DetalleCorridaMrp.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/DetalleCorridaMrp.java
@@ -3,20 +3,28 @@ package com.willyes.clemenintegra.planeacion.model;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.planeacion.model.enums.TipoCambioMrp;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 
 @Entity
 @Table(name = "detalles_corrida_mrp")
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class DetalleCorridaMrp {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/PlanProduccionSemanal.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/PlanProduccionSemanal.java
@@ -3,7 +3,12 @@ package com.willyes.clemenintegra.planeacion.model;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoPlanProduccion;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -12,14 +17,17 @@ import java.util.List;
 
 @Entity
 @Table(name = "plan_produccion_semanal")
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class PlanProduccionSemanal {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @Column(name = "semana_inicio", nullable = false)

--- a/src/main/java/com/willyes/clemenintegra/planeacion/model/SugerenciaAbastecimiento.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/model/SugerenciaAbastecimiento.java
@@ -3,7 +3,12 @@ package com.willyes.clemenintegra.planeacion.model;
 import com.willyes.clemenintegra.planeacion.model.enums.EstadoSugerenciaAbastecimiento;
 import com.willyes.clemenintegra.planeacion.model.enums.TipoSugerenciaAbastecimiento;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -12,14 +17,17 @@ import java.util.List;
 
 @Entity
 @Table(name = "sugerencias_abastecimiento")
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class SugerenciaAbastecimiento {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/willyes/clemenintegra/shared/model/Usuario.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/model/Usuario.java
@@ -2,7 +2,12 @@ package com.willyes.clemenintegra.shared.model;
 
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -12,14 +17,17 @@ import java.time.LocalDateTime;
         // TODO: Reactivar la restricción de unicidad del correo al desplegar en producción.
         // @UniqueConstraint(name = "un_correo_usuario_UNIQUE", columnNames = "correo")
 })
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Usuario {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @Column(name = "nombre_usuario", nullable = false, length = 45)

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerIntegrationTest.java
@@ -180,4 +180,14 @@ class MrpControllerIntegrationTest extends IntegrationTestMySqlContainer {
                 .andExpect(jsonPath("$.detalles[0].categoriaInsumo").value("MP"))
                 .andExpect(jsonPath("$.sugerencias[0].productoNombre").value(insumo.getNombre()));
     }
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void ejecutarCorridaMrpNoGeneraErrorServidor() throws Exception {
+        mockMvc.perform(post("/api/mrp/corridas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"planSemanalId\":" + plan.getId() + "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.detalles").isArray());
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent StackOverflowError from recursive `equals`/`hashCode` caused by Lombok `@Data` across JPA relationships in the MRP domain. 
- Stabilize entity identity semantics so JPA-managed associations are not traversed by `equals`/`hashCode`. 

### Description
- Replaced Lombok `@Data` with `@Getter`/`@Setter` and added `@EqualsAndHashCode(onlyExplicitlyIncluded = true)` on the entities `Usuario`, `PlanProduccionSemanal`, `CorridaMrp`, `DetalleCorridaMrp`, and `SugerenciaAbastecimiento`. 
- Included only the `@Id` field with `@EqualsAndHashCode.Include` in each modified entity so no relationships are considered in `equals`/`hashCode`. 
- Added an integration test `ejecutarCorridaMrpNoGeneraErrorServidor()` to `MrpControllerIntegrationTest` which asserts the `/api/mrp/corridas` endpoint returns HTTP `200` and that `detalles` is an array. 

### Testing
- Ran `mvn -Dtest=MrpControllerIntegrationTest test` to exercise the modified integration test. 
- Testcontainers could not start because Docker was not available, so the integration test suite reported `0` tests run. 
- Maven build completed successfully despite Testcontainers not being available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69653f1ced508333b8792284bb199cc5)