### PR TITLE
Fix evaluacion calidad tests for refetch flow

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerSecurityTest.java
@@ -168,7 +168,7 @@ class EvaluacionCalidadControllerSecurityTest {
                 .nombreProducto("Producto X")
                 .nombreEvaluador("Analista Calidad")
                 .build();
-        when(evaluacionCalidadService.crear(any(), anyList())).thenReturn(response);
+        when(evaluacionCalidadService.crear(any(), any())).thenReturn(response);
 
         mockMvc.perform(multipart("/api/calidad/evaluaciones")
                         .param("tipoEvaluacion", "FISICO")
@@ -192,7 +192,7 @@ class EvaluacionCalidadControllerSecurityTest {
                 .nombreProducto("Producto Y")
                 .nombreEvaluador("Microbiologo")
                 .build();
-        when(evaluacionCalidadService.crear(any(), anyList())).thenReturn(response);
+        when(evaluacionCalidadService.crear(any(), any())).thenReturn(response);
 
         mockMvc.perform(multipart("/api/calidad/evaluaciones")
                         .param("tipoEvaluacion", "QUIMICO_MICROBIOLOGICO")

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -120,12 +121,23 @@ class EvaluacionCalidadServiceImplTest {
             eval.setId(50L);
             return eval;
         });
+        EvaluacionCalidad evaluacionCompleta = EvaluacionCalidad.builder()
+                .id(50L)
+                .tipoEvaluacion(TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .observaciones("OK")
+                .loteProducto(lote)
+                .usuarioEvaluador(evaluador)
+                .fechaEvaluacion(LocalDateTime.now())
+                .build();
+        when(repository.findById(50L)).thenReturn(Optional.of(evaluacionCompleta));
 
         var respuesta = service.crear(dto, null);
 
         assertThat(respuesta.getId()).isEqualTo(50L);
         assertThat(respuesta.getTipoEvaluacion()).isEqualTo(TipoEvaluacion.QUIMICO_MICROBIOLOGICO);
         assertThat(respuesta.getResultado()).isEqualTo(ResultadoEvaluacion.CONFORME);
+        verify(repository).findById(50L);
     }
 
     @Test
@@ -147,6 +159,7 @@ class EvaluacionCalidadServiceImplTest {
         when(repository.findFirstByLoteProductoIdAndTipoEvaluacion(10L, TipoEvaluacion.QUIMICO_MICROBIOLOGICO))
                 .thenReturn(Optional.of(existente));
         when(repository.save(any(EvaluacionCalidad.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(repository.findById(60L)).thenReturn(Optional.of(existente));
 
         EvaluacionCalidadRequestDTO dto = EvaluacionCalidadRequestDTO.builder()
                 .loteProductoId(10L)
@@ -163,6 +176,7 @@ class EvaluacionCalidadServiceImplTest {
         assertThat(existente.getArchivosAdjuntos())
                 .extracting(ArchivoEvaluacion::getNombreVisible)
                 .contains("Químico");
+        verify(repository).findById(60L);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Tests started failing after adding a post-save re-fetch in the evaluacion flow that returns an entity with relations and an `id` for the response DTO.
- Unit tests must mock the new repository `findById(...)` call and controller tests must accept the service being called with a nullable multipart list so JSON `id` expectations remain valid.

### Description

- Updated `src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java` to mock `repository.findById(50L)` and `repository.findById(60L)`, build corresponding complete `EvaluacionCalidad` instances, and verify `findById(...)` is invoked after `save`. 
- Adjusted `src/test/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadControllerSecurityTest.java` to mock `evaluacionCalidadService.crear(any(), any())` (accepting a nullable multipart list) so the mocked `EvaluacionCalidadResponseDTO` returned to the controller contains a non-null `id` and the JSON path assertions remain valid. 
- Kept existing DTO assertions intact so behavior/contract remains the same for callers.

### Testing

- Ran `mvn test` to exercise the unit and slice tests; the modified tests executed but the build aborted with a compilation error: `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`, so the overall Maven build failed. 
- The updated unit and controller tests themselves are present and aligned with the new post-save refetch flow and include `verify(repository).findById(...)` checks, but the CI/local JVM compilation issue prevented completing a full green run. 
- Further action required: resolve the environment/JDK/tooling compilation error and re-run `mvn test` to confirm all tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a5f94223c83339409c9097ea46e00)