### PR TITLE
Fix calidad Excel export lazy loading and estado filter

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/ReportesCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/ReportesCalidadController.java
@@ -1,7 +1,7 @@
 package com.willyes.clemenintegra.calidad.controller;
 
 import com.willyes.clemenintegra.calidad.dto.AuditoriaLoteResponseDTO;
-import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.calidad.service.AuditoriaLoteService;
 import com.willyes.clemenintegra.calidad.service.CarpetaLotePdfService;
 import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
@@ -52,8 +52,8 @@ public class ReportesCalidadController {
     // Reporte: Excel consolidado de evaluaciones de calidad.
     public ResponseEntity<byte[]> exportarEvaluacionesExcel(@RequestParam(required = false) LocalDate fechaInicio,
                                                             @RequestParam(required = false) LocalDate fechaFin,
-                                                            @RequestParam(required = false) ResultadoEvaluacion resultado) {
-        byte[] excel = evaluacionCalidadService.generarReporteEvaluacionesExcel(fechaInicio, fechaFin, resultado);
+                                                            @RequestParam(required = false) EstadoLote estado) {
+        byte[] excel = evaluacionCalidadService.generarReporteEvaluacionesExcel(fechaInicio, fechaFin, estado);
         String nombreArchivo = "reporte-evaluaciones-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmm")) + ".xlsx";
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))

--- a/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/repository/EvaluacionCalidadRepository.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.calidad.repository;
 import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -27,6 +28,19 @@ public interface EvaluacionCalidadRepository extends JpaRepository<EvaluacionCal
     @EntityGraph(attributePaths = {"loteProducto.producto", "usuarioEvaluador"})
     @Query("SELECT e FROM EvaluacionCalidad e")
     java.util.List<EvaluacionCalidad> findAllWithRelations();
+
+    @Query("SELECT DISTINCT e FROM EvaluacionCalidad e " +
+            "LEFT JOIN FETCH e.archivosAdjuntos " +
+            "JOIN FETCH e.usuarioEvaluador " +
+            "JOIN FETCH e.loteProducto l " +
+            "JOIN FETCH l.producto p " +
+            "WHERE (:inicio IS NULL OR e.fechaEvaluacion >= :inicio) " +
+            "AND (:fin IS NULL OR e.fechaEvaluacion <= :fin) " +
+            "AND (:estado IS NULL OR l.estado = :estado)")
+    java.util.List<EvaluacionCalidad> findAllForExcel(
+            @Param("inicio") LocalDateTime inicio,
+            @Param("fin") LocalDateTime fin,
+            @Param("estado") EstadoLote estado);
 
     @Query("SELECT e FROM EvaluacionCalidad e " +
             "JOIN FETCH e.loteProducto l " +

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
@@ -3,7 +3,7 @@ package com.willyes.clemenintegra.calidad.service;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.ConsolidadoPorLoteDTO;
-import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,5 +23,5 @@ public interface EvaluacionCalidadService {
                                                                           Pageable pageable);
     void eliminar(Long id);
 
-    byte[] generarReporteEvaluacionesExcel(LocalDate fechaInicio, LocalDate fechaFin, ResultadoEvaluacion resultado);
+    byte[] generarReporteEvaluacionesExcel(LocalDate fechaInicio, LocalDate fechaFin, EstadoLote estado);
 }

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -22,6 +22,7 @@ import com.willyes.clemenintegra.calidad.service.NoConformidadService;
 import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
@@ -616,24 +617,12 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
     }
 
     @Override
