### PR TITLE
Filtrar autocomplete de productos por almacenId en /api/productos/buscar

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -48,9 +48,10 @@ public class ProductoController {
             @RequestParam(name = "q", required = false) String q,
             @RequestParam(name = "term", required = false) String term,
             @RequestParam(name = "activo", required = false) Boolean activo,
+            @RequestParam(name = "almacenId", required = false) Long almacenId,
             @PageableDefault(size = 10, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {
         String criterio = (term != null && !term.isBlank()) ? term : q;
-        Page<ProductoOptionDTO> page = productoService.buscarOpciones(criterio, activo, pageable);
+        Page<ProductoOptionDTO> page = productoService.buscarOpciones(criterio, activo, almacenId, pageable);
         return ResponseEntity.ok(page);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -57,6 +57,20 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
     """)
     Page<Producto> buscarPorTexto(@Param("q") String q, @Param("activo") Boolean activo, Pageable pageable);
 
+    @Query("""
+    select distinct p
+    from Producto p
+    join LoteProducto l on l.producto = p
+    where l.almacen.id = :almacenId
+      and (
+            :q is null or :q = ''
+         or lower(p.nombre) like lower(concat('%', :q, '%'))
+         or lower(p.codigoSku) like lower(concat('%', :q, '%'))
+         or lower(concat(p.nombre, ' (', p.codigoSku, ')')) like lower(concat('%', :q, '%'))
+      )
+    """)
+    Page<Producto> buscarParaConteo(@Param("q") String q, @Param("almacenId") Long almacenId, Pageable pageable);
+
     /**
      * Busca insumos (MP, ME, suministros y semielaborados) por nombre.
      */

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -35,7 +35,7 @@ public interface ProductoService {
      */
     Producto findById(Long id);
 
-    Page<ProductoOptionDTO> buscarOpciones(String q, Boolean activo, Pageable pageable);
+    Page<ProductoOptionDTO> buscarOpciones(String q, Boolean activo, Long almacenId, Pageable pageable);
 
     Page<ProductoResumenDTO> buscarInsumos(String term, Pageable pageable);
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -363,7 +363,7 @@ public class ProductoServiceImpl implements ProductoService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ProductoOptionDTO> buscarOpciones(String q, Boolean activo, Pageable pageable) {
+    public Page<ProductoOptionDTO> buscarOpciones(String q, Boolean activo, Long almacenId, Pageable pageable) {
         // Mantén tu “safe sort”
         Sort sort = pageable.getSort();
         Sort safe = Sort.by(sort.stream()
@@ -375,7 +375,9 @@ public class ProductoServiceImpl implements ProductoService {
         Pageable safePage = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), safe);
 
         String term = q == null ? null : q.trim();
-        Page<Producto> page = productoRepository.buscarPorTexto(term, activo, safePage);
+        Page<Producto> page = almacenId == null
+                ? productoRepository.buscarPorTexto(term, activo, safePage)
+                : productoRepository.buscarParaConteo(term, almacenId, safePage);
 
         // ✅ Ahora mapeamos también la unidad
         return page.map(p -> {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -44,6 +44,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
@@ -378,7 +379,7 @@ class ProductoServiceImplTest {
         when(productoRepository.buscarPorTexto(anyString(), any(Boolean.class), any(Pageable.class)))
                 .thenReturn(page);
 
-        Page<ProductoOptionDTO> resultado = service.buscarOpciones("  RVC ", true, pageable);
+        Page<ProductoOptionDTO> resultado = service.buscarOpciones("  RVC ", true, null, pageable);
 
         assertThat(resultado.getTotalElements()).isEqualTo(1);
         ArgumentCaptor<String> termCaptor = ArgumentCaptor.forClass(String.class);
@@ -395,10 +396,29 @@ class ProductoServiceImplTest {
         when(productoRepository.buscarPorTexto(null, null, pageable))
                 .thenReturn(Page.empty(pageable));
 
-        Page<ProductoOptionDTO> resultado = service.buscarOpciones(null, null, pageable);
+        Page<ProductoOptionDTO> resultado = service.buscarOpciones(null, null, null, pageable);
 
         assertThat(resultado).isEmpty();
         verify(productoRepository).buscarPorTexto(null, null, pageable);
+    }
+
+    @Test
+    @DisplayName("buscarOpciones con almacenId usa búsqueda por lotes de almacén")
+    void buscarOpciones_conAlmacenIdUsaBusquedaParaConteo() {
+        Pageable pageable = PageRequest.of(0, 5, Sort.by("nombre"));
+        Producto producto = new Producto();
+        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
+        when(productoRepository.buscarParaConteo(anyString(), anyLong(), any(Pageable.class)))
+                .thenReturn(page);
+
+        Page<ProductoOptionDTO> resultado = service.buscarOpciones("  Lote ", null, 4L, pageable);
+
+        assertThat(resultado.getTotalElements()).isEqualTo(1);
+        ArgumentCaptor<String> termCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> almacenCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(productoRepository).buscarParaConteo(termCaptor.capture(), almacenCaptor.capture(), any(Pageable.class));
+        assertThat(termCaptor.getValue()).isEqualTo("Lote");
+        assertThat(almacenCaptor.getValue()).isEqualTo(4L);
     }
 
     private static Stream<Arguments> banderasCalidad() {

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -197,7 +198,8 @@ class ProductoControllerSmokeTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 10);
         Page<ProductoOptionDTO> page = new PageImpl<>(List.of(option), pageable, 1);
-        when(productoService.buscarOpciones(anyString(), any(Boolean.class), any(Pageable.class))).thenReturn(page);
+        when(productoService.buscarOpciones(anyString(), any(Boolean.class), any(), any(Pageable.class)))
+                .thenReturn(page);
 
         mockMvc.perform(get("/api/productos/buscar")
                         .param("term", "RVC")
@@ -210,7 +212,35 @@ class ProductoControllerSmokeTest {
                 .andExpect(jsonPath("$.content[0].sku").value("RVC001"))
                 .andExpect(jsonPath("$.totalElements").value(1));
 
-        verify(productoService).buscarOpciones(eq("RVC"), eq(true), any(Pageable.class));
+        verify(productoService).buscarOpciones(eq("RVC"), eq(true), eq(null), any(Pageable.class));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    @DisplayName("GET /api/productos/buscar envía almacenId al servicio cuando se proporciona")
+    void buscarProductos_conAlmacenId() throws Exception {
+        ProductoOptionDTO option = ProductoOptionDTO.builder()
+                .id(7L)
+                .nombre("Producto Bodega")
+                .sku("BOD001")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ProductoOptionDTO> page = new PageImpl<>(List.of(option), pageable, 1);
+        when(productoService.buscarOpciones(anyString(), any(), anyLong(), any(Pageable.class)))
+                .thenReturn(page);
+
+        mockMvc.perform(get("/api/productos/buscar")
+                        .param("q", "BOD")
+                        .param("almacenId", "8")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(7))
+                .andExpect(jsonPath("$.content[0].sku").value("BOD001"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+
+        verify(productoService).buscarOpciones(eq("BOD"), eq(null), eq(8L), any(Pageable.class));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Limitar los resultados del autocomplete usado en ConteoDetalle para que, cuando el frontend envíe `almacenId`, solo se devuelvan productos que tienen al menos un lote en ese almacén.
- Reusar el endpoint existente `/api/productos/buscar` sin cambiar el contrato ni crear rutas nuevas.

### Description
- Agrega el `@RequestParam(required = false) Long almacenId` al endpoint `GET /api/productos/buscar` y lo pasa al service. (`ProductoController`).
- Extiende la firma de servicio `buscarOpciones(...)` para recibir `Long almacenId` y selecciona la búsqueda adecuada en tiempo de ejecución: global cuando `almacenId == null` y por lotes de almacén cuando viene `almacenId`. (`ProductoService`, `ProductoServiceImpl`).
- Añade `ProductoRepository.buscarParaConteo(String q, Long almacenId, Pageable pageable)` con una JPQL que hace `JOIN` con `LoteProducto` y filtra por `l.almacen.id = :almacenId` y por texto en `nombre`/`codigoSku` manteniendo paginación y orden. (`ProductoRepository`).
- Actualiza tests existentes y agrega comprobaciones: `ProductoControllerSmokeTest` verifica que el controller reenvía `almacenId` (nuevo test que envía `almacenId` y el anterior ajustado); `ProductoServiceImplTest` verifica que con `almacenId` se invoca `productoRepository.buscarParaConteo(...)` y que sin `almacenId` se mantiene `buscarPorTexto(...)`.

### Testing
- Ejecuté `mvn test` para ejecutar la suite de pruebas automáticas, pero la build falló en la fase de compilación con el error: `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN` (falla de compilador JVM/tooling), por lo que los tests no llegaron a completarse.
- Incluidos/actualizados tests de unidad y controller: `ProductoServiceImplTest` (nuevo caso para `buscarParaConteo`) y `ProductoControllerSmokeTest` (verifica envío de `almacenId`), ambos añadidos/ajustados en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c0bf58a2c83338fda7838f49d1cc4)