### PR TITLE
Agregar `loteId` al listado consolidado de evaluaciones

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaListadoDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaListadoDTO.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 public class EvaluacionConsolidadaListadoDTO {
 
     private final Long id;
+    private final Long loteId;
     private final LocalDateTime fechaEvaluacion;
     private final String codigoLote;
     private final String nombreProducto;
@@ -20,6 +21,7 @@ public class EvaluacionConsolidadaListadoDTO {
     private final boolean tieneAdjuntos;
 
     public EvaluacionConsolidadaListadoDTO(Long id,
+                                           Long loteId,
                                            LocalDateTime fechaEvaluacion,
                                            String codigoLote,
                                            String nombreProducto,
@@ -28,6 +30,7 @@ public class EvaluacionConsolidadaListadoDTO {
                                            String usuarioCreador,
                                            Long cantidadAdjuntos) {
         this.id = id;
+        this.loteId = loteId;
         this.fechaEvaluacion = fechaEvaluacion;
         this.codigoLote = codigoLote;
         this.nombreProducto = nombreProducto;

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
@@ -38,7 +38,7 @@ public interface EvaluacionCalidadRepository extends JpaRepository<EvaluacionCal
             @Param("fin") LocalDateTime fin);
 
     @Query(value = "SELECT new com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaListadoDTO(" +
-            "e.id, e.fechaEvaluacion, l.codigoLote, p.nombre, e.resultado, e.tipoEvaluacion, " +
+            "e.id, l.id, e.fechaEvaluacion, l.codigoLote, p.nombre, e.resultado, e.tipoEvaluacion, " +
             "u.nombreCompleto, COUNT(a)) " +
             "FROM EvaluacionCalidad e " +
             "JOIN e.loteProducto l " +
@@ -46,7 +46,7 @@ public interface EvaluacionCalidadRepository extends JpaRepository<EvaluacionCal
             "JOIN e.usuarioEvaluador u " +
             "LEFT JOIN e.archivosAdjuntos a " +
             "WHERE e.fechaEvaluacion BETWEEN :inicio AND :fin " +
-            "GROUP BY e.id, e.fechaEvaluacion, l.codigoLote, p.nombre, e.resultado, e.tipoEvaluacion, u.nombreCompleto",
+            "GROUP BY e.id, l.id, e.fechaEvaluacion, l.codigoLote, p.nombre, e.resultado, e.tipoEvaluacion, u.nombreCompleto",
             countQuery = "SELECT COUNT(e.id) FROM EvaluacionCalidad e " +
                     "WHERE e.fechaEvaluacion BETWEEN :inicio AND :fin")
     Page<EvaluacionConsolidadaListadoDTO> findConsolidadoListado(

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -202,6 +202,7 @@ class EvaluacionCalidadServiceImplTest {
 
         EvaluacionConsolidadaListadoDTO consolidado = new EvaluacionConsolidadaListadoDTO(
                 71L,
+                lote.getId(),
                 evalFisico.getFechaEvaluacion(),
                 "LOT-10",
                 "Producto Q",
@@ -218,6 +219,7 @@ class EvaluacionCalidadServiceImplTest {
 
         assertThat(consolidados).hasSize(1);
         var dto = consolidados.getContent().get(0);
+        assertThat(dto.getLoteId()).isEqualTo(lote.getId());
         assertThat(dto.getCodigoLote()).isEqualTo("LOT-10");
         assertThat(dto.getNombreProducto()).isEqualTo("Producto Q");
         assertThat(dto.getTipoEvaluacion()).isEqualTo(TipoEvaluacion.QUIMICO_MICROBIOLOGICO);
@@ -246,6 +248,7 @@ class EvaluacionCalidadServiceImplTest {
 
         EvaluacionConsolidadaListadoDTO consolidado = new EvaluacionConsolidadaListadoDTO(
                 80L,
+                loteSoloMicro.getId(),
                 evalMicro.getFechaEvaluacion(),
                 "LOT-30",
                 "Producto Micro",
@@ -261,6 +264,7 @@ class EvaluacionCalidadServiceImplTest {
 
         assertThat(consolidados).hasSize(1);
         var dto = consolidados.getContent().get(0);
+        assertThat(dto.getLoteId()).isEqualTo(loteSoloMicro.getId());
         assertThat(dto.getCodigoLote()).isEqualTo("LOT-30");
         assertThat(dto.isTieneAdjuntos()).isFalse();
     }
@@ -286,6 +290,7 @@ class EvaluacionCalidadServiceImplTest {
 
         EvaluacionConsolidadaListadoDTO consolidado = new EvaluacionConsolidadaListadoDTO(
                 90L,
+                loteSinMicro.getId(),
                 evalFisico.getFechaEvaluacion(),
                 "LOT-40",
                 "Producto F",
@@ -301,6 +306,7 @@ class EvaluacionCalidadServiceImplTest {
 
         assertThat(consolidados).hasSize(1);
         var dto = consolidados.getContent().get(0);
+        assertThat(dto.getLoteId()).isEqualTo(loteSinMicro.getId());
         assertThat(dto.getCodigoLote()).isEqualTo("LOT-40");
         assertThat(dto.isTieneAdjuntos()).isTrue();
     }


### PR DESCRIPTION
### Motivation
- The frontend needs to open an audit view per lote but the consolidated list response did not include the `loteId`, forcing the client to call an incorrect endpoint. 
- The change preserves the projection/DTO approach (no lazy loading) so the repository query must populate the DTO directly. 

### Description
- Added a `Long loteId` field and constructor parameter to `EvaluacionConsolidadaListadoDTO` and exposed it via the existing Lombok `@Getter`.
- Updated the repository projection in `EvaluacionCalidadRepository.findConsolidadoListado` to select `l.id` and include it in the `GROUP BY` so the constructor expression `new ...EvaluacionConsolidadaListadoDTO(...)` fills `loteId`.
- Updated `EvaluacionCalidadServiceImpl` test usages by changing `new EvaluacionConsolidadaListadoDTO(...)` calls and adding assertions for `getLoteId()` in `EvaluacionCalidadServiceImplTest`.

### Testing
- Compiled the project with `mvn -q -DskipTests clean package` which completed successfully (compile OK).
- Updated unit tests (`EvaluacionCalidadServiceImplTest`) to use the new constructor signature and assert `loteId` (tests were adapted but not executed in the build above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654fc0d8788333967daaf61e99fe3e)