### PR TITLE
Fix devolución cliente validation flow and test setup

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -196,6 +196,38 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                     "ENTRADA_PT_REQUIERE_ORDEN_PRODUCCION_ID");
         }
 
+        boolean esOpDesdeDto = dto.ordenProduccionId() != null;
+        TipoMovimiento tipoMovimiento = dto.tipoMovimiento();
+        ClasificacionMovimientoInventario clasificacion = dto.clasificacionMovimientoInventario();
+        Long tipoMovimientoDetalleId = dto.tipoMovimientoDetalleId();
+        Integer almacenDestinoIdNormalizado = dto.almacenDestinoId();
+
+        boolean esRecepcionDevolucionCliente = tipoMovimiento == TipoMovimiento.RECEPCION
+                && clasificacion == ClasificacionMovimientoInventario.RECEPCION_DEVOLUCION_CLIENTE;
+        boolean loteLegacy = Boolean.TRUE.equals(dto.loteLegacy());
+
+        if (esRecepcionDevolucionCliente) {
+            validarRecepcionDevolucionCliente(dto);
+
+            if (!loteLegacy && dto.loteProductoId() == null) {
+                throw new CustomBusinessException(ApiErrorCode.DEVOLUCION_PT_LOTE_REQUERIDO,
+                        "Debe especificar el lote para la devolución de cliente",
+                        Map.of("productoId", dto.productoId()));
+            }
+
+            Long almacenPtId = catalogResolver.getAlmacenPtId();
+            Long almacenCuarentenaId = catalogResolver.getAlmacenCuarentenaId();
+            if (almacenPtId == null || almacenCuarentenaId == null) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "CONFIG_FALTANTE");
+            }
+
+            boolean vaABodegaPt = !loteLegacy
+                    && dto.causaDevolucionPt() == CausaDevolucionPT.TROCADO
+                    && dto.condicionProductoDevuelto() == CondicionProductoDevuelto.OPTIMO;
+            Long destinoId = vaABodegaPt ? almacenPtId : almacenCuarentenaId;
+            almacenDestinoIdNormalizado = Math.toIntExact(destinoId);
+        }
+
         MovimientoInventario movimiento = mapper.toEntity(dto);
         if (StringUtils.hasText(idempotencyKey)) {
             movimiento.setIdempotencyKey(idempotencyKey);
@@ -205,12 +237,6 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             fechaIngreso = ZonedDateTime.now(ZONA_BOGOTA).toLocalDateTime();
             movimiento.setFechaIngreso(fechaIngreso);
         }
-
-        boolean esOpDesdeDto = dto.ordenProduccionId() != null;
-        TipoMovimiento tipoMovimiento = dto.tipoMovimiento();
-        ClasificacionMovimientoInventario clasificacion = dto.clasificacionMovimientoInventario();
-        Long tipoMovimientoDetalleId = dto.tipoMovimientoDetalleId();
-        Integer almacenDestinoIdNormalizado = dto.almacenDestinoId();
 
         // >>> NUEVO: identifica si el cierre de OP está enviando una ENTRADA de PT
         final boolean esEntradaPt = (tipoMovimiento == TipoMovimiento.ENTRADA);
@@ -252,32 +278,6 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         // 1. Cargar entidades principales
         Producto producto = productoRepository.findById(dto.productoId().longValue())
                 .orElseThrow(() -> new NoSuchElementException("Producto no encontrado"));
