### PR TITLE
Add lightweight DTO-based insumo autocomplete query

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -122,13 +122,12 @@ public class ProductoController {
 
     @GetMapping("/insumos/autocomplete")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
-    public ResponseEntity<Page<ProductoResponseDTO>> buscarInsumosAutocomplete(
+    public ResponseEntity<Page<InsumoAutocompleteDTO>> buscarInsumosAutocomplete(
             @RequestParam("term") String term,
             Pageable pageable
     ) {
-        Page<Producto> page = productoService.buscarInsumosAutocomplete(term, pageable);
-        Page<ProductoResponseDTO> dtoPage = page.map(productoMapper::toDto);
-        return ResponseEntity.ok(dtoPage);
+        Page<InsumoAutocompleteDTO> page = productoService.buscarInsumosAutocomplete(term, pageable);
+        return ResponseEntity.ok(page);
     }
 
     @GetMapping("/terminados")

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/InsumoAutocompleteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/InsumoAutocompleteDTO.java
@@ -1,0 +1,15 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InsumoAutocompleteDTO {
+    private Long id;
+    private String sku;
+    private String nombre;
+    private String unidad;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.repository;
 
+import com.willyes.clemenintegra.inventario.dto.InsumoAutocompleteDTO;
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
@@ -121,10 +122,14 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
     List<StockDisponibleProjection> calcularStockDisponiblePorProductoEnAlmacenes(List<Long> ids, List<Long> almacenes);
 
     @Query(value = """
-    SELECT DISTINCT p
+    SELECT new com.willyes.clemenintegra.inventario.dto.InsumoAutocompleteDTO(
+        p.id,
+        p.codigoSku,
+        p.nombre,
+        um.nombre
+    )
     FROM Producto p
-    JOIN FETCH p.unidadMedida um
-    JOIN FETCH p.categoriaProducto cp
+    JOIN p.unidadMedida um
     WHERE p.categoriaProducto.tipo IN :tipos
       AND p.activo = true
       AND (
@@ -141,7 +146,7 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
         OR UPPER(p.codigoSku) LIKE CONCAT('%', UPPER(:term), '%')
       )
     """)
-    Page<Producto> buscarInsumosAutocomplete(
+    Page<InsumoAutocompleteDTO> buscarInsumosAutocomplete(
             @Param("tipos") Collection<TipoCategoria> tipos,
             @Param("term") String term,
             Pageable pageable

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -43,7 +43,7 @@ public interface ProductoService {
 
     List<ProductoResponseDTO> findProductosFabricables();
 
-    Page<Producto> buscarInsumosAutocomplete(String term, Pageable pageable);
+    Page<InsumoAutocompleteDTO> buscarInsumosAutocomplete(String term, Pageable pageable);
 
     Page<Producto> buscarProductosFabricablesAutocomplete(String term, Pageable pageable);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -618,7 +618,7 @@ public class ProductoServiceImpl implements ProductoService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<Producto> buscarInsumosAutocomplete(String term, Pageable pageable) {
+    public Page<InsumoAutocompleteDTO> buscarInsumosAutocomplete(String term, Pageable pageable) {
         if (term == null || term.trim().isEmpty()) {
             return Page.empty(pageable);
         }

--- a/src/test/java/com/willyes/clemenintegra/inventario/repository/ProductoRepositoryAutocompleteTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/repository/ProductoRepositoryAutocompleteTest.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.repository;
 
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.dto.InsumoAutocompleteDTO;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
@@ -9,7 +10,6 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
-import org.hibernate.Hibernate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,18 +88,18 @@ class ProductoRepositoryAutocompleteTest {
     }
 
     @Test
-    @DisplayName("buscarInsumosAutocomplete carga unidad de medida con JOIN FETCH")
+    @DisplayName("buscarInsumosAutocomplete retorna campos mínimos para el autocomplete")
     void buscarInsumosAutocomplete_cargaUnidadMedida() {
-        Page<Producto> page = productoRepository.buscarInsumosAutocomplete(
+        Page<InsumoAutocompleteDTO> page = productoRepository.buscarInsumosAutocomplete(
                 List.of(TipoCategoria.MATERIA_PRIMA),
                 "MP",
                 PageRequest.of(0, 5)
         );
 
         assertThat(page.getContent()).hasSize(1);
-        Producto resultado = page.getContent().get(0);
+        InsumoAutocompleteDTO resultado = page.getContent().get(0);
         assertThat(resultado.getId()).isEqualTo(producto.getId());
-        assertThat(Hibernate.isInitialized(resultado.getUnidadMedida())).isTrue();
-        assertThat(resultado.getUnidadMedida().getNombre()).isNotBlank();
+        assertThat(resultado.getSku()).isEqualTo("MP-001");
+        assertThat(resultado.getUnidad()).isEqualTo("Unidad");
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.dto.InsumoAutocompleteDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoOptionDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
@@ -301,7 +302,7 @@ class ProductoServiceImplTest {
     void buscarInsumosAutocomplete_sinTermino_devuelveVacio() {
         Pageable pageable = PageRequest.of(0, 5);
 
-        Page<Producto> resultado = service.buscarInsumosAutocomplete("   ", pageable);
+        Page<InsumoAutocompleteDTO> resultado = service.buscarInsumosAutocomplete("   ", pageable);
 
         assertThat(resultado).isEmpty();
         verify(productoRepository, never()).buscarInsumosAutocomplete(anyList(), anyString(), any(Pageable.class));
@@ -311,14 +312,14 @@ class ProductoServiceImplTest {
     @DisplayName("Debe buscar insumos en categorías permitidas y mapear término recortado")
     void buscarInsumosAutocomplete_conTermino_invocaRepositorioConFiltros() {
         Pageable pageable = PageRequest.of(0, 10);
-        Producto producto = new Producto();
-        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
+        InsumoAutocompleteDTO dto = new InsumoAutocompleteDTO(1L, "MP-1", "MP", "Unidad");
+        Page<InsumoAutocompleteDTO> page = new PageImpl<>(List.of(dto), pageable, 1);
         when(productoRepository.buscarInsumosAutocomplete(anyList(), anyString(), any(Pageable.class)))
                 .thenReturn(page);
 
-        Page<Producto> resultado = service.buscarInsumosAutocomplete("  mp ", pageable);
+        Page<InsumoAutocompleteDTO> resultado = service.buscarInsumosAutocomplete("  mp ", pageable);
 
-        assertThat(resultado.getContent()).containsExactly(producto);
+        assertThat(resultado.getContent()).containsExactly(dto);
 
         ArgumentCaptor<List<TipoCategoria>> tiposCaptor = ArgumentCaptor.forClass(List.class);
         ArgumentCaptor<String> termCaptor = ArgumentCaptor.forClass(String.class);

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -2,12 +2,12 @@ package com.willyes.clemenintegra.inventario.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.willyes.clemenintegra.inventario.controller.ProductoController;
+import com.willyes.clemenintegra.inventario.dto.InsumoAutocompleteDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoOptionDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.UnidadMedidaResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.ProductoMapper;
-import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
@@ -248,18 +248,11 @@ class ProductoControllerSmokeTest {
     @WithMockUser(authorities = "ROL_SUPER_ADMIN")
     @DisplayName("GET /api/productos/insumos/autocomplete devuelve 200 y unidad de medida en DTO")
     void buscarInsumosAutocomplete_deberiaRetornarUnidadMedida() throws Exception {
-        Producto producto = new Producto();
-        ProductoResponseDTO response = ProductoResponseDTO.builder()
-                .id(15L)
-                .sku("MP-015")
-                .nombre("Insumo 15")
-                .unidadMedida(new UnidadMedidaResponseDTO(3L, "Unidad", "U"))
-                .build();
+        InsumoAutocompleteDTO response = new InsumoAutocompleteDTO(15L, "MP-015", "Insumo 15", "Unidad");
         Pageable pageable = PageRequest.of(0, 10);
-        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
+        Page<InsumoAutocompleteDTO> page = new PageImpl<>(List.of(response), pageable, 1);
 
         when(productoService.buscarInsumosAutocomplete(anyString(), any(Pageable.class))).thenReturn(page);
-        when(productoMapper.toDto(any(Producto.class))).thenReturn(response);
 
         mockMvc.perform(get("/api/productos/insumos/autocomplete")
                         .param("term", "MP")
@@ -268,8 +261,7 @@ class ProductoControllerSmokeTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.content[0].id").value(15))
-                .andExpect(jsonPath("$.content[0].unidadMedida.nombre").value("Unidad"))
-                .andExpect(jsonPath("$.content[0].unidadMedida.simbolo").value("U"));
+                .andExpect(jsonPath("$.content[0].unidad").value("Unidad"));
 
         verify(productoService).buscarInsumosAutocomplete(eq("MP"), any(Pageable.class));
     }


### PR DESCRIPTION
### Motivation

- The insumos autocomplete endpoint triggered `LazyInitializationException` because the controller used entity-to-DTO mappers that access several LAZY relations; JOIN FETCH chaining only postponed the error. 
- The intent is to return a minimal, safe result for autocomplete without returning entities or using `ProductoMapperImpl`, and to load only the fields required by the UI.

### Description

- Add `InsumoAutocompleteDTO` with fields `id`, `sku`, `nombre` and `unidad` to represent the minimal autocomplete payload. 
- Replace the `buscarInsumosAutocomplete` repository query with a JPQL constructor projection (`SELECT new ...`) that `JOIN`s only `p.unidadMedida` and returns `InsumoAutocompleteDTO` directly. 
- Change the service signature and implementation to return `Page<InsumoAutocompleteDTO>` instead of entities, and update the controller to return the DTO page without using the mapper. 
- Update tests that exercised this endpoint to use the new DTOs (`ProductoControllerSmokeTest`, `ProductoRepositoryAutocompleteTest`, `ProductoServiceImplTest`).

### Testing

- No automated test suite was executed as part of this change. 
- Unit/integration tests were adjusted to the new DTO-based contract: `ProductoRepositoryAutocompleteTest`, `ProductoServiceImplTest`, and `ProductoControllerSmokeTest` were updated to assert the DTO fields. 
- By using a JPQL constructor projection that selects only scalar fields and `unidadMedida.nombre`, the endpoint no longer returns entities or touches LAZY relations in mappers, which removes the root cause of `LazyInitializationException` for the insumos autocomplete endpoint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d261c30e08333b065fe33c1d1f099)