### PR TITLE
Corregir LazyInitialization en evaluaciones de Calidad (re-fetch y DTO seguro)

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
@@ -68,4 +68,7 @@ public interface EvaluacionCalidadRepository extends JpaRepository<EvaluacionCal
             "JOIN FETCH e.loteProducto l " +
             "WHERE l.id = :loteId")
     java.util.List<EvaluacionCalidad> findByLoteProductoIdWithAdjuntos(@Param("loteId") Long loteId);
+
+    @EntityGraph(attributePaths = {"loteProducto", "loteProducto.producto", "loteProducto.almacen", "usuarioEvaluador", "archivosAdjuntos"})
+    java.util.Optional<EvaluacionCalidad> findByIdConRelaciones(Long id);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -40,6 +40,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -90,6 +91,7 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
         return page.map(mapper::toResponseDTO);
     }
 
+    @Transactional
     public EvaluacionCalidadResponseDTO crear(EvaluacionCalidadRequestDTO dto, java.util.List<MultipartFile> archivos) {
         Usuario user = usuarioService.obtenerUsuarioAutenticado();
 
@@ -157,9 +159,11 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
 
         verificarAlmacenPostOperacion(lote.getId(), cuarentenaId, operacion, user);
 
-        return mapper.toResponseDTO(entidad);
+        EvaluacionCalidad evaluacion = obtenerEvaluacionConRelaciones(entidad.getId());
+        return mapper.toResponseDTO(evaluacion);
     }
 
+    @Transactional
     public EvaluacionCalidadResponseDTO actualizar(Long id, EvaluacionCalidadRequestDTO dto) {
         EvaluacionCalidad existing = repository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("Evaluación no encontrada con ID: " + id));
@@ -217,7 +221,8 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
 
         verificarAlmacenPostOperacion(lote.getId(), cuarentenaId, operacion, user);
 
-        return mapper.toResponseDTO(existing);
+        EvaluacionCalidad evaluacion = obtenerEvaluacionConRelaciones(existing.getId());
+        return mapper.toResponseDTO(evaluacion);
     }
 
     public EvaluacionCalidadResponseDTO obtenerPorId(Long id) {
@@ -524,5 +529,11 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
                     dto.getObservaciones(), usuario);
             retencionLoteService.asegurarRetencionNoConformidad(lote, "NC pendiente", noConformidad, usuario);
         }
+    }
+
+    private EvaluacionCalidad obtenerEvaluacionConRelaciones(Long id) {
+        return repository.findByIdConRelaciones(id)
+                .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                        "Evaluación no encontrada"));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerSecurityTest.java
@@ -2,6 +2,8 @@ package com.willyes.clemenintegra.calidad.controller;
 
 import com.willyes.clemenintegra.calidad.dto.PlantillaAnalisisMicroDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
+import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
 import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
 import com.willyes.clemenintegra.calidad.service.PlantillaAnalisisMicroService;
 import com.willyes.clemenintegra.calidad.service.ResultadoAnalisisMicroService;
@@ -31,10 +33,13 @@ import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(EvaluacionCalidadController.class)
@@ -152,5 +157,53 @@ class EvaluacionCalidadControllerSecurityTest {
                         .with(SecurityMockMvcRequestPostProcessors.user("micro")
                                 .authorities(() -> "ROL_MICROBIOLOGO")))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void permiteAnalistaRegistrarEvaluacion() throws Exception {
+        EvaluacionCalidadResponseDTO response = EvaluacionCalidadResponseDTO.builder()
+                .id(1L)
+                .tipoEvaluacion(TipoEvaluacion.FISICO)
+                .nombreLote("LOTE-01")
+                .nombreProducto("Producto X")
+                .nombreEvaluador("Analista Calidad")
+                .build();
+        when(evaluacionCalidadService.crear(any(), anyList())).thenReturn(response);
+
+        mockMvc.perform(multipart("/api/calidad/evaluaciones")
+                        .param("tipoEvaluacion", "FISICO")
+                        .param("observaciones", "OK")
+                        .param("loteProductoId", "10")
+                        .with(SecurityMockMvcRequestPostProcessors.user("analista")
+                                .authorities(() -> "ROL_ANALISTA_CALIDAD")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.nombreLote").value("LOTE-01"))
+                .andExpect(jsonPath("$.nombreProducto").value("Producto X"))
+                .andExpect(jsonPath("$.nombreEvaluador").value("Analista Calidad"));
+    }
+
+    @Test
+    void permiteMicrobiologoRegistrarEvaluacion() throws Exception {
+        EvaluacionCalidadResponseDTO response = EvaluacionCalidadResponseDTO.builder()
+                .id(2L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .nombreLote("LOTE-02")
+                .nombreProducto("Producto Y")
+                .nombreEvaluador("Microbiologo")
+                .build();
+        when(evaluacionCalidadService.crear(any(), anyList())).thenReturn(response);
+
+        mockMvc.perform(multipart("/api/calidad/evaluaciones")
+                        .param("tipoEvaluacion", "QUIMICO_MICROBIOLOGICO")
+                        .param("observaciones", "OK")
+                        .param("loteProductoId", "20")
+                        .with(SecurityMockMvcRequestPostProcessors.user("micro")
+                                .authorities(() -> "ROL_MICROBIOLOGO")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(2L))
+                .andExpect(jsonPath("$.nombreLote").value("LOTE-02"))
+                .andExpect(jsonPath("$.nombreProducto").value("Producto Y"))
+                .andExpect(jsonPath("$.nombreEvaluador").value("Microbiologo"));
     }
 }


### PR DESCRIPTION
### Motivation
- Evitar errores 500 por `LazyInitializationException` al devolver `EvaluacionCalidad` a los clientes cuando el mapper/Jackson accede a relaciones LAZY fuera de la transacción/session.
- La corrección mínima es: persistir la entidad, re-consultar con fetch de las relaciones necesarias y construir/retornar únicamente DTOs dentro de la transacción.

### Description
- Se añadió en el repository el método `findByIdConRelaciones(Long id)` con `@EntityGraph(attributePaths = {"loteProducto","loteProducto.producto","loteProducto.almacen","usuarioEvaluador","archivosAdjuntos"})` para cargar exactamente las relaciones usadas por el mapper/DTO.
- En `EvaluacionCalidadServiceImpl` se marcó `crear` y `actualizar` con `@Transactional`, se mantiene el `save`, y después del guardado se re-consulta la evaluación con `obtenerEvaluacionConRelaciones(entidad.getId())` y se mapea a DTO antes de retornar.
- Se agregó el helper `obtenerEvaluacionConRelaciones(Long id)` que lanza una excepción de negocio (`CustomBusinessException` con `ApiErrorCode.RECURSO_NO_ENCONTRADO`) si no encuentra la entidad cargada.
- Se añadieron pruebas unitarias en `EvaluacionCalidadControllerSecurityTest` que ejercitan el endpoint de creación (`POST /api/calidad/evaluaciones` multipart) para roles `ROL_ANALISTA_CALIDAD` y `ROL_MICROBIOLOGO`, validando la estructura mínima del `EvaluacionCalidadResponseDTO` retornado.

### Testing
- No se ejecutaron pruebas automatizadas locales durante este cambio; los nuevos tests unitarios fueron añadidos en `src/test/java/.../EvaluacionCalidadControllerSecurityTest.java` y cubren la creación de evaluaciones para Analista y Microbiólogo, pero la ejecución queda para CI o ejecución local posterior.
- Cambios compilables y cobertura de flujo manualmente revisada en el código para asegurar que el mapeo a DTO se realiza tras re-consultar las relaciones necesarias dentro de la transacción.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4a85dd208333b72133437ed3bab9)