### PR TITLE
Fix BOM selector projection for product IDs

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoSelectorDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoSelectorDTO.java
@@ -23,4 +23,18 @@ public class FormulaProductoSelectorDTO {
         this.productoSku = productoSku;
         this.productoNombre = productoNombre;
     }
+
+    public FormulaProductoSelectorDTO(Long formulaId,
+                                      String version,
+                                      EstadoFormula estado,
+                                      Integer productoId,
+                                      String productoSku,
+                                      String productoNombre) {
+        this(formulaId,
+                version,
+                estado,
+                productoId != null ? productoId.longValue() : null,
+                productoSku,
+                productoNombre);
+    }
 }

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoListadoIntegrationTest.java
@@ -141,6 +141,7 @@ class FormulaProductoListadoIntegrationTest extends IntegrationTestMySqlContaine
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[*].productoId", hasItems(productoUno.getId(), productoDos.getId())))
                 .andExpect(jsonPath("$.content[*].productoSku", hasItems("SKU-SEL-1", "SKU-SEL-2")))
                 .andExpect(jsonPath("$.content[*].productoNombre", hasItems("Producto Selector Uno", "Producto Selector Dos")));
     }


### PR DESCRIPTION
### Motivation
- The GET /api/bom/formulas endpoint threw a 500 because Hibernate could not match the JPQL constructor projection `new FormulaProductoSelectorDTO(...)` where `p.id` is an `Integer` while the DTO had a constructor expecting `Long` for the product id, producing the runtime error about missing constructor signature.
- Fix must be minimal and non-breaking for the endpoint JSON contract consumed by the frontend.

### Description
- Added an overloaded constructor to `FormulaProductoSelectorDTO` that accepts an `Integer productoId` and converts it to the existing `Long productoId` field so Hibernate can instantiate the projection when `p.id` is an `Integer`.
- Kept repository JPQL and endpoint contracts unchanged to avoid breaking the frontend response shape.
- Extended the BOM integration test `FormulaProductoListadoIntegrationTest` to assert that `productoId` is present in the returned JSON, guarding against regressions in the selector projection mapping.

### Testing
- Ran `mvn -q test` to exercise the suite and the modified integration test.
- The build run executed and exercised the BOM listing test, but the full test suite failed due to unrelated integration issues (DataIntegrityViolation: unique constraint violation in `OrdenProduccionListadoIntegrationTest`) and environment warnings about Testcontainers/Docker availability, not due to the selector projection change.
- The new assertion in `FormulaProductoListadoIntegrationTest` is present to prevent future regressions of the projection mapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb7dfff788333b8a7c1ead2a7968e)