### PR TITLE
Fix fabricables autocomplete eager loading and add integration test

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -165,7 +165,7 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
         OR UPPER(p.codigoSku) LIKE CONCAT('%', UPPER(:term), '%')
       )
     """)
-    @EntityGraph(attributePaths = {"unidadMedida"})
+    @EntityGraph(attributePaths = {"unidadMedida", "categoriaProducto"})
     Page<Producto> buscarFabricablesAutocomplete(
             @Param("tipos") Collection<TipoCategoria> tipos,
             @Param("term") String term,

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoFabricablesIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoFabricablesIntegrationTest.java
@@ -1,0 +1,108 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestH2;
+import java.math.BigDecimal;
+import java.util.Locale;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class ProductoFabricablesIntegrationTest extends IntegrationTestH2 {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void buscarFabricables_devuelveRelacionesPrecargadas() throws Exception {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("tester-fab-" + suffix)
+                .clave("secret")
+                .nombreCompleto("Tester Fabricables")
+                .correo("tester-fab-" + suffix + "@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad Fabricable " + suffix)
+                .simbolo("UF")
+                .codigo("UF1")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria Fabricable " + suffix)
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        productoRepository.save(Producto.builder()
+                .codigoSku("CITRAT-" + suffix)
+                .nombre("Citrato de Prueba " + suffix)
+                .stockMinimo(BigDecimal.ONE)
+                .activo(true)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .build());
+
+        String expectedUnidad = ("Unidad Fabricable " + suffix).toUpperCase(Locale.ROOT);
+
+        mockMvc.perform(get("/api/productos/buscar-fabricables")
+                        .param("term", "citrat")
+                        .param("page", "0")
+                        .param("size", "15"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].sku").value("CITRAT-" + suffix))
+                .andExpect(jsonPath("$.content[0].categoria").value("Categoria Fabricable " + suffix))
+                .andExpect(jsonPath("$.content[0].unidadMedida.nombre").value(expectedUnidad));
+    }
+}


### PR DESCRIPTION
### Motivation

- El endpoint `GET /api/productos/buscar-fabricables` lanzaba `LazyInitializationException` al mapear a DTO porque `categoriaProducto` no estaba precargada; se desea evitar OpenSessionInView y precargar las relaciones usadas por el mapper.

### Description

- Ajusta la consulta de repositorio para precargar las relaciones necesarias en `ProductoRepository` usando `@EntityGraph(attributePaths = {"unidadMedida","categoriaProducto"})` para `buscarFabricablesAutocomplete`.
- Agrega un test de integración `ProductoFabricablesIntegrationTest` que crea datos en una base H2, llama `GET /api/productos/buscar-fabricables?term=citrat&page=0&size=15` y verifica `200 OK` y que la respuesta serializa correctamente campos dependientes (`categoria` y `unidadMedida.nombre`).
- No se cambió ningún DTO ni el contrato del endpoint; la solución es a nivel de repositorio y pruebas para garantizar las relaciones precargadas.

### Testing

- Ejecutado: `mvn test -Dtest=ProductoFabricablesIntegrationTest` and the test passed (BUILD SUCCESS).
- La prueba comprueba que la API devuelve `200` y que el JSON contiene `sku`, `categoria` y `unidadMedida.nombre` sin LazyInitializationException.
- No se ejecutaron cambios de pruebas adicionales en este PR; sólo se añadió la integración enfocada en el caso reportado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea73ce4108333863567cf7ae6c937)