### PR TITLE
Use @AuthenticationPrincipal for producto audit metadata

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.ProductoService;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import com.willyes.clemenintegra.shared.util.PaginationUtil;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,9 +138,13 @@ public class ProductoController {
 
     @PostMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_SUPER_ADMIN')")
-    public ResponseEntity<?> crear(@Valid @RequestBody ProductoRequestDTO dto) {
+    public ResponseEntity<?> crear(@Valid @RequestBody ProductoRequestDTO dto,
+                                   @AuthenticationPrincipal CustomUserDetails principal) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Usuario no autenticado");
+        }
         try {
-            ProductoResponseDTO creado = productoService.crearProducto(dto);
+            ProductoResponseDTO creado = productoService.crearProducto(dto, principal.getId());
             return ResponseEntity.status(201).body(creado);
         } catch (DataIntegrityViolationException e) {
             return ResponseEntity.status(409).body("SKU duplicado o restricción de integridad violada");
@@ -158,8 +164,13 @@ public class ProductoController {
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_SUPER_ADMIN')")
-    public ResponseEntity<ProductoResponseDTO> actualizar(@PathVariable Long id, @Valid @RequestBody ProductoRequestDTO dto) {
-        ProductoResponseDTO actualizado = productoService.actualizarProducto(id, dto);
+    public ResponseEntity<ProductoResponseDTO> actualizar(@PathVariable Long id,
+                                                          @Valid @RequestBody ProductoRequestDTO dto,
+                                                          @AuthenticationPrincipal CustomUserDetails principal) {
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Usuario no autenticado");
+        }
+        ProductoResponseDTO actualizado = productoService.actualizarProducto(id, dto, principal.getId());
         return ResponseEntity.ok(actualizado);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -13,9 +13,9 @@ public interface ProductoService {
     List<ProductoResponseDTO> buscarPorCategoria(String categoria);
     List<ProductoResponseDTO> findByCategoriaTipo(String tipo);
     List<ProductoResponseDTO> findByCategoriaTipoIn(List<String> tipos);
-    ProductoResponseDTO crearProducto(ProductoRequestDTO dto);
+    ProductoResponseDTO crearProducto(ProductoRequestDTO dto, Long usuarioId);
     ProductoResponseDTO obtenerPorId(Long id);
-    ProductoResponseDTO actualizarProducto(Long id, ProductoRequestDTO dto);
+    ProductoResponseDTO actualizarProducto(Long id, ProductoRequestDTO dto, Long usuarioId);
     ProductoResponseDTO actualizarCamposCalidad(Long id, ProductoCalidadUpdateDTO dto);
     // PROD-INACTIVAR BEGIN
     ProductoResponseDTO actualizarEstado(Long id, Boolean activo);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -13,8 +13,6 @@ import com.willyes.clemenintegra.calidad.repository.PlantillaAnalisisMicrobiolog
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
-import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
-import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.Cell;
@@ -28,8 +26,6 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,24 +49,8 @@ public class ProductoServiceImpl implements ProductoService {
     private final LoteProductoRepository loteProductoRepository;
     private final MovimientoInventarioRepository movimientoInventarioRepository;
     private final ProductoMapper productoMapper;
-    private final JwtTokenService jwtTokenService;
     private final StockQueryService stockQueryService;
     private final PlantillaAnalisisMicrobiologicoRepository plantillaAnalisisMicrobiologicoRepository;
-
-    private Long obtenerUsuarioIdDesdeToken() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null) {
-            throw new IllegalStateException("No hay autenticación en el contexto");
-        }
-
-        if (authentication.getCredentials() instanceof String token) {
-            Claims claims = jwtTokenService.extraerClaims(token);
-            return claims.get("usuarioId", Long.class);
-        }
-
-        throw new IllegalStateException("No se pudo extraer el token JWT");
-    }
 
     private boolean esProductoFabricable(com.willyes.clemenintegra.inventario.model.CategoriaProducto categoria, String sku) {
         if (categoria == null || categoria.getTipo() == null || sku == null) {
@@ -228,7 +208,7 @@ public class ProductoServiceImpl implements ProductoService {
 
     @Override
     @Transactional
-    public ProductoResponseDTO crearProducto(ProductoRequestDTO dto) {
+    public ProductoResponseDTO crearProducto(ProductoRequestDTO dto, Long usuarioId) {
         validarDuplicados(dto.getSku(), dto.getNombre());
 
         var unidad = unidadMedidaRepository.findById(dto.getUnidadMedidaId())
@@ -236,8 +216,6 @@ public class ProductoServiceImpl implements ProductoService {
 
         var categoria = categoriaProductoRepository.findById(dto.getCategoriaProductoId())
                 .orElseThrow(() -> new IllegalArgumentException("Categoría no encontrada"));
-
-        Long usuarioId = obtenerUsuarioIdDesdeToken();
 
         var usuario = usuarioRepository.findById(usuarioId)
                 .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado"));
@@ -270,7 +248,7 @@ public class ProductoServiceImpl implements ProductoService {
 
     @Override
     @Transactional
-    public ProductoResponseDTO actualizarProducto(Long id, ProductoRequestDTO dto) {
+    public ProductoResponseDTO actualizarProducto(Long id, ProductoRequestDTO dto, Long usuarioId) {
         Producto producto = productoRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Producto no encontrado con ID: " + id));
 
@@ -283,7 +261,6 @@ public class ProductoServiceImpl implements ProductoService {
         var categoria = categoriaProductoRepository.findById(dto.getCategoriaProductoId())
                 .orElseThrow(() -> new IllegalArgumentException("Categoría no encontrada"));
 
-        Long usuarioId = obtenerUsuarioIdDesdeToken();
         var usuario = usuarioRepository.findById(usuarioId)
                 .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado"));
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -15,9 +15,6 @@ import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
-import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
-import io.jsonwebtoken.impl.DefaultClaims;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,9 +33,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.math.BigDecimal;
 import java.util.Collections;
@@ -52,8 +46,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -69,7 +61,6 @@ class ProductoServiceImplTest {
     @Mock private LoteProductoRepository loteProductoRepository;
     @Mock private MovimientoInventarioRepository movimientoInventarioRepository;
     @Mock private ProductoMapper productoMapper;
-    @Mock private JwtTokenService jwtTokenService;
     @Mock private StockQueryService stockQueryService;
 
     @InjectMocks
@@ -77,16 +68,7 @@ class ProductoServiceImplTest {
 
     @BeforeEach
     void setUpSecurity() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getCredentials()).thenReturn("token-mock");
-        SecurityContext context = mock(SecurityContext.class);
-        when(context.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(context);
-
-        DefaultClaims claims = new DefaultClaims(Map.of("usuarioId", 1L));
-        when(jwtTokenService.extraerClaims("token-mock")).thenReturn(claims);
-        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(new Usuario()));
-
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(new Usuario(1L)));
         when(productoMapper.toDto(any(Producto.class))).thenReturn(new ProductoResponseDTO());
         when(stockQueryService.obtenerStockDisponible(any(Long.class))).thenReturn(BigDecimal.ZERO);
         when(stockQueryService.obtenerStockDisponible(anyList())).thenReturn(Collections.emptyMap());
@@ -97,11 +79,6 @@ class ProductoServiceImplTest {
             producto.setId(10);
             return producto;
         });
-    }
-
-    @AfterEach
-    void clearSecurity() {
-        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -131,7 +108,7 @@ class ProductoServiceImplTest {
 
         ArgumentCaptor<Producto> captor = ArgumentCaptor.forClass(Producto.class);
 
-        service.crearProducto(dto);
+        service.crearProducto(dto, 1L);
 
         verify(productoRepository).save(captor.capture());
         assertThat(captor.getValue().getRendimientoUnidad())
@@ -164,7 +141,7 @@ class ProductoServiceImplTest {
                 .build();
 
         ArgumentCaptor<Producto> captor = ArgumentCaptor.forClass(Producto.class);
-        service.crearProducto(dto);
+        service.crearProducto(dto, 1L);
         verify(productoRepository).save(captor.capture());
 
         assertThat(captor.getValue().getRendimientoUnidad())
@@ -197,7 +174,7 @@ class ProductoServiceImplTest {
                 .rendimientoUnidad(null)
                 .build();
 
-        assertThatThrownBy(() -> service.crearProducto(dto))
+        assertThatThrownBy(() -> service.crearProducto(dto, 1L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("rendimiento por unidad es obligatorio");
     }
@@ -260,7 +237,7 @@ class ProductoServiceImplTest {
                 .build();
 
         ArgumentCaptor<Producto> captor = ArgumentCaptor.forClass(Producto.class);
-        service.crearProducto(dto);
+        service.crearProducto(dto, 1L);
 
         verify(productoRepository).save(captor.capture());
         Producto guardado = captor.getValue();
@@ -309,7 +286,7 @@ class ProductoServiceImplTest {
                 .build();
 
         ArgumentCaptor<Producto> captor = ArgumentCaptor.forClass(Producto.class);
-        service.actualizarProducto(10L, dto);
+        service.actualizarProducto(10L, dto, 1L);
 
         verify(productoRepository).save(captor.capture());
         Producto actualizado = captor.getValue();

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -11,9 +11,12 @@ import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepos
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
 import com.willyes.clemenintegra.inventario.service.ProductoService;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
 import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +29,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -82,7 +86,6 @@ class ProductoControllerSmokeTest {
     private UsuarioInactivoFilter usuarioInactivoFilter;
 
     @Test
-    @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
     @DisplayName("POST /api/productos devuelve 201 y datos mínimos al crear un producto")
     void crearProducto_deberiaRetornar201() throws Exception {
         ProductoRequestDTO request = ProductoRequestDTO.builder()
@@ -102,11 +105,21 @@ class ProductoControllerSmokeTest {
                 .fechaCreacion(LocalDateTime.now())
                 .build();
 
-        when(productoService.crearProducto(any(ProductoRequestDTO.class))).thenReturn(response);
+        Usuario usuario = Usuario.builder()
+                .id(1L)
+                .rol(RolUsuario.ROL_JEFE_ALMACENES)
+                .nombreUsuario("almacen")
+                .clave("secret")
+                .activo(true)
+                .bloqueado(false)
+                .build();
+
+        when(productoService.crearProducto(any(ProductoRequestDTO.class), eq(1L))).thenReturn(response);
 
         mockMvc.perform(post("/api/productos")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(SecurityMockMvcRequestPostProcessors.user(new CustomUserDetails(usuario))))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").value(100))
@@ -118,6 +131,14 @@ class ProductoControllerSmokeTest {
     @WithMockUser(authorities = "ROL_JEFE_ALMACENES")
     @DisplayName("POST /api/productos con datos inválidos devuelve 400 y estructura de error global")
     void crearProducto_conBodyInvalido_deberiaRetornar400() throws Exception {
+        Usuario usuario = Usuario.builder()
+                .id(2L)
+                .rol(RolUsuario.ROL_JEFE_ALMACENES)
+                .nombreUsuario("almacen")
+                .clave("secret")
+                .activo(true)
+                .bloqueado(false)
+                .build();
         Map<String, Object> payload = Map.of(
                 "stockMinimo", 5,
                 "unidadMedidaId", 1,
@@ -126,7 +147,8 @@ class ProductoControllerSmokeTest {
 
         mockMvc.perform(post("/api/productos")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(payload)))
+                        .content(objectMapper.writeValueAsString(payload))
+                        .with(SecurityMockMvcRequestPostProcessors.user(new CustomUserDetails(usuario))))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("SOLICITUD_INVALIDA"))


### PR DESCRIPTION
### Motivation
- Replace fragile manual JWT extraction with Spring Security principal-based authentication to reliably obtain the user who creates/updates products.
- Preserve audit traceability so `Producto.creadoPor` is set correctly using the authenticated user's id.
- Simplify service logic by removing direct token/claims parsing from inventory service.

### Description
- Controller: `ProductoController.crear` and `ProductoController.actualizar` now receive `@AuthenticationPrincipal CustomUserDetails principal` and call `principal.getId()` to obtain the authenticated `usuarioId` before delegating to the service.
- Service API: `ProductoService` signature changed to `crearProducto(ProductoRequestDTO, Long usuarioId)` and `actualizarProducto(Long, ProductoRequestDTO, Long usuarioId)` and `ProductoServiceImpl` was updated accordingly to set `Producto.creadoPor` using the provided `usuarioId` and the `UsuarioRepository` lookup; the manual `obtenerUsuarioIdDesdeToken()` and JWT extraction usage were removed.
- Tests: `ProductoControllerSmokeTest` updated to send a mocked `CustomUserDetails` with MockMvc (`SecurityMockMvcRequestPostProcessors.user(new CustomUserDetails(usuario))`) and to expect the service to be called with the `usuarioId`, and `ProductoServiceImplTest` updated to pass `usuarioId` explicitly and to mock `UsuarioRepository.findById(..)` for that id.
- Note: the principal type used is `CustomUserDetails` (from `com.willyes.clemenintegra.shared.security.service.CustomUserDetails`) and the id is read with `principal.getId()`.

### Testing
- Ran the full test suite with `mvn test`, which executed but the build failed during compilation with a fatal error: `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN` (so automated tests did not complete successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967e2383b548333b062781faf592e60)