### PR TITLE
Aplicar filtro de EstadoLote en endpoint de evaluaciones consolidadas

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/EvaluacionCalidadController.java
@@ -8,6 +8,7 @@ import com.willyes.clemenintegra.calidad.dto.PlantillaAnalisisMicroDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroRequestDTO;
 import com.willyes.clemenintegra.calidad.dto.ResultadoAnalisisMicroResponseDTO;
 import com.willyes.clemenintegra.calidad.model.enums.ResultadoEvaluacion;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
 import com.willyes.clemenintegra.calidad.service.ResultadoAnalisisMicroService;
 import com.willyes.clemenintegra.calidad.service.PlantillaAnalisisMicroService;
@@ -49,8 +50,11 @@ public class EvaluacionCalidadController {
     public ResponseEntity<Page<ConsolidadoPorLoteDTO>> getEvaluacionesConsolidadas(
             @RequestParam("fechaInicio") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam("fechaFin") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin,
+            @RequestParam(required = false) EstadoLote estadoLote,
+            @RequestParam(required = false, name = "estado") EstadoLote estadoAlias,
             @PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(service.obtenerEvaluacionesConsolidadas(fechaInicio, fechaFin, pageable));
+        EstadoLote filtro = estadoLote != null ? estadoLote : estadoAlias;
+        return ResponseEntity.ok(service.obtenerEvaluacionesConsolidadas(fechaInicio, fechaFin, filtro, pageable));
     }
 
     @GetMapping

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadService.java
@@ -20,8 +20,9 @@ public interface EvaluacionCalidadService {
     com.willyes.clemenintegra.calidad.dto.EvaluacionCalidadDetalleDTO obtenerDetalle(Long id);
     java.util.List<EvaluacionCalidadResponseDTO> listarPorLote(Long loteId);
     Page<ConsolidadoPorLoteDTO> obtenerEvaluacionesConsolidadas(LocalDate fechaInicio,
-                                                                          LocalDate fechaFin,
-                                                                          Pageable pageable);
+                                                                LocalDate fechaFin,
+                                                                EstadoLote estadoLote,
+                                                                Pageable pageable);
     void eliminar(Long id);
 
     byte[] generarReporteEvaluacionesExcel(LocalDate fechaInicio, LocalDate fechaFin, EstadoLote estado);

--- a/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImpl.java
@@ -275,6 +275,7 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
     @Override
     public Page<ConsolidadoPorLoteDTO> obtenerEvaluacionesConsolidadas(LocalDate fechaInicio,
                                                                        LocalDate fechaFin,
+                                                                       EstadoLote estadoLote,
                                                                        Pageable pageable) {
         LocalDateTime inicio = fechaInicio.atStartOfDay();
         LocalDateTime fin = fechaFin.atTime(LocalTime.MAX);
@@ -288,7 +289,12 @@ public class EvaluacionCalidadServiceImpl implements EvaluacionCalidadService {
                 com.willyes.clemenintegra.inventario.model.enums.EstadoLote.LIBERADO
         );
 
-        org.springframework.data.domain.Page<LoteProducto> lotes = loteRepository.findConsolidadoCalidad(inicio, fin, estados, effective);
+        org.springframework.data.domain.Page<LoteProducto> lotes = loteRepository.findConsolidadoCalidad(
+                inicio,
+                fin,
+                estados,
+                estadoLote,
+                effective);
         if (lotes.isEmpty()) {
             return org.springframework.data.domain.Page.empty(effective);
         }

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -149,11 +149,13 @@ WHERE lp.codigoLote = :codigoLote
          FROM LoteProducto lp
         WHERE lp.fechaFabricacion BETWEEN :inicio AND :fin
           AND lp.estado IN :estados
+          AND (:estadoLote IS NULL OR lp.estado = :estadoLote)
     """)
     org.springframework.data.domain.Page<LoteProducto> findConsolidadoCalidad(
             @Param("inicio") LocalDateTime inicio,
             @Param("fin") LocalDateTime fin,
             @Param("estados") Collection<EstadoLote> estados,
+            @Param("estadoLote") EstadoLote estadoLote,
             org.springframework.data.domain.Pageable pageable);
 
     @EntityGraph(attributePaths = {

--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/CalidadListadoIntegrationTest.java
@@ -247,6 +247,40 @@ class CalidadListadoIntegrationTest extends IntegrationTestMySqlContainer {
 
     @Test
     @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
+    void listarEvaluacionesConsolidadasFiltraPorEstadoLote() throws Exception {
+        loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LP-CAL-LIB")
+                .fechaFabricacion(LocalDateTime.now().minusDays(1))
+                .stockLote(BigDecimal.TEN)
+                .estado(EstadoLote.LIBERADO)
+                .producto(loteProducto.getProducto())
+                .almacen(loteProducto.getAlmacen())
+                .usuarioLiberador(usuario)
+                .build());
+
+        LocalDate hoy = LocalDate.now();
+        mockMvc.perform(get("/api/calidad/evaluaciones/consolidadas")
+                        .param("fechaInicio", hoy.minusDays(2).toString())
+                        .param("fechaFin", hoy.plusDays(1).toString())
+                        .param("estadoLote", "EN_CUARENTENA")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.estadoLote == 'LIBERADO')]").isEmpty())
+                .andExpect(jsonPath("$.content[?(@.estadoLote == 'EN_CUARENTENA')]").isNotEmpty());
+
+        mockMvc.perform(get("/api/calidad/evaluaciones/consolidadas")
+                        .param("fechaInicio", hoy.minusDays(2).toString())
+                        .param("fechaFin", hoy.plusDays(1).toString())
+                        .param("estado", "EN_CUARENTENA")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.estadoLote == 'LIBERADO')]").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
     void listarNoConformidadesIncluyeNombreUsuario() throws Exception {
         mockMvc.perform(get("/api/calidad/no-conformidades")
                         .param("page", "0")

--- a/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/service/EvaluacionCalidadServiceImplTest.java
@@ -218,7 +218,7 @@ class EvaluacionCalidadServiceImplTest {
                                 .build()))
                 .build();
 
-        when(loteRepository.findConsolidadoCalidad(any(), any(), any(), any()))
+        when(loteRepository.findConsolidadoCalidad(any(), any(), any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(lote)));
         when(repository.findByLoteProductoIdInWithRelacion(List.of(lote.getId())))
                 .thenReturn(List.of(evalFisico, evalQuimicoMicro));
@@ -229,7 +229,7 @@ class EvaluacionCalidadServiceImplTest {
                         .build()));
 
         var consolidados = service.obtenerEvaluacionesConsolidadas(evalFisico.getFechaEvaluacion().toLocalDate(),
-                evalFisico.getFechaEvaluacion().toLocalDate(), PageRequest.of(0, 10));
+                evalFisico.getFechaEvaluacion().toLocalDate(), null, PageRequest.of(0, 10));
 
         assertThat(consolidados).hasSize(1);
         ConsolidadoPorLoteDTO dto = consolidados.getContent().get(0);
@@ -261,7 +261,7 @@ class EvaluacionCalidadServiceImplTest {
                 .fechaEvaluacion(LocalDateTime.now())
                 .build();
 
-        when(loteRepository.findConsolidadoCalidad(any(), any(), any(), any()))
+        when(loteRepository.findConsolidadoCalidad(any(), any(), any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(loteSoloMicro)));
         when(repository.findByLoteProductoIdInWithRelacion(List.of(loteSoloMicro.getId())))
                 .thenReturn(List.of(evalMicro));
@@ -269,7 +269,7 @@ class EvaluacionCalidadServiceImplTest {
                 .thenReturn(List.of());
 
         var consolidados = service.obtenerEvaluacionesConsolidadas(evalMicro.getFechaEvaluacion().toLocalDate(),
-                evalMicro.getFechaEvaluacion().toLocalDate(), PageRequest.of(0, 10));
+                evalMicro.getFechaEvaluacion().toLocalDate(), null, PageRequest.of(0, 10));
 
         assertThat(consolidados).hasSize(1);
         ConsolidadoPorLoteDTO dto = consolidados.getContent().get(0);
@@ -297,13 +297,13 @@ class EvaluacionCalidadServiceImplTest {
                 .fechaEvaluacion(LocalDateTime.now())
                 .build();
 
-        when(loteRepository.findConsolidadoCalidad(any(), any(), any(), any()))
+        when(loteRepository.findConsolidadoCalidad(any(), any(), any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(loteSinMicro)));
         when(repository.findByLoteProductoIdInWithRelacion(List.of(loteSinMicro.getId())))
                 .thenReturn(List.of(evalFisico));
 
         var consolidados = service.obtenerEvaluacionesConsolidadas(evalFisico.getFechaEvaluacion().toLocalDate(),
-                evalFisico.getFechaEvaluacion().toLocalDate(), PageRequest.of(0, 10));
+                evalFisico.getFechaEvaluacion().toLocalDate(), null, PageRequest.of(0, 10));
 
         assertThat(consolidados).hasSize(1);
         ConsolidadoPorLoteDTO dto = consolidados.getContent().get(0);


### PR DESCRIPTION
### Motivation

- El listado consolidado de evaluaciones no estaba aplicando el filtro por estado del lote (`estadoLote`), por lo que al enviar `estadoLote=EN_CUARENTENA` seguían apareciendo lotes `LIBERADO` en la respuesta.
- Se necesita aceptar también el alias `estado` por compatibilidad con frontend antiguo y normalizar ambos parámetros a un único filtro aplicado sobre la columna `estado` de `lotes_productos`.

### Description

- El controlador `GET /api/calidad/evaluaciones/consolidadas` ahora acepta `@RequestParam(required=false) EstadoLote estadoLote` y `@RequestParam(required=false, name="estado") EstadoLote estadoAlias`, y normaliza a `EstadoLote filtro = estadoLote != null ? estadoLote : estadoAlias` antes de delegar al servicio.
- La firma del servicio `obtenerEvaluacionesConsolidadas` fue actualizada para recibir el `EstadoLote` filtro y el servicio lo pasa al repositorio sin alterar la semántica de rango de fechas ni la paginación.
- La consulta en `LoteProductoRepository.findConsolidadoCalidad` (JPQL) recibió el predicate opcional `(:estadoLote IS NULL OR lp.estado = :estadoLote)` para aplicar el filtro directamente sobre `lotes_productos.estado` y así evitar filtrar por estados internos de evaluación.
- Se agregó un test de integración `listarEvaluacionesConsolidadasFiltraPorEstadoLote` en `CalidadListadoIntegrationTest` que crea un lote en `LIBERADO` y verifica que la petición con `estadoLote=EN_CUARENTENA` (y con el alias `estado`) no retorna lotes `LIBERADO`, y se actualizaron mocks en `EvaluacionCalidadServiceImplTest` para la nueva firma del repositorio.

### Testing

- Ejecuté el comando de test enfocado `mvn -q -Dtest=CalidadListadoIntegrationTest test`; la compilación/test falló con error de compilador: `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`, por lo que las pruebas no pudieron completarse.
- Los tests unitarios relevantes fueron adaptados (mocks actualizados) pero no se pudieron ejecutar debido al fallo de compilación anterior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bd74f68908333b52871609772846d)