### PR TITLE
Filtrar lotes de conteo a estados contables (DISPONIBLE, LIBERADO)

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 public class ConteoCiclicoService {
 
     private static final EnumSet<EstadoLote> LOTES_OPERABLES = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
-    private static final EnumSet<EstadoLote> LOTES_VISIBLES_EN_CONTEO = EnumSet.allOf(EstadoLote.class);
+    private static final EnumSet<EstadoLote> LOTES_CONTABLES = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
 
     private final ConteoCiclicoRepository conteoRepository;
     private final ConteoCiclicoDetalleRepository detalleRepository;
@@ -110,7 +110,7 @@ public class ConteoCiclicoService {
                 almacenId,
                 ubicacion != null ? ubicacion.getId() : null,
                 filtroTexto,
-                LOTES_VISIBLES_EN_CONTEO);
+                LOTES_CONTABLES);
 
         log.debug("[ConteoCiclico] lotes encontrados antes de mapear: {}", lotes.size());
         lotes.stream()

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
@@ -133,6 +133,13 @@ class ConteoCiclicoControllerTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    void listarLotesParaConteoSinProductoIdDevuelve400() throws Exception {
+        mockMvc.perform(get("/api/inventario/conteos/8/lotes"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @WithMockUser(authorities = "ROL_CONTADOR")
     void obtenerPorIdNoEncontradoDevuelve404() throws Exception {
         when(conteoCiclicoService.obtenerPorId(99L))

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
@@ -399,7 +399,7 @@ class ConteoCiclicoServiceTest {
     }
 
     @Test
-    void listarLotesIncluyeEstadosNoOperables() {
+    void listarLotesParaConteoUsaEstadosContables() {
         ConteoCiclico conteo = ConteoCiclico.builder()
                 .id(2L)
                 .almacen(new Almacen(7))
@@ -407,19 +407,19 @@ class ConteoCiclicoServiceTest {
         Producto producto = new Producto();
         producto.setId(3);
 
-        LoteProducto loteRetenido = LoteProducto.builder()
+        LoteProducto loteDisponible = LoteProducto.builder()
                 .id(15L)
                 .producto(producto)
                 .almacen(conteo.getAlmacen())
-                .codigoLote("RET-001")
-                .estado(EstadoLote.RETENIDO)
+                .codigoLote("DIS-001")
+                .estado(EstadoLote.DISPONIBLE)
                 .stockLote(BigDecimal.ZERO)
                 .build();
 
         when(conteoCiclicoRepository.findById(2L)).thenReturn(Optional.of(conteo));
         when(productoRepository.findById(3L)).thenReturn(Optional.of(producto));
         when(loteProductoRepository.buscarParaConteo(eq(3L), eq(7), isNull(), isNull(), anyCollection()))
-                .thenReturn(List.of(loteRetenido));
+                .thenReturn(List.of(loteDisponible));
 
         ArgumentCaptor<Collection<EstadoLote>> estadosCaptor = ArgumentCaptor.forClass(Collection.class);
 
@@ -430,7 +430,8 @@ class ConteoCiclicoServiceTest {
         assertThat(respuesta.getFirst().getId()).isEqualTo(15L);
 
         verify(loteProductoRepository).buscarParaConteo(eq(3L), eq(7), isNull(), isNull(), estadosCaptor.capture());
-        assertThat(estadosCaptor.getValue()).containsExactlyInAnyOrder(EstadoLote.values());
+        assertThat(estadosCaptor.getValue())
+                .containsExactlyInAnyOrder(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Evitar que el endpoint de conteo liste o permita seleccionar lotes no contables al filtrar por estados de lote.
- Hacer un cambio mínimo que afecte solo al endpoint `/api/inventario/conteos/{id}/lotes` sin tocar otros listados de lotes.
- Mantener la regla actual de que `stockSistema` se recalcula a partir del `LoteProducto` y no del payload.

### Description
- Reemplacé el uso de `EnumSet.allOf(EstadoLote.class)` por `LOTES_CONTABLES = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO)` y hago que `loteProductoRepository.buscarParaConteo(...)` reciba `LOTES_CONTABLES` en `ConteoCiclicoService`.
- Actualicé el test de servicio `ConteoCiclicoServiceTest#listarLotesParaConteoUsaEstadosContables` para verificar que el repositorio recibe únicamente los estados contables.
- Agregué un `WebMvcTest` (`ConteoCiclicoControllerTest#listarLotesParaConteoSinProductoIdDevuelve400`) que valida que falta `productoId` produce `400` en la llamada a `/api/inventario/conteos/{id}/lotes`.
- Cambios mínimos y localizados en `ConteoCiclicoService` y pruebas, sin refactors adicionales ni cambios en la lógica de stock.

### Testing
- Se añadieron los tests unitarios `src/test/java/.../ConteoCiclicoServiceTest.java::listarLotesParaConteoUsaEstadosContables` y el WebMvcTest `src/test/java/.../ConteoCiclicoControllerTest.java::listarLotesParaConteoSinProductoIdDevuelve400`.
- Ejecuté `mvn test`, pero la compilación falló con error de compilador: `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN` y por lo tanto la suite automática no terminó correctamente.
- Debido al fallo de compilación la ejecución de los tests no se completó, por lo que las nuevas pruebas no pudieron ser verificadas en el entorno de CI local.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bf64132e48333ad533f3e9ec779f5)