### PR TITLE
Evitar LazyInitializationException en movimientos y cierres de OP (EntityGraph) y agregar tests MockMvc

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -97,13 +97,15 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "lote.producto",
-            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa",
+            "motivoMovimiento", "solicitudMovimiento", "recepcionOc"
     })
     Page<MovimientoInventario> findByOrdenProduccionId(Long ordenProduccionId, Pageable pageable);
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "lote.producto",
-            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa",
+            "motivoMovimiento", "solicitudMovimiento", "recepcionOc"
     })
     Page<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaId(Long ordenProduccionId,
                                                                                Long ordenProduccionEtapaId,
@@ -111,7 +113,8 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "lote.producto",
-            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa",
+            "motivoMovimiento", "solicitudMovimiento", "recepcionOc"
     })
     Page<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacion(
             Long ordenProduccionId,
@@ -121,7 +124,8 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "lote.producto",
-            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa",
+            "motivoMovimiento", "solicitudMovimiento", "recepcionOc"
     })
     List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdOrderByFechaIngresoAsc(
             Long ordenProduccionId,
@@ -129,7 +133,8 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "lote.producto",
-            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa",
+            "motivoMovimiento", "solicitudMovimiento", "recepcionOc"
     })
     List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(
             Long ordenProduccionId,
@@ -138,7 +143,8 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "lote.producto",
-            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa",
+            "motivoMovimiento", "solicitudMovimiento", "recepcionOc"
     })
     List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdOrderByFechaIngresoDesc(
             Long ordenProduccionId,
@@ -146,7 +152,8 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "lote.producto",
-            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa",
+            "motivoMovimiento", "solicitudMovimiento", "recepcionOc"
     })
     List<MovimientoInventario> findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoDesc(
             Long ordenProduccionId,
@@ -168,7 +175,8 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "lote.producto",
-            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa",
+            "motivoMovimiento", "solicitudMovimiento", "recepcionOc"
     })
     Page<MovimientoInventario> findByOrdenProduccionIdAndClasificacion(Long ordenProduccionId,
                                                                        ClasificacionMovimientoInventario clasificacion,
@@ -337,7 +345,8 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     @EntityGraph(attributePaths = {
             "producto", "producto.unidadMedida", "lote", "lote.producto",
-            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa"
+            "almacenOrigen", "almacenDestino", "registradoPor", "ordenProduccion", "ordenProduccionEtapa",
+            "motivoMovimiento", "solicitudMovimiento", "recepcionOc"
     })
     List<MovimientoInventario> findByOrdenProduccionIdOrderByFechaIngresoAsc(Long ordenProduccionId);
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/CierreProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/CierreProduccionRepository.java
@@ -3,9 +3,11 @@ package com.willyes.clemenintegra.produccion.repository;
 import com.willyes.clemenintegra.produccion.model.CierreProduccion;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CierreProduccionRepository extends JpaRepository<CierreProduccion, Long> {
+    @EntityGraph(attributePaths = {"ordenProduccion", "ordenProduccion.unidadMedida"})
     Page<CierreProduccion> findByOrdenProduccionId(Long ordenId, Pageable pageable);
 
     long countByOrdenProduccionId(Long ordenId);

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionCierresControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionCierresControllerTest.java
@@ -1,0 +1,150 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.produccion.model.CierreProduccion;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.TipoCierre;
+import com.willyes.clemenintegra.produccion.repository.CierreProduccionRepository;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OrdenProduccionCierresControllerTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private OrdenProduccionRepository ordenProduccionRepository;
+
+    @Autowired
+    private CierreProduccionRepository cierreProduccionRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @BeforeEach
+    void setup() {
+        cierreProduccionRepository.deleteAll();
+        ordenProduccionRepository.deleteAll();
+        productoRepository.deleteAll();
+        categoriaProductoRepository.deleteAll();
+        unidadMedidaRepository.deleteAll();
+        usuarioRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void listarCierresIncluyeUnidadMedida() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("tester-cierre")
+                .clave("clave")
+                .nombreCompleto("Usuario Cierre")
+                .correo("tester+cierre@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidadMedida = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .nombrePlural("Unidades")
+                .simbolo("u")
+                .codigo("UND")
+                .simboloImpresion("u")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("PT")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-CIERRE")
+                .nombre("Producto Cierre")
+                .stockMinimo(BigDecimal.ZERO)
+                .activo(true)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidadMedida)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+
+        OrdenProduccion ordenProduccion = ordenProduccionRepository.save(OrdenProduccion.builder()
+                .codigoOrden("OP-400")
+                .loteProduccion("LOTE-OP-400")
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(new BigDecimal("40"))
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .producto(producto)
+                .unidadMedida(unidadMedida)
+                .responsable(usuario)
+                .build());
+
+        cierreProduccionRepository.save(CierreProduccion.builder()
+                .ordenProduccion(ordenProduccion)
+                .cantidad(new BigDecimal("5"))
+                .tipo(TipoCierre.PARCIAL)
+                .usuarioId(usuario.getId())
+                .usuarioNombre(usuario.getNombreCompleto())
+                .build());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}/cierres", ordenProduccion.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].unidadMedidaSimbolo").value("u"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionMovimientosControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionMovimientosControllerTest.java
@@ -9,6 +9,7 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
 import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
@@ -74,6 +75,9 @@ class OrdenProduccionMovimientosControllerTest extends IntegrationTestMySqlConta
     private MovimientoInventarioRepository movimientoInventarioRepository;
 
     @Autowired
+    private SolicitudMovimientoRepository solicitudMovimientoRepository;
+
+    @Autowired
     private OrdenProduccionRepository ordenProduccionRepository;
 
     @Autowired
@@ -88,6 +92,7 @@ class OrdenProduccionMovimientosControllerTest extends IntegrationTestMySqlConta
     @BeforeEach
     void setup() {
         movimientoInventarioRepository.deleteAll();
+        solicitudMovimientoRepository.deleteAll();
         etapaProduccionRepository.deleteAll();
         loteProductoRepository.deleteAll();
         ordenProduccionRepository.deleteAll();
@@ -306,5 +311,114 @@ class OrdenProduccionMovimientosControllerTest extends IntegrationTestMySqlConta
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].ordenProduccionEtapaId").value(etapa.getId()))
                 .andExpect(jsonPath("$.content[0].nombreEtapaProduccion").value(etapa.getNombre()));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void listarMovimientosIncluyeEstadoDeSolicitud() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("tester-solicitud")
+                .clave("clave")
+                .nombreCompleto("Usuario Solicitud")
+                .correo("tester+solicitud@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidadMedida = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .nombrePlural("Unidades")
+                .simbolo("u")
+                .codigo("UND")
+                .simboloImpresion("u")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("MP")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-SOL")
+                .nombre("Producto Solicitud")
+                .stockMinimo(BigDecimal.ZERO)
+                .activo(true)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidadMedida)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+
+        OrdenProduccion ordenProduccion = ordenProduccionRepository.save(OrdenProduccion.builder()
+                .codigoOrden("OP-300")
+                .loteProduccion("LOTE-OP-300")
+                .fechaInicio(LocalDateTime.now())
+                .cantidadProgramada(new BigDecimal("30"))
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .producto(producto)
+                .unidadMedida(unidadMedida)
+                .responsable(usuario)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Principal")
+                .ubicacion("Bodega Central")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        LoteProducto lote = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LOTE-789")
+                .stockLote(new BigDecimal("15"))
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(producto)
+                .almacen(almacen)
+                .build());
+
+        MotivoMovimiento motivo = motivoMovimientoRepository.save(MotivoMovimiento.builder()
+                .descripcion("Solicitud producción")
+                .motivo(ClasificacionMovimientoInventario.SALIDA_PRODUCCION)
+                .build());
+
+        TipoMovimientoDetalle tipoDetalle = tipoMovimientoDetalleRepository.save(
+                TipoMovimientoDetalle.builder()
+                        .descripcion("Consumo solicitud")
+                        .build()
+        );
+
+        SolicitudMovimiento solicitud = solicitudMovimientoRepository.save(SolicitudMovimiento.builder()
+                .tipoMovimiento(TipoMovimiento.SALIDA)
+                .producto(producto)
+                .cantidad(new BigDecimal("3"))
+                .usuarioSolicitante(usuario)
+                .ordenProduccion(ordenProduccion)
+                .estado(EstadoSolicitudMovimiento.AUTORIZADA)
+                .build());
+
+        movimientoInventarioRepository.save(MovimientoInventario.builder()
+                .cantidad(new BigDecimal("3"))
+                .tipoMovimiento(TipoMovimiento.SALIDA)
+                .clasificacion(ClasificacionMovimientoInventario.SALIDA_PRODUCCION)
+                .registradoPor(usuario)
+                .producto(producto)
+                .lote(lote)
+                .almacenOrigen(almacen)
+                .motivoMovimiento(motivo)
+                .tipoMovimientoDetalle(tipoDetalle)
+                .ordenProduccion(ordenProduccion)
+                .solicitudMovimiento(solicitud)
+                .build());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}/movimientos", ordenProduccion.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].solicitudId").value(solicitud.getId()))
+                .andExpect(jsonPath("$.content[0].estadoSolicitud").value(EstadoSolicitudMovimiento.AUTORIZADA.name()));
     }
 }


