### PR TITLE
Fix fabricables autocomplete fetch to avoid lazy loading

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -8,6 +8,7 @@ import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -164,6 +165,7 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
         OR UPPER(p.codigoSku) LIKE CONCAT('%', UPPER(:term), '%')
       )
     """)
+    @EntityGraph(attributePaths = {"unidadMedida"})
     Page<Producto> buscarFabricablesAutocomplete(
             @Param("tipos") Collection<TipoCategoria> tipos,
             @Param("term") String term,

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -8,6 +8,7 @@ import com.willyes.clemenintegra.inventario.dto.ProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.UnidadMedidaResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.ProductoMapper;
+import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
@@ -186,6 +187,37 @@ class ProductoControllerSmokeTest {
                 .andExpect(jsonPath("$.content[0].sku").value("SKU-010"))
                 .andExpect(jsonPath("$.totalElements").value(1))
                 .andExpect(jsonPath("$.totalPages").value(1));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("GET /api/productos/buscar-fabricables devuelve 200")
+    void buscarFabricables_deberiaRetornar200() throws Exception {
+        Producto producto = Producto.builder()
+                .id(1)
+                .codigoSku("SKU-FAB")
+                .nombre("Producto Fabricable")
+                .build();
+        Pageable pageable = PageRequest.of(0, 15);
+        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
+        ProductoResponseDTO responseDTO = ProductoResponseDTO.builder()
+                .id(1L)
+                .sku("SKU-FAB")
+                .nombre("Producto Fabricable")
+                .build();
+
+        when(productoService.buscarProductosFabricablesAutocomplete(eq("re"), any(Pageable.class)))
+                .thenReturn(page);
+        when(productoMapper.toDto(any(Producto.class))).thenReturn(responseDTO);
+
+        mockMvc.perform(get("/api/productos/buscar-fabricables")
+                        .param("term", "re")
+                        .param("page", "0")
+                        .param("size", "15"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].sku").value("SKU-FAB"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- The `GET /api/productos/buscar-fabricables` endpoint could throw `LazyInitializationException` when the mapper accessed `unidadMedida`, so the repository query must eagerly load `unidadMedida` for this search without enabling OpenSessionInView.

### Description
- Added `@EntityGraph(attributePaths = {"unidadMedida"})` to `ProductoRepository.buscarFabricablesAutocomplete(...)` so `unidadMedida` is fetched with the query.
- Added a `WebMvcTest` in `ProductoControllerSmokeTest` that performs `GET /api/productos/buscar-fabricables?term=re&page=0&size=15` and asserts a `200` response and expected JSON content.

### Testing
- Executed `mvn test -Dtest=ProductoControllerSmokeTest` and the test class ran (8 tests) with `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e9e8e884083339d56eb21f2a1c13f)