### PR TITLE
NoConformidad detail DTO + restore Evaluaciones consolidadas fields

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.controller;
 
 import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
+import com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.TipoIncidente;
@@ -37,7 +38,7 @@ public class NoConformidadController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
-    public ResponseEntity<NoConformidadDTO> obtener(@PathVariable Long id) {
+    public ResponseEntity<NoConformidadDetalleDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerPorId(id));
     }
 
@@ -85,4 +86,3 @@ public class NoConformidadController {
         return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaListadoDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/EvaluacionConsolidadaListadoDTO.java
@@ -1,7 +1,9 @@
 package com.willyes.clemenintegra.calidad.dto;
 
+import com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -17,6 +19,8 @@ public class EvaluacionConsolidadaListadoDTO {
     private final ResultadoEvaluacion resultado;
     private final TipoEvaluacion tipoEvaluacion;
     private final String usuarioCreador;
+    private final EstadoEvaluacionCalidad estadoEvaluacion;
+    private final EstadoLote estadoLote;
     private final long cantidadAdjuntos;
     private final boolean tieneAdjuntos;
 
@@ -28,6 +32,8 @@ public class EvaluacionConsolidadaListadoDTO {
                                            ResultadoEvaluacion resultado,
                                            TipoEvaluacion tipoEvaluacion,
                                            String usuarioCreador,
+                                           EstadoEvaluacionCalidad estadoEvaluacion,
+                                           EstadoLote estadoLote,
                                            Long cantidadAdjuntos) {
         this.id = id;
         this.loteId = loteId;
@@ -37,6 +43,8 @@ public class EvaluacionConsolidadaListadoDTO {
         this.resultado = resultado;
         this.tipoEvaluacion = tipoEvaluacion;
         this.usuarioCreador = usuarioCreador;
+        this.estadoEvaluacion = estadoEvaluacion;
+        this.estadoLote = estadoLote;
         this.cantidadAdjuntos = cantidadAdjuntos != null ? cantidadAdjuntos : 0L;
         this.tieneAdjuntos = this.cantidadAdjuntos > 0;
     }

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/NoConformidadDetalleDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/NoConformidadDetalleDTO.java
@@ -1,0 +1,76 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
+import com.willyes.clemenintegra.calidad.model.enums.TipoIncidente;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NoConformidadDetalleDTO {
+
+    private final Long id;
+    private final String codigo;
+    private final OrigenNoConformidad origen;
+    private final SeveridadNoConformidad severidad;
+    private final TipoIncidente tipoIncidente;
+    private final EstadoNoConformidad estado;
+    private final String descripcion;
+    private final String evidencia;
+    private final LocalDateTime fechaRegistro;
+    private final LocalDateTime fechaCierre;
+    private final Long usuarioReportaId;
+    private final Long loteId;
+    private final Long productoId;
+    private final Long evaluacionId;
+    private final String codigoLote;
+    private final String reportadoPorNombre;
+    private final String productoNombre;
+    private final Long creadoPor;
+    private final Long actualizadoPor;
+    private final LocalDateTime actualizadoEn;
+
+    public NoConformidadDetalleDTO(Long id,
+                                   String codigo,
+                                   OrigenNoConformidad origen,
+                                   SeveridadNoConformidad severidad,
+                                   TipoIncidente tipoIncidente,
+                                   EstadoNoConformidad estado,
+                                   String descripcion,
+                                   String evidencia,
+                                   LocalDateTime fechaRegistro,
+                                   LocalDateTime fechaCierre,
+                                   Long usuarioReportaId,
+                                   Long loteId,
+                                   Long productoId,
+                                   Long evaluacionId,
+                                   String codigoLote,
+                                   String reportadoPorNombre,
+                                   String productoNombre,
+                                   Long creadoPor,
+                                   Long actualizadoPor,
+                                   LocalDateTime actualizadoEn) {
+        this.id = id;
+        this.codigo = codigo;
+        this.origen = origen;
+        this.severidad = severidad;
+        this.tipoIncidente = tipoIncidente;
+        this.estado = estado;
+        this.descripcion = descripcion;
+        this.evidencia = evidencia;
+        this.fechaRegistro = fechaRegistro;
+        this.fechaCierre = fechaCierre;
+        this.usuarioReportaId = usuarioReportaId;
+        this.loteId = loteId;
+        this.productoId = productoId;
+        this.evaluacionId = evaluacionId;
+        this.codigoLote = codigoLote;
+        this.reportadoPorNombre = reportadoPorNombre;
+        this.productoNombre = productoNombre;
+        this.creadoPor = creadoPor;
+        this.actualizadoPor = actualizadoPor;
+        this.actualizadoEn = actualizadoEn;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
@@ -39,14 +39,16 @@ public interface EvaluacionCalidadRepository extends JpaRepository<EvaluacionCal
 
     @Query(value = "SELECT new com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaListadoDTO(" +
             "e.id, l.id, e.fechaEvaluacion, l.codigoLote, p.nombre, e.resultado, e.tipoEvaluacion, " +
-            "u.nombreCompleto, COUNT(a)) " +
+            "u.nombreCompleto, " +
+            "com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad.EVALUADO, " +
+            "l.estado, COUNT(a)) " +
             "FROM EvaluacionCalidad e " +
             "JOIN e.loteProducto l " +
             "JOIN l.producto p " +
             "JOIN e.usuarioEvaluador u " +
             "LEFT JOIN e.archivosAdjuntos a " +
             "WHERE e.fechaEvaluacion BETWEEN :inicio AND :fin " +
-            "GROUP BY e.id, l.id, e.fechaEvaluacion, l.codigoLote, p.nombre, e.resultado, e.tipoEvaluacion, u.nombreCompleto",
+            "GROUP BY e.id, l.id, e.fechaEvaluacion, l.codigoLote, p.nombre, e.resultado, e.tipoEvaluacion, u.nombreCompleto, l.estado",
             countQuery = "SELECT COUNT(e.id) FROM EvaluacionCalidad e " +
                     "WHERE e.fechaEvaluacion BETWEEN :inicio AND :fin")
     Page<EvaluacionConsolidadaListadoDTO> findConsolidadoListado(

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/NoConformidadRepository.java
@@ -5,6 +5,7 @@ import com.willyes.clemenintegra.calidad.model.enums.EstadoNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.TipoIncidente;
+import com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -85,4 +86,16 @@ public interface NoConformidadRepository extends JpaRepository<NoConformidad, Lo
                                                      @Param("origen") OrigenNoConformidad origen,
                                                      @Param("tipoIncidente") TipoIncidente tipoIncidente,
                                                      Pageable pageable);
+
+    @Query("SELECT new com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO(" +
+            "n.id, n.codigo, n.origen, n.severidad, n.tipoIncidente, n.estado, n.descripcion, n.evidencia, " +
+            "n.fechaRegistro, n.fechaCierre, u.id, l.id, p.id, e.id, l.codigoLote, u.nombreCompleto, p.nombre, " +
+            "n.creadoPor, n.actualizadoPor, n.actualizadoEn) " +
+            "FROM NoConformidad n " +
+            "JOIN n.usuarioReporta u " +
+            "LEFT JOIN n.lote l " +
+            "LEFT JOIN n.producto p " +
+            "LEFT JOIN n.evaluacion e " +
+            "WHERE n.id = :id")
+    Optional<NoConformidadDetalleDTO> findDetalleById(@Param("id") Long id);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadService.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
+import com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.model.NoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.OrigenNoConformidad;
 import com.willyes.clemenintegra.calidad.model.enums.SeveridadNoConformidad;
@@ -25,7 +26,7 @@ public interface NoConformidadService {
 
     void eliminar(Long id);
 
-    NoConformidadDTO obtenerPorId(Long id);
+    NoConformidadDetalleDTO obtenerPorId(Long id);
 
     NoConformidadDTO cerrar(Long id, Usuario authUser);
 

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/NoConformidadServiceImpl.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.NoConformidadDTO;
+import com.willyes.clemenintegra.calidad.dto.NoConformidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.mapper.NoConformidadMapper;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.NoConformidad;
@@ -21,10 +22,12 @@ import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.time.YearMonth;
@@ -151,10 +154,12 @@ public class NoConformidadServiceImpl implements NoConformidadService {
         repository.deleteById(id);
     }
 
-    public NoConformidadDTO obtenerPorId(Long id) {
-        return repository.findById(id)
-                .map(mapper::toDTO)
-                .orElseThrow(() -> new NoSuchElementException("No conformidad no encontrada con ID: " + id));
+    @Transactional(readOnly = true)
+    public NoConformidadDetalleDTO obtenerPorId(Long id) {
+        return repository.findDetalleById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "No conformidad no encontrada con ID: " + id));
     }
 
     @Override

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadListadoIntegrationTest.java
@@ -82,6 +82,7 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
     private Usuario usuario;
     private LoteProducto loteProducto;
     private EvaluacionCalidad evaluacion;
+    private NoConformidad noConformidad;
 
     @BeforeEach
     void setUp() {
@@ -151,7 +152,7 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
                 .usuarioEvaluador(usuario)
                 .build());
 
-        noConformidadRepository.save(NoConformidad.builder()
+        noConformidad = noConformidadRepository.save(NoConformidad.builder()
                 .codigo("NC-TEST-001")
                 .origen(OrigenNoConformidad.LOTE)
                 .severidad(SeveridadNoConformidad.MAYOR)
@@ -177,6 +178,8 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].codigoLote").value("LP-CAL-1"))
+                .andExpect(jsonPath("$.content[0].loteId").value(loteProducto.getId()))
+                .andExpect(jsonPath("$.content[0].estadoEvaluacion").value("EVALUADO"))
                 .andExpect(jsonPath("$.content[0].cantidadAdjuntos").value(1))
                 .andExpect(jsonPath("$.content[0].tieneAdjuntos").value(true));
     }
@@ -190,5 +193,24 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].reportadoPorNombre").value("Usuario Calidad Listado"))
                 .andExpect(jsonPath("$.content[0].codigo").value("NC-TEST-001"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void obtenerNoConformidadDetalleNoDisparaLazy() throws Exception {
+        mockMvc.perform(get("/api/calidad/no-conformidades/{id}", noConformidad.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(noConformidad.getId()))
+                .andExpect(jsonPath("$.reportadoPorNombre").value("Usuario Calidad Listado"))
+                .andExpect(jsonPath("$.productoNombre").value("Producto Calidad"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void obtenerAuditoriaLoteDevuelveOk() throws Exception {
+        mockMvc.perform(get("/api/calidad/auditoria-lote/{loteId}", loteProducto.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.loteId").value(loteProducto.getId()))
+                .andExpect(jsonPath("$.codigoLote").value("LP-CAL-1"));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -209,6 +209,8 @@ class EvaluacionCalidadServiceImplTest {
                 ResultadoEvaluacion.CONFORME,
                 TipoEvaluacion.QUIMICO_MICROBIOLOGICO,
                 evaluador.getNombreCompleto(),
+                com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad.EVALUADO,
+                EstadoLote.EN_CUARENTENA,
                 2L);
 
         when(repository.findConsolidadoListado(any(), any(), any()))
@@ -255,6 +257,8 @@ class EvaluacionCalidadServiceImplTest {
                 ResultadoEvaluacion.CONFORME,
                 TipoEvaluacion.QUIMICO_MICROBIOLOGICO,
                 evaluador.getNombreCompleto(),
+                com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad.EVALUADO,
+                EstadoLote.EN_CUARENTENA,
                 0L);
         when(repository.findConsolidadoListado(any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(consolidado)));
@@ -297,6 +301,8 @@ class EvaluacionCalidadServiceImplTest {
                 ResultadoEvaluacion.CONFORME,
                 TipoEvaluacion.FISICO,
                 evaluador.getNombreCompleto(),
+                com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad.EVALUADO,
+                EstadoLote.EN_CUARENTENA,
                 1L);
         when(repository.findConsolidadoListado(any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(consolidado)));


### PR DESCRIPTION
### Motivation
- Evitar `LazyInitializationException` al solicitar detalle de no conformidad en `GET /api/calidad/no-conformidades/{id}` sin usar `OpenSessionInView` ni `@Transactional` en controllers. 
- Restaurar compatibilidad del frontend en el listado de evaluaciones consolidadas añadiendo los campos que esperaba la UI (estado y datos del lote). 
- Asegurar que la auditoría por lote esté accesible por la ruta real `/api/calidad/auditoria-lote/{loteId}` y pueda devolver datos cuando exista el lote.

### Description
- Añadido `NoConformidadDetalleDTO` y nuevo query en `NoConformidadRepository` `findDetalleById(Long id)` que construye el DTO con `JOIN`/`LEFT JOIN` para poblar `reportadoPorNombre`, `productoNombre`, `codigoLote` y evitar navegación lazy. 
- Cambiada la firma de `NoConformidadService.obtenerPorId` para devolver `NoConformidadDetalleDTO` y implementada en `NoConformidadServiceImpl` usando `repository.findDetalleById(...)` retornando `404` con `ResponseStatusException` cuando no existe. 
- Actualizado `NoConformidadController` para que `GET /api/calidad/no-conformidades/{id}` devuelva el DTO de detalle en vez de la entidad/DTO previo. 
- Restaurado el contrato de `EvaluacionConsolidadaListadoDTO` añadiendo `estadoEvaluacion` y `estadoLote`, y actualizado el `@Query` en `EvaluacionCalidadRepository.findConsolidadoListado(...)` para poblar esos campos sin navegación lazy; ajustados tests para reflejar los cambios.

### Testing
- Ajusté tests unitarios en `EvaluacionCalidadServiceImplTest` para construir el nuevo `EvaluacionConsolidadaListadoDTO` con los parámetros añadidos y permitir compilación. (Compilación local validada durante desarrollo). 
- Añadí integración en `CalidadListadoIntegrationTest` que verifica: detalle de no conformidad sin lazy, `loteId` y `estadoEvaluacion` en consolidado, y `GET /api/calidad/auditoria-lote/{loteId}` devuelve `200` cuando existe lote. 
- Intenté ejecutar `mvn -Dtest=CalidadListadoIntegrationTest test`, pero la ejecución de pruebas de integración falló en este entorno porque Testcontainers requiere Docker y no está disponible (error de configuración de Docker). 
- No se introdujeron cambios de persistencia que dependan de `OpenSessionInView` ni se marcó ningún controller como `@Transactional`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656388dfa48333b1815d15092fc829)