### PR TITLE
Fix missing ResultadoEvaluacion import in EvaluacionCalidadService

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.calidad.service;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadResponseDTO;
 import com.willyes.clemenintegra.calidad.dto.ConsolidadoPorLoteDTO;
+import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;


### PR DESCRIPTION
### Motivation
- The `EvaluacionCalidadService` interface referenced `ResultadoEvaluacion` but lacked the corresponding import, causing a compile-time symbol resolution error.

### Description
- Added the import `com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion` to `src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java` so the `listar` method signature resolves.

### Testing
- Ran `mvn -q test`; the build reached compilation but the test run failed with a JVM/compiler initialization error: `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN` (compilation step triggered this error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bd2ab513c8333b82d9163807cb7a6)