### PR TITLE
Fix MultipleBagFetchException for picklist PT PDF

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/PicklistPtRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/PicklistPtRepository.java
@@ -14,9 +14,12 @@ import java.util.Optional;
 
 public interface PicklistPtRepository extends JpaRepository<PicklistPt, Long> {
 
-    @EntityGraph(attributePaths = {"lineas", "lineas.producto", "lineas.loteProducto",
-            "asignaciones", "asignaciones.producto", "asignaciones.loteProducto", "asignaciones.loteProducto.almacen"})
-    Optional<PicklistPt> findWithDetallesById(Long id);
+    @EntityGraph(attributePaths = {"lineas", "lineas.producto", "lineas.loteProducto"})
+    Optional<PicklistPt> findByIdWithLineas(Long id);
+
+    @EntityGraph(attributePaths = {"asignaciones", "asignaciones.producto", "asignaciones.producto.unidadMedida",
+            "asignaciones.loteProducto", "asignaciones.loteProducto.almacen", "asignaciones.loteProducto.ubicacionFisica"})
+    Optional<PicklistPt> findByIdWithAsignaciones(Long id);
 
     Optional<PicklistPt> findTopByCodigoStartingWithOrderByCodigoDesc(String prefix);
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/PicklistPtServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/PicklistPtServiceImpl.java
@@ -111,18 +111,14 @@ public class PicklistPtServiceImpl implements PicklistPtService {
     @Override
     @Transactional(readOnly = true)
     public PicklistPtResponse obtener(Long id) {
-        PicklistPt picklist = picklistRepository.findWithDetallesById(id)
-                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
-                        "Picklist no encontrado"));
+        PicklistPt picklist = cargarPicklistConLineasYAsignaciones(id);
         return toResponse(picklist);
     }
 
     @Override
     @Transactional(readOnly = true)
     public byte[] generarPdf(Long id) {
-        PicklistPt picklist = picklistRepository.findWithDetallesById(id)
-                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
-                        "Picklist no encontrado"));
+        PicklistPt picklist = cargarPicklistConLineasYAsignaciones(id);
         return buildPdf(picklist);
     }
 
@@ -146,9 +142,7 @@ public class PicklistPtServiceImpl implements PicklistPtService {
     @Override
     @Transactional
     public PicklistPtResponse ejecutar(Long id) {
-        PicklistPt picklist = picklistRepository.findWithDetallesById(id)
-                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
-                        "Picklist no encontrado"));
+        PicklistPt picklist = cargarPicklistConLineasYAsignaciones(id);
         if (picklist.getEstado() == PicklistPtEstado.EJECUTADO) {
             return toResponse(picklist);
         }
@@ -503,6 +497,16 @@ public class PicklistPtServiceImpl implements PicklistPtService {
             }
         }
         return prefix + String.format("%04d", siguiente);
+    }
+
+    private PicklistPt cargarPicklistConLineasYAsignaciones(Long id) {
+        PicklistPt picklist = picklistRepository.findByIdWithLineas(id)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Picklist no encontrado"));
+        picklistRepository.findByIdWithAsignaciones(id)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Picklist no encontrado"));
+        return picklist;
     }
 
     private PicklistPtResponse toResponse(PicklistPt picklist) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/PicklistPtPdfIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/PicklistPtPdfIntegrationTest.java
