### PR TITLE
Permitir lectura de categorías y alertas para Jefe de Calidad

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/IndicadoresProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/IndicadoresProduccionController.java
@@ -35,7 +35,7 @@ public class IndicadoresProduccionController {
     }
 
     @GetMapping("/ordenes/alertas")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
     public ResponseEntity<List<AlertaOrdenProduccionDTO>> obtenerAlertas(
             @RequestParam(required = false) LocalDate fechaReferencia,
             @RequestParam(required = false, defaultValue = "3") Integer diasVentana) {

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -114,6 +114,23 @@ public class SecurityConfig {
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
+                    auth.requestMatchers(HttpMethod.GET, "/api/categorias", "/api/categorias/**").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_ALMACENISTA.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers(HttpMethod.GET,
+                            "/api/produccion/ordenes/alertas",
+                            "/api/produccion/ordenes/alertas/**").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_LIDER_ALIMENTOS.name(),
+                            RolUsuario.ROL_LIDER_HOMEOPATICOS.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
                     auth.requestMatchers(
                             "/api/productos/**",
                             "/api/motivos/**", "/api/lotes/**", "/api/almacenes/**",

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/CategoriaProductoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/CategoriaProductoControllerSecurityTest.java
@@ -1,0 +1,106 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.CategoriaProductoResponseDTO;
+import com.willyes.clemenintegra.inventario.service.CategoriaProductoService;
+import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CategoriaProductoController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import(SecurityConfig.class)
+@ImportAutoConfiguration({SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
+class CategoriaProductoControllerSecurityTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    @org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity(prePostEnabled = true)
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CategoriaProductoService categoriaProductoService;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private RequestTimingFilter requestTimingFilter;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void configureFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestTimingFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    void permiteAccesoConRolJefeCalidad() throws Exception {
+        when(categoriaProductoService.listarTodas()).thenReturn(Collections.singletonList(CategoriaProductoResponseDTO.builder().build()));
+
+        mockMvc.perform(get("/api/categorias")
+                        .with(SecurityMockMvcRequestPostProcessors.user("jefe-calidad")
+                                .authorities(() -> "ROL_JEFE_CALIDAD")))
+                .andExpect(status().isOk());
+
+        verify(categoriaProductoService).listarTodas();
+    }
+
+    @Test
+    void rechazaRolNoAutorizado() throws Exception {
+        mockMvc.perform(get("/api/categorias")
+                        .with(SecurityMockMvcRequestPostProcessors.user("analista")
+                                .authorities(() -> "ROL_ANALISTA_CALIDAD")))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/AlertasProduccionControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/AlertasProduccionControllerSecurityTest.java
@@ -1,0 +1,112 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.produccion.dto.AlertaOrdenProduccionDTO;
+import com.willyes.clemenintegra.produccion.service.ProduccionIndicadoresService;
+import com.willyes.clemenintegra.produccion.service.ReporteIndicadoresProduccionService;
+import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(IndicadoresProduccionController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import(SecurityConfig.class)
+@ImportAutoConfiguration({SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
+class AlertasProduccionControllerSecurityTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    @org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity(prePostEnabled = true)
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProduccionIndicadoresService produccionIndicadoresService;
+    @MockBean
+    private ReporteIndicadoresProduccionService reporteIndicadoresProduccionService;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private RequestTimingFilter requestTimingFilter;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void configureFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestTimingFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    void permiteAccesoConRolJefeCalidad() throws Exception {
+        when(produccionIndicadoresService.obtenerOrdenesConAlertas(any(java.time.LocalDate.class), org.mockito.ArgumentMatchers.anyInt()))
+                .thenReturn(Collections.singletonList(AlertaOrdenProduccionDTO.builder().build()));
+
+        mockMvc.perform(get("/api/produccion/ordenes/alertas")
+                        .param("fechaReferencia", "2026-01-12")
+                        .with(SecurityMockMvcRequestPostProcessors.user("jefe-calidad")
+                                .authorities(() -> "ROL_JEFE_CALIDAD")))
+                .andExpect(status().isOk());
+
+        verify(produccionIndicadoresService).obtenerOrdenesConAlertas(any(java.time.LocalDate.class), org.mockito.ArgumentMatchers.anyInt());
+    }
+
+    @Test
+    void rechazaRolNoAutorizado() throws Exception {
+        mockMvc.perform(get("/api/produccion/ordenes/alertas")
+                        .param("fechaReferencia", "2026-01-12")
+                        .with(SecurityMockMvcRequestPostProcessors.user("almacenista")
+                                .authorities(() -> "ROL_ALMACENISTA")))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
### Motivation
- El layout de Jefe de Calidad necesita consumir catálogos globales y alertas que hoy devuelven `403` para `ROL_JEFE_CALIDAD`.
- No se deben abrir operaciones de escritura sobre categorías o alertas, solo lectura.
- Habilitar el endpoint real de alertas usado por el frontend para que `ROL_JEFE_CALIDAD` pueda consultarlo.
- Agregar pruebas MockMvc que validen acceso `200`/`403` según rol.

### Description
- En `SecurityConfig.java` se agregó permiso explícito de solo lectura `GET` para `/api/categorias` y `/api/categorias/**` otorgado a `ROL_JEFE_CALIDAD` y `ROL_SUPER_ADMIN` (y roles de almacén existentes que ya tenían acceso). 
- En `SecurityConfig.java` se habilitó `GET` a `/api/produccion/ordenes/alertas` (y `/**`) para `ROL_JEFE_CALIDAD` junto con los roles de producción ya existentes; nota: el path exacto habilitado es `/api/produccion/ordenes/alertas`.
- Se amplió la anotación `@PreAuthorize` en `IndicadoresProduccionController.obtenerAlertas` para incluir `ROL_JEFE_CALIDAD`.
- Se añadieron pruebas MockMvc: `CategoriaProductoControllerSecurityTest` y `AlertasProduccionControllerSecurityTest` que verifican `200` para `ROL_JEFE_CALIDAD` y `403` para roles no autorizados.

### Testing
- Ejecutado: `mvn -q -Dtest=*Security* test`.
- Las pruebas de seguridad añadidas (`CategoriaProductoControllerSecurityTest` y `AlertasProduccionControllerSecurityTest`) se ejecutaron como parte del conjunto y validaron los códigos `200`/`403` esperados.
- Se corrigieron errores iniciales de compilación y de uso de matchers en tests durante la implementación hasta que la suite de pruebas de seguridad pasó.
- No se modificaron permisos de escritura para categorías/alertas; solo se añadieron reglas `GET` en `SecurityConfig`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696587f3e52083339b79dd78d5c1217c)