### PR TITLE
NoConformidad detail: return DTO projection to avoid LazyInitializationException

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.controller;
 
 import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
+import com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.TipoIncidente;
@@ -37,7 +38,7 @@ public class NoConformidadController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
-    public ResponseEntity<NoConformidadDTO> obtener(@PathVariable Long id) {
+    public ResponseEntity<NoConformidadDetalleDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerPorId(id));
     }
 
@@ -85,4 +86,3 @@ public class NoConformidadController {
         return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/NoConformidadDetalleDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/NoConformidadDetalleDTO.java
@@ -1,0 +1,61 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.TipoIncidente;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoConformidadDetalleDTO {
+
+    private Long id;
+
+    private String codigo;
+
+    private OrigenNoConformidad origen;
+
+    private SeveridadNoConformidad severidad;
+
+    private TipoIncidente tipoIncidente;
+
+    private EstadoNoConformidad estado;
+
+    private String descripcion;
+
+    private String evidencia;
+
+    private LocalDateTime fechaRegistro;
+
+    private LocalDateTime fechaCierre;
+
+    private Long usuarioReportaId;
+
+    private Long loteId;
+
+    private Long productoId;
+
+    private Long evaluacionId;
+
+    private String codigoLote;
+
+    private String reportadoPorNombre;
+
+    private String productoNombre;
+
+    private Long creadoPor;
+
+    private Long actualizadoPor;
+
+    private LocalDateTime actualizadoEn;
+
+    private Boolean retener;
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.calidad.repository;
 
+import com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
@@ -85,4 +86,21 @@ public interface NoConformidadRepository extends JpaRepository<NoConformidad, Lo
                                                      @Param("origen") OrigenNoConformidad origen,
                                                      @Param("tipoIncidente") TipoIncidente tipoIncidente,
                                                      Pageable pageable);
+
+    @Query("SELECT new com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO(" +
+            "n.id, n.codigo, n.origen, n.severidad, n.tipoIncidente, n.estado, " +
+            "n.descripcion, n.evidencia, n.fechaRegistro, n.fechaCierre, " +
+            "u.id, l.id, p.id, e.id, l.codigoLote, u.nombreCompleto, p.nombre, " +
+            "n.creadoPor, n.actualizadoPor, n.actualizadoEn, " +
+            "CASE WHEN r.id IS NOT NULL THEN true ELSE false END) " +
+            "FROM NoConformidad n " +
+            "JOIN n.usuarioReporta u " +
+            "LEFT JOIN n.lote l " +
+            "LEFT JOIN n.producto p " +
+            "LEFT JOIN n.evaluacion e " +
+            "LEFT JOIN RetencionLote r ON r.noConformidad = n " +
+            "AND r.estado = com.willyes.clemenintegra.calidad.model.enums.EstadoRetencion.RETENIDO " +
+            "AND r.motivo = com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion.NO_CONFORMIDAD " +
+            "WHERE n.id = :id")
+    Optional<NoConformidadDetalleDTO> findDetalleById(@Param("id") Long id);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadService.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
+import com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
@@ -25,7 +26,7 @@ public interface NoConformidadService {
 
     void eliminar(Long id);
 
-    NoConformidadDTO obtenerPorId(Long id);
+    NoConformidadDetalleDTO obtenerPorId(Long id);
 
     NoConformidadDTO cerrar(Long id, Usuario authUser);
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImpl.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
+import com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.mapper.NoConformidadMapper;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.NoConformidad;
@@ -151,9 +152,8 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         repository.deleteById(id);
     }
 
-    public NoConformidadDTO obtenerPorId(Long id) {
-        return repository.findById(id)
-                .map(mapper::toDTO)
+    public NoConformidadDetalleDTO obtenerPorId(Long id) {
+        return repository.findDetalleById(id)
                 .orElseThrow(() -> new NoSuchElementException("No conformidad no encontrada con ID: " + id));
     }
 

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadListadoIntegrationTest.java
@@ -82,6 +82,7 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
     private Usuario usuario;
     private LoteProducto loteProducto;
     private EvaluacionCalidad evaluacion;
+    private NoConformidad noConformidad;
 
     @BeforeEach
     void setUp() {
@@ -151,7 +152,7 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
                 .usuarioEvaluador(usuario)
                 .build());
 
-        noConformidadRepository.save(NoConformidad.builder()
+        noConformidad = noConformidadRepository.save(NoConformidad.builder()
                 .codigo("NC-TEST-001")
                 .origen(OrigenNoConformidad.LOTE)
                 .severidad(SeveridadNoConformidad.MAYOR)
@@ -190,5 +191,14 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].reportadoPorNombre").value("Usuario Calidad Listado"))
                 .andExpect(jsonPath("$.content[0].codigo").value("NC-TEST-001"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void obtenerNoConformidadIncluyeNombresRelacionados() throws Exception {
+        mockMvc.perform(get("/api/calidad/no-conformidades/{id}", noConformidad.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reportadoPorNombre").value("Usuario Calidad Listado"))
+                .andExpect(jsonPath("$.productoNombre").value("Producto Calidad"));
     }
 }


### PR DESCRIPTION
### Motivation

- Evitar el `LazyInitializationException` al obtener el detalle de una No Conformidad en `GET /api/calidad/no-conformidades/{id}` provocado por inicializar relaciones perezosas fuera de sesión. 
- Proveer una respuesta de detalle mínima y estable para el frontend sin exponer entidades relacionadas completas ni abrir sesión en la vista.

### Description

- Se añadió el DTO de detalle `NoConformidadDetalleDTO` con los campos requeridos (IDs, nombres, fechas, `retener`, auditoría), en `src/main/java/com/willyes/clemenintegra/calidad/dto/NoConformidadDetalleDTO.java`.
- Se agregó la consulta de proyección dedicada `Optional<NoConformidadDetalleDTO> findDetalleById(Long id)` en `NoConformidadRepository` implementada con JPQL `new ...` y los `JOIN`/`LEFT JOIN` necesarios, incluyendo `LEFT JOIN RetencionLote` para calcular `retener`.
- Se cambió la firma de `NoConformidadService.obtenerPorId` para devolver `NoConformidadDetalleDTO` y se actualizó `NoConformidadServiceImpl.obtenerPorId` para usar `repository.findDetalleById(id)` y lanzar `NoSuchElementException` si no existe.
- Se ajustó el controller `GET /api/calidad/no-conformidades/{id}` en `NoConformidadController` para devolver el DTO de detalle (`NoConformidadDetalleDTO`) en lugar de mapear la entidad, evitando lazy-loads en la capa web.

### Testing

- Se añadió un test de integración `CalidadListadoIntegrationTest.obtenerNoConformidadIncluyeNombresRelacionados` que verifica que el endpoint de detalle incluye `reportadoPorNombre` y `productoNombre`.
- Se intentó ejecutar `mvn -q -Dtest=CalidadListadoIntegrationTest test` pero la ejecución fue interrumpida y no completó; por tanto la ejecución automática no finalizó en este entorno.
- No se modificaron las llamadas existentes al listado paginado que ya usan proyecciones, y los cambios son mínimos y enfocados solo al endpoint de detalle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655b1610c48333b7adaa49e5e3ccfc)