### PR TITLE
Return lightweight ProductoAutocompleteDTO for /buscar-fabricables to avoid LazyInitializationException

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -1,7 +1,6 @@
 package com.willyes.clemenintegra.inventario.controller;
 
 import com.willyes.clemenintegra.inventario.dto.*;
-import com.willyes.clemenintegra.inventario.mapper.ProductoMapper;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.ProductoService;
@@ -39,7 +38,6 @@ public class ProductoController {
     private final MovimientoInventarioRepository movimientoInventarioRepository;
     private final UnidadMedidaRepository unidadMedidaRepository;
     private final UsuarioRepository usuarioRepository;
-    private final ProductoMapper productoMapper;
 
     @GetMapping("/buscar")
     @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
@@ -77,13 +75,12 @@ public class ProductoController {
 
     @GetMapping("/buscar-fabricables")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public ResponseEntity<Page<ProductoResponseDTO>> buscarProductosFabricablesAutocomplete(
+    public ResponseEntity<Page<ProductoAutocompleteDTO>> buscarProductosFabricablesAutocomplete(
             @RequestParam("term") String term,
             Pageable pageable
     ) {
-        Page<Producto> page = productoService.buscarProductosFabricablesAutocomplete(term, pageable);
-        Page<ProductoResponseDTO> dtoPage = page.map(productoMapper::toDto);
-        return ResponseEntity.ok(dtoPage);
+        Page<ProductoAutocompleteDTO> page = productoService.buscarProductosFabricablesAutocomplete(term, pageable);
+        return ResponseEntity.ok(page);
     }
 
     @GetMapping("/categoria/{nombre}")

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoAutocompleteDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ProductoAutocompleteDTO.java
@@ -1,0 +1,4 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+public record ProductoAutocompleteDTO(Integer id, String codigoSku, String nombre) {
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.repository;
 
 import com.willyes.clemenintegra.inventario.dto.InsumoAutocompleteDTO;
+import com.willyes.clemenintegra.inventario.dto.ProductoAutocompleteDTO;
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
@@ -8,7 +9,6 @@ import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -155,8 +155,21 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
             Pageable pageable
     );
 
-    @Query("""
-    SELECT p
+    @Query(value = """
+    SELECT new com.willyes.clemenintegra.inventario.dto.ProductoAutocompleteDTO(
+        p.id,
+        p.codigoSku,
+        p.nombre
+    )
+    FROM Producto p
+    WHERE p.categoriaProducto.tipo IN :tipos
+      AND p.activo = true
+      AND (
+           UPPER(p.nombre) LIKE CONCAT('%', UPPER(:term), '%')
+        OR UPPER(p.codigoSku) LIKE CONCAT('%', UPPER(:term), '%')
+      )
+    """, countQuery = """
+    SELECT COUNT(p)
     FROM Producto p
     WHERE p.categoriaProducto.tipo IN :tipos
       AND p.activo = true
@@ -165,8 +178,7 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
         OR UPPER(p.codigoSku) LIKE CONCAT('%', UPPER(:term), '%')
       )
     """)
-    @EntityGraph(attributePaths = {"unidadMedida", "categoriaProducto"})
-    Page<Producto> buscarFabricablesAutocomplete(
+    Page<ProductoAutocompleteDTO> buscarFabricablesAutocomplete(
             @Param("tipos") Collection<TipoCategoria> tipos,
             @Param("term") String term,
             Pageable pageable

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoService.java
@@ -45,5 +45,5 @@ public interface ProductoService {
 
     Page<InsumoAutocompleteDTO> buscarInsumosAutocomplete(String term, Pageable pageable);
 
-    Page<Producto> buscarProductosFabricablesAutocomplete(String term, Pageable pageable);
+    Page<ProductoAutocompleteDTO> buscarProductosFabricablesAutocomplete(String term, Pageable pageable);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImpl.java
@@ -601,7 +601,7 @@ public class ProductoServiceImpl implements ProductoService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<Producto> buscarProductosFabricablesAutocomplete(String term, Pageable pageable) {
+    public Page<ProductoAutocompleteDTO> buscarProductosFabricablesAutocomplete(String term, Pageable pageable) {
         if (term == null || term.trim().isEmpty()) {
             return Page.empty(pageable);
         }

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoFabricablesIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoFabricablesIntegrationTest.java
@@ -13,7 +13,6 @@ import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.support.IntegrationTestH2;
 import java.math.BigDecimal;
-import java.util.Locale;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,7 +56,7 @@ class ProductoFabricablesIntegrationTest extends IntegrationTestH2 {
 
     @Test
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
-    void buscarFabricables_devuelveRelacionesPrecargadas() throws Exception {
+    void buscarFabricables_devuelveDatosBasicos() throws Exception {
         String suffix = UUID.randomUUID().toString().substring(0, 8);
         Usuario usuario = usuarioRepository.save(Usuario.builder()
                 .nombreUsuario("tester-fab-" + suffix)
@@ -94,15 +93,13 @@ class ProductoFabricablesIntegrationTest extends IntegrationTestH2 {
                 .creadoPor(usuario)
                 .build());
 
-        String expectedUnidad = ("Unidad Fabricable " + suffix).toUpperCase(Locale.ROOT);
-
         mockMvc.perform(get("/api/productos/buscar-fabricables")
                         .param("term", "citrat")
                         .param("page", "0")
                         .param("size", "15"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].sku").value("CITRAT-" + suffix))
-                .andExpect(jsonPath("$.content[0].categoria").value("Categoria Fabricable " + suffix))
-                .andExpect(jsonPath("$.content[0].unidadMedida.nombre").value(expectedUnidad));
+                .andExpect(jsonPath("$.content[0].id").isNumber())
+                .andExpect(jsonPath("$.content[0].codigoSku").value("CITRAT-" + suffix))
+                .andExpect(jsonPath("$.content[0].nombre").value("Citrato de Prueba " + suffix));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ProductoServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.InsumoAutocompleteDTO;
+import com.willyes.clemenintegra.inventario.dto.ProductoAutocompleteDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoOptionDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
@@ -340,7 +341,7 @@ class ProductoServiceImplTest {
     void buscarProductosFabricablesAutocomplete_sinTermino_devuelveVacio() {
         Pageable pageable = PageRequest.of(0, 5);
 
-        Page<Producto> resultado = service.buscarProductosFabricablesAutocomplete("   ", pageable);
+        Page<ProductoAutocompleteDTO> resultado = service.buscarProductosFabricablesAutocomplete("   ", pageable);
 
         assertThat(resultado).isEmpty();
         verify(productoRepository, never()).buscarFabricablesAutocomplete(anyList(), anyString(), any(Pageable.class));
@@ -350,14 +351,14 @@ class ProductoServiceImplTest {
     @DisplayName("Debe buscar fabricables en PT y PS y normalizar el término")
     void buscarProductosFabricablesAutocomplete_conTermino_invocaRepositorioConFiltros() {
         Pageable pageable = PageRequest.of(0, 10);
-        Producto producto = new Producto();
-        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
+        ProductoAutocompleteDTO dto = new ProductoAutocompleteDTO(1, "PS-1", "Producto Semi");
+        Page<ProductoAutocompleteDTO> page = new PageImpl<>(List.of(dto), pageable, 1);
         when(productoRepository.buscarFabricablesAutocomplete(anyList(), anyString(), any(Pageable.class)))
                 .thenReturn(page);
 
-        Page<Producto> resultado = service.buscarProductosFabricablesAutocomplete("  ps ", pageable);
+        Page<ProductoAutocompleteDTO> resultado = service.buscarProductosFabricablesAutocomplete("  ps ", pageable);
 
-        assertThat(resultado.getContent()).containsExactly(producto);
+        assertThat(resultado.getContent()).containsExactly(dto);
 
         ArgumentCaptor<List<TipoCategoria>> tiposCaptor = ArgumentCaptor.forClass(List.class);
         ArgumentCaptor<String> termCaptor = ArgumentCaptor.forClass(String.class);

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -3,12 +3,11 @@ package com.willyes.clemenintegra.inventario.web;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.willyes.clemenintegra.inventario.controller.ProductoController;
 import com.willyes.clemenintegra.inventario.dto.InsumoAutocompleteDTO;
+import com.willyes.clemenintegra.inventario.dto.ProductoAutocompleteDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoOptionDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.ProductoResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.UnidadMedidaResponseDTO;
-import com.willyes.clemenintegra.inventario.mapper.ProductoMapper;
-import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
 import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
@@ -71,9 +70,6 @@ class ProductoControllerSmokeTest {
 
     @MockBean
     private ProductoService productoService;
-
-    @MockBean
-    private ProductoMapper productoMapper;
 
     @MockBean
     private ProductoRepository productoRepository;
@@ -193,22 +189,12 @@ class ProductoControllerSmokeTest {
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     @DisplayName("GET /api/productos/buscar-fabricables devuelve 200")
     void buscarFabricables_deberiaRetornar200() throws Exception {
-        Producto producto = Producto.builder()
-                .id(1)
-                .codigoSku("SKU-FAB")
-                .nombre("Producto Fabricable")
-                .build();
+        ProductoAutocompleteDTO producto = new ProductoAutocompleteDTO(1, "SKU-FAB", "Producto Fabricable");
         Pageable pageable = PageRequest.of(0, 15);
-        Page<Producto> page = new PageImpl<>(List.of(producto), pageable, 1);
-        ProductoResponseDTO responseDTO = ProductoResponseDTO.builder()
-                .id(1L)
-                .sku("SKU-FAB")
-                .nombre("Producto Fabricable")
-                .build();
+        Page<ProductoAutocompleteDTO> page = new PageImpl<>(List.of(producto), pageable, 1);
 
         when(productoService.buscarProductosFabricablesAutocomplete(eq("re"), any(Pageable.class)))
                 .thenReturn(page);
-        when(productoMapper.toDto(any(Producto.class))).thenReturn(responseDTO);
 
         mockMvc.perform(get("/api/productos/buscar-fabricables")
                         .param("term", "re")
@@ -217,7 +203,7 @@ class ProductoControllerSmokeTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.content[0].id").value(1))
-                .andExpect(jsonPath("$.content[0].sku").value("SKU-FAB"));
+                .andExpect(jsonPath("$.content[0].codigoSku").value("SKU-FAB"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- The `/api/productos/buscar-fabricables` endpoint was causing `LazyInitializationException` when mapping full `Producto` entities outside a session, and autocomplete only requires a small payload.  
- Replace full-entity mapping with a repository projection to avoid OSIV/fetch-graph changes and keep the response minimal (`id`, `codigoSku`, `nombre`).

### Description
- Added a lightweight projection record `ProductoAutocompleteDTO` (`id`, `codigoSku`, `nombre`) in `com.willyes.clemenintegra.inventario.dto`.  
- Replaced the repository method `buscarFabricablesAutocomplete` to return `Page<ProductoAutocompleteDTO>` using `SELECT new ...` projection and removed the previous `@EntityGraph` fetch on that query.  
- Updated service API/signature (`ProductoService` / `ProductoServiceImpl`) to return `Page<ProductoAutocompleteDTO>` and delegated the call to the new repository projection.  
- Changed controller `ProductoController.buscarProductosFabricablesAutocomplete` to return the `Page<ProductoAutocompleteDTO>` directly (removed `productoMapper::toDto` usage) and updated related tests to assert the new payload shape.

### Testing
- Updated tests: `ProductoFabricablesIntegrationTest`, `ProductoServiceImplTest`, and `ProductoControllerSmokeTest` to expect `id/codigoSku/nombre` in autocomplete responses; these tests were modified to use `ProductoAutocompleteDTO`.  
- Ran `mvn test -Dtest=ProductoFabricablesIntegrationTest` which failed during project compilation due to unrelated compilation errors in other modules during the build, so the integration test could not complete successfully (build output shows compilation errors unrelated to the changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ed3bbbb648333bd76693fb93cd3e9)