### PR TITLE
Split FormulaProducto fetch to avoid MultipleBagFetchException

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -40,12 +40,18 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
             "detalles",
             "detalles.insumo",
             "detalles.unidadMedida",
-            "documentos",
-            "documentos.usuario",
             "actualizadoPor",
             "creadoPor"
     })
-    Optional<FormulaProducto> findByIdConDetalles(Long id);
+    @Query("select f from FormulaProducto f where f.id = :id")
+    Optional<FormulaProducto> findByIdConDetalles(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = {
+            "documentos",
+            "documentos.usuario"
+    })
+    @Query("select f from FormulaProducto f where f.id = :id")
+    Optional<FormulaProducto> findByIdWithDocumentos(@Param("id") Long id);
 
     List<FormulaProducto> findAllByProductoId(Long productoId);
 

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -65,8 +65,17 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
     @Override
     @Transactional(readOnly = true)
     public Optional<FormulaProductoDetalleDTO> buscarDetallePorId(Long id) {
-        return formulaRepository.findByIdConDetalles(id)
-                .map(this::mapDetalleFormula);
+        Optional<FormulaProducto> formulaOpt = formulaRepository.findByIdConDetalles(id);
+        if (formulaOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        FormulaProducto formula = formulaOpt.get();
+        List<DocumentoFormula> documentos = formulaRepository.findByIdWithDocumentos(id)
+                .map(FormulaProducto::getDocumentos)
+                .orElse(Collections.emptyList());
+
+        return Optional.of(mapDetalleFormula(formula, documentos));
     }
 
     public FormulaProducto guardar(FormulaProducto formula) {
@@ -226,7 +235,7 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
         return String.valueOf(numeroVersion);
     }
 
-    private FormulaProductoDetalleDTO mapDetalleFormula(FormulaProducto formula) {
+    private FormulaProductoDetalleDTO mapDetalleFormula(FormulaProducto formula, List<DocumentoFormula> documentos) {
         FormulaProductoDetalleDTO dto = new FormulaProductoDetalleDTO();
         dto.id = formula.getId();
         dto.codigo = formula.getProducto() != null ? formula.getProducto().getCodigoSku() : null;
@@ -254,7 +263,8 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                     return detalleDto;
                 })
                 .collect(Collectors.toList());
-        dto.documentos = formula.getDocumentos() == null ? Collections.emptyList() : formula.getDocumentos().stream()
+        List<DocumentoFormula> documentosSeguro = documentos == null ? Collections.emptyList() : documentos;
+        dto.documentos = documentosSeguro.stream()
                 .map(bomMapper::toResponseDTO)
                 .collect(Collectors.toList());
         return dto;

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoDetalleIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoDetalleIntegrationTest.java
@@ -1,8 +1,10 @@
 package com.willyes.clemenintegra.bom.controller;
 
 import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.DocumentoFormula;
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.model.enums.TipoDocumento;
 import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
@@ -117,6 +119,14 @@ class FormulaProductoDetalleIntegrationTest extends IntegrationTestMySqlContaine
                 .activo(true)
                 .build());
 
+        DocumentoFormula documento = DocumentoFormula.builder()
+                .tipoDocumento(TipoDocumento.PROCEDIMIENTO)
+                .nombreArchivo("procedimiento.pdf")
+                .rutaArchivo("/tmp/procedimiento.pdf")
+                .fechaSubida(LocalDateTime.now())
+                .usuario(usuario)
+                .build();
+
         FormulaProducto formula = FormulaProducto.builder()
                 .producto(producto)
                 .version("V2")
@@ -125,7 +135,7 @@ class FormulaProductoDetalleIntegrationTest extends IntegrationTestMySqlContaine
                 .activo(true)
                 .creadoPor(usuario)
                 .detalles(List.of())
-                .documentos(List.of())
+                .documentos(List.of(documento))
                 .build();
 
         DetalleFormula detalle = DetalleFormula.builder()
@@ -136,6 +146,7 @@ class FormulaProductoDetalleIntegrationTest extends IntegrationTestMySqlContaine
                 .obligatorio(true)
                 .build();
 
+        documento.setFormula(formula);
         formula.setDetalles(List.of(detalle));
         FormulaProducto guardada = formulaProductoRepository.save(formula);
 
@@ -145,7 +156,9 @@ class FormulaProductoDetalleIntegrationTest extends IntegrationTestMySqlContaine
                 .andExpect(jsonPath("$.productoNombre").value("Producto Formula Detalle"))
                 .andExpect(jsonPath("$.detalles").isArray())
                 .andExpect(jsonPath("$.detalles[0].insumoNombre").value("Insumo Detalle"))
-                .andExpect(jsonPath("$.detalles[0].cantidad").value(2));
+                .andExpect(jsonPath("$.detalles[0].cantidad").value(2))
+                .andExpect(jsonPath("$.documentos").isArray())
+                .andExpect(jsonPath("$.documentos[0].nombreVisible").value("procedimiento.pdf"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- The GET `/api/bom/formulas/{id}` endpoint failed with `MultipleBagFetchException` because the repository attempted to fetch two `List` (bag) associations (`detalles` and `documentos`) in the same entity-graph/fetch join under Hibernate 6.x. 
- The goal was to remove the exception while preserving the existing DTO response shape and not exposing JPA entities. 
- The fix must be minimal and respect constraints: no data-model/DB changes, no global `EAGER`, and no `OpenSessionInView`.

### Description

- Narrowed repository entity-graph for details by removing `documentos` from `findByIdConDetalles` and added `@Query("select f from FormulaProducto f where f.id = :id")` to it, preventing simultaneous bag fetches.
- Added a second repository method `findByIdWithDocumentos` annotated with `@EntityGraph(attributePaths = {"documentos","documentos.usuario"})` and `@Query("select f from FormulaProducto f where f.id = :id")` to load documents in a separate query.
- Changed service flow in `FormulaProductoServiceImpl.buscarDetallePorId(Long)` to first load the formula with details via `findByIdConDetalles`, then load documents via `findByIdWithDocumentos`, and map both into the DTO with a new `mapDetalleFormula(formula, documentos)` signature that converts `DocumentoFormula` to `DocumentoFormulaResponseDTO` via `bomMapper` (no entity leaks).
- Updated `FormulaProductoDetalleIntegrationTest` to persist a `DocumentoFormula` linked to the formula and assert that the returned JSON contains the expected document (`$.documentos[0].nombreVisible`).

### Testing

- Updated the integration test `FormulaProductoDetalleIntegrationTest` to include and assert document data in the response payload.
- No automated test suite was executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69657b967e988333bab78ce9c950c863)