### PR TITLE
Fix LazyInitializationException in listarLotesParaConteo: add transaction + fetch join and test/build fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <java.version>21</java.version>
-    <lombok.version>1.18.36</lombok.version>
+    <lombok.version>1.18.40</lombok.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.19.7</testcontainers.version>
@@ -270,7 +270,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.1.2</version>
         <configuration>
+          <argLine>-Dnet.bytebuddy.experimental=true</argLine>
           <properties>
             <excludeTags>${junit.excludeTags}</excludeTags>
           </properties>

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -267,7 +267,7 @@ WHERE lp.codigoLote = :codigoLote
     @Query("""
         select lp
         from LoteProducto lp
-        left join lp.ubicacionFisica uf
+        left join fetch lp.ubicacionFisica uf
         where lp.producto.id = :productoId
           and lp.almacen.id = :almacenId
           and lp.estado in :estados

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -68,6 +68,7 @@ public class ConteoCiclicoService {
         return mapper.toResponseCompleto(conteo);
     }
 
+    @Transactional(readOnly = true)
     public List<ConteoCiclicoLoteResponseDTO> listarLotesParaConteo(Long conteoId,
                                                                    Long productoId,
                                                                    Long ubicacionFisicaId,

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
@@ -465,6 +465,45 @@ class ConteoCiclicoServiceTest {
     }
 
     @Test
+    void listarLotesParaConteoIncluyeCodigoDeUbicacion() {
+        Almacen almacen = new Almacen(4);
+        ConteoCiclico conteo = ConteoCiclico.builder()
+                .id(14L)
+                .almacen(almacen)
+                .build();
+        Producto producto = new Producto();
+        producto.setId(11);
+
+        UbicacionFisica ubicacion = UbicacionFisica.builder()
+                .id(22L)
+                .almacen(almacen)
+                .codigo("U-22")
+                .build();
+
+        LoteProducto lote = LoteProducto.builder()
+                .id(105L)
+                .producto(producto)
+                .almacen(almacen)
+                .ubicacionFisica(ubicacion)
+                .codigoLote("L-105")
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(BigDecimal.ONE)
+                .build();
+
+        when(conteoCiclicoRepository.findById(14L)).thenReturn(Optional.of(conteo));
+        when(productoRepository.findById(11L)).thenReturn(Optional.of(producto));
+        when(loteProductoRepository.buscarParaConteo(eq(11L), eq(4), isNull(), isNull(), anyCollection()))
+                .thenReturn(List.of(lote));
+
+        List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
+                .listarLotesParaConteo(14L, 11L, null, null);
+
+        assertThat(respuesta).hasSize(1);
+        assertThat(respuesta.getFirst().getUbicacionFisicaId()).isEqualTo(22L);
+        assertThat(respuesta.getFirst().getUbicacionCodigo()).isEqualTo("U-22");
+    }
+
+    @Test
     void listarLotesParaConteoConTextoAplicaFiltro() {
         ConteoCiclico conteo = ConteoCiclico.builder()
                 .id(13L)

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionListadoIntegrationTest.java
@@ -16,6 +16,7 @@ import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -65,11 +66,12 @@ class OrdenProduccionListadoIntegrationTest extends IntegrationTestH2 {
     @Test
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     void listarOrdenesPaginadas_precargaRelaciones() throws Exception {
+        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
         Usuario usuario = usuarioRepository.save(Usuario.builder()
-                .nombreUsuario("responsable-op")
+                .nombreUsuario("responsable-op-" + uniqueSuffix)
                 .clave("secret")
                 .nombreCompleto("Responsable OP")
-                .correo("responsable-op@example.com")
+                .correo("resp-op-" + uniqueSuffix + "@ex.com")
                 .rol(RolUsuario.ROL_JEFE_PRODUCCION)
                 .activo(true)
                 .bloqueado(false)


### PR DESCRIPTION
### Motivation

- Prevent LazyInitializationException when mapping `UbicacionFisica.codigo` in `listarLotesParaConteo` without relying on OSIV, keeping the existing controller contract and filters intact. 

### Description

- Add `@Transactional(readOnly = true)` to `ConteoCiclicoService.listarLotesParaConteo(...)` so entity associations are available while mapping. 
- Update `LoteProductoRepository.buscarParaConteo` JPQL to use `left join fetch lp.ubicacionFisica uf` so `ubicacionFisica.codigo` is initialized by the query. 
- Add a unit test `listarLotesParaConteoIncluyeCodigoDeUbicacion` to `ConteoCiclicoServiceTest` to assert `ubicacionFisicaId` and `ubicacionCodigo` are returned. 
- Fix an integration test data collision by making the saved test `Usuario` unique and shortening the test email in `OrdenProduccionListadoIntegrationTest`. 
- Resolve build/test issues on Java 25 by bumping Lombok to `1.18.40` and configuring Surefire to set `-Dnet.bytebuddy.experimental=true` so Mockito/ByteBuddy inline mocking works with the JDK. 

### Testing

- Ran `mvn test` iteratively; initial run failed due to Java 25 / Lombok / ByteBuddy incompatibilities, which were addressed by updating `lombok.version` and enabling `net.bytebuddy.experimental` in Surefire. 
- Re-ran focused tests `mvn -Dtest=ConteoCiclicoServiceTest,OrdenProduccionListadoIntegrationTest test`; both tests passed after the fixes. 
- Re-ran the full test suite (`mvn test`) after fixes and validated the previously failing issues were resolved (unit and integration tests that exercised the changed code passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c1e9602f0833391b806a800f24557)