### PR TITLE
Add /api/inventarios/trazabilidad/lote/{loteId} alias for auditoría

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/TrazabilidadLoteController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/TrazabilidadLoteController.java
@@ -1,0 +1,35 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
+import com.willyes.clemenintegra.calidad.service.AuditoriaLoteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/inventarios/trazabilidad")
+@RequiredArgsConstructor
+public class TrazabilidadLoteController {
+
+    private final AuditoriaLoteService auditoriaLoteService;
+
+    @GetMapping("/lote/{loteId}")
+    @PreAuthorize("hasAnyAuthority(" +
+            "'ROL_JEFE_ALMACENES'," +
+            "'ROL_ALMACENISTA'," +
+            "'ROL_JEFE_PRODUCCION'," +
+            "'ROL_LIDER_ALIMENTOS'," +
+            "'ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD'," +
+            "'ROL_ANALISTA_CALIDAD'," +
+            "'ROL_MICROBIOLOGO'," +
+            "'ROL_SUPER_ADMIN'" +
+            ")")
+    public ResponseEntity<AuditoriaLoteResponseDTO> obtenerAuditoriaLote(@PathVariable Long loteId) {
+        return ResponseEntity.ok(auditoriaLoteService.obtenerAuditoriaDeLote(loteId));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/TrazabilidadLoteControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/TrazabilidadLoteControllerIntegrationTest.java
@@ -1,0 +1,141 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.calidad.dto.EstadoCalidadLoteResponseDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.inventario.service.LoteProductoService;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TrazabilidadLoteControllerIntegrationTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private AlmacenRepository almacenRepository;
+
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @MockBean
+    private LoteProductoService loteProductoService;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void retornaAuditoriaLoteParaAliasInventarios() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("auditor")
+                .clave("secret")
+                .nombreCompleto("Auditor Calidad")
+                .correo("auditor@example.com")
+                .rol(RolUsuario.ROL_JEFE_CALIDAD)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("U")
+                .codigo("U")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria Auditoria")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-AUDIT")
+                .nombre("Producto Auditoria")
+                .descripcionProducto("Producto prueba auditoria")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Almacen Auditoria")
+                .ubicacion("Zona A")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        LoteProducto lote = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LOTE-AUDIT")
+                .producto(producto)
+                .almacen(almacen)
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(new BigDecimal("10.00"))
+                .stockReservado(BigDecimal.ZERO.setScale(6))
+                .agotado(false)
+                .build());
+
+        when(loteProductoService.obtenerEstadoCalidad(lote.getId()))
+                .thenReturn(EstadoCalidadLoteResponseDTO.builder()
+                        .loteId(lote.getId())
+                        .estadoLote("DISPONIBLE")
+                        .build());
+
+        mockMvc.perform(get("/api/inventarios/trazabilidad/lote/{loteId}", lote.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.loteId").value(lote.getId()))
+                .andExpect(jsonPath("$.codigoLote").value("LOTE-AUDIT"))
+                .andExpect(jsonPath("$.nombreProducto").value("Producto Auditoria"));
+    }
+}


### PR DESCRIPTION
### Motivation
- The frontend expects `GET /api/inventarios/trazabilidad/lote/{loteId}` but the route did not exist and returned 404. 
- The goal is to provide a lightweight alias that returns the same `AuditoriaLoteResponseDTO` without duplicating audit logic. 

### Description
- Added `TrazabilidadLoteController` with `@RequestMapping("/api/inventarios/trazabilidad")` and `@GetMapping("/lote/{loteId}")` that calls `auditoriaLoteService.obtenerAuditoriaDeLote(loteId)` and returns the `AuditoriaLoteResponseDTO`. 
- The new endpoint reuses the existing `AuditoriaLoteService` and does not duplicate any audit/business logic. 
- Access is guarded with the same role-based `@PreAuthorize` authorities used across inventory controllers. 
- Added integration test `TrazabilidadLoteControllerIntegrationTest` that seeds a lote and asserts the alias endpoint returns a 200 and the expected fields. 

### Testing
- Ran the integration test with `mvn -Dtest=TrazabilidadLoteControllerIntegrationTest test`. 
- Test execution attempted to start Testcontainers but could not find a Docker environment, resulting in the integration test reporting `0` executed. 
- The Maven build finished successfully (no compilation errors) even though the container-backed test did not run. 
- No additional unit tests were modified or added beyond the integration test provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696556e209748333af38da465db5d94d)