### PR TITLE
Fix LazyLoading in GET /api/produccion/ordenes/{id} using EntityGraph

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
@@ -38,6 +38,10 @@ public interface OrdenProduccionRepository extends JpaRepository<OrdenProduccion
     @Query("select o from OrdenProduccion o where o.id = :id")
     Optional<OrdenProduccion> findByIdForUpdate(@Param("id") Long id);
 
+    @EntityGraph(attributePaths = {"producto", "producto.categoriaProducto"})
+    @Query("select op from OrdenProduccion op where op.id = :id")
+    Optional<OrdenProduccion> findByIdWithProductoCategoria(@Param("id") Long id);
+
     List<OrdenProduccion> findByFechaFinBetween(LocalDateTime inicio, LocalDateTime fin);
 
     List<OrdenProduccion> findByEstadoNotInAndFechaFinBetween(Collection<EstadoProduccion> estados, LocalDateTime inicio, LocalDateTime fin);

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -569,8 +569,9 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         return repository.findAll();
     }
 
+    @Transactional(readOnly = true)
     public Optional<OrdenProduccion> buscarPorId(Long id) {
-        return repository.findById(id).map(this::adjuntarFechaVencimientoLotePt);
+        return repository.findByIdWithProductoCategoria(id).map(this::adjuntarFechaVencimientoLotePt);
     }
 
     private OrdenProduccion adjuntarFechaVencimientoLotePt(OrdenProduccion orden) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionObtenerPorIdIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionObtenerPorIdIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.willyes.clemenintegra.produccion.controller;
+
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestH2;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class OrdenProduccionObtenerPorIdIntegrationTest extends IntegrationTestH2 {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private OrdenProduccionRepository ordenProduccionRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void obtenerPorIdIncluyeCategoriaProducto() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("responsable-op")
+                .clave("secret")
+                .nombreCompleto("Responsable OP")
+                .correo("responsable-op@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad OP")
+                .simbolo("UOP")
+                .codigo("UOP")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria OP")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-OP")
+                .nombre("Producto OP")
+                .descripcionProducto("Producto para orden")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        OrdenProduccion orden = ordenProduccionRepository.save(OrdenProduccion.builder()
+                .codigoOrden("OP-GET-001")
+                .fechaInicio(LocalDateTime.now().minusHours(1))
+                .cantidadProgramada(BigDecimal.TEN)
+                .cantidadProducida(BigDecimal.ZERO)
+                .cantidadProducidaAcumulada(BigDecimal.ZERO)
+                .estado(EstadoProduccion.EN_PROCESO)
+                .producto(producto)
+                .unidadMedida(unidad)
+                .responsable(usuario)
+                .build());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}", orden.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nombreProducto").value("Producto OP"))
+                .andExpect(jsonPath("$.categoriaProducto").value(TipoCategoria.PRODUCTO_TERMINADO.name()));
+    }
+}


### PR DESCRIPTION
### Motivation
- The endpoint `GET /api/produccion/ordenes/{id}` raised a `LazyInitializationException` when `ProduccionMapper.toResponse` accessed `producto.categoriaProducto.tipo` outside a session. 
- The intent is to preload the minimal relations required by the mapper without enabling Open Session In View or adding try/catch patches. 

### Description
- Added a repository method `findByIdWithProductoCategoria(Long id)` annotated with `@EntityGraph(attributePaths = {"producto","producto.categoriaProducto"})` to preload `producto` and its `categoriaProducto`. 
- Switched the service lookup `buscarPorId` to use `repository.findByIdWithProductoCategoria(id)` so the mapper will not trigger lazy loading. 
- Files changed: `OrdenProduccionRepository.java` (new EntityGraph query, ~L41-L45), `OrdenProduccionServiceImpl.java` (`buscarPorId` now calls `findByIdWithProductoCategoria`, ~L572-L575), and added an integration test `OrdenProduccionObtenerPorIdIntegrationTest.java` that validates the JSON includes the category `tipo`; `ProduccionMapper.toResponse` (reads `producto.categoriaProducto.tipo`, ~L46) remains unchanged. 

### Testing
- Added and ran the integration test `OrdenProduccionObtenerPorIdIntegrationTest` which calls `GET /api/produccion/ordenes/{id}` and asserts `$.nombreProducto` and `$.categoriaProducto` are present. 
- The test was executed with `mvn -Dtest=OrdenProduccionObtenerPorIdIntegrationTest test` and completed successfully. 
- Test results: `Tests run: 1, Failures: 0, Errors: 0` and `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965a03028c88333aea38f16789575b5)