@@ -1,0 +1,186 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.PicklistPt;
+import com.willyes.clemenintegra.inventario.model.PicklistPtAsignacion;
+import com.willyes.clemenintegra.inventario.model.PicklistPtLinea;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UbicacionFisica;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.PicklistPtEstado;
+import com.willyes.clemenintegra.inventario.model.enums.PicklistPtModoAsignacion;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.PicklistPtRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UbicacionFisicaRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class PicklistPtPdfIntegrationTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private AlmacenRepository almacenRepository;
+    @Autowired
+    private UbicacionFisicaRepository ubicacionFisicaRepository;
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+    @Autowired
+    private PicklistPtRepository picklistPtRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    private PicklistPt picklist;
+
+    @BeforeEach
+    void setUp() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("pdf-user")
+                .clave("secret")
+                .nombreCompleto("Usuario PDF")
+                .correo("pdf@example.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("UND")
+                .codigo("UND")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria PT")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-PT-001")
+                .nombre("Producto PT")
+                .descripcionProducto("Producto para PDF")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Almacen PT")
+                .ubicacion("Zona PT")
+                .categoria(TipoCategoria.PRODUCTO_TERMINADO)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        UbicacionFisica ubicacion = ubicacionFisicaRepository.save(UbicacionFisica.builder()
+                .almacen(almacen)
+                .codigo("UB-PT-01")
+                .descripcion("Ubicacion PT")
+                .activo(true)
+                .build());
+
+        LoteProducto loteProducto = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LP-PT-001")
+                .stockLote(new BigDecimal("100.000"))
+                .estado(EstadoLote.LIBERADO)
+                .producto(producto)
+                .almacen(almacen)
+                .ubicacionFisica(ubicacion)
+                .build());
+
+        picklist = PicklistPt.builder()
+                .codigo("PL-PT-TEST-001")
+                .clienteNombre("Cliente PDF")
+                .minVidaUtilDias(30)
+                .estado(PicklistPtEstado.GENERADO)
+                .almacenPtId(almacen.getId())
+                .tipoMovimientoDetalleId(1)
+                .docReferencia("DOC-PDF")
+                .observaciones("Obs PDF")
+                .creadoPor(usuario)
+                .build();
+
+        PicklistPtLinea linea = PicklistPtLinea.builder()
+                .picklist(picklist)
+                .producto(producto)
+                .cantidad(new BigDecimal("5.000"))
+                .modoAsignacion(PicklistPtModoAsignacion.MANUAL_LOTE)
+                .loteProducto(loteProducto)
+                .build();
+
+        PicklistPtAsignacion asignacion = PicklistPtAsignacion.builder()
+                .picklist(picklist)
+                .producto(producto)
+                .loteProducto(loteProducto)
+                .cantidadAsignada(new BigDecimal("5.000"))
+                .fechaVencimiento(LocalDateTime.now().plusDays(60))
+                .almacenId(almacen.getId())
+                .orden((short) 1)
+                .build();
+
+        picklist.setLineas(List.of(linea));
+        picklist.setAsignaciones(List.of(asignacion));
+        picklist = picklistPtRepository.save(picklist);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
+    void pdfEntregaRespuestaOkSinMultipleBagFetch() throws Exception {
+        mockMvc.perform(get("/api/inventario/picklists-pt/{id}/pdf", picklist.getId()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_PDF));
+    }
+}


### PR DESCRIPTION
### Motivation
- Avoid `MultipleBagFetchException` when generating the Picklist PT PDF by preventing simultaneous eager fetch of the `lineas` and `asignaciones` collection bags. 
- Also mitigate N+1 risk by preloading the needed nested relations for each collection in dedicated queries so the PDF builder can access product/lote/ubicación data without extra lazy queries. 

### Description
- Replaced the single `@EntityGraph` that fetched both collections with two repository methods: `findByIdWithLineas(id)` and `findByIdWithAsignaciones(id)` in `PicklistPtRepository`. 
- Implemented `cargarPicklistConLineasYAsignaciones(Long id)` in `PicklistPtServiceImpl` and updated `obtener`, `generarPdf` and `ejecutar` to use it so `lineas` and `asignaciones` are loaded via separate queries inside the same transaction. 
- Added an integration test `PicklistPtPdfIntegrationTest` that persists a minimal picklist with `lineas` and `asignaciones` and exercises `GET /api/inventario/picklists-pt/{id}/pdf` asserting a `200` and `application/pdf` content type. 

### Testing
- Added `PicklistPtPdfIntegrationTest` which constructs persistent fixtures and asserts the PDF endpoint returns `200` and `Content-Type: application/pdf`. 
- No automated test suite was executed as part of this change (the new integration test was added but not run in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967cdb7dc58833399211d9fc612ccbd)