### PR TITLE
feat(bom): add selector DTO and paged formula list for BOM selector

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
@@ -11,6 +11,9 @@ import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
 import com.willyes.clemenintegra.inventario.service.ProductoService;
 import com.willyes.clemenintegra.shared.model.Usuario;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -44,10 +47,11 @@ public class FormulaProductoController {
 
     @GetMapping
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
-    public List<FormulaProductoResumenDTO> listarTodas(
+    public Page<FormulaProductoSelectorDTO> listarTodas(
             @RequestParam(required = false) EstadoFormula estado,
-            @RequestParam(required = false) String producto) {
-        return formulaService.listarResumen(estado, producto);
+            @RequestParam(required = false) String producto,
+            @PageableDefault(size = 20) Pageable pageable) {
+        return formulaService.listarResumen(estado, producto, pageable);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoSelectorDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoSelectorDTO.java
@@ -1,0 +1,26 @@
+package com.willyes.clemenintegra.bom.dto;
+
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+
+public class FormulaProductoSelectorDTO {
+    public Long formulaId;
+    public String version;
+    public String estado;
+    public Long productoId;
+    public String productoSku;
+    public String productoNombre;
+
+    public FormulaProductoSelectorDTO(Long formulaId,
+                                      String version,
+                                      EstadoFormula estado,
+                                      Long productoId,
+                                      String productoSku,
+                                      String productoNombre) {
+        this.formulaId = formulaId;
+        this.version = version;
+        this.estado = estado != null ? estado.name() : null;
+        this.productoId = productoId;
+        this.productoSku = productoSku;
+        this.productoNombre = productoNombre;
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -2,7 +2,10 @@ package com.willyes.clemenintegra.bom.repository;
 
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.dto.FormulaProductoSelectorDTO;
 import com.willyes.clemenintegra.inventario.model.Producto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -65,6 +68,18 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
             "or lower(p.nombre) like lower(concat('%', :producto, '%'))) " +
             "order by coalesce(f.fechaActualizacion, f.fechaCreacion) desc, f.id desc")
     List<FormulaProducto> findAllForResumen(@Param("estado") EstadoFormula estado, @Param("producto") String producto);
+
+    @Query("select new com.willyes.clemenintegra.bom.dto.FormulaProductoSelectorDTO(" +
+            "f.id, f.version, f.estado, p.id, p.codigoSku, p.nombre) " +
+            "from FormulaProducto f " +
+            "join f.producto p " +
+            "where (:estado is null or f.estado = :estado) " +
+            "and (:producto is null or lower(p.codigoSku) like lower(concat('%', :producto, '%')) " +
+            "or lower(p.nombre) like lower(concat('%', :producto, '%'))) " +
+            "order by coalesce(f.fechaActualizacion, f.fechaCreacion) desc, f.id desc")
+    Page<FormulaProductoSelectorDTO> findAllForSelector(@Param("estado") EstadoFormula estado,
+                                                       @Param("producto") String producto,
+                                                       Pageable pageable);
 
     @Modifying(clearAutomatically = true)
     @Query("update FormulaProducto f set f.activo = false where f.producto = :producto and f.id <> :id")

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoService.java
@@ -3,17 +3,19 @@ package com.willyes.clemenintegra.bom.service;
 import com.willyes.clemenintegra.bom.dto.FormulaActivaProduccionDTO;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoDetalleDTO;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResponse;
-import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
+import com.willyes.clemenintegra.bom.dto.FormulaProductoSelectorDTO;
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface FormulaProductoService {
     List<FormulaProducto> listarTodas();
-    List<FormulaProductoResumenDTO> listarResumen(EstadoFormula estado, String producto);
+    Page<FormulaProductoSelectorDTO> listarResumen(EstadoFormula estado, String producto, Pageable pageable);
     Optional<FormulaProducto> buscarPorId(Long id);
     Optional<FormulaProductoDetalleDTO> buscarDetallePorId(Long id);
     FormulaProducto guardar(FormulaProducto formula);

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -15,6 +15,8 @@ import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -43,15 +45,13 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<FormulaProductoResumenDTO> listarResumen(EstadoFormula estado, String producto) {
+    public Page<FormulaProductoSelectorDTO> listarResumen(EstadoFormula estado, String producto, Pageable pageable) {
         String filtroProducto = producto != null ? producto.trim() : null;
         if (filtroProducto != null && filtroProducto.isEmpty()) {
             filtroProducto = null;
         }
 
-        return formulaRepository.findAllForResumen(estado, filtroProducto).stream()
-                .map(bomMapper::toResumenDTO)
-                .collect(Collectors.toList());
+        return formulaRepository.findAllForSelector(estado, filtroProducto, pageable);
     }
 
     public List<FormulaProducto> listarTodas() {

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoControllerSecurityTest.java
@@ -5,7 +5,7 @@ import com.willyes.clemenintegra.bom.dto.CambiarEstadoFormulaRequest;
 import com.willyes.clemenintegra.bom.dto.DocumentoFormulaDescargaDTO;
 import com.willyes.clemenintegra.bom.dto.DocumentoFormulaResponseDTO;
 import com.willyes.clemenintegra.bom.dto.FormulaActivaProduccionDTO;
-import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
+import com.willyes.clemenintegra.bom.dto.FormulaProductoSelectorDTO;
 import com.willyes.clemenintegra.bom.mapper.BomMapper;
 import com.willyes.clemenintegra.bom.model.FormulaProducto;
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
@@ -35,6 +35,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.data.domain.PageImpl;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -103,15 +104,13 @@ class FormulaProductoControllerSecurityTest {
             return null;
         }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
 
-        FormulaProductoResumenDTO resumenDTO = new FormulaProductoResumenDTO();
-        resumenDTO.id = 1L;
-        resumenDTO.productoId = 10L;
-        resumenDTO.codigoProducto = "P-001";
-        resumenDTO.nombreProducto = "Producto Test";
-        resumenDTO.version = "v1";
-        resumenDTO.estado = EstadoFormula.BORRADOR.name();
-        resumenDTO.activo = false;
-        resumenDTO.usuarioResponsable = "tester";
+        FormulaProductoSelectorDTO resumenDTO = new FormulaProductoSelectorDTO(
+                1L,
+                "v1",
+                EstadoFormula.BORRADOR,
+                10L,
+                "P-001",
+                "Producto Test");
 
         FormulaActivaProduccionDTO formulaActiva = new FormulaActivaProduccionDTO();
         formulaActiva.formulaId = 2L;
@@ -134,7 +133,7 @@ class FormulaProductoControllerSecurityTest {
         FormulaProducto formula = new FormulaProducto();
         formula.setId(3L);
 
-        when(formulaProductoService.listarResumen(any(), any())).thenReturn(List.of(resumenDTO));
+        when(formulaProductoService.listarResumen(any(), any(), any())).thenReturn(new PageImpl<>(List.of(resumenDTO)));
         when(formulaProductoService.obtenerFormulaActivaProduccion(anyLong())).thenReturn(formulaActiva);
         when(formulaProductoService.clonarFormula(anyLong(), anyLong())).thenReturn(formula);
         when(formulaProductoService.cambiarEstado(anyLong(), any(EstadoFormula.class), anyLong())).thenReturn(formula);

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoListadoIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.willyes.clemenintegra.bom.controller;
+
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class FormulaProductoListadoIntegrationTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private FormulaProductoRepository formulaProductoRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void listarFormulasIncluyeSkuYNombreProducto() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("bom-list-user")
+                .clave("secret")
+                .nombreCompleto("Usuario BOM Listado")
+                .correo("bom-list-user@example.com")
+                .rol(RolUsuario.ROL_JEFE_PRODUCCION)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad BOM")
+                .simbolo("UBO")
+                .codigo("UBO")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria BOM Listado")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto productoUno = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-SEL-1")
+                .nombre("Producto Selector Uno")
+                .descripcionProducto("Producto selector uno")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        Producto productoDos = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-SEL-2")
+                .nombre("Producto Selector Dos")
+                .descripcionProducto("Producto selector dos")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        FormulaProducto formulaUno = FormulaProducto.builder()
+                .producto(productoUno)
+                .version("V1")
+                .estado(EstadoFormula.BORRADOR)
+                .fechaCreacion(LocalDateTime.now().minusDays(1))
+                .activo(true)
+                .creadoPor(usuario)
+                .build();
+
+        FormulaProducto formulaDos = FormulaProducto.builder()
+                .producto(productoDos)
+                .version("V2")
+                .estado(EstadoFormula.EN_REVISION)
+                .fechaCreacion(LocalDateTime.now())
+                .activo(true)
+                .creadoPor(usuario)
+                .build();
+
+        formulaProductoRepository.saveAll(List.of(formulaUno, formulaDos));
+
+        mockMvc.perform(get("/api/bom/formulas")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[*].productoSku", hasItems("SKU-SEL-1", "SKU-SEL-2")))
+                .andExpect(jsonPath("$.content[*].productoNombre", hasItems("Producto Selector Uno", "Producto Selector Dos")));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -4,7 +4,7 @@ import com.willyes.clemenintegra.bom.dto.DetalleFormulaProduccionDTO;
 import com.willyes.clemenintegra.bom.dto.DetalleFormulaResponse;
 import com.willyes.clemenintegra.bom.dto.FormulaActivaProduccionDTO;
 import com.willyes.clemenintegra.bom.dto.FormulaProductoResponse;
-import com.willyes.clemenintegra.bom.dto.FormulaProductoResumenDTO;
+import com.willyes.clemenintegra.bom.dto.FormulaProductoSelectorDTO;
 import com.willyes.clemenintegra.bom.dto.LoteResumenDTO;
 import com.willyes.clemenintegra.bom.mapper.BomMapper;
 import com.willyes.clemenintegra.bom.model.DetalleFormula;
@@ -31,10 +31,12 @@ import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -175,106 +177,75 @@ class FormulaProductoServiceImplTest {
     @Test
     @DisplayName("listarResumen devuelve los campos necesarios sin detalles ni documentos")
     void listarResumenDevuelveCamposClaves() {
-        Producto producto = new Producto();
-        producto.setId(1);
-        producto.setCodigoSku("PR-001");
-        producto.setNombre("Producto Test");
+        FormulaProductoSelectorDTO selector = new FormulaProductoSelectorDTO(
+                10L,
+                "v1",
+                EstadoFormula.BORRADOR,
+                1L,
+                "PR-001",
+                "Producto Test");
 
-        Usuario responsable = new Usuario();
-        responsable.setNombreCompleto("Responsable Calidad");
+        when(formulaRepository.findAllForSelector(isNull(), isNull(), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(selector)));
 
-        FormulaProducto formula = new FormulaProducto();
-        formula.setId(10L);
-        formula.setProducto(producto);
-        formula.setVersion("v1");
-        formula.setEstado(EstadoFormula.BORRADOR);
-        formula.setActivo(true);
-        formula.setFechaActualizacion(LocalDateTime.of(2024, 1, 15, 10, 30));
-        formula.setActualizadoPor(responsable);
+        Page<FormulaProductoSelectorDTO> resultado = service.listarResumen(null, null, PageRequest.of(0, 10));
 
-        when(formulaRepository.findAllForResumen(null, null)).thenReturn(List.of(formula));
-
-        List<FormulaProductoResumenDTO> resultado = service.listarResumen(null, null);
-
-        assertThat(resultado).hasSize(1);
-        FormulaProductoResumenDTO dto = resultado.get(0);
-        assertThat(dto.id).isEqualTo(10L);
+        assertThat(resultado.getContent()).hasSize(1);
+        FormulaProductoSelectorDTO dto = resultado.getContent().get(0);
+        assertThat(dto.formulaId).isEqualTo(10L);
         assertThat(dto.productoId).isEqualTo(1L);
-        assertThat(dto.codigoProducto).isEqualTo("PR-001");
-        assertThat(dto.nombreProducto).isEqualTo("Producto Test");
+        assertThat(dto.productoSku).isEqualTo("PR-001");
+        assertThat(dto.productoNombre).isEqualTo("Producto Test");
         assertThat(dto.version).isEqualTo("v1");
         assertThat(dto.estado).isEqualTo("BORRADOR");
-        assertThat(dto.activo).isTrue();
-        assertThat(dto.fechaActualizacion).isEqualTo(LocalDateTime.of(2024, 1, 15, 10, 30));
-        assertThat(dto.usuarioResponsable).isEqualTo("Responsable Calidad");
-
-        assertThat(Arrays.stream(FormulaProductoResumenDTO.class.getDeclaredFields())
-                .map(java.lang.reflect.Field::getName))
-                .doesNotContain("detalles", "documentos");
     }
 
     @Test
     @DisplayName("listarResumen filtra por estado cuando se proporciona")
     void listarResumenFiltraPorEstado() {
-        Producto producto = new Producto();
-        producto.setId(2);
-        producto.setCodigoSku("PR-002");
-        producto.setNombre("Producto Borrador");
+        FormulaProductoSelectorDTO selector = new FormulaProductoSelectorDTO(
+                20L,
+                "v3",
+                EstadoFormula.BORRADOR,
+                2L,
+                "PR-002",
+                "Producto Borrador");
 
-        Usuario responsable = new Usuario();
-        responsable.setNombreCompleto("Responsable Borrador");
+        when(formulaRepository.findAllForSelector(eq(EstadoFormula.BORRADOR), isNull(), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(selector)));
 
-        FormulaProducto formula = new FormulaProducto();
-        formula.setId(20L);
-        formula.setProducto(producto);
-        formula.setVersion("v3");
-        formula.setEstado(EstadoFormula.BORRADOR);
-        formula.setActivo(false);
-        formula.setFechaActualizacion(LocalDateTime.of(2024, 2, 20, 9, 15));
-        formula.setActualizadoPor(responsable);
+        Page<FormulaProductoSelectorDTO> resultado = service.listarResumen(EstadoFormula.BORRADOR, null, PageRequest.of(0, 5));
 
-        when(formulaRepository.findAllForResumen(EstadoFormula.BORRADOR, null)).thenReturn(List.of(formula));
-
-        List<FormulaProductoResumenDTO> resultado = service.listarResumen(EstadoFormula.BORRADOR, null);
-
-        assertThat(resultado).hasSize(1);
-        FormulaProductoResumenDTO dto = resultado.get(0);
+        assertThat(resultado.getContent()).hasSize(1);
+        FormulaProductoSelectorDTO dto = resultado.getContent().get(0);
         assertThat(dto.estado).isEqualTo(EstadoFormula.BORRADOR.name());
-        assertThat(dto.codigoProducto).isEqualTo("PR-002");
-        verify(formulaRepository).findAllForResumen(EstadoFormula.BORRADOR, null);
+        assertThat(dto.productoSku).isEqualTo("PR-002");
+        verify(formulaRepository).findAllForSelector(eq(EstadoFormula.BORRADOR), isNull(), any(PageRequest.class));
     }
 
     @Test
     @DisplayName("listarResumen normaliza el filtro de producto antes de consultar el repositorio")
     void listarResumenFiltraPorTextoProducto() {
-        Producto producto = new Producto();
-        producto.setId(3);
-        producto.setCodigoSku("PT-0311");
-        producto.setNombre("CVC-COMPRIMIDO VITAMINA C 500 MG");
+        FormulaProductoSelectorDTO selector = new FormulaProductoSelectorDTO(
+                30L,
+                "v5",
+                EstadoFormula.APROBADA,
+                3L,
+                "PT-0311",
+                "CVC-COMPRIMIDO VITAMINA C 500 MG");
 
-        Usuario responsable = new Usuario();
-        responsable.setNombreCompleto("Responsable Texto");
+        when(formulaRepository.findAllForSelector(any(), any(), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(selector)));
 
-        FormulaProducto formula = new FormulaProducto();
-        formula.setId(30L);
-        formula.setProducto(producto);
-        formula.setVersion("v5");
-        formula.setEstado(EstadoFormula.APROBADA);
-        formula.setActivo(true);
-        formula.setFechaActualizacion(LocalDateTime.of(2024, 3, 10, 8, 45));
-        formula.setActualizadoPor(responsable);
+        Page<FormulaProductoSelectorDTO> resultado = service.listarResumen(null, "  vitamina c   ", PageRequest.of(0, 10));
 
-        when(formulaRepository.findAllForResumen(any(), any())).thenReturn(List.of(formula));
-
-        List<FormulaProductoResumenDTO> resultado = service.listarResumen(null, "  vitamina c   ");
-
-        assertThat(resultado).hasSize(1);
-        FormulaProductoResumenDTO dto = resultado.get(0);
-        assertThat(dto.codigoProducto).isEqualTo("PT-0311");
-        assertThat(dto.nombreProducto).contains("VITAMINA C");
+        assertThat(resultado.getContent()).hasSize(1);
+        FormulaProductoSelectorDTO dto = resultado.getContent().get(0);
+        assertThat(dto.productoSku).isEqualTo("PT-0311");
+        assertThat(dto.productoNombre).contains("VITAMINA C");
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(formulaRepository).findAllForResumen(isNull(), captor.capture());
+        verify(formulaRepository).findAllForSelector(isNull(), captor.capture(), any(PageRequest.class));
         assertThat(captor.getValue()).isEqualTo("vitamina c");
     }
 
@@ -581,4 +552,3 @@ class FormulaProductoServiceImplTest {
                 .hasFieldOrPropertyWithValue("code", ApiErrorCode.RECURSO_NO_ENCONTRADO);
     }
 }
-


### PR DESCRIPTION
### Motivation
- The frontend selector for "Fórmula" needs stable, lightweight data (id, version, estado, productoId, sku, nombre) to build human-friendly labels and autocomplete behavior without LazyInitialization issues.
- Ensure a stable ordering so the UI does not show inconsistent labels like “Fórmula 29 - 0”.

### Description
- Added `FormulaProductoSelectorDTO` to carry `formulaId`, `version`, `estado`, `productoId`, `productoSku` and `productoNombre` for selector use.
- Introduced a projection JPQL query `findAllForSelector(...)` in `FormulaProductoRepository` that returns a `Page<FormulaProductoSelectorDTO>` and applies a stable order by `coalesce(fechaActualizacion, fechaCreacion) desc, id desc`.
- Changed service and controller signatures to return paged selector results (`Page<FormulaProductoSelectorDTO> listarResumen(...)`) and normalize the product filter before querying.
- Updated and added tests to validate the selector contract and filtering behavior without assuming a specific first element by SKU, including adjustments in `FormulaProductoServiceImplTest`, `FormulaProductoControllerSecurityTest`, and a new integration test `FormulaProductoListadoIntegrationTest` that asserts `productoSku` and `productoNombre` appear in the paged response.

### Testing
- Unit tests updated: `FormulaProductoServiceImplTest` was modified to use `Page<FormulaProductoSelectorDTO>` and verifies returned selector fields; these tests were added/updated but not executed in this rollout. 
- Controller tests updated: `FormulaProductoControllerSecurityTest` was adapted to expect paged selector results; the test code was changed but not run here. 
- Integration test added: `FormulaProductoListadoIntegrationTest` exercises the `/api/bom/formulas` endpoint and asserts `productoSku`/`productoNombre` in the paged JSON content; this integration test was added but not executed in this rollout. 
- No automated test suite was executed as part of this change (tests were created/updated only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fa786ff088333a1c03d6598f7f494)