### PR TITLE
Load EvaluacionCalidad relations with @EntityGraph on findById

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import java.util.Optional;
 import java.time.LocalDateTime;
 
 public interface EvaluacionCalidadRepository extends JpaRepository<EvaluacionCalidad, Long> {
@@ -69,6 +70,7 @@ public interface EvaluacionCalidadRepository extends JpaRepository<EvaluacionCal
             "WHERE l.id = :loteId")
     java.util.List<EvaluacionCalidad> findByLoteProductoIdWithAdjuntos(@Param("loteId") Long loteId);
 
+    @Override
     @EntityGraph(attributePaths = {"loteProducto", "loteProducto.producto", "usuarioEvaluador", "archivosAdjuntos"})
-    java.util.Optional<EvaluacionCalidad> findByIdConRelaciones(Long id);
+    Optional<EvaluacionCalidad> findById(Long id);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -532,7 +532,7 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
     }
 
     private EvaluacionCalidad obtenerEvaluacionConRelaciones(Long id) {
-        return repository.findByIdConRelaciones(id)
+        return repository.findById(id)
                 .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
                         "Evaluación no encontrada con ID: " + id));
     }


### PR DESCRIPTION
### Motivation
- Fix startup error caused by a wrongly interpreted derived query `findByIdConRelaciones(Long)` and prevent `LazyInitializationException` when mapping `Producto.getNombre()` after saving an evaluation.
- Ensure the repository returns the evaluation with required relations loaded so the mapper can safely access `loteProducto`, `producto`, `usuarioEvaluador` and `archivosAdjuntos` inside the service transaction.

### Description
- Removed the custom derived method `findByIdConRelaciones(Long)` and added an `@Override` of `findById(Long id)` annotated with `@EntityGraph(attributePaths = {"loteProducto","loteProducto.producto","usuarioEvaluador","archivosAdjuntos"})` in `EvaluacionCalidadRepository`.
- Updated `EvaluacionCalidadServiceImpl.obtenerEvaluacionConRelaciones` to call `repository.findById(id)` (the entity-graph-enabled `findById`) and throw the same `CustomBusinessException` if not found.
- Kept the `@Transactional` behavior in `crear(...)`, still `save`ing the entity and re-querying by id before mapping to DTO so relations are loaded for `EvaluacionCalidadMapper.toResponseDTO`.
- Added required import adjustments (`Optional`) and minor formatting to match the repository change.

### Testing
- Ran `mvn test` and the build failed during compilation with `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN` (failure appears unrelated to the repository change but prevents completing the test run).
- No further automated tests were executed due to the compilation error reported by `mvn test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a54a20b488333821f752bc594a909)