### PR TITLE
Load formula details eagerly and return DTO for GET /api/bom/formulas/{id}

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
@@ -52,9 +52,8 @@ public class FormulaProductoController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public ResponseEntity<FormulaProductoResponse> obtenerPorId(@PathVariable Long id) {
-        return formulaService.buscarPorId(id)
-                .map(formula -> bomMapper.toResponseDTO(formula))
+    public ResponseEntity<FormulaProductoDetalleDTO> obtenerPorId(@PathVariable Long id) {
+        return formulaService.buscarDetallePorId(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -190,4 +189,3 @@ public class FormulaProductoController {
         return ResponseEntity.ok(formulaService.obtenerFormulaActivaProduccion(productoId));
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaDetalleDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaDetalleDTO.java
@@ -1,0 +1,11 @@
+package com.willyes.clemenintegra.bom.dto;
+
+import java.math.BigDecimal;
+
+public class DetalleFormulaDetalleDTO {
+    public Long id;
+    public Long insumoId;
+    public String insumoNombre;
+    public BigDecimal cantidad;
+    public String unidad;
+}

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoDetalleDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoDetalleDTO.java
@@ -1,0 +1,20 @@
+package com.willyes.clemenintegra.bom.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class FormulaProductoDetalleDTO {
+    public Long id;
+    public String codigo;
+    public String version;
+    public String estado;
+    public Long productoId;
+    public String productoNombre;
+    public LocalDateTime fechaCreacion;
+    public String creadoPorNombre;
+    public String observacion;
+    public LocalDateTime fechaActualizacion;
+    public String actualizadoPorNombre;
+    public List<DetalleFormulaDetalleDTO> detalles;
+    public List<DocumentoFormulaResponseDTO> documentos;
+}

--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -35,6 +35,18 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
     })
     Optional<FormulaProducto> findByProductoIdAndEstadoAndActivoTrue(Long productoId, EstadoFormula estado);
 
+    @EntityGraph(attributePaths = {
+            "producto",
+            "detalles",
+            "detalles.insumo",
+            "detalles.unidadMedida",
+            "documentos",
+            "documentos.usuario",
+            "actualizadoPor",
+            "creadoPor"
+    })
+    Optional<FormulaProducto> findByIdConDetalles(Long id);
+
     List<FormulaProducto> findAllByProductoId(Long productoId);
 
     @Query("select f from FormulaProducto f " +

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.bom.service;
 
 import com.willyes.clemenintegra.bom.dto.FormulaActivaProduccionDTO;
+import com.willyes.clemenintegra.bom.dto.FormulaProductoDetalleDTO;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResponse;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
@@ -14,6 +15,7 @@ public interface FormulaProductoService {
     List<FormulaProducto> listarTodas();
     List<FormulaProductoResumenDTO> listarResumen(EstadoFormula estado, String producto);
     Optional<FormulaProducto> buscarPorId(Long id);
+    Optional<FormulaProductoDetalleDTO> buscarDetallePorId(Long id);
     FormulaProducto guardar(FormulaProducto formula);
     void eliminar(Long id);
 

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -62,6 +62,13 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
         return formulaRepository.findById(id);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<FormulaProductoDetalleDTO> buscarDetallePorId(Long id) {
+        return formulaRepository.findByIdConDetalles(id)
+                .map(this::mapDetalleFormula);
+    }
+
     public FormulaProducto guardar(FormulaProducto formula) {
         if (formula.getEstado() == EstadoFormula.APROBADA) {
             formula.setActivo(true);
@@ -217,6 +224,40 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
             return prefijo + numeroVersion + (sufijo != null ? sufijo : "");
         }
         return String.valueOf(numeroVersion);
+    }
+
+    private FormulaProductoDetalleDTO mapDetalleFormula(FormulaProducto formula) {
+        FormulaProductoDetalleDTO dto = new FormulaProductoDetalleDTO();
+        dto.id = formula.getId();
+        dto.codigo = formula.getProducto() != null ? formula.getProducto().getCodigoSku() : null;
+        dto.version = formula.getVersion();
+        dto.estado = formula.getEstado() != null ? formula.getEstado().name() : null;
+        dto.productoId = formula.getProducto() != null && formula.getProducto().getId() != null
+                ? formula.getProducto().getId().longValue()
+                : null;
+        dto.productoNombre = formula.getProducto() != null ? formula.getProducto().getNombre() : null;
+        dto.fechaCreacion = formula.getFechaCreacion();
+        dto.creadoPorNombre = formula.getCreadoPor() != null ? formula.getCreadoPor().getNombreCompleto() : null;
+        dto.observacion = formula.getObservacion();
+        dto.fechaActualizacion = formula.getFechaActualizacion();
+        dto.actualizadoPorNombre = formula.getActualizadoPor() != null ? formula.getActualizadoPor().getNombreCompleto() : null;
+        dto.detalles = formula.getDetalles() == null ? Collections.emptyList() : formula.getDetalles().stream()
+                .map(detalle -> {
+                    DetalleFormulaDetalleDTO detalleDto = new DetalleFormulaDetalleDTO();
+                    detalleDto.id = detalle.getId();
+                    detalleDto.insumoId = detalle.getInsumo() != null && detalle.getInsumo().getId() != null
+                            ? detalle.getInsumo().getId().longValue()
+                            : null;
+                    detalleDto.insumoNombre = detalle.getInsumo() != null ? detalle.getInsumo().getNombre() : null;
+                    detalleDto.cantidad = detalle.getCantidadNecesaria();
+                    detalleDto.unidad = detalle.getUnidadMedida() != null ? detalle.getUnidadMedida().getSimbolo() : null;
+                    return detalleDto;
+                })
+                .collect(Collectors.toList());
+        dto.documentos = formula.getDocumentos() == null ? Collections.emptyList() : formula.getDocumentos().stream()
+                .map(bomMapper::toResponseDTO)
+                .collect(Collectors.toList());
+        return dto;
     }
 
     @Override

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoDetalleIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoDetalleIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.willyes.clemenintegra.bom.controller;
+
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class FormulaProductoDetalleIntegrationTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private FormulaProductoRepository formulaProductoRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void obtenerDetalleFormula_porId_incluyeDetalles() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("bom-det-user")
+                .clave("secret")
+                .nombreCompleto("Usuario BOM Detalle")
+                .correo("bom-det-user@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Litro BOM")
+                .simbolo("LBO")
+                .codigo("LBO")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria BOM Det")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-FORM-DET")
+                .nombre("Producto Formula Detalle")
+                .descripcionProducto("Producto formula detalle")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        Producto insumo = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-INS-DET")
+                .nombre("Insumo Detalle")
+                .descripcionProducto("Insumo detalle")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        FormulaProducto formula = FormulaProducto.builder()
+                .producto(producto)
+                .version("V2")
+                .estado(EstadoFormula.EN_REVISION)
+                .fechaCreacion(LocalDateTime.now())
+                .activo(true)
+                .creadoPor(usuario)
+                .detalles(List.of())
+                .documentos(List.of())
+                .build();
+
+        DetalleFormula detalle = DetalleFormula.builder()
+                .formula(formula)
+                .insumo(insumo)
+                .unidadMedida(unidad)
+                .cantidadNecesaria(BigDecimal.valueOf(2))
+                .obligatorio(true)
+                .build();
+
+        formula.setDetalles(List.of(detalle));
+        FormulaProducto guardada = formulaProductoRepository.save(formula);
+
+        mockMvc.perform(get("/api/bom/formulas/{id}", guardada.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(guardada.getId()))
+                .andExpect(jsonPath("$.productoNombre").value("Producto Formula Detalle"))
+                .andExpect(jsonPath("$.detalles").isArray())
+                .andExpect(jsonPath("$.detalles[0].insumoNombre").value("Insumo Detalle"))
+                .andExpect(jsonPath("$.detalles[0].cantidad").value(2));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void obtenerDetalleFormula_noExiste_retorna404() throws Exception {
+        mockMvc.perform(get("/api/bom/formulas/{id}", 999999L))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
### Motivation
- Fix 500 caused by `LazyInitializationException` when requesting `GET /api/bom/formulas/{id}` by avoiding returning JPA entities that contain LAZY collections.
- Ensure the formula + its `detalles` and each detalle's `insumo`/`unidadMedida` are loaded explicitly to produce a stable JSON response.
- Return a dedicated DTO instead of exposing entities so Jackson won't trigger lazy loading outside a session.
- Add an integration test to prevent regressions for detail-view endpoints.

### Description
- Add repository method `findByIdConDetalles(Long id)` annotated with `@EntityGraph` to eagerly load `producto`, `detalles`, `detalles.insumo`, `detalles.unidadMedida`, `documentos` and user relationships (`src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java`).
- Create DTOs `FormulaProductoDetalleDTO` and `DetalleFormulaDetalleDTO` to represent the formula detail response and its detalle items (`src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoDetalleDTO.java`, `DetalleFormulaDetalleDTO.java`).
- Add `buscarDetallePorId(Long id)` to `FormulaProductoService` and implement mapping in `FormulaProductoServiceImpl#mapDetalleFormula` to convert the loaded entity to the new DTO (`src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java`, `FormulaProductoServiceImpl.java`).
- Update controller `GET /api/bom/formulas/{id}` to return `FormulaProductoDetalleDTO` using the new service method, and add `FormulaProductoDetalleIntegrationTest` covering 200 and 404 scenarios (`src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java`, `src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoDetalleIntegrationTest.java`).

### Testing
- Ran the new integration test with `mvn -q -Dtest=FormulaProductoDetalleIntegrationTest test`, which attempted to start Testcontainers and failed because no Docker environment was available (Testcontainers error), causing the test run to be cancelled.
- No full test-suite run was completed in this environment due to the Testcontainers/Docker limitation, but the change is covered by the added integration test which should pass when run in an environment with Docker available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696573a655d08333aa354983ece5a7dc)