### PR TITLE
test: include picklist line in PicklistPtServiceImplTest

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/inventario/service/PicklistPtServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/PicklistPtServiceImplTest.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.PicklistPt;
 import com.willyes.clemenintegra.inventario.model.PicklistPtAsignacion;
+import com.willyes.clemenintegra.inventario.model.PicklistPtLinea;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.model.enums.PicklistPtEstado;
@@ -230,12 +231,20 @@ class PicklistPtServiceImplTest {
                 .loteProducto(loteAsignado)
                 .cantidadAsignada(new BigDecimal("8"))
                 .build();
+        PicklistPtLinea linea = PicklistPtLinea.builder()
+                .id(5L)
+                .producto(producto)
+                .loteProducto(loteAsignado)
+                .cantidad(new BigDecimal("8"))
+                .modoAsignacion(PicklistPtModoAsignacion.MANUAL_LOTE)
+                .build();
         PicklistPt picklist = PicklistPt.builder()
                 .id(99L)
                 .estado(PicklistPtEstado.CONFIRMADO)
                 .almacenPtId(10)
                 .tipoMovimientoDetalleId(20)
                 .asignaciones(List.of(asignacion))
+                .lineas(List.of(linea))
                 .build();
 
         given(picklistRepository.findByIdWithLineas(99L)).willReturn(Optional.of(picklist));


### PR DESCRIPTION
### Motivation
- The service loads a picklist in two steps (`findByIdWithLineas` then `findByIdWithAsignaciones`) but the test fixture used only `asignaciones`, so the mocked Picklist needed a minimal `lineas` entry to mirror the real load flow and the data the service expects.

### Description
- Added import for `PicklistPtLinea` and created a minimal `PicklistPtLinea` (id, producto, loteProducto, cantidad, modoAsignacion) in `ejecutarPicklistFallaSiStockCambio`.
- Populated the mocked `PicklistPt` with `.lineas(List.of(linea))` in addition to `.asignaciones(...)` to reflect the service behavior, with no production code changes and no new repository methods added.

### Testing
- Ran `mvn test` after the change and the build failed with a compiler error `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`, so the Maven test run did not complete successfully and the failure appears unrelated to this small test fixture change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d7c624a083338611ca01f2bd7666)