### PR TITLE
Cargar usuarios en detalle de ConteoCiclico para evitar LazyInitializationException

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/mapper/ConteoCiclicoMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/mapper/ConteoCiclicoMapper.java
@@ -20,16 +20,18 @@ public class ConteoCiclicoMapper {
         if (conteo == null) {
             return null;
         }
+        Usuario creadoPor = conteo.getCreadoPor();
+        Usuario aplicadoPor = conteo.getAplicadoPor();
         return ConteoCiclicoResumenResponseDTO.builder()
                 .id(conteo.getId())
                 .almacenId(conteo.getAlmacen() != null ? conteo.getAlmacen().getId() : null)
                 .estado(conteo.getEstado())
                 .fechaCreacion(conteo.getFechaCreacion())
                 .aplicadoEn(conteo.getAplicadoEn())
-                .creadoPorId(conteo.getCreadoPor() != null ? conteo.getCreadoPor().getId() : null)
-                .creadoPorNombre(resolveUsuarioNombre(conteo.getCreadoPor()))
-                .aplicadoPorId(conteo.getAplicadoPor() != null ? conteo.getAplicadoPor().getId() : null)
-                .aplicadoPorNombre(resolveUsuarioNombre(conteo.getAplicadoPor()))
+                .creadoPorId(resolveUsuarioId(creadoPor))
+                .creadoPorNombre(resolveUsuarioNombre(creadoPor))
+                .aplicadoPorId(resolveUsuarioId(aplicadoPor))
+                .aplicadoPorNombre(resolveUsuarioNombre(aplicadoPor))
                 .build();
     }
 
@@ -37,16 +39,18 @@ public class ConteoCiclicoMapper {
         if (conteo == null) {
             return null;
         }
+        Usuario creadoPor = conteo.getCreadoPor();
+        Usuario aplicadoPor = conteo.getAplicadoPor();
         return ConteoCiclicoResponseDTO.builder()
                 .id(conteo.getId())
                 .almacenId(conteo.getAlmacen() != null ? conteo.getAlmacen().getId() : null)
                 .estado(conteo.getEstado())
                 .fechaCreacion(conteo.getFechaCreacion())
                 .aplicadoEn(conteo.getAplicadoEn())
-                .creadoPorId(conteo.getCreadoPor() != null ? conteo.getCreadoPor().getId() : null)
-                .creadoPorNombre(resolveUsuarioNombre(conteo.getCreadoPor()))
-                .aplicadoPorId(conteo.getAplicadoPor() != null ? conteo.getAplicadoPor().getId() : null)
-                .aplicadoPorNombre(resolveUsuarioNombre(conteo.getAplicadoPor()))
+                .creadoPorId(resolveUsuarioId(creadoPor))
+                .creadoPorNombre(resolveUsuarioNombre(creadoPor))
+                .aplicadoPorId(resolveUsuarioId(aplicadoPor))
+                .aplicadoPorNombre(resolveUsuarioNombre(aplicadoPor))
                 .detalles(toDetalles(conteo.getDetalles()))
                 .build();
     }
@@ -87,5 +91,9 @@ public class ConteoCiclicoMapper {
             return usuario.getNombreUsuario();
         }
         return null;
+    }
+
+    private Long resolveUsuarioId(Usuario usuario) {
+        return usuario != null ? usuario.getId() : null;
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ConteoCiclicoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ConteoCiclicoRepository.java
@@ -39,6 +39,18 @@ public interface ConteoCiclicoRepository extends JpaRepository<ConteoCiclico, Lo
     @EntityGraph(attributePaths = {
             "almacen",
             "creadoPor",
+            "aplicadoPor",
+            "detalles",
+            "detalles.producto",
+            "detalles.loteProducto",
+            "detalles.ubicacionFisica"
+    })
+    @Query("select distinct c from ConteoCiclico c left join c.detalles d where c.id = :id")
+    Optional<ConteoCiclico> findByIdWithUsuario(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = {
+            "almacen",
+            "creadoPor",
             "aplicadoPor"
     })
     @Query("select c from ConteoCiclico c where (:almacenId is null or c.almacen.id = :almacenId) " +

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -60,8 +60,9 @@ public class ConteoCiclicoService {
         return conteos.map(mapper::toResumen);
     }
 
+    @Transactional(readOnly = true)
     public ConteoCiclicoResponseDTO obtenerPorId(Long conteoId) {
-        ConteoCiclico conteo = conteoRepository.findByIdWithDetalles(conteoId)
+        ConteoCiclico conteo = conteoRepository.findByIdWithUsuario(conteoId)
                 .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
                         "Conteo no encontrado"));
         return mapper.toResponseCompleto(conteo);

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerIntegrationTest.java
@@ -151,6 +151,7 @@ class ConteoCiclicoControllerIntegrationTest extends IntegrationTestMySqlContain
         mockMvc.perform(get("/api/inventario/conteos/{id}", conteo.getId())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.creadoPorNombre").value("Usuario Contador"))
                 .andExpect(jsonPath("$.detalles[0].productoId").value(producto.getId()));
     }
 }


### PR DESCRIPTION
### Motivation
- El endpoint de detalle `GET /api/inventario/conteos/{id}` lanzaba `LazyInitializationException` al acceder a `creadoPor`/`aplicadoPor` fuera de sesión, sin querer habilitar OSIV ni cambiar cargas a `EAGER`.

### Description
- Agregado `Optional<ConteoCiclico> findByIdWithUsuario(Long id)` en `ConteoCiclicoRepository` con `@EntityGraph` para traer `creadoPor` y `aplicadoPor` junto con `detalles` y sus relaciones.
- Cambiado `ConteoCiclicoService.obtenerPorId` para usar `findByIdWithUsuario` y marcado con `@Transactional(readOnly = true)` para mantener la sesión durante el mapeo.
- Modificado `ConteoCiclicoMapper` para resolver `creadoPor`/`aplicadoPor` en variables locales y mapear `creadoPorId`/`creadoPorNombre`/`aplicadoPorId`/`aplicadoPorNombre` de forma null-safe usando `resolveUsuarioId` y `resolveUsuarioNombre`.
- Ajustado `ConteoCiclicoControllerIntegrationTest` para validar que la respuesta de detalle contiene `creadoPorNombre` y así cubrir el caso que provocaba el `LazyInitializationException`.

### Testing
- Ejecutado el comando `mvn -Dtest=ConteoCiclicoControllerIntegrationTest test` para ejecutar el test de integración modificado, pero la compilación falló con `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN` durante la fase de compilación, por lo que los tests no pudieron completarse.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968420ef61c8333baa1e88474a9e874)