### PR DESCRIPTION
### Motivation
- Evitar el `LazyInitializationException` al serializar movimientos de inventario usados por el mapper cargando relaciones necesarias en la consulta.
- Evitar 500 al listar cierres asegurando que la `OrdenProduccion.unidadMedida` esté disponible para el mapeo de respuesta.
- Añadir pruebas MockMvc para cubrir los casos y prevenir regresiones en el futuro.

### Description
- Amplié los `@EntityGraph` en `MovimientoInventarioRepository` para las consultas por orden de producción incluyendo `motivoMovimiento`, `solicitudMovimiento` y `recepcionOc` para garantizar que el mapper no acceda a proxys no inicializados. (archivo: `src/main/java/.../MovimientoInventarioRepository.java`).
- Añadí `@EntityGraph(attributePaths = {"ordenProduccion", "ordenProduccion.unidadMedida"})` en `CierreProduccionRepository` para precargar la unidad de medida necesaria al mapear cierres. (archivo: `src/main/java/.../CierreProduccionRepository.java`).
- Actualicé `OrdenProduccionMovimientosControllerTest` para limpiar/crear datos de `SolicitudMovimiento` y añadí una prueba `listarMovimientosIncluyeEstadoDeSolicitud` que verifica `solicitudId` y `estadoSolicitud` en la respuesta. (archivo: `src/test/java/.../OrdenProduccionMovimientosControllerTest.java`).
- Añadí `OrdenProduccionCierresControllerTest` con la prueba `listarCierresIncluyeUnidadMedida` que valida que `unidadMedidaSimbolo` se incluya en la respuesta. (archivo nuevo: `src/test/java/.../OrdenProduccionCierresControllerTest.java`).

### Testing
- Nuevas pruebas MockMvc añadidas: `listarMovimientosIncluyeEstadoDeSolicitud` y `listarCierresIncluyeUnidadMedida` located in the controller test classes.
- Intenté ejecutar los tests con `mvn -q -Dtest=*OrdenProduccion*Test,*Movimiento*Test test`, pero la ejecución se interrumpió en este entorno y fue cancelada. 
- Las pruebas están diseñadas como tests de integración (MockMvc + contenedor de BD de integración) y deberían ejecutarse en el pipeline/integración local donde la ejecución completa está permitida.
- No se cambiaron los mappers (`MovimientoInventarioMapper` ni `ProduccionMapper`) para preservar la respuesta JSON actual al frontend.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658d0278548333addf661deebb7838)