### PR TITLE
Salida PT: flujo PickList (FEFO/manual), PDF con ubicaciones y endpoints

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SalidaPtController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SalidaPtController.java
@@ -60,7 +60,7 @@ public class SalidaPtController {
             return ResponseEntity.ok(List.of());
         }
 
-        EnumSet<EstadoLote> estadosElegibles = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
+        EnumSet<EstadoLote> estadosElegibles = EnumSet.of(EstadoLote.LIBERADO);
         List<LoteProducto> candidatos = loteProductoRepository.findFefoSalidaPt(
                 productoId,
                 almacenPtId,

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SalidaPtPicklistController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SalidaPtPicklistController.java
@@ -1,0 +1,48 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.PicklistPtCreateRequest;
+import com.willyes.clemenintegra.inventario.dto.PicklistPtResponse;
+import com.willyes.clemenintegra.inventario.service.PicklistPtService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/inventario/salida-pt/picklist")
+@RequiredArgsConstructor
+public class SalidaPtPicklistController {
+
+    private final PicklistPtService picklistPtService;
+
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<PicklistPtResponse> generar(@Valid @RequestBody PicklistPtCreateRequest request) {
+        return ResponseEntity.ok(picklistPtService.crear(request));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<PicklistPtResponse> detalle(@PathVariable Long id) {
+        return ResponseEntity.ok(picklistPtService.obtener(id));
+    }
+
+    @GetMapping("/{id}/pdf")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<byte[]> pdf(@PathVariable Long id) {
+        byte[] pdf = picklistPtService.generarPdf(id);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=picklist-pt-" + id + ".pdf")
+                .body(pdf);
+    }
+
+    @PostMapping("/{id}/ejecutar")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    public ResponseEntity<PicklistPtResponse> ejecutar(@PathVariable Long id) {
+        return ResponseEntity.ok(picklistPtService.ejecutar(id));
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/PicklistPtAsignacionResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/PicklistPtAsignacionResponse.java
@@ -11,6 +11,8 @@ public record PicklistPtAsignacionResponse(
         String codigoLote,
         BigDecimal cantidadAsignada,
         LocalDateTime fechaVencimiento,
+        String codigoUbicacionInterna,
+        String descripcionUbicacionInterna,
         Integer almacenId,
         Short orden
 ) {

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/PicklistPtCreateRequest.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/PicklistPtCreateRequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record PicklistPtCreateRequest(
         @NotBlank String clienteNombre,
         Integer minVidaUtilDias,
+        Integer minVidaUtilSemanas,
         String docReferencia,
         String observaciones,
         @NotEmpty List<PicklistPtLineaRequest> lineas

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/PicklistPtServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/PicklistPtServiceImpl.java
@@ -48,7 +48,7 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class PicklistPtServiceImpl implements PicklistPtService {
 
-    private static final EnumSet<EstadoLote> ESTADOS_FEFO = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
+    private static final EnumSet<EstadoLote> ESTADOS_FEFO = EnumSet.of(EstadoLote.LIBERADO);
 
     private final PicklistPtRepository picklistRepository;
     private final ProductoRepository productoRepository;
@@ -66,11 +66,12 @@ public class PicklistPtServiceImpl implements PicklistPtService {
         Integer almacenPtId = obtenerAlmacenPtRequerido();
         Integer tipoDetalleSalidaPt = obtenerTipoDetalleSalidaPt();
         String codigo = generarCodigoPicklist();
+        Integer minVidaUtilDias = resolverMinVidaUtilDias(request);
 
         PicklistPt picklist = PicklistPt.builder()
                 .codigo(codigo)
                 .clienteNombre(request.clienteNombre())
-                .minVidaUtilDias(request.minVidaUtilDias())
+                .minVidaUtilDias(minVidaUtilDias)
                 .estado(PicklistPtEstado.BORRADOR)
                 .almacenPtId(almacenPtId)
                 .tipoMovimientoDetalleId(tipoDetalleSalidaPt)
@@ -148,9 +149,13 @@ public class PicklistPtServiceImpl implements PicklistPtService {
         PicklistPt picklist = picklistRepository.findWithDetallesById(id)
                 .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
                         "Picklist no encontrado"));
-        if (picklist.getEstado() != PicklistPtEstado.CONFIRMADO) {
+        if (picklist.getEstado() == PicklistPtEstado.EJECUTADO) {
+            return toResponse(picklist);
+        }
+        if (picklist.getEstado() != PicklistPtEstado.CONFIRMADO
+                && picklist.getEstado() != PicklistPtEstado.GENERADO) {
             throw new CustomBusinessException(ApiErrorCode.PICKLIST_ESTADO_INVALIDO,
-                    "Solo se puede ejecutar un picklist en estado CONFIRMADO");
+                    "Solo se puede ejecutar un picklist en estado CONFIRMADO o GENERADO");
         }
 
         var usuario = usuarioService.obtenerUsuarioAutenticado();
@@ -204,6 +209,19 @@ public class PicklistPtServiceImpl implements PicklistPtService {
             throw new CustomBusinessException(ApiErrorCode.PICKLIST_LINEAS_REQUERIDAS,
                     "Debe incluir al menos una línea");
         }
+    }
+
+    private Integer resolverMinVidaUtilDias(PicklistPtCreateRequest request) {
+        if (request == null) {
+            return null;
+        }
+        if (request.minVidaUtilDias() != null) {
+            return request.minVidaUtilDias();
+        }
+        if (request.minVidaUtilSemanas() == null) {
+            return null;
+        }
+        return request.minVidaUtilSemanas() * 7;
     }
 
     private List<PicklistPtLinea> construirLineas(PicklistPt picklist, List<PicklistPtLineaRequest> lineas) {
@@ -324,6 +342,7 @@ public class PicklistPtServiceImpl implements PicklistPtService {
             throw new CustomBusinessException(ApiErrorCode.PICKLIST_LOTE_INVALIDO,
                     "El lote no pertenece al almacén PT");
         }
+        validarLoteLiberado(lote);
         validarMinVidaUtil(lote.getFechaVencimiento(), minVidaUtilDias, ahora);
         loteCalidadValidator.validarLoteUtilizable(lote);
         BigDecimal disponible = disponibleParaSalida(lote);
@@ -334,6 +353,9 @@ public class PicklistPtServiceImpl implements PicklistPtService {
     }
 
     private boolean esLoteElegibleAuto(LoteProducto lote, Integer minVidaUtilDias, LocalDateTime ahora) {
+        if (!esLoteLiberado(lote)) {
+            return false;
+        }
         if (!validarMinVidaUtilSuave(lote.getFechaVencimiento(), minVidaUtilDias, ahora)) {
             return false;
         }
@@ -343,6 +365,17 @@ public class PicklistPtServiceImpl implements PicklistPtService {
             return false;
         }
         return true;
+    }
+
+    private void validarLoteLiberado(LoteProducto lote) {
+        if (!esLoteLiberado(lote)) {
+            throw new CustomBusinessException(ApiErrorCode.CALIDAD_LOTE_NO_LIBERADO,
+                    "El lote no está liberado para salida PT");
+        }
+    }
+
+    private boolean esLoteLiberado(LoteProducto lote) {
+        return lote != null && lote.getEstado() == EstadoLote.LIBERADO;
     }
 
     private void validarMinVidaUtil(LocalDateTime fechaVencimiento,
@@ -398,6 +431,10 @@ public class PicklistPtServiceImpl implements PicklistPtService {
             if (almacenActual == null || !Objects.equals(almacenActual, picklist.getAlmacenPtId().longValue())) {
                 throw new CustomBusinessException(ApiErrorCode.PICKLIST_DESACTUALIZADO,
                         "El lote asignado ya no está en el almacén PT");
+            }
+            if (!esLoteLiberado(lote)) {
+                throw new CustomBusinessException(ApiErrorCode.PICKLIST_DESACTUALIZADO,
+                        "El lote asignado ya no está liberado");
             }
             try {
                 validarMinVidaUtil(lote.getFechaVencimiento(), minVidaUtilDias, ahora);
@@ -494,6 +531,8 @@ public class PicklistPtServiceImpl implements PicklistPtService {
                         asignacion.getLoteProducto() != null ? asignacion.getLoteProducto().getCodigoLote() : null,
                         asignacion.getCantidadAsignada(),
                         asignacion.getFechaVencimiento(),
+                        obtenerCodigoUbicacion(asignacion.getLoteProducto()),
+                        obtenerDescripcionUbicacion(asignacion.getLoteProducto()),
                         asignacion.getAlmacenId(),
                         asignacion.getOrden()
                 ))
@@ -555,9 +594,10 @@ public class PicklistPtServiceImpl implements PicklistPtService {
                 document.add(new Paragraph("Observaciones: " + picklist.getObservaciones()).setFontSize(9));
             }
 
-            float[] widths = {26f, 16f, 12f, 10f, 10f, 14f};
+            float[] widths = {22f, 14f, 10f, 10f, 8f, 12f, 12f, 12f};
             Table table = new Table(widths).useAllAvailableWidth();
-            String[] headers = {"Producto", "Lote", "Vencimiento", "Cant.", "UM", "Almacén"};
+            String[] headers = {"Producto", "Lote", "Vencimiento", "Cant.", "UM", "Almacén",
+                    "Ubicación", "Desc. ubicación"};
             for (String h : headers) {
                 table.addHeaderCell(new Cell()
                         .add(new Paragraph(h).setFontSize(9).setBold())
@@ -588,8 +628,10 @@ public class PicklistPtServiceImpl implements PicklistPtService {
                         && asignacion.getLoteProducto().getAlmacen() != null
                         ? asignacion.getLoteProducto().getAlmacen().getNombre()
                         : "-";
+                String ubicacion = valorSeguro(obtenerCodigoUbicacion(asignacion.getLoteProducto()));
+                String ubicacionDesc = valorSeguro(obtenerDescripcionUbicacion(asignacion.getLoteProducto()));
 
-                String[] valores = {producto, lote, venc, cantidad, unidad, almacen};
+                String[] valores = {producto, lote, venc, cantidad, unidad, almacen, ubicacion, ubicacionDesc};
                 for (int i = 0; i < valores.length; i++) {
                     Cell cell = new Cell()
                             .add(new Paragraph(valores[i]).setFontSize(9))
@@ -624,5 +666,29 @@ public class PicklistPtServiceImpl implements PicklistPtService {
         } catch (Exception e) {
             throw new RuntimeException("Error generando PDF", e);
         }
+    }
+
+    private String obtenerCodigoUbicacion(LoteProducto lote) {
+        if (lote == null) {
+            return null;
+        }
+        if (lote.getUbicacionFisica() != null && lote.getUbicacionFisica().getCodigo() != null) {
+            return lote.getUbicacionFisica().getCodigo();
+        }
+        return lote.getCodigoUbicacionInterna();
+    }
+
+    private String obtenerDescripcionUbicacion(LoteProducto lote) {
+        if (lote == null) {
+            return null;
+        }
+        if (lote.getUbicacionFisica() != null && lote.getUbicacionFisica().getDescripcion() != null) {
+            return lote.getUbicacionFisica().getDescripcion();
+        }
+        return lote.getDescripcionUbicacionInterna();
+    }
+
+    private String valorSeguro(String valor) {
+        return valor != null && !valor.isBlank() ? valor : "-";
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/SalidaPtPicklistControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/SalidaPtPicklistControllerTest.java
@@ -1,0 +1,46 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.service.PicklistPtService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SalidaPtPicklistController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SalidaPtPicklistControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PicklistPtService picklistPtService;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    @WithMockUser(username = "carlos", authorities = "ROL_JEFE_ALMACENES")
+    void pdfSalidaPtDevuelveContentTypePdf() throws Exception {
+        when(picklistPtService.generarPdf(7L)).thenReturn(new byte[]{1, 2, 3});
+
+        mockMvc.perform(get("/api/inventario/salida-pt/picklist/7/pdf"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/PicklistPtServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/PicklistPtServiceImplTest.java
@@ -64,8 +64,10 @@ class PicklistPtServiceImplTest {
         Producto producto = crearProducto(10);
         LoteProducto loteInvalido = crearLote(1L, producto, LocalDateTime.now().plusDays(5),
                 new BigDecimal("10"), BigDecimal.ZERO, 10);
-        LoteProducto loteValido = crearLote(2L, producto, LocalDateTime.now().plusDays(20),
-                new BigDecimal("10"), BigDecimal.ZERO, 10);
+        LoteProducto loteValidoUno = crearLote(2L, producto, LocalDateTime.now().plusDays(20),
+                new BigDecimal("2"), BigDecimal.ZERO, 10);
+        LoteProducto loteValidoDos = crearLote(3L, producto, LocalDateTime.now().plusDays(40),
+                new BigDecimal("4"), BigDecimal.ZERO, 10);
 
         given(usuarioService.obtenerUsuarioAutenticado()).willReturn(new Usuario(1L));
         given(catalogResolver.getAlmacenPtId()).willReturn(10L);
@@ -74,12 +76,13 @@ class PicklistPtServiceImplTest {
                 .willReturn(Optional.empty());
         given(productoRepository.findById(10L)).willReturn(Optional.of(producto));
         given(loteProductoRepository.findFefoSalidaPt(eq(10L), eq(10L), any()))
-                .willReturn(List.of(loteInvalido, loteValido));
+                .willReturn(List.of(loteInvalido, loteValidoUno, loteValidoDos));
         given(picklistRepository.save(any(PicklistPt.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         PicklistPtCreateRequest request = new PicklistPtCreateRequest(
                 "Cliente X",
                 10,
+                null,
                 "DOC-1",
                 null,
                 List.of(new PicklistPtLineaRequest(10L, new BigDecimal("5"),
@@ -88,8 +91,11 @@ class PicklistPtServiceImplTest {
 
         var response = service.crear(request);
 
-        assertThat(response.asignaciones()).hasSize(1);
+        assertThat(response.asignaciones()).hasSize(2);
         assertThat(response.asignaciones().get(0).loteProductoId()).isEqualTo(2L);
+        assertThat(response.asignaciones().get(0).cantidadAsignada()).isEqualByComparingTo("2.000000");
+        assertThat(response.asignaciones().get(1).loteProductoId()).isEqualTo(3L);
+        assertThat(response.asignaciones().get(1).cantidadAsignada()).isEqualByComparingTo("3.000000");
     }
 
     @Test
@@ -111,6 +117,7 @@ class PicklistPtServiceImplTest {
                 30,
                 null,
                 null,
+                null,
                 List.of(new PicklistPtLineaRequest(11L, new BigDecimal("4"),
                         PicklistPtModoAsignacion.MANUAL_LOTE, 3L))
         );
@@ -119,6 +126,97 @@ class PicklistPtServiceImplTest {
                 .isInstanceOf(CustomBusinessException.class)
                 .extracting(ex -> ((CustomBusinessException) ex).getCode())
                 .isEqualTo(ApiErrorCode.PICKLIST_VIDA_UTIL_INSUFICIENTE);
+    }
+
+    @Test
+    void modoManualFallaSiLoteNoEsDePt() {
+        Producto producto = crearProducto(12);
+        LoteProducto lote = crearLote(6L, producto, LocalDateTime.now().plusDays(20),
+                new BigDecimal("10"), BigDecimal.ZERO, 11);
+
+        given(usuarioService.obtenerUsuarioAutenticado()).willReturn(new Usuario(1L));
+        given(catalogResolver.getAlmacenPtId()).willReturn(10L);
+        given(catalogResolver.getTipoDetalleSalidaPtId()).willReturn(20L);
+        given(picklistRepository.findTopByCodigoStartingWithOrderByCodigoDesc(any()))
+                .willReturn(Optional.empty());
+        given(productoRepository.findById(12L)).willReturn(Optional.of(producto));
+        given(loteProductoRepository.findById(6L)).willReturn(Optional.of(lote));
+
+        PicklistPtCreateRequest request = new PicklistPtCreateRequest(
+                "Cliente Z",
+                null,
+                null,
+                null,
+                null,
+                List.of(new PicklistPtLineaRequest(12L, new BigDecimal("4"),
+                        PicklistPtModoAsignacion.MANUAL_LOTE, 6L))
+        );
+
+        assertThatThrownBy(() -> service.crear(request))
+                .isInstanceOf(CustomBusinessException.class)
+                .extracting(ex -> ((CustomBusinessException) ex).getCode())
+                .isEqualTo(ApiErrorCode.PICKLIST_LOTE_INVALIDO);
+    }
+
+    @Test
+    void modoManualFallaSiLoteNoLiberado() {
+        Producto producto = crearProducto(13);
+        LoteProducto lote = crearLote(7L, producto, LocalDateTime.now().plusDays(20),
+                new BigDecimal("10"), BigDecimal.ZERO, 10);
+        lote.setEstado(com.willyes.clemenintegra.inventario.model.enums.EstadoLote.DISPONIBLE);
+
+        given(usuarioService.obtenerUsuarioAutenticado()).willReturn(new Usuario(1L));
+        given(catalogResolver.getAlmacenPtId()).willReturn(10L);
+        given(catalogResolver.getTipoDetalleSalidaPtId()).willReturn(20L);
+        given(picklistRepository.findTopByCodigoStartingWithOrderByCodigoDesc(any()))
+                .willReturn(Optional.empty());
+        given(productoRepository.findById(13L)).willReturn(Optional.of(producto));
+        given(loteProductoRepository.findById(7L)).willReturn(Optional.of(lote));
+
+        PicklistPtCreateRequest request = new PicklistPtCreateRequest(
+                "Cliente Z",
+                null,
+                null,
+                null,
+                null,
+                List.of(new PicklistPtLineaRequest(13L, new BigDecimal("4"),
+                        PicklistPtModoAsignacion.MANUAL_LOTE, 7L))
+        );
+
+        assertThatThrownBy(() -> service.crear(request))
+                .isInstanceOf(CustomBusinessException.class)
+                .extracting(ex -> ((CustomBusinessException) ex).getCode())
+                .isEqualTo(ApiErrorCode.CALIDAD_LOTE_NO_LIBERADO);
+    }
+
+    @Test
+    void modoManualFallaSiStockInsuficiente() {
+        Producto producto = crearProducto(14);
+        LoteProducto lote = crearLote(8L, producto, LocalDateTime.now().plusDays(20),
+                new BigDecimal("2"), BigDecimal.ZERO, 10);
+
+        given(usuarioService.obtenerUsuarioAutenticado()).willReturn(new Usuario(1L));
+        given(catalogResolver.getAlmacenPtId()).willReturn(10L);
+        given(catalogResolver.getTipoDetalleSalidaPtId()).willReturn(20L);
+        given(picklistRepository.findTopByCodigoStartingWithOrderByCodigoDesc(any()))
+                .willReturn(Optional.empty());
+        given(productoRepository.findById(14L)).willReturn(Optional.of(producto));
+        given(loteProductoRepository.findById(8L)).willReturn(Optional.of(lote));
+
+        PicklistPtCreateRequest request = new PicklistPtCreateRequest(
+                "Cliente Z",
+                null,
+                null,
+                null,
+                null,
+                List.of(new PicklistPtLineaRequest(14L, new BigDecimal("4"),
+                        PicklistPtModoAsignacion.MANUAL_LOTE, 8L))
+        );
+
+        assertThatThrownBy(() -> service.crear(request))
+                .isInstanceOf(CustomBusinessException.class)
+                .extracting(ex -> ((CustomBusinessException) ex).getCode())
+                .isEqualTo(ApiErrorCode.PICKLIST_STOCK_INSUFICIENTE);
     }
 
     @Test
@@ -173,6 +271,7 @@ class PicklistPtServiceImplTest {
         LoteProducto lote = new LoteProducto();
         lote.setId(id);
         lote.setProducto(producto);
+        lote.setEstado(com.willyes.clemenintegra.inventario.model.enums.EstadoLote.LIBERADO);
         lote.setFechaVencimiento(vencimiento);
         lote.setStockLote(stock);
         lote.setStockReservado(reservado);


### PR DESCRIPTION
### Motivation
- Unificar la salida PT para que todo el flujo de salida por cliente se gestione vía PickList reutilizando las tablas existentes (`picklists_pt`, `picklists_pt_lineas`, `picklists_pt_asignaciones`).
- Asegurar asignaciones FEFO sólo sobre lotes `LIBERADO`, permitir asignación manual por lote, convertir vida útil expresada en semanas a días y anexar ubicaciones en la impresión del picklist.

### Description
- Añadido nuevo controlador `SalidaPtPicklistController` con rutas para crear (`POST /api/inventario/salida-pt/picklist`), detalle (`GET /api/inventario/salida-pt/picklist/{id}`), PDF (`GET .../{id}/pdf`) y ejecutar (`POST .../{id}/ejecutar`).
- Extendido DTO `PicklistPtCreateRequest` para aceptar `minVidaUtilSemanas` y agregado en `PicklistPtAsignacionResponse` campos `codigoUbicacionInterna` y `descripcionUbicacionInterna`.
- Ajustada la lógica de negocio en `PicklistPtServiceImpl`: FEFO sólo sobre `EstadoLote.LIBERADO`, conversión de semanas a días con `resolverMinVidaUtilDias`, validaciones explícitas para lotes no liberados, split de cantidades entre múltiples lotes en modo `AUTO_FEFO`, validación manual (propiedad del almacén PT, estado `LIBERADO`, stock suficiente) y comportamiento idempotente/permitir ejecución desde `GENERADO` o `CONFIRMADO` devolviendo inmediato si ya está `EJECUTADO`.
- Se añadió inclusión de `codigoUbicacionInterna`/`descripcionUbicacionInterna` al construir las `asignaciones` y se amplió la tabla del PDF para mostrar `Ubicación` y `Desc. ubicación` utilizando `ubicacionFisica` o campos internos de `LoteProducto`.
- Se actualizó `SalidaPtController` para filtrar lotes disponibles sólo en estado `LIBERADO` y se agregó el nuevo `SalidaPtPicklistController` para exponer el flujo unificado.
- Se agregaron/ajustaron pruebas unitarias en `PicklistPtServiceImplTest` que cubren: asignaciones `AUTO_FEFO` repartidas en múltiples lotes respetando `minVidaUtilDias`, fallos en `MANUAL_LOTE` por lote fuera de PT / no liberado / stock insuficiente; y un test de integración ligera (smoke) del endpoint PDF en `SalidaPtPicklistControllerTest`.

### Testing
- Se agregaron pruebas unitarias: `PicklistPtServiceImplTest` (casos `AUTO_FEFO` split y validaciones `MANUAL_LOTE`) y `SalidaPtPicklistControllerTest` (PDF smoke test). 
- No se ejecutaron las suites automatizadas en este cambio (ninguna ejecución de `mvn test` o pipeline durante la modificación).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967bf9dd9a08333b70ffd4bc1d17be5)