### PR TITLE
Update Lombok to 1.18.36 and set compiler release 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <java.version>21</java.version>
+    <lombok.version>1.18.36</lombok.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.19.7</testcontainers.version>
@@ -77,7 +78,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.30</version>
+      <version>${lombok.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -192,11 +193,12 @@
           <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+          <release>21</release>
           <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.30</version>
+              <version>${lombok.version}</version>
             </path>
             <path>
               <groupId>org.mapstruct</groupId>


### PR DESCRIPTION
### Motivation
- Javac en Java 21 provocaba un error de inicialización (`TypeTag :: UNKNOWN`) con la versión antigua de Lombok, por lo que Lombok se actualiza a una versión compatible.
- Mantener MapStruct en `1.5.5.Final` y no tocar código de negocio o tests para una corrección mínima en `pom.xml`.

### Description
- Se añadió la propiedad `lombok.version` con valor `1.18.36` en `<properties>` y se reutiliza en la dependencia `org.projectlombok:lombok`.
- Se cambió la entrada de `annotationProcessorPaths` del `maven-compiler-plugin` para usar `${lombok.version}` y se dejó `mapstruct-processor` en `1.5.5.Final` sin modificaciones.
- Se añadió `<release>21</release>` en la configuración del `maven-compiler-plugin` para alinear la compilación con Java 21.
- Se documentó y ejecutó la limpieza local del cache de Lombok con `rm -rf ~/.m2/repository/org/projectlombok/lombok/1.18.30` para evitar jars corruptos.

### Testing
- Ejecuté `rm -rf ~/.m2/repository/org/projectlombok/lombok/1.18.30` para eliminar la versión antigua del repositorio local (comando ejecutado correctamente).
- Ejecuté `mvn -q -DskipTests clean test` y la compilación falló con `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`.
- Ejecuté `mvn -q test` y la suite completa también falló con `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f010394883339d49621f0e81099a)