-
-        boolean esRecepcionDevolucionCliente = tipoMovimiento == TipoMovimiento.RECEPCION
-                && clasificacion == ClasificacionMovimientoInventario.RECEPCION_DEVOLUCION_CLIENTE;
-        boolean loteLegacy = Boolean.TRUE.equals(dto.loteLegacy());
-
-        if (esRecepcionDevolucionCliente) {
-            validarRecepcionDevolucionCliente(dto);
-
-            if (!loteLegacy && dto.loteProductoId() == null) {
-                throw new CustomBusinessException(ApiErrorCode.DEVOLUCION_PT_LOTE_REQUERIDO,
-                        "Debe especificar el lote para la devolución de cliente",
-                        Map.of("productoId", dto.productoId()));
-            }
-
-            Long almacenPtId = catalogResolver.getAlmacenPtId();
-            Long almacenCuarentenaId = catalogResolver.getAlmacenCuarentenaId();
-            if (almacenPtId == null || almacenCuarentenaId == null) {
-                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "CONFIG_FALTANTE");
-            }
-
-            boolean vaABodegaPt = !loteLegacy
-                    && dto.causaDevolucionPt() == CausaDevolucionPT.TROCADO
-                    && dto.condicionProductoDevuelto() == CondicionProductoDevuelto.OPTIMO;
-            Long destinoId = vaABodegaPt ? almacenPtId : almacenCuarentenaId;
-            almacenDestinoIdNormalizado = Math.toIntExact(destinoId);
-        }
 
         Long resolvedTipoDetalleId = esOpDesdeDto
                 ? tipoMovimientoDetalleId
@@ -684,11 +684,18 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         if (motivoMovimientoId == null && esRecepcionDevolucionCliente) {
             motivoMovimientoId = resolverMotivoDevolucionCliente(almacenDestino);
         }
+        if (motivoMovimientoId == null && esRecepcionDevolucionCliente) {
+            throw new CustomBusinessException(ApiErrorCode.DEVOLUCION_PT_DATOS_INCOMPLETOS,
+                    "Debe indicar un motivo para registrar la devolución",
+                    Map.of("productoId", dto.productoId()));
+        }
 
         MotivoMovimiento motivoMovimiento = null;
         if (motivoMovimientoId != null) {
             motivoMovimiento = motivoMovimientoRepository.findById(motivoMovimientoId)
-                    .orElseThrow(() -> new NoSuchElementException("Motivo no encontrado"));
+                    .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.CATALOGO_FALTANTE,
+                            "Motivo no encontrado",
+                            Map.of("motivoMovimientoId", motivoMovimientoId)));
         }
         motivoMovimiento = resolverMotivoMovimientoPorClasificacion(clasificacion, motivoMovimiento);
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDevolucionClienteTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDevolucionClienteTest.java
@@ -109,6 +109,24 @@ class MovimientoInventarioServiceDevolucionClienteTest {
         lenient().when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(
                 Usuario.builder().id(1L).nombreCompleto("Tester").build()
         );
+
+        MotivoMovimiento motivoEntradaPt = new MotivoMovimiento();
+        motivoEntradaPt.setId(MOTIVO_ENTRADA_PT_ID);
+        motivoEntradaPt.setMotivo(ClasificacionMovimientoInventario.ENTRADA_PRODUCTO_TERMINADO);
+        MotivoMovimiento motivoTransferenciaCalidad = new MotivoMovimiento();
+        motivoTransferenciaCalidad.setId(MOTIVO_TRANSFERENCIA_CALIDAD_ID);
+        motivoTransferenciaCalidad.setMotivo(ClasificacionMovimientoInventario.TRANSFERENCIA_GENERAL);
+
+        lenient().when(catalogResolver.getMotivoIdEntradaProductoTerminado()).thenReturn(MOTIVO_ENTRADA_PT_ID);
+        lenient().when(catalogResolver.getMotivoIdTransferenciaCalidad()).thenReturn(MOTIVO_TRANSFERENCIA_CALIDAD_ID);
+        lenient().when(motivoMovimientoRepository.findById(MOTIVO_ENTRADA_PT_ID))
+                .thenReturn(Optional.of(motivoEntradaPt));
+        lenient().when(motivoMovimientoRepository.findById(MOTIVO_TRANSFERENCIA_CALIDAD_ID))
+                .thenReturn(Optional.of(motivoTransferenciaCalidad));
+        lenient().when(catalogResolver.getAlmacenPtId()).thenReturn(ALMACEN_PT_ID);
+        lenient().when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(ALMACEN_CUARENTENA_ID);
+        lenient().when(catalogResolver.getTipoDetalleEntradaId()).thenReturn(TIPO_DETALLE_ENTRADA_ID);
+        lenient().when(catalogResolver.decimals(any())).thenReturn(2);
     }
 
     @Test
@@ -229,12 +247,6 @@ class MovimientoInventarioServiceDevolucionClienteTest {
                 CausaDevolucionPT.TROCADO, CondicionProductoDevuelto.OPTIMO, false, TIPO_DETALLE_EXPLICITO_ID);
 
         configurarMocksBasicos(producto, lote, ALMACEN_PT_ID, TIPO_DETALLE_EXPLICITO_ID);
-        MotivoMovimiento motivoEntradaPt = new MotivoMovimiento();
-        motivoEntradaPt.setId(MOTIVO_ENTRADA_PT_ID);
-        motivoEntradaPt.setMotivo(ClasificacionMovimientoInventario.ENTRADA_PRODUCTO_TERMINADO);
-        given(catalogResolver.getMotivoIdEntradaProductoTerminado()).willReturn(MOTIVO_ENTRADA_PT_ID);
-        given(motivoMovimientoRepository.findById(MOTIVO_ENTRADA_PT_ID)).willReturn(Optional.of(motivoEntradaPt));
-
         MovimientoInventario movimientoEntidad = new MovimientoInventario();
         movimientoEntidad.setFechaIngreso(LocalDateTime.now());
         movimientoEntidad.setTipoMovimiento(dto.tipoMovimiento());
@@ -266,13 +278,6 @@ class MovimientoInventarioServiceDevolucionClienteTest {
                 TIPO_DETALLE_EXPLICITO_ID);
 
         configurarMocksBasicos(producto, lote, ALMACEN_CUARENTENA_ID, TIPO_DETALLE_EXPLICITO_ID);
-        MotivoMovimiento motivoTransferencia = new MotivoMovimiento();
-        motivoTransferencia.setId(MOTIVO_TRANSFERENCIA_CALIDAD_ID);
-        motivoTransferencia.setMotivo(ClasificacionMovimientoInventario.TRANSFERENCIA_GENERAL);
-        given(catalogResolver.getMotivoIdTransferenciaCalidad()).willReturn(MOTIVO_TRANSFERENCIA_CALIDAD_ID);
-        given(motivoMovimientoRepository.findById(MOTIVO_TRANSFERENCIA_CALIDAD_ID))
-                .willReturn(Optional.of(motivoTransferencia));
-
         MovimientoInventario movimientoEntidad = new MovimientoInventario();
         movimientoEntidad.setFechaIngreso(LocalDateTime.now());
         movimientoEntidad.setTipoMovimiento(dto.tipoMovimiento());
@@ -301,15 +306,6 @@ class MovimientoInventarioServiceDevolucionClienteTest {
         MovimientoInventarioDTO dto = construirDtoRecepcionCompra(producto.getId());
 
         given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
-        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
-        tipoDetalle.setId(TIPO_DETALLE_ENTRADA_ID);
-        given(tipoMovimientoDetalleRepository.findById(TIPO_DETALLE_ENTRADA_ID)).willReturn(Optional.of(tipoDetalle));
-        given(entityManager.getReference(eq(Almacen.class), any()))
-                .willAnswer(invocation -> new Almacen(((Number) invocation.getArgument(1)).intValue()));
-        given(catalogResolver.getTipoDetalleEntradaId()).willReturn(TIPO_DETALLE_ENTRADA_ID);
-        given(catalogResolver.decimals(any())).willReturn(2);
-        given(catalogResolver.getAlmacenPtId()).willReturn(ALMACEN_PT_ID);
-        given(catalogResolver.getAlmacenCuarentenaId()).willReturn(ALMACEN_CUARENTENA_ID);
 
         MovimientoInventario movimientoEntidad = new MovimientoInventario();
         movimientoEntidad.setFechaIngreso(LocalDateTime.now());
@@ -354,31 +350,16 @@ class MovimientoInventarioServiceDevolucionClienteTest {
     }
 
     private void configurarMocksBasicos(Producto producto, LoteProducto lote, long almacenDestinoId, long tipoDetalleId) {
-        MotivoMovimiento motivo = new MotivoMovimiento();
-        motivo.setId(1L);
-        motivo.setMotivo(ClasificacionMovimientoInventario.RECEPCION_DEVOLUCION_CLIENTE);
-
         given(productoRepository.findById(producto.getId().longValue())).willReturn(Optional.of(producto));
         TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
         tipoDetalle.setId(tipoDetalleId);
         given(tipoMovimientoDetalleRepository.findById(tipoDetalleId)).willReturn(Optional.of(tipoDetalle));
-        given(motivoMovimientoRepository.findByMotivo(ClasificacionMovimientoInventario.RECEPCION_DEVOLUCION_CLIENTE))
-                .willReturn(Optional.of(motivo));
         given(loteProductoRepository.findByIdForUpdate(lote.getId())).willReturn(Optional.of(lote));
         given(loteProductoRepository.findByCodigoLoteAndProductoIdAndAlmacenId(
                 lote.getCodigoLote(), producto.getId(), (int) almacenDestinoId))
                 .willReturn(Optional.empty());
         given(entityManager.getReference(eq(Almacen.class), any()))
                 .willAnswer(invocation -> new Almacen(((Number) invocation.getArgument(1)).intValue()));
-        given(catalogResolver.getAlmacenPtId()).willReturn(ALMACEN_PT_ID);
-        given(catalogResolver.getAlmacenCuarentenaId()).willReturn(ALMACEN_CUARENTENA_ID);
-        lenient().when(catalogResolver.getMotivoIdEntradaProductoTerminado()).thenReturn(MOTIVO_ENTRADA_PT_ID);
-        lenient().when(catalogResolver.getMotivoIdTransferenciaCalidad()).thenReturn(MOTIVO_TRANSFERENCIA_CALIDAD_ID);
-        lenient().when(catalogResolver.getTipoDetalleEntradaId()).thenReturn(TIPO_DETALLE_ENTRADA_ID);
-        given(catalogResolver.decimals(any())).willReturn(2);
-        lenient().when(catalogResolver.isSalidaPtEnabled()).thenReturn(false);
-        lenient().when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(TIPO_DETALLE_ENTRADA_ID);
-        lenient().when(catalogResolver.getTipoDetalleSalidaPtId()).thenReturn(TIPO_DETALLE_ENTRADA_ID);
     }
 
     private MovimientoInventarioDTO construirDto(Integer productoId,


### PR DESCRIPTION
### Motivation
- Fix a production bug that caused NPEs when required fields are missing in client-return (devolución) flow by ensuring validations run before any use of `movimiento` data. 
- Make tests for `RECEPCION_DEVOLUCION_CLIENTE` deterministic by providing the minimal catalog data the service expects. 
- Keep changes minimal and correct, preserving existing DTO constructors and avoiding disabled tests.

### Description
- Reordered validations in `registrarMovimiento` so `validarRecepcionDevolucionCliente` and checks for `loteProductoId`/destination selection run before calling `mapper.toEntity(dto)` or accessing `movimiento` fields. 
- Added explicit `CustomBusinessException` for missing motivo in devolución (`DEVOLUCION_PT_DATOS_INCOMPLETOS`) and replaced a `NoSuchElementException` on motivo lookup with a `CustomBusinessException(ApiErrorCode.CATALOGO_FALTANTE)` to avoid NPE/NoSuchElement leaks. 
- Kept existing behavior for assigning destino (PT vs Cuarentena) and for resolving tipoDetalle; ensured validations that determine these values execute in the correct order. 
- Updated `MovimientoInventarioServiceDevolucionClienteTest` to seed required catalog/motivo mocks in `@BeforeEach`, remove unused stubbings from `configurarMocksBasicos`, and provide consistent `catalogResolver`/`motivoMovimientoRepository` behavior so tests reflect the service flow.

### Testing
- Executed `mvn -Dtest=MovimientoInventarioServiceDevolucionClienteTest test` to validate the modified test class. 
- Result: build failed during compilation with a JVM/javac initialization error (`java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`) so the test run did not complete; no unit test failures from the modified logic were observed because the compile error prevented running the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69691a3d49788333a51a62b4ac4d0016)