### PR TITLE
Eliminar stubbing innecesario de resultadoAnalisisMicrobiologicoRepository en test consolidaMicroNoRequerido

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -301,8 +301,6 @@ class EvaluacionCalidadServiceImplTest {
                 .thenReturn(new PageImpl<>(List.of(loteSinMicro)));
         when(repository.findByLoteProductoIdInWithRelacion(List.of(loteSinMicro.getId())))
                 .thenReturn(List.of(evalFisico));
-        when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(List.of()))
-                .thenReturn(List.of());
 
         var consolidados = service.obtenerEvaluacionesConsolidadas(evalFisico.getFechaEvaluacion().toLocalDate(),
                 evalFisico.getFechaEvaluacion().toLocalDate(), PageRequest.of(0, 10));


### PR DESCRIPTION
### Motivation
- Resolver el `UnnecessaryStubbing` reportado en la prueba `consolidaMicroNoRequerido` eliminando un `when(...).thenReturn(...)` que no es invocado por el SUT cuando no hay evaluaciones microbiológicas.

### Description
- Se removió la línea de stubbing `when(resultadoAnalisisMicrobiologicoRepository.findByEvaluacionIdIn(List.of())).thenReturn(List.of());` del test `consolidaMicroNoRequerido` en `src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java` porque en este escenario solo existe una evaluación de tipo `FISICO` y el servicio no llama al repositorio cuando la lista de ids está vacía.

### Testing
- Ejecuté `mvn -q test` pero la ejecución falló durante la compilación con `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`, por lo que no se pudo confirmar la suite completa; el cambio al test es localizado y debería eliminar el `UnnecessaryStubbing` aunque no se pudo validar por el error de compilación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a901a87888333b121d41e27bc8673)