### PR TITLE
Add PATCH /api/inventario/productos/{id}/calidad endpoint to update quality flags

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoCalidadController.java
@@ -1,0 +1,31 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.ProductoCalidadUpdateDTO;
+import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.service.ProductoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/inventario/productos")
+@RequiredArgsConstructor
+public class ProductoCalidadController {
+
+    private final ProductoService productoService;
+
+    @PatchMapping("/{id}/calidad")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    public ResponseEntity<ProductoResponseDTO> actualizarCamposCalidad(
+            @PathVariable Long id,
+            @Valid @RequestBody ProductoCalidadUpdateDTO dto) {
+        ProductoResponseDTO actualizado = productoService.actualizarCamposCalidad(id, dto);
+        return ResponseEntity.ok(actualizado);
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoCalidadUpdateDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoCalidadUpdateDTO.java
@@ -1,0 +1,21 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductoCalidadUpdateDTO {
+
+    @NotNull
+    private Boolean requiereAnalisisFisico;
+
+    @NotNull
+    private Boolean requiereAnalisisQuimico;
+
+    @NotNull
+    private Boolean requiereAnalisisMicrobiologico;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -16,6 +16,7 @@ public interface ProductoService {
     ProductoResponseDTO crearProducto(ProductoRequestDTO dto);
     ProductoResponseDTO obtenerPorId(Long id);
     ProductoResponseDTO actualizarProducto(Long id, ProductoRequestDTO dto);
+    ProductoResponseDTO actualizarCamposCalidad(Long id, ProductoCalidadUpdateDTO dto);
     // PROD-INACTIVAR BEGIN
     ProductoResponseDTO actualizarEstado(Long id, Boolean activo);
     // PROD-INACTIVAR END

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -10,6 +10,8 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.calidad.repository.PlantillaAnalisisMicrobiologicoRepository;
+import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
+import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
 import io.jsonwebtoken.Claims;
@@ -303,6 +305,23 @@ public class ProductoServiceImpl implements ProductoService {
         aplicarBanderasCalidadDesdeDto(producto, dto);
 
         producto.setRendimientoUnidad(resolverRendimientoUnidad(dto, categoria));
+
+        productoRepository.save(producto);
+        BigDecimal stock = stockQueryService.obtenerStockDisponible(producto.getId().longValue());
+        return buildDto(producto, stock);
+    }
+
+    @Override
+    @Transactional
+    public ProductoResponseDTO actualizarCamposCalidad(Long id, ProductoCalidadUpdateDTO dto) {
+        Producto producto = productoRepository.findById(id)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Producto no encontrado con ID: " + id));
+
+        producto.setRequiereAnalisisFisico(dto.getRequiereAnalisisFisico());
+        producto.setRequiereAnalisisQuimico(dto.getRequiereAnalisisQuimico());
+        producto.setRequiereAnalisisMicrobiologico(dto.getRequiereAnalisisMicrobiologico());
+        producto.recomputarTipoAnalisisDesdeBanderas();
 
         productoRepository.save(producto);
         BigDecimal stock = stockQueryService.obtenerStockDisponible(producto.getId().longValue());

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -104,6 +104,16 @@ public class SecurityConfig {
                             "/api/public/**"
                     ).permitAll();
 
+                    auth.requestMatchers(HttpMethod.PATCH, "/api/inventario/productos/*/calidad").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers(HttpMethod.GET, "/api/inventario/productos/**").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
                     auth.requestMatchers(
                             "/api/productos/**",
                             "/api/motivos/**", "/api/lotes/**", "/api/almacenes/**",

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoCalidadControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoCalidadControllerTest.java
@@ -1,0 +1,142 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.willyes.clemenintegra.inventario.dto.ProductoCalidadUpdateDTO;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestH2;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ProductoCalidadControllerTest extends IntegrationTestH2 {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    private Long productoId;
+
+    @BeforeEach
+    void setUp() {
+        Usuario usuario = Usuario.builder()
+                .nombreUsuario("calidad.test")
+                .clave("secret")
+                .nombreCompleto("Jefe Calidad Test")
+                .correo("calidad.test@example.com")
+                .rol(RolUsuario.ROL_JEFE_CALIDAD)
+                .activo(true)
+                .bloqueado(false)
+                .build();
+        usuarioRepository.save(usuario);
+
+        UnidadMedida unidad = UnidadMedida.builder()
+                .nombre("KILOGRAMO")
+                .simbolo("KG")
+                .build();
+        unidadMedidaRepository.save(unidad);
+
+        CategoriaProducto categoria = CategoriaProducto.builder()
+                .nombre("Categoria Calidad")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build();
+        categoriaProductoRepository.save(categoria);
+
+        Producto producto = Producto.builder()
+                .codigoSku("SKU-CALIDAD-001")
+                .nombre("Producto Calidad")
+                .stockMinimo(BigDecimal.ONE)
+                .stockMinimoProveedor(BigDecimal.ZERO)
+                .activo(true)
+                .fechaCreacion(LocalDateTime.now())
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .build();
+        productoRepository.save(producto);
+        productoId = producto.getId().longValue();
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void jefeCalidadPuedeActualizarCamposCalidad() throws Exception {
+        ProductoCalidadUpdateDTO dto = new ProductoCalidadUpdateDTO(true, false, true);
+
+        mockMvc.perform(patch("/api/inventario/productos/{id}/calidad", productoId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requiereAnalisisFisico").value(true))
+                .andExpect(jsonPath("$.requiereAnalisisQuimico").value(false))
+                .andExpect(jsonPath("$.requiereAnalisisMicrobiologico").value(true));
+
+        Producto actualizado = productoRepository.findById(productoId).orElseThrow();
+        assertThat(actualizado.isRequiereAnalisisFisico()).isTrue();
+        assertThat(actualizado.isRequiereAnalisisQuimico()).isFalse();
+        assertThat(actualizado.isRequiereAnalisisMicrobiologico()).isTrue();
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    void rolNoAutorizadoRecibeForbidden() throws Exception {
+        ProductoCalidadUpdateDTO dto = new ProductoCalidadUpdateDTO(true, true, true);
+
+        mockMvc.perform(patch("/api/inventario/productos/{id}/calidad", productoId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void idInexistenteDevuelveNotFound() throws Exception {
+        ProductoCalidadUpdateDTO dto = new ProductoCalidadUpdateDTO(true, true, false);
+
+        mockMvc.perform(patch("/api/inventario/productos/{id}/calidad", 999999L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
### Motivation

- Permitir desde el layout de calidad que el `ROL_JEFE_CALIDAD` (y `ROL_SUPER_ADMIN`) pueda actualizar únicamente las tres banderas de análisis de un producto. 
- Evitar por diseño que se modifiquen otros campos del producto exponiendo un DTO restringido. 
- Mantener el resto de la API de productos sin cambios funcionales ni exposición directa de la entidad JPA.

### Description

- Se creó el DTO `ProductoCalidadUpdateDTO` con solo `requiereAnalisisFisico`, `requiereAnalisisQuimico` y `requiereAnalisisMicrobiologico` en `src/main/java/.../inventario/dto/ProductoCalidadUpdateDTO.java`.
- Se agregó el controlador `ProductoCalidadController` que expone `PATCH /api/inventario/productos/{id}/calidad` y está protegido con `@PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")` en `src/main/java/.../inventario/controller/ProductoCalidadController.java`.
- Se añadió la firma `actualizarCamposCalidad(Long id, ProductoCalidadUpdateDTO dto)` en `ProductoService` y su implementación en `ProductoServiceImpl` que busca el producto, asigna SOLO las tres banderas, recomputa `tipoAnalisis` y retorna `ProductoResponseDTO` usando el mapper existente.
- Se actualizaron reglas en `SecurityConfig` para permitir `PATCH /api/inventario/productos/*/calidad` y lectura `GET /api/inventario/productos/**` para `ROL_JEFE_CALIDAD` (y `ROL_SUPER_ADMIN`) sin romper reglas existentes.

### Testing

- Se añadió un test de integración con MockMvc `ProductoCalidadControllerTest` que cubre: jefe de calidad puede actualizar (200), rol no autorizado recibe 403 y id inexistente devuelve 404, en `src/test/java/.../ProductoCalidadControllerTest.java`.
- Se intentó ejecutar `mvn -Dtest=ProductoCalidadControllerTest test` en el entorno, pero la ejecución quedó abortada/no produjo salida completa en este contexto.
- Los tests están implementados con `@SpringBootTest` + `@AutoConfigureMockMvc` y usan la base `IntegrationTestH2` para evitar dependencias externas; pueden ejecutarse localmente o en CI para validar el comportamiento.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965840b86f883338c5037d8b5c3bcdf)