### PR TITLE
Stub motivo transferencia calidad en test de devolución

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDevolucionClienteTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDevolucionClienteTest.java
@@ -527,6 +527,10 @@ class MovimientoInventarioServiceDevolucionClienteTest {
         lenient().when(catalogResolver.getMotivoIdEntradaProductoTerminado()).thenReturn(MOTIVO_ENTRADA_PT_ID);
         lenient().when(motivoMovimientoRepository.findById(MOTIVO_ENTRADA_PT_ID))
                 .thenReturn(Optional.of(motivoEntradaPt));
+        lenient().when(catalogResolver.getMotivoIdTransferenciaCalidad())
+                .thenReturn(MOTIVO_TRANSFERENCIA_CALIDAD_ID);
+        lenient().when(motivoMovimientoRepository.findById(MOTIVO_TRANSFERENCIA_CALIDAD_ID))
+                .thenReturn(Optional.of(motivoTransferenciaCalidad));
         lenient().when(catalogResolver.getAlmacenPtId()).thenReturn(ALMACEN_PT_ID);
         lenient().when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(ALMACEN_CUARENTENA_ID);
         lenient().when(catalogResolver.getTipoDetalleEntradaId()).thenReturn(TIPO_DETALLE_ENTRADA_ID);


### PR DESCRIPTION
### Motivation
- El test `shouldAssignMotivoTransferenciaCalidad_whenDestinoCuarentena` fallaba por ausencia del catálogo de motivo para "transferencia calidad", causando `CustomBusinessException: Motivo no encontrado` al resolver el motivo en el helper de pruebas.

### Description
- Se agregaron stubs lenient para `catalogResolver.getMotivoIdTransferenciaCalidad()` devolviendo `MOTIVO_TRANSFERENCIA_CALIDAD_ID` y para `motivoMovimientoRepository.findById(MOTIVO_TRANSFERENCIA_CALIDAD_ID)` devolviendo `Optional.of(motivoTransferenciaCalidad)` dentro de `stubCatalogosRecepcionDevolucion()`.

### Testing
- No se ejecutaron tests automatizados en este cambio; la modificación está orientada a permitir que `mvn -Dtest=MovimientoInventarioServiceDevolucionClienteTest#shouldAssignMotivoTransferenciaCalidad_whenDestinoCuarentena test` pase cuando se ejecute en CI o localmente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696940448d6c8333be769cefe59604e9)