### PR TITLE
Agregar unidadMedidaId a DetalleFormulaResponse y mapear en BomMapper

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
@@ -16,6 +16,7 @@ public class DetalleFormulaResponse {
     public String estadoStock;
     public String unidad;
     public String unidadSimbolo;
+    public Long unidadMedidaId;
     public Boolean obligatorio;
     // LÍNEA CODEx: nuevos campos para exponer disponibilidad detallada de lotes
     public DisponibilidadInsumoDTO disponibilidad;

--- a/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
@@ -57,6 +57,7 @@ public interface BomMapper {
     @Mapping(target = "formulaVersion", source = "formula.version")
     @Mapping(target = "formulaEstado", source = "formula.estado", qualifiedByName = "mapEstadoFormula")
     @Mapping(target = "insumoNombre", source = "insumo", qualifiedByName = "mapProductoNombre")
+    @Mapping(target = "unidadMedidaId", source = "unidadMedida", qualifiedByName = "mapUnidadId")
     @Mapping(target = "unidad", source = "unidadMedida", qualifiedByName = "mapUnidadNombre")
     @Mapping(target = "unidadSimbolo", source = "unidadMedida", qualifiedByName = "mapUnidadSimbolo")
     DetalleFormulaResponse toResponseDTO(DetalleFormula detalle);


### PR DESCRIPTION
### Motivation
- El frontend requiere que el endpoint de detalle de fórmula entregue explícitamente `unidadMedidaId` para que React Hook Form pueda setear la unidad sin inferir IDs desde nombres.

### Description
- Se agregó el campo `unidadMedidaId` en `DetalleFormulaResponse` y se mapeó desde la relación real `unidadMedida` en `BomMapper` usando el helper existente `mapUnidadId`, sin cambiar otros campos ni la lógica de negocio (archivos modificados: `src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java`, `src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java`).

### Testing
- No se ejecutaron pruebas automáticas; el cambio es limitado a DTO y mapeo y utiliza los helpers existentes que manejan `null` de forma segura.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fda1808a483338d2d5fcc09fc9e11)