### PR TITLE
Stabilize fabricables autocomplete ordering and test assertions

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java
@@ -168,6 +168,7 @@ public interface ProductoRepository extends JpaRepository<Producto, Long>, JpaSp
            UPPER(p.nombre) LIKE CONCAT('%', UPPER(:term), '%')
         OR UPPER(p.codigoSku) LIKE CONCAT('%', UPPER(:term), '%')
       )
+    ORDER BY p.codigoSku ASC
     """, countQuery = """
     SELECT COUNT(p)
     FROM Producto p

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoFabricablesIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoFabricablesIntegrationTest.java
@@ -24,6 +24,9 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -94,12 +97,14 @@ class ProductoFabricablesIntegrationTest extends IntegrationTestH2 {
                 .build());
 
         mockMvc.perform(get("/api/productos/buscar-fabricables")
-                        .param("term", "citrat")
-                        .param("page", "0")
-                        .param("size", "15"))
+                .param("term", "citrat")
+                .param("page", "0")
+                .param("size", "15"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].id").isNumber())
-                .andExpect(jsonPath("$.content[0].codigoSku").value("CITRAT-" + suffix))
-                .andExpect(jsonPath("$.content[0].nombre").value("Citrato de Prueba " + suffix));
+                .andExpect(jsonPath("$.content[*].codigoSku", hasItem("CITRAT-" + suffix)))
+                .andExpect(jsonPath("$.content[?(@.codigoSku == 'CITRAT-" + suffix + "')].nombre",
+                        hasItem("Citrato de Prueba " + suffix)))
+                .andExpect(jsonPath("$.content[?(@.codigoSku == 'CITRAT-" + suffix + "')].id",
+                        not(empty())));
     }
 }


### PR DESCRIPTION
### Motivation
- El test de integración `buscarFabricables_devuelveDatosBasicos` fallaba porque verificaba el primer elemento del listado y el orden de resultados no era determinista tras cambios en los datos y el DTO que retorna el endpoint.
- Se busca que la verificación sea robusta frente al orden y que la consulta devuelva resultados en orden estable para evitar regresiones.

### Description
- Cambiado el test `src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoFabricablesIntegrationTest.java` para no depender del índice 0 y usar `jsonPath` con `$.content[*].codigoSku` y matchers de Hamcrest (`hasItem`, `not`, `empty`) para validar `codigoSku`, `nombre` e `id` del DTO.
- Agregadas las importaciones de Hamcrest necesarias en el test (`empty`, `hasItem`, `not`).
- Añadido `ORDER BY p.codigoSku ASC` en la consulta JPQL `buscarFabricablesAutocomplete` en `src/main/java/com/willyes/clemenintegra/inventario/repository/ProductoRepository.java` para asegurar un orden determinístico de resultados.

### Testing
- Ejecutado `mvn test -Dtest=ProductoFabricablesIntegrationTest` y el test pasó (1 test, 0 fallos), con `BUILD SUCCESS` para esa ejecución.
- No se ejecutó la suite completa (`mvn test`) para evitar un tiempo de ejecución prolongado en este entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f9503c324833388b8cd17d2ea969a)