### PR TITLE
Cargar categoriaProducto y unidadMedida en autocomplete de insumos

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -121,9 +121,10 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
     List<StockDisponibleProjection> calcularStockDisponiblePorProductoEnAlmacenes(List<Long> ids, List<Long> almacenes);
 
     @Query(value = """
-    SELECT p
+    SELECT DISTINCT p
     FROM Producto p
     JOIN FETCH p.unidadMedida um
+    JOIN FETCH p.categoriaProducto cp
     WHERE p.categoriaProducto.tipo IN :tipos
       AND p.activo = true
       AND (


### PR DESCRIPTION
### Motivation
- Evitar `LazyInitializationException` al mapear entidades en el endpoint `GET /api/productos/insumos/autocomplete` cargando explícitamente las relaciones que el mapper accede (`unidadMedida` y `categoriaProducto`).

### Description
- Se modificó la consulta de `buscarInsumosAutocomplete` en `ProductoRepository` para usar `SELECT DISTINCT p FROM Producto p JOIN FETCH p.unidadMedida um JOIN FETCH p.categoriaProducto cp ...`, asegurando que `unidadMedida` y `categoriaProducto` estén inicializadas para el mapper.

### Testing
- No se ejecutaron tests automatizados para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d2416a3c48333a950a7bde7a75e63)