### PR TITLE
Expose parent formula metadata in DetalleFormulaResponse

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
@@ -2,6 +2,10 @@ package com.willyes.clemenintegra.bom.dto;
 
 public class DetalleFormulaResponse {
     public Long id;
+    public Long formulaId;
+    public String formulaNombre;
+    public String formulaVersion;
+    public String formulaEstado;
     public String insumoNombre;
     public java.math.BigDecimal cantidadNecesaria;
     public java.math.BigDecimal cantidadTotalNecesaria;

--- a/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
@@ -52,6 +52,10 @@ public interface BomMapper {
     //@Mapping(target = "cantidadNecesaria", expression = "java(java.math.BigDecimal.valueOf(dto.cantidadNecesaria))")
     DetalleFormula toEntity(DetalleFormulaRequest dto, FormulaProducto formula, Producto insumo, UnidadMedida unidad);
 
+    @Mapping(target = "formulaId", source = "formula.id")
+    @Mapping(target = "formulaNombre", source = "formula.producto", qualifiedByName = "mapProductoNombre")
+    @Mapping(target = "formulaVersion", source = "formula.version")
+    @Mapping(target = "formulaEstado", source = "formula.estado", qualifiedByName = "mapEstadoFormula")
     @Mapping(target = "insumoNombre", source = "insumo", qualifiedByName = "mapProductoNombre")
     @Mapping(target = "unidad", source = "unidadMedida", qualifiedByName = "mapUnidadNombre")
     @Mapping(target = "unidadSimbolo", source = "unidadMedida", qualifiedByName = "mapUnidadSimbolo")


### PR DESCRIPTION
### Motivation
- When fetching a formula detail the response lacked data about its parent formula, preventing the frontend from auto-filling the "Fórmula" field in edit mode.
- The requirement was to add minimal formula metadata to the existing detail DTO without adding endpoints, changing URLs, or exposing entities.

### Description
- Extended the DTO `DetalleFormulaResponse` to include `formulaId`, `formulaNombre`, `formulaVersion` and `formulaEstado`.
- Updated `BomMapper` to map the new DTO fields from the existing `DetalleFormula` → `FormulaProducto` relationship using `formula.id`, `formula.version`, `formula.estado` and `formula.producto` (via `mapProductoNombre`) so contracts are preserved.
- Files modified: `src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java` and `src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd70667e483339c9ba92294b0ce41)