### PR TITLE
Include unidadMedidaId and unidadMedidaNombre in insumo autocomplete

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/InsumoAutocompleteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/InsumoAutocompleteDTO.java
@@ -12,4 +12,6 @@ public class InsumoAutocompleteDTO {
     private String sku;
     private String nombre;
     private String unidad;
+    private Long unidadMedidaId;
+    private String unidadMedidaNombre;
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -126,6 +126,8 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
         p.id,
         p.codigoSku,
         p.nombre,
+        um.nombre,
+        um.id,
         um.nombre
     )
     FROM Producto p

--- a/src/test/java/com/willyes/clemenintegra/inventario/repository/ProductoRepositoryAutocompleteTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/repository/ProductoRepositoryAutocompleteTest.java
@@ -47,6 +47,7 @@ class ProductoRepositoryAutocompleteTest {
     private UsuarioRepository usuarioRepository;
 
     private Producto producto;
+    private UnidadMedida unidad;
 
     @BeforeEach
     void setUp() {
@@ -60,7 +61,7 @@ class ProductoRepositoryAutocompleteTest {
                 .bloqueado(false)
                 .build());
 
-        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+        unidad = unidadMedidaRepository.save(UnidadMedida.builder()
                 .nombre("Unidad")
                 .simbolo("U")
                 .codigo("U1")
@@ -101,5 +102,7 @@ class ProductoRepositoryAutocompleteTest {
         assertThat(resultado.getId()).isEqualTo(producto.getId());
         assertThat(resultado.getSku()).isEqualTo("MP-001");
         assertThat(resultado.getUnidad()).isEqualTo("Unidad");
+        assertThat(resultado.getUnidadMedidaId()).isEqualTo(unidad.getId());
+        assertThat(resultado.getUnidadMedidaNombre()).isEqualTo("Unidad");
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -312,7 +312,7 @@ class ProductoServiceImplTest {
     @DisplayName("Debe buscar insumos en categorías permitidas y mapear término recortado")
     void buscarInsumosAutocomplete_conTermino_invocaRepositorioConFiltros() {
         Pageable pageable = PageRequest.of(0, 10);
-        InsumoAutocompleteDTO dto = new InsumoAutocompleteDTO(1, "MP-1", "MP", "Unidad");
+        InsumoAutocompleteDTO dto = new InsumoAutocompleteDTO(1, "MP-1", "MP", "Unidad", 5L, "Unidad");
         Page<InsumoAutocompleteDTO> page = new PageImpl<>(List.of(dto), pageable, 1);
         when(productoRepository.buscarInsumosAutocomplete(anyList(), anyString(), any(Pageable.class)))
                 .thenReturn(page);

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -248,7 +248,7 @@ class ProductoControllerSmokeTest {
     @WithMockUser(authorities = "ROL_SUPER_ADMIN")
     @DisplayName("GET /api/productos/insumos/autocomplete devuelve 200 y unidad de medida en DTO")
     void buscarInsumosAutocomplete_deberiaRetornarUnidadMedida() throws Exception {
-        InsumoAutocompleteDTO response = new InsumoAutocompleteDTO(15, "MP-015", "Insumo 15", "Unidad");
+        InsumoAutocompleteDTO response = new InsumoAutocompleteDTO(15, "MP-015", "Insumo 15", "Unidad", 3L, "Unidad");
         Pageable pageable = PageRequest.of(0, 10);
         Page<InsumoAutocompleteDTO> page = new PageImpl<>(List.of(response), pageable, 1);
 
@@ -261,7 +261,9 @@ class ProductoControllerSmokeTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.content[0].id").value(15))
-                .andExpect(jsonPath("$.content[0].unidad").value("Unidad"));
+                .andExpect(jsonPath("$.content[0].unidad").value("Unidad"))
+                .andExpect(jsonPath("$.content[0].unidadMedidaId").value(3))
+                .andExpect(jsonPath("$.content[0].unidadMedidaNombre").value("Unidad"));
 
         verify(productoService).buscarInsumosAutocomplete(eq("MP"), any(Pageable.class));
     }


### PR DESCRIPTION
### Motivation
- The autocomplete endpoint for insumos must return the unit-of-measure identifier so the frontend BOM form can set and validate the `unidadMedida` select automatically.

### Description
- Extended `InsumoAutocompleteDTO` to add `unidadMedidaId` and `unidadMedidaNombre` fields.
- Updated the JPQL autocomplete query in `ProductoRepository.buscarInsumosAutocomplete` to `JOIN p.unidadMedida um` and select `um.nombre`, `um.id`, `um.nombre` so the `SELECT new ...` constructor arguments match the DTO order exactly.
- Updated tests and mocks to include and validate the new fields in `ProductoRepositoryAutocompleteTest`, `ProductoControllerSmokeTest`, and `ProductoServiceImplTest`.

### Testing
- Updated automated tests: `ProductoRepositoryAutocompleteTest` (DataJpaTest) now asserts `unidadMedidaId` and `unidadMedidaNombre`, `ProductoControllerSmokeTest` checks the JSON fields `unidadMedidaId` and `unidadMedidaNombre`, and `ProductoServiceImplTest` mocks DTOs with the new fields; tests were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d2d9785b88333be1782a56c9c8ce9)