### PR TITLE
Fix lambda capture for motivoMovimientoId in MovimientoInventarioServiceImpl

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -692,10 +692,11 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
         MotivoMovimiento motivoMovimiento = null;
         if (motivoMovimientoId != null) {
+            final Long motivoMovimientoIdFinal = motivoMovimientoId;
             motivoMovimiento = motivoMovimientoRepository.findById(motivoMovimientoId)
                     .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.CATALOGO_FALTANTE,
                             "Motivo no encontrado",
-                            Map.of("motivoMovimientoId", motivoMovimientoId)));
+                            Map.of("motivoMovimientoId", motivoMovimientoIdFinal)));
         }
         motivoMovimiento = resolverMotivoMovimientoPorClasificacion(clasificacion, motivoMovimiento);
 


### PR DESCRIPTION
### Motivation
- Evitar el error de compilación provocado por una lambda que captura una variable local no efectivamente final (`motivoMovimientoId`) sin alterar la lógica de negocio.

### Description
- Se añadió `final Long motivoMovimientoIdFinal = motivoMovimientoId;` y se usa esa variable dentro del `orElseThrow` en `src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java` para impedir la captura de la variable mutable.

### Testing
- Ejecuté `mvn -q -DskipTests compile` y la compilación falló con `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`.
- Ejecuté `mvn -q -Dtest=MovimientoInventarioServiceDevolucionClienteTest test` y la ejecución falló por la misma excepción de compilación; el cambio de código fue aplicado correctamente pero la compilación completa no finalizó exitosamente en este entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69692182a30883339bbcc2777ce66efc)