-    public byte[] generarReporteEvaluacionesExcel(LocalDate fechaInicio, LocalDate fechaFin, ResultadoEvaluacion resultado) {
+    @Transactional(readOnly = true)
+    public byte[] generarReporteEvaluacionesExcel(LocalDate fechaInicio, LocalDate fechaFin, EstadoLote estado) {
         LocalDateTime inicio = fechaInicio != null ? fechaInicio.atStartOfDay() : null;
         LocalDateTime fin = fechaFin != null ? fechaFin.atTime(LocalTime.MAX) : null;
 
-        java.util.List<EvaluacionCalidad> evaluaciones = repository.findAllWithRelations();
-
-        java.util.stream.Stream<EvaluacionCalidad> stream = evaluaciones.stream();
-        if (inicio != null) {
-            stream = stream.filter(e -> e.getFechaEvaluacion() != null && !e.getFechaEvaluacion().isBefore(inicio));
-        }
-        if (fin != null) {
-            stream = stream.filter(e -> e.getFechaEvaluacion() != null && !e.getFechaEvaluacion().isAfter(fin));
-        }
-        if (resultado != null) {
-            stream = stream.filter(e -> e.getResultado() == resultado);
-        }
-
-        java.util.List<EvaluacionCalidad> filtradas = stream.toList();
+        java.util.List<EvaluacionCalidad> filtradas = repository.findAllForExcel(inicio, fin, estado);
 
         Workbook workbook = new XSSFWorkbook();
         Sheet sheet = workbook.createSheet("Evaluaciones Calidad");

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/ReportesCalidadExcelIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/ReportesCalidadExcelIntegrationTest.java
@@ -1,0 +1,177 @@
+package com.willyes.clemenintegra.calidad.controller;
+
+import com.willyes.clemenintegra.calidad.model.ArchivoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.EvaluacionCalidad;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.calidad.model.enums.TipoEvaluacion;
+import com.willyes.clemenintegra.calidad.repository.EvaluacionCalidadRepository;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ReportesCalidadExcelIntegrationTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private AlmacenRepository almacenRepository;
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+    @Autowired
+    private EvaluacionCalidadRepository evaluacionCalidadRepository;
+
+    private LoteProducto loteEnCuarentena;
+
+    @BeforeEach
+    void setUp() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("jefe.calidad")
+                .clave("secret")
+                .nombreCompleto("Jefe Calidad")
+                .correo("jefe.calidad@example.com")
+                .rol(RolUsuario.ROL_JEFE_CALIDAD)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad Excel")
+                .simbolo("UEX")
+                .codigo("UEX")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria Excel")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-EXCEL")
+                .nombre("Producto Excel")
+                .descripcionProducto("Producto excel")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.FISICO)
+                .requiereAnalisisFisico(true)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Almacen Excel")
+                .ubicacion("Zona QA")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(TipoAlmacen.PRINCIPAL)
+                .build());
+
+        loteEnCuarentena = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LOTE-CUARENTENA")
+                .fechaFabricacion(LocalDateTime.now().minusDays(2))
+                .stockLote(BigDecimal.TEN)
+                .estado(EstadoLote.EN_CUARENTENA)
+                .producto(producto)
+                .almacen(almacen)
+                .usuarioLiberador(usuario)
+                .build());
+
+        LoteProducto loteLiberado = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LOTE-LIBERADO")
+                .fechaFabricacion(LocalDateTime.now().minusDays(3))
+                .stockLote(BigDecimal.TEN)
+                .estado(EstadoLote.LIBERADO)
+                .producto(producto)
+                .almacen(almacen)
+                .usuarioLiberador(usuario)
+                .build());
+
+        evaluacionCalidadRepository.save(EvaluacionCalidad.builder()
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .tipoEvaluacion(TipoEvaluacion.FISICO)
+                .fechaEvaluacion(LocalDateTime.of(2026, 1, 5, 10, 0))
+                .observaciones("Observaciones")
+                .archivosAdjuntos(List.of(ArchivoEvaluacion.builder()
+                        .nombreArchivo("reporte.pdf")
+                        .nombreVisible("reporte visible")
+                        .build()))
+                .loteProducto(loteEnCuarentena)
+                .usuarioEvaluador(usuario)
+                .build());
+
+        evaluacionCalidadRepository.save(EvaluacionCalidad.builder()
+                .resultado(ResultadoEvaluacion.CONFORME)
+                .tipoEvaluacion(TipoEvaluacion.FISICO)
+                .fechaEvaluacion(LocalDateTime.of(2026, 1, 6, 10, 0))
+                .observaciones("Observaciones")
+                .archivosAdjuntos(List.of())
+                .loteProducto(loteLiberado)
+                .usuarioEvaluador(usuario)
+                .build());
+    }
+
+    @Test
+    @WithMockUser(username = "jefe.calidad", authorities = "ROL_JEFE_CALIDAD")
+    void exportarExcelFiltraPorEstadoYLazyInit() throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/calidad/reportes/evaluaciones/excel")
+                        .param("fechaInicio", "2026-01-01")
+                        .param("fechaFin", "2026-01-17")
+                        .param("estado", "EN_CUARENTENA"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(result.getResponse().getContentAsByteArray()))) {
+            var sheet = workbook.getSheetAt(0);
+            assertThat(sheet.getLastRowNum()).isEqualTo(1);
+            var dataRow = sheet.getRow(1);
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("LOTE-CUARENTENA");
+            assertThat(dataRow.getCell(9).getStringCellValue()).isEqualTo("SI");
+        }
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -400,7 +400,7 @@ class EvaluacionCalidadServiceImplTest {
         eval.setUsuarioEvaluador(evaluador);
         eval.setArchivosAdjuntos(List.of(ArchivoEvaluacion.builder().nombreArchivo("a.pdf").build()));
 
-        when(repository.findAllWithRelations()).thenReturn(List.of(eval));
+        when(repository.findAllForExcel(any(), any(), any())).thenReturn(List.of(eval));
         when(noConformidadService.obtenerActivaPorLoteYEvaluacion(any(), any())).thenReturn(Optional.empty());
 
         byte[] excel = service.generarReporteEvaluacionesExcel(null, null, null);


### PR DESCRIPTION
### Motivation
- The Excel export for evaluations was failing with `LazyInitializationException` when accessing `evaluacion.archivosAdjuntos` outside a Hibernate session and the endpoint needs to support filtering by `fechaInicio`, `fechaFin` and lote `estado`.

### Description
- Change the controller endpoint to accept `estado` as `EstadoLote` and pass it to the service via `exportarEvaluacionesExcel`.
- Add a repository query `findAllForExcel` that performs a `LEFT JOIN FETCH e.archivosAdjuntos` and joins `loteProducto`/`producto`, applying `:inicio`, `:fin` and `:estado` filters to return a ready-to-iterate list.
- Make the export service read-only (`@Transactional(readOnly = true)`), update the service API to accept `EstadoLote`, and switch the implementation to use `repository.findAllForExcel(...)` so adjuntos are fetched within the transaction and no lazy loading happens during Excel generation.
- Update unit tests to mock the new repository method and add an integration test `ReportesCalidadExcelIntegrationTest` that creates evaluaciones (with at least one `archivosAdjuntos`) and verifies the produced XLSX respects the `estado` filter and includes the resolved attachments indicator.

### Testing
- Updated unit test `EvaluacionCalidadServiceImplTest#generaExcelEvaluacionesConFilaDeDatos` to mock `findAllForExcel` (not run here).
- Executed `mvn -q -Dtest=ReportesCalidadExcelIntegrationTest test` which attempted to run the new integration test but failed during compilation with `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN` (environmental/compilation issue), so the integration assertion did not run to completion.
- No other automated test runs were performed in this session; the added tests and changes are ready for CI where the compilation environment can be adjusted and the integration test re-run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bcad0c818833385ca24f1cf2df96a)