### PR TITLE
Load unidadMedida in insumos autocomplete (JOIN FETCH) to fix LazyInitializationException

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -120,8 +120,18 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
             """, nativeQuery = true)
     List<StockDisponibleProjection> calcularStockDisponiblePorProductoEnAlmacenes(List<Long> ids, List<Long> almacenes);
 
-    @Query("""
+    @Query(value = """
     SELECT p
+    FROM Producto p
+    JOIN FETCH p.unidadMedida um
+    WHERE p.categoriaProducto.tipo IN :tipos
+      AND p.activo = true
+      AND (
+           UPPER(p.nombre) LIKE CONCAT('%', UPPER(:term), '%')
+        OR UPPER(p.codigoSku) LIKE CONCAT('%', UPPER(:term), '%')
+      )
+    """, countQuery = """
+    SELECT COUNT(p)
     FROM Producto p
     WHERE p.categoriaProducto.tipo IN :tipos
       AND p.activo = true

--- a/src/test/java/com/willyes/clemenintegra/inventario/repository/ProductoRepositoryAutocompleteTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/repository/ProductoRepositoryAutocompleteTest.java
@@ -1,0 +1,105 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop",
+        "spring.flyway.enabled=false",
+        "DB_SECURPASS=dummy",
+        "DB_SECURNAME=dummy"
+})
+class ProductoRepositoryAutocompleteTest {
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    private Producto producto;
+
+    @BeforeEach
+    void setUp() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("tester")
+                .clave("secret")
+                .nombreCompleto("Test User")
+                .correo("test@example.com")
+                .rol(RolUsuario.ROL_SUPER_ADMIN)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("U")
+                .codigo("U1")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("MP")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        producto = productoRepository.save(Producto.builder()
+                .codigoSku("MP-001")
+                .nombre("Insumo Prueba")
+                .stockMinimo(BigDecimal.ONE)
+                .activo(true)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+    }
+
+    @Test
+    @DisplayName("buscarInsumosAutocomplete carga unidad de medida con JOIN FETCH")
+    void buscarInsumosAutocomplete_cargaUnidadMedida() {
+        Page<Producto> page = productoRepository.buscarInsumosAutocomplete(
+                List.of(TipoCategoria.MATERIA_PRIMA),
+                "MP",
+                PageRequest.of(0, 5)
+        );
+
+        assertThat(page.getContent()).hasSize(1);
+        Producto resultado = page.getContent().get(0);
+        assertThat(resultado.getId()).isEqualTo(producto.getId());
+        assertThat(Hibernate.isInitialized(resultado.getUnidadMedida())).isTrue();
+        assertThat(resultado.getUnidadMedida().getNombre()).isNotBlank();
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.inventario.dto.ProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.UnidadMedidaResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.ProductoMapper;
+import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
@@ -241,6 +242,36 @@ class ProductoControllerSmokeTest {
                 .andExpect(jsonPath("$.totalElements").value(1));
 
         verify(productoService).buscarOpciones(eq("BOD"), eq(null), eq(8L), any(Pageable.class));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    @DisplayName("GET /api/productos/insumos/autocomplete devuelve 200 y unidad de medida en DTO")
+    void buscarInsumosAutocomplete_deberiaRetornarUnidadMedida() throws Exception {
+        Producto producto = new Producto();
+        ProductoResponseDTO response = ProductoResponseDTO.builder()
+                .id(15L)
+                .sku("MP-015")
+                .nombre("Insumo 15")
+                .unidadMedida(new UnidadMedidaResponseDTO(3L, "Unidad", "U"))
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
+
+        when(productoService.buscarInsumosAutocomplete(anyString(), any(Pageable.class))).thenReturn(page);
+        when(productoMapper.toDto(any(Producto.class))).thenReturn(response);
+
+        mockMvc.perform(get("/api/productos/insumos/autocomplete")
+                        .param("term", "MP")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(15))
+                .andExpect(jsonPath("$.content[0].unidadMedida.nombre").value("Unidad"))
+                .andExpect(jsonPath("$.content[0].unidadMedida.simbolo").value("U"));
+
+        verify(productoService).buscarInsumosAutocomplete(eq("MP"), any(Pageable.class));
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- The insumos autocomplete endpoint was causing `LazyInitializationException` when the mapper accessed `unidadMedida.nombre` after the transaction had closed, so the relation must be loaded inside the repository. 

### Description

- Updated repository method `buscarInsumosAutocomplete` in `ProductoRepository` to include `JOIN FETCH p.unidadMedida` and a `countQuery` to preserve correct pagination and ensure `unidadMedida` is initialized before the entity leaves the repository. 
- Kept existing filters (active products, allowed `TipoCategoria` set, and search by `nombre` or `codigoSku`) and pagination semantics intact. 
- Added an integration `@DataJpaTest` `ProductoRepositoryAutocompleteTest` that asserts the returned `Producto` has `unidadMedida` initialized. 
- Added a controller smoke test in `ProductoControllerSmokeTest` to verify `/api/productos/insumos/autocomplete` returns 200 and the DTO includes `unidadMedida` fields, and did not change `FetchType`, mappers, controllers, or global Hibernate config. 

### Testing

- Added tests `ProductoRepositoryAutocompleteTest` and a smoke test in `ProductoControllerSmokeTest` to validate that `unidadMedida` is loaded and the DTO contains the unit data. 
- Ran `mvn -q -Dtest=ProductoRepositoryAutocompleteTest,ProductoControllerSmokeTest test` but the run failed due to a dependency resolution error (502 Bad Gateway fetching `org.apache.commons:commons-compress:1.21`), so the automated tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d213ac0788333b1d658d04f2d3add)