### PR TITLE
Align InsumoAutocompleteDTO id type with Producto id for JPQL projection

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/InsumoAutocompleteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/InsumoAutocompleteDTO.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class InsumoAutocompleteDTO {
-    private Long id;
+    private Integer id;
     private String sku;
     private String nombre;
     private String unidad;

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -312,7 +312,7 @@ class ProductoServiceImplTest {
     @DisplayName("Debe buscar insumos en categorías permitidas y mapear término recortado")
     void buscarInsumosAutocomplete_conTermino_invocaRepositorioConFiltros() {
         Pageable pageable = PageRequest.of(0, 10);
-        InsumoAutocompleteDTO dto = new InsumoAutocompleteDTO(1L, "MP-1", "MP", "Unidad");
+        InsumoAutocompleteDTO dto = new InsumoAutocompleteDTO(1, "MP-1", "MP", "Unidad");
         Page<InsumoAutocompleteDTO> page = new PageImpl<>(List.of(dto), pageable, 1);
         when(productoRepository.buscarInsumosAutocomplete(anyList(), anyString(), any(Pageable.class)))
                 .thenReturn(page);

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -248,7 +248,7 @@ class ProductoControllerSmokeTest {
     @WithMockUser(authorities = "ROL_SUPER_ADMIN")
     @DisplayName("GET /api/productos/insumos/autocomplete devuelve 200 y unidad de medida en DTO")
     void buscarInsumosAutocomplete_deberiaRetornarUnidadMedida() throws Exception {
-        InsumoAutocompleteDTO response = new InsumoAutocompleteDTO(15L, "MP-015", "Insumo 15", "Unidad");
+        InsumoAutocompleteDTO response = new InsumoAutocompleteDTO(15, "MP-015", "Insumo 15", "Unidad");
         Pageable pageable = PageRequest.of(0, 10);
         Page<InsumoAutocompleteDTO> page = new PageImpl<>(List.of(response), pageable, 1);
 


### PR DESCRIPTION
### Motivation

- Hibernate could not instantiate `InsumoAutocompleteDTO` from the JPQL `SELECT new ...` projection because the DTO `id` type (`Long`) did not match the `Producto.id` type (`Integer`).

### Description

- Changed `InsumoAutocompleteDTO.id` from `Long` to `Integer` to match `Producto.id` and the JPQL constructor parameter type in `ProductoRepository.buscarInsumosAutocomplete`.
- Updated tests that construct `InsumoAutocompleteDTO` to use `Integer` ids in `ProductoServiceImplTest` and `ProductoControllerSmokeTest`.
- Files modified: `src/main/java/com/willyes/clemenintegra/inventario/dto/InsumoAutocompleteDTO.java`, `src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java`, and `src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java`.

### Testing

- Updated unit tests were adjusted to use `Integer` ids but no automated test suite was executed in this change. 
- The change is minimal and targeted to allow Hibernate to instantiate the DTO from the JPQL `SELECT new` projection without changing endpoint contracts or JSON output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d28c0919483339b33f5ea400ddd98)