### PR TITLE
Consolidar evaluaciones por lote y corregir cálculo de análisis requeridos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
@@ -3,7 +3,7 @@ package com.willyes.clemenintegra.calidad.controller;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
-import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaListadoDTO;
+import com.willyes.clemenintegra.calidad.dto.ConsolidadoPorLoteDTO;
 import com.willyes.clemenintegra.calidad.dto.PlantillaAnalisisMicroDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
@@ -46,7 +46,7 @@ public class EvaluacionCalidadController {
 
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_SUPER_ADMIN')")
     @GetMapping("/consolidadas")
-    public ResponseEntity<Page<EvaluacionConsolidadaListadoDTO>> getEvaluacionesConsolidadas(
+    public ResponseEntity<Page<ConsolidadoPorLoteDTO>> getEvaluacionesConsolidadas(
             @RequestParam("fechaInicio") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam("fechaFin") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin,
             @PageableDefault(size = 10) Pageable pageable) {

--- a/src/main/java/com/willyes/clemenintegra/calidad/dto/ConsolidadoPorLoteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/dto/ConsolidadoPorLoteDTO.java
@@ -1,0 +1,36 @@
+package com.willyes.clemenintegra.calidad.dto;
+
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ConsolidadoPorLoteDTO {
+
+    private final Long loteId;
+    private final String codigoLote;
+    private final String nombreProducto;
+    private final String tipoAnalisisCalidad;
+    private final EstadoLote estadoLote;
+    private final DisciplinaConsolidadoDTO fisico;
+    private final DisciplinaConsolidadoDTO quimicoMicrobiologico;
+    private final DisciplinaConsolidadoDTO microbiologico;
+    private final boolean liberable;
+    private final boolean faltanEvaluaciones;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class DisciplinaConsolidadoDTO {
+        private final boolean requerido;
+        private final String estado;
+        private final String resultado;
+        private final LocalDateTime fechaUltimaEvaluacion;
+        private final String evaluador;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
@@ -3,7 +3,6 @@ package com.willyes.clemenintegra.calidad.repository;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
-import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaListadoDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -38,30 +37,16 @@ public interface EvaluacionCalidadRepository extends JpaRepository<EvaluacionCal
             @Param("inicio") LocalDateTime inicio,
             @Param("fin") LocalDateTime fin);
 
-    @Query(value = "SELECT new com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaListadoDTO(" +
-            "e.id, l.id, e.fechaEvaluacion, l.codigoLote, p.nombre, e.resultado, e.tipoEvaluacion, " +
-            "u.nombreCompleto, " +
-            "com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad.EVALUADO, " +
-            "l.estado, COUNT(a)) " +
-            "FROM EvaluacionCalidad e " +
-            "JOIN e.loteProducto l " +
-            "JOIN l.producto p " +
-            "JOIN e.usuarioEvaluador u " +
-            "LEFT JOIN e.archivosAdjuntos a " +
-            "WHERE e.fechaEvaluacion BETWEEN :inicio AND :fin " +
-            "GROUP BY e.id, l.id, e.fechaEvaluacion, l.codigoLote, p.nombre, e.resultado, e.tipoEvaluacion, u.nombreCompleto, l.estado",
-            countQuery = "SELECT COUNT(e.id) FROM EvaluacionCalidad e " +
-                    "WHERE e.fechaEvaluacion BETWEEN :inicio AND :fin")
-    Page<EvaluacionConsolidadaListadoDTO> findConsolidadoListado(
-            @Param("inicio") LocalDateTime inicio,
-            @Param("fin") LocalDateTime fin,
-            Pageable pageable);
+    @EntityGraph(attributePaths = {"loteProducto", "loteProducto.producto", "usuarioEvaluador", "archivosAdjuntos"})
+    java.util.List<EvaluacionCalidad> findByLoteProductoIdIn(java.util.List<Long> loteIds);
 
     boolean existsByLoteProductoIdAndTipoEvaluacion(Long loteId, TipoEvaluacion tipo);
 
     java.util.List<EvaluacionCalidad> findByLoteProductoId(Long loteId);
 
-    java.util.List<EvaluacionCalidad> findByLoteProductoIdIn(java.util.List<Long> loteIds);
+    @EntityGraph(attributePaths = {"loteProducto", "loteProducto.producto", "usuarioEvaluador", "archivosAdjuntos"})
+    @Query("SELECT e FROM EvaluacionCalidad e WHERE e.loteProducto.id IN :loteIds")
+    java.util.List<EvaluacionCalidad> findByLoteProductoIdInWithRelacion(@Param("loteIds") java.util.List<Long> loteIds);
 
     @Query("SELECT DISTINCT e FROM EvaluacionCalidad e " +
             "LEFT JOIN FETCH e.archivosAdjuntos " +

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AnalisisCalidadHelper.java
@@ -25,15 +25,42 @@ public final class AnalisisCalidadHelper {
     }
 
     public static boolean requiereFisico(Producto producto) {
-        return producto != null && producto.isRequiereAnalisisFisico();
+        if (producto == null) {
+            return false;
+        }
+        if (tieneBanderasCalidad(producto)) {
+            return producto.isRequiereAnalisisFisico();
+        }
+        return producto.getTipoAnalisisCalidad() == com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.FISICO
+                || producto.getTipoAnalisisCalidad() == com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.AMBOS;
     }
 
     public static boolean requiereQuimico(Producto producto) {
-        return producto != null && producto.isRequiereAnalisisQuimico();
+        if (producto == null) {
+            return false;
+        }
+        if (tieneBanderasCalidad(producto)) {
+            return producto.isRequiereAnalisisQuimico();
+        }
+        return producto.getTipoAnalisisCalidad() == com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO
+                || producto.getTipoAnalisisCalidad() == com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.AMBOS;
     }
 
     public static boolean requiereMicro(Producto producto) {
-        return producto != null && producto.isRequiereAnalisisMicrobiologico();
+        if (producto == null) {
+            return false;
+        }
+        if (tieneBanderasCalidad(producto)) {
+            return producto.isRequiereAnalisisMicrobiologico();
+        }
+        return producto.getTipoAnalisisCalidad() == com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO
+                || producto.getTipoAnalisisCalidad() == com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.AMBOS;
+    }
+
+    private static boolean tieneBanderasCalidad(Producto producto) {
+        return producto != null && (producto.isRequiereAnalisisFisico()
+                || producto.isRequiereAnalisisQuimico()
+                || producto.isRequiereAnalisisMicrobiologico());
     }
 
     public static ResultadoValidacionDisciplinas validarDisciplinasCompletas(

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImpl.java
@@ -49,9 +49,9 @@ public class AuditoriaLoteServiceImpl implements AuditoriaLoteService {
         LoteProducto lote = loteProductoRepository.findById(loteId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "LOTE_NO_ENCONTRADO"));
 
-        boolean requiereFisico = lote.getProducto() != null && lote.getProducto().isRequiereAnalisisFisico();
-        boolean requiereQuimico = lote.getProducto() != null && lote.getProducto().isRequiereAnalisisQuimico();
-        boolean requiereMicro = lote.getProducto() != null && lote.getProducto().isRequiereAnalisisMicrobiologico();
+        boolean requiereFisico = AnalisisCalidadHelper.requiereFisico(lote.getProducto());
+        boolean requiereQuimico = AnalisisCalidadHelper.requiereQuimico(lote.getProducto());
+        boolean requiereMicro = AnalisisCalidadHelper.requiereMicro(lote.getProducto());
         TipoAnalisisCalidad tipoAnalisis = TipoAnalisisCalidad.fromFlags(requiereFisico, requiereQuimico, requiereMicro);
 
         EstadoCalidadLoteResponseDTO estadoCalidad = loteProductoService.obtenerEstadoCalidad(loteId);

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
@@ -2,7 +2,7 @@ package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
-import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaListadoDTO;
+import com.willyes.clemenintegra.calidad.dto.ConsolidadoPorLoteDTO;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +18,7 @@ public interface EvaluacionCalidadService {
     EvaluacionCalidadResponseDTO obtenerPorId(Long id);
     com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO obtenerDetalle(Long id);
     java.util.List<EvaluacionCalidadResponseDTO> listarPorLote(Long loteId);
-    Page<EvaluacionConsolidadaListadoDTO> obtenerEvaluacionesConsolidadas(LocalDate fechaInicio,
+    Page<ConsolidadoPorLoteDTO> obtenerEvaluacionesConsolidadas(LocalDate fechaInicio,
                                                                           LocalDate fechaFin,
                                                                           Pageable pageable);
     void eliminar(Long id);

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -4,7 +4,7 @@ import com.willyes.clemenintegra.calidad.dto.ArchivoEvaluacionDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
-import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaListadoDTO;
+import com.willyes.clemenintegra.calidad.dto.ConsolidadoPorLoteDTO;
 import com.willyes.clemenintegra.calidad.dto.CondicionUsoCreateDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCondicionDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
@@ -55,6 +55,7 @@ import java.time.LocalTime;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -270,15 +271,121 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
     }
 
     @Override
-    public Page<EvaluacionConsolidadaListadoDTO> obtenerEvaluacionesConsolidadas(LocalDate fechaInicio,
-                                                                                 LocalDate fechaFin,
-                                                                                 Pageable pageable) {
+    public Page<ConsolidadoPorLoteDTO> obtenerEvaluacionesConsolidadas(LocalDate fechaInicio,
+                                                                       LocalDate fechaFin,
+                                                                       Pageable pageable) {
         LocalDateTime inicio = fechaInicio.atStartOfDay();
         LocalDateTime fin = fechaFin.atTime(LocalTime.MAX);
         Pageable effective = pageable.getSort().isSorted() ? pageable
                 : org.springframework.data.domain.PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.DESC, "fechaEvaluacion"));
-        return repository.findConsolidadoListado(inicio, fin, effective);
+                org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.DESC, "fechaFabricacion"));
+
+        java.util.List<com.willyes.clemenintegra.inventario.model.enums.EstadoLote> estados = java.util.List.of(
+                com.willyes.clemenintegra.inventario.model.enums.EstadoLote.EN_CUARENTENA,
+                com.willyes.clemenintegra.inventario.model.enums.EstadoLote.RETENIDO,
+                com.willyes.clemenintegra.inventario.model.enums.EstadoLote.LIBERADO
+        );
+
+        org.springframework.data.domain.Page<LoteProducto> lotes = loteRepository.findConsolidadoCalidad(inicio, fin, estados, effective);
+        if (lotes.isEmpty()) {
+            return org.springframework.data.domain.Page.empty(effective);
+        }
+
+        java.util.List<Long> loteIds = lotes.getContent().stream()
+                .map(LoteProducto::getId)
+                .filter(Objects::nonNull)
+                .toList();
+
+        java.util.List<EvaluacionCalidad> evaluaciones = loteIds.isEmpty()
+                ? java.util.List.of()
+                : repository.findByLoteProductoIdInWithRelacion(loteIds);
+
+        java.util.Map<Long, java.util.List<EvaluacionCalidad>> evaluacionesPorLote = evaluaciones.stream()
+                .filter(e -> e.getLoteProducto() != null && e.getLoteProducto().getId() != null)
+                .collect(Collectors.groupingBy(e -> e.getLoteProducto().getId()));
+
+        java.util.List<Long> evaluacionMicroIds = evaluaciones.stream()
+                .filter(e -> e.getTipoEvaluacion() == TipoEvaluacion.QUIMICO_MICROBIOLOGICO)
+                .map(EvaluacionCalidad::getId)
+                .filter(Objects::nonNull)
+                .toList();
+
+        java.util.Set<Long> evaluacionesConResultadosMicro = evaluacionMicroIds.isEmpty()
+                ? java.util.Set.of()
+                : resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(evaluacionMicroIds)
+                .stream()
+                .map(r -> r.getEvaluacion() != null ? r.getEvaluacion().getId() : null)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        java.util.List<ConsolidadoPorLoteDTO> content = lotes.getContent().stream()
+                .map(lote -> construirConsolidadoPorLote(lote,
+                        evaluacionesPorLote.getOrDefault(lote.getId(), java.util.List.of()),
+                        evaluacionesConResultadosMicro))
+                .toList();
+
+        return new org.springframework.data.domain.PageImpl<>(content, effective, lotes.getTotalElements());
+    }
+
+    private ConsolidadoPorLoteDTO construirConsolidadoPorLote(LoteProducto lote,
+                                                              java.util.List<EvaluacionCalidad> evaluaciones,
+                                                              java.util.Set<Long> evaluacionesConResultadosMicro) {
+        AnalisisCalidadHelper.EstadoDisciplinasCalidad estadoDisciplinas = AnalisisCalidadHelper.calcularEstadoDisciplinas(
+                lote.getProducto(),
+                evaluaciones,
+                evaluacionesConResultadosMicro::contains);
+
+        AnalisisCalidadHelper.ResultadoValidacionDisciplinas validacion = AnalisisCalidadHelper.validarDisciplinasCompletas(
+                lote,
+                evaluaciones,
+                evaluacionesConResultadosMicro::contains);
+
+        boolean fisicoCompleto = estadoDisciplinas.fisico().estado() == com.willyes.clemenintegra.calidad.model.enums.DisciplinaEstado.EVALUADO;
+        boolean quimicoCompleto = estadoDisciplinas.quimicoMicrobiologico().estado() == com.willyes.clemenintegra.calidad.model.enums.DisciplinaEstado.EVALUADO;
+        boolean microCompleto = estadoDisciplinas.microbiologico().estado() == com.willyes.clemenintegra.calidad.model.enums.DisciplinaEstado.EVALUADO;
+
+        com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad estadoEvaluacion =
+                AnalisisCalidadHelper.calcularEstadoEvaluacion(
+                        estadoDisciplinas.fisico().requerido(),
+                        fisicoCompleto,
+                        estadoDisciplinas.quimicoMicrobiologico().requerido(),
+                        quimicoCompleto,
+                        estadoDisciplinas.microbiologico().requerido(),
+                        microCompleto);
+
+        return ConsolidadoPorLoteDTO.builder()
+                .loteId(lote.getId())
+                .codigoLote(lote.getCodigoLote())
+                .nombreProducto(lote.getProducto() != null ? lote.getProducto().getNombre() : null)
+                .tipoAnalisisCalidad(lote.getProducto() != null && lote.getProducto().getTipoAnalisisCalidad() != null
+                        ? lote.getProducto().getTipoAnalisisCalidad().name()
+                        : null)
+                .estadoLote(lote.getEstado())
+                .fisico(mapDisciplinaListado(estadoDisciplinas.fisico()))
+                .quimicoMicrobiologico(mapDisciplinaListado(estadoDisciplinas.quimicoMicrobiologico()))
+                .microbiologico(mapDisciplinaListado(estadoDisciplinas.microbiologico()))
+                .liberable(estadoEvaluacion == com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad.EVALUADO)
+                .faltanEvaluaciones(validacion != null && !validacion.esValido())
+                .build();
+    }
+
+    private ConsolidadoPorLoteDTO.DisciplinaConsolidadoDTO mapDisciplinaListado(AnalisisCalidadHelper.DisciplinaCalidadEstado estado) {
+        if (estado == null) {
+            return ConsolidadoPorLoteDTO.DisciplinaConsolidadoDTO.builder()
+                    .requerido(false)
+                    .estado(null)
+                    .resultado(null)
+                    .fechaUltimaEvaluacion(null)
+                    .evaluador(null)
+                    .build();
+        }
+        return ConsolidadoPorLoteDTO.DisciplinaConsolidadoDTO.builder()
+                .requerido(estado.requerido())
+                .estado(estado.estado() != null ? estado.estado().name() : null)
+                .resultado(estado.resultado())
+                .fechaUltimaEvaluacion(estado.fechaUltimaEvaluacion())
+                .evaluador(estado.evaluador())
+                .build();
     }
 
     public void eliminar(Long id) {

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -143,6 +143,19 @@ WHERE lp.codigoLote = :codigoLote
     @EntityGraph(attributePaths = {"producto", "almacen"})
     List<LoteProducto> findByOrdenProduccionId(Long ordenProduccionId);
 
+    @EntityGraph(attributePaths = {"producto"})
+    @Query("""
+       SELECT lp
+         FROM LoteProducto lp
+        WHERE lp.fechaFabricacion BETWEEN :inicio AND :fin
+          AND lp.estado IN :estados
+    """)
+    org.springframework.data.domain.Page<LoteProducto> findConsolidadoCalidad(
+            @Param("inicio") LocalDateTime inicio,
+            @Param("fin") LocalDateTime fin,
+            @Param("estados") Collection<EstadoLote> estados,
+            org.springframework.data.domain.Pageable pageable);
+
     @EntityGraph(attributePaths = {
             "almacen",
             "producto",

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadListadoIntegrationTest.java
@@ -169,7 +169,7 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
 
     @Test
     @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
-    void listarEvaluacionesConsolidadasIncluyeCantidadAdjuntos() throws Exception {
+    void listarEvaluacionesConsolidadasIncluyeRequeridos() throws Exception {
         LocalDate hoy = LocalDate.now();
         mockMvc.perform(get("/api/calidad/evaluaciones/consolidadas")
                         .param("fechaInicio", hoy.minusDays(1).toString())
@@ -179,9 +179,11 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].codigoLote").value("LP-CAL-1"))
                 .andExpect(jsonPath("$.content[0].loteId").value(loteProducto.getId()))
-                .andExpect(jsonPath("$.content[0].estadoEvaluacion").value("EVALUADO"))
-                .andExpect(jsonPath("$.content[0].cantidadAdjuntos").value(1))
-                .andExpect(jsonPath("$.content[0].tieneAdjuntos").value(true));
+                .andExpect(jsonPath("$.content[0].tipoAnalisisCalidad").value("FISICO"))
+                .andExpect(jsonPath("$.content[0].fisico.requerido").value(true))
+                .andExpect(jsonPath("$.content[0].fisico.estado").value("EVALUADO"))
+                .andExpect(jsonPath("$.content[0].quimicoMicrobiologico.requerido").value(false))
+                .andExpect(jsonPath("$.content[0].microbiologico.requerido").value(false));
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/AuditoriaLoteServiceImplTest.java
@@ -23,6 +23,7 @@ import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
@@ -251,6 +252,39 @@ class AuditoriaLoteServiceImplTest {
         assertThat(dto.getCalidad().getQuimicoMicrobiologico().getEstado()).isEqualTo("EVALUADO");
         assertThat(dto.getCalidad().getMicrobiologico().isRequerido()).isTrue();
         assertThat(dto.getCalidad().getMicrobiologico().getEstado()).isEqualTo("PENDIENTE");
+    }
+
+    @Test
+    void auditoriaAmbosMarcaQuimicoMicroRequerido() {
+        Producto producto = new Producto();
+        producto.setNombre("Producto Ambos");
+        producto.setRequiereAnalisisFisico(false);
+        producto.setRequiereAnalisisQuimico(false);
+        producto.setRequiereAnalisisMicrobiologico(false);
+        producto.setTipoAnalisisCalidad(TipoAnalisisCalidad.AMBOS);
+
+        LoteProducto lote = LoteProducto.builder()
+                .id(5L)
+                .codigoLote("L-AMBOS-01")
+                .estado(EstadoLote.EN_CUARENTENA)
+                .producto(producto)
+                .build();
+
+        when(loteProductoRepository.findById(5L)).thenReturn(Optional.of(lote));
+        when(loteProductoService.obtenerEstadoCalidad(5L))
+                .thenReturn(EstadoCalidadLoteResponseDTO.builder().estadoLote("EN_CUARENTENA").build());
+        when(noConformidadRepository.findByLote_Id(5L)).thenReturn(List.of());
+        when(retencionLoteService.obtenerRetencionesPorLote(5L)).thenReturn(List.of());
+        when(condicionUsoService.getActivasByLote(5L)).thenReturn(List.of());
+        when(movimientoInventarioRepository.findByLote_IdOrderByFechaIngresoDesc(5L)).thenReturn(List.of());
+        when(evaluacionCalidadRepository.findByLoteProductoIdWithAdjuntos(5L)).thenReturn(List.of());
+
+        AuditoriaLoteResponseDTO dto = service.obtenerAuditoriaDeLote(5L);
+
+        assertThat(dto.getTipoAnalisisCalidad()).isEqualTo("AMBOS");
+        assertThat(dto.getCalidad().getFisico().isRequerido()).isTrue();
+        assertThat(dto.getCalidad().getQuimicoMicrobiologico().isRequerido()).isTrue();
+        assertThat(dto.getCalidad().getMicrobiologico().isRequerido()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.willyes.clemenintegra.calidad.service;
 
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
-import com.willyes.clemenintegra.calidad.dto.EvaluacionConsolidadaListadoDTO;
+import com.willyes.clemenintegra.calidad.dto.ConsolidadoPorLoteDTO;
 import com.willyes.clemenintegra.calidad.mapper.EvaluacionCalidadMapper;
 import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
@@ -14,6 +14,7 @@ import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
 import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
@@ -182,6 +183,9 @@ class EvaluacionCalidadServiceImplTest {
     @Test
     void consolidaFqmConDisciplinasConformes() {
         lote.getProducto().setRequiereAnalisisFisico(true);
+        lote.getProducto().setRequiereAnalisisQuimico(true);
+        lote.getProducto().setRequiereAnalisisMicrobiologico(true);
+        lote.getProducto().setTipoAnalisisCalidad(TipoAnalisisCalidad.AMBOS);
 
         EvaluacionCalidad evalFisico = EvaluacionCalidad.builder()
                 .id(70L)
@@ -214,33 +218,27 @@ class EvaluacionCalidadServiceImplTest {
                                 .build()))
                 .build();
 
-        EvaluacionConsolidadaListadoDTO consolidado = new EvaluacionConsolidadaListadoDTO(
-                71L,
-                lote.getId(),
-                evalFisico.getFechaEvaluacion(),
-                "LOT-10",
-                "Producto Q",
-                ResultadoEvaluacion.CONFORME,
-                TipoEvaluacion.QUIMICO_MICROBIOLOGICO,
-                evaluador.getNombreCompleto(),
-                com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad.EVALUADO,
-                EstadoLote.EN_CUARENTENA,
-                2L);
-
-        when(repository.findConsolidadoListado(any(), any(), any()))
-                .thenReturn(new PageImpl<>(List.of(consolidado)));
+        when(loteRepository.findConsolidadoCalidad(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(lote)));
+        when(repository.findByLoteProductoIdInWithRelacion(List.of(lote.getId())))
+                .thenReturn(List.of(evalFisico, evalQuimicoMicro));
+        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(List.of(71L)))
+                .thenReturn(List.of(ResultadoAnalisisMicrobiologico.builder()
+                        .id(1L)
+                        .evaluacion(evalQuimicoMicro)
+                        .build()));
 
         var consolidados = service.obtenerEvaluacionesConsolidadas(evalFisico.getFechaEvaluacion().toLocalDate(),
                 evalFisico.getFechaEvaluacion().toLocalDate(), PageRequest.of(0, 10));
 
         assertThat(consolidados).hasSize(1);
-        var dto = consolidados.getContent().get(0);
+        ConsolidadoPorLoteDTO dto = consolidados.getContent().get(0);
         assertThat(dto.getLoteId()).isEqualTo(lote.getId());
-        assertThat(dto.getCodigoLote()).isEqualTo("LOT-10");
-        assertThat(dto.getNombreProducto()).isEqualTo("Producto Q");
-        assertThat(dto.getTipoEvaluacion()).isEqualTo(TipoEvaluacion.QUIMICO_MICROBIOLOGICO);
-        assertThat(dto.getCantidadAdjuntos()).isEqualTo(2L);
-        assertThat(dto.isTieneAdjuntos()).isTrue();
+        assertThat(dto.getFisico().isRequerido()).isTrue();
+        assertThat(dto.getQuimicoMicrobiologico().isRequerido()).isTrue();
+        assertThat(dto.getMicrobiologico().isRequerido()).isTrue();
+        assertThat(dto.getMicrobiologico().getEstado()).isEqualTo("EVALUADO");
+        assertThat(dto.isLiberable()).isTrue();
     }
 
     @Test
@@ -248,6 +246,7 @@ class EvaluacionCalidadServiceImplTest {
         Producto productoSoloMicro = new Producto();
         productoSoloMicro.setId(2);
         productoSoloMicro.setRequiereAnalisisMicrobiologico(true);
+        productoSoloMicro.setTipoAnalisisCalidad(TipoAnalisisCalidad.QUIMICO_MICROBIOLOGICO);
         LoteProducto loteSoloMicro = new LoteProducto();
         loteSoloMicro.setId(30L);
         loteSoloMicro.setProducto(productoSoloMicro);
@@ -262,29 +261,20 @@ class EvaluacionCalidadServiceImplTest {
                 .fechaEvaluacion(LocalDateTime.now())
                 .build();
 
-        EvaluacionConsolidadaListadoDTO consolidado = new EvaluacionConsolidadaListadoDTO(
-                80L,
-                loteSoloMicro.getId(),
-                evalMicro.getFechaEvaluacion(),
-                "LOT-30",
-                "Producto Micro",
-                ResultadoEvaluacion.CONFORME,
-                TipoEvaluacion.QUIMICO_MICROBIOLOGICO,
-                evaluador.getNombreCompleto(),
-                com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad.EVALUADO,
-                EstadoLote.EN_CUARENTENA,
-                0L);
-        when(repository.findConsolidadoListado(any(), any(), any()))
-                .thenReturn(new PageImpl<>(List.of(consolidado)));
+        when(loteRepository.findConsolidadoCalidad(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(loteSoloMicro)));
+        when(repository.findByLoteProductoIdInWithRelacion(List.of(loteSoloMicro.getId())))
+                .thenReturn(List.of(evalMicro));
+        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(List.of(80L)))
+                .thenReturn(List.of());
 
         var consolidados = service.obtenerEvaluacionesConsolidadas(evalMicro.getFechaEvaluacion().toLocalDate(),
                 evalMicro.getFechaEvaluacion().toLocalDate(), PageRequest.of(0, 10));
 
         assertThat(consolidados).hasSize(1);
-        var dto = consolidados.getContent().get(0);
+        ConsolidadoPorLoteDTO dto = consolidados.getContent().get(0);
         assertThat(dto.getLoteId()).isEqualTo(loteSoloMicro.getId());
-        assertThat(dto.getCodigoLote()).isEqualTo("LOT-30");
-        assertThat(dto.isTieneAdjuntos()).isFalse();
+        assertThat(dto.getMicrobiologico().getEstado()).isEqualTo("PENDIENTE");
     }
 
     @Test
@@ -292,6 +282,7 @@ class EvaluacionCalidadServiceImplTest {
         Producto productoSinMicro = new Producto();
         productoSinMicro.setId(3);
         productoSinMicro.setRequiereAnalisisMicrobiologico(false);
+        productoSinMicro.setTipoAnalisisCalidad(TipoAnalisisCalidad.FISICO);
         LoteProducto loteSinMicro = new LoteProducto();
         loteSinMicro.setId(40L);
         loteSinMicro.setProducto(productoSinMicro);
@@ -306,29 +297,20 @@ class EvaluacionCalidadServiceImplTest {
                 .fechaEvaluacion(LocalDateTime.now())
                 .build();
 
-        EvaluacionConsolidadaListadoDTO consolidado = new EvaluacionConsolidadaListadoDTO(
-                90L,
-                loteSinMicro.getId(),
-                evalFisico.getFechaEvaluacion(),
-                "LOT-40",
-                "Producto F",
-                ResultadoEvaluacion.CONFORME,
-                TipoEvaluacion.FISICO,
-                evaluador.getNombreCompleto(),
-                com.willyes.clemenintegra.calidad.model.enums.EstadoEvaluacionCalidad.EVALUADO,
-                EstadoLote.EN_CUARENTENA,
-                1L);
-        when(repository.findConsolidadoListado(any(), any(), any()))
-                .thenReturn(new PageImpl<>(List.of(consolidado)));
+        when(loteRepository.findConsolidadoCalidad(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(loteSinMicro)));
+        when(repository.findByLoteProductoIdInWithRelacion(List.of(loteSinMicro.getId())))
+                .thenReturn(List.of(evalFisico));
+        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(List.of()))
+                .thenReturn(List.of());
 
         var consolidados = service.obtenerEvaluacionesConsolidadas(evalFisico.getFechaEvaluacion().toLocalDate(),
                 evalFisico.getFechaEvaluacion().toLocalDate(), PageRequest.of(0, 10));
 
         assertThat(consolidados).hasSize(1);
-        var dto = consolidados.getContent().get(0);
+        ConsolidadoPorLoteDTO dto = consolidados.getContent().get(0);
         assertThat(dto.getLoteId()).isEqualTo(loteSinMicro.getId());
-        assertThat(dto.getCodigoLote()).isEqualTo("LOT-40");
-        assertThat(dto.isTieneAdjuntos()).isTrue();
+        assertThat(dto.getMicrobiologico().isRequerido()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- La vista de `Jefe de Calidad` necesita un listado consolidado por lote con el estado/resultado/fecha/evaluador por disciplina para evitar que el frontend muestre "No Requiere" por falta de contexto por evaluación individual. 
- Se detectó una inconsistencia en auditoría donde `tipoAnalisisCalidad` (legacy) no forzaba correctamente las banderas por disciplina (por ejemplo `AMBOS` no marcaba `quimicoMicrobiologico.requerido=true`).

### Description
- Se añade el DTO `ConsolidadoPorLoteDTO` con sub-DTO `DisciplinaConsolidadoDTO` que expone `requerido`, `estado`, `resultado`, `fechaUltimaEvaluacion` y `evaluador` por disciplina y flags `liberable` y `faltanEvaluaciones`.
- Se cambia el endpoint `/api/calidad/evaluaciones/consolidadas` para devolver `Page<ConsolidadoPorLoteDTO>` y se actualiza el `EvaluacionCalidadService`/`EvaluacionCalidadServiceImpl` para construir un consolidado por lote usando `LoteProductoRepository.findConsolidadoCalidad` y las últimas evaluaciones obtenidas por `EvaluacionCalidadRepository.findByLoteProductoIdInWithRelacion`.
- Se implementa la agregación y cálculo de estados en `EvaluacionCalidadServiceImpl.obtenerEvaluacionesConsolidadas`, que agrupa evaluaciones por lote, obtiene resultados micro y usa `AnalisisCalidadHelper` para calcular disciplina/estado/liberable/faltanEvaluaciones y mapear al DTO.
- Se corrige la resolución de qué disciplinas son requeridas en `AnalisisCalidadHelper` para respetar las nuevas banderas por disciplina y mantener compatibilidad legacy consultando `producto.getTipoAnalisisCalidad()` cuando las banderas no están presentes, y se usa este helper en `AuditoriaLoteServiceImpl`.
- Se actualizan repositorios (`EvaluacionCalidadRepository`, `LoteProductoRepository`) para nuevas consultas y se adaptan tests e integraciones que verifican los nuevos campos en las respuestas.

### Testing
- Se ejecutó el comando de prueba automática `mvn -q -Dtest=AuditoriaLoteServiceImplTest,EvaluacionCalidadServiceImplTest test`, el cual falló durante compilación con un error del compilador Maven: `ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`.
- Se actualizaron y añadieron aserciones en tests unitarios/integración para verificar que `tipoAnalisisCalidad` y las banderas `fisico/quimicoMicrobiologico/microbiologico` se exponen correctamente en el consolidado y en la auditoría; esas pruebas locales fueron adaptadas pero la ejecución automatizada indicó el fallo de compilación mencionado arriba.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7ab5a05483339c22a0a73a624bce)