### PR TITLE
Add insumoId to DetalleFormulaResponse and map in BomMapper

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/DetalleFormulaResponse.java
@@ -6,6 +6,7 @@ public class DetalleFormulaResponse {
     public String formulaNombre;
     public String formulaVersion;
     public String formulaEstado;
+    public Long insumoId;
     public String insumoNombre;
     public java.math.BigDecimal cantidadNecesaria;
     public java.math.BigDecimal cantidadTotalNecesaria;

--- a/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/mapper/BomMapper.java
@@ -56,6 +56,7 @@ public interface BomMapper {
     @Mapping(target = "formulaNombre", source = "formula.producto", qualifiedByName = "mapProductoNombre")
     @Mapping(target = "formulaVersion", source = "formula.version")
     @Mapping(target = "formulaEstado", source = "formula.estado", qualifiedByName = "mapEstadoFormula")
+    @Mapping(target = "insumoId", source = "insumo", qualifiedByName = "mapProductoId")
     @Mapping(target = "insumoNombre", source = "insumo", qualifiedByName = "mapProductoNombre")
     @Mapping(target = "unidadMedidaId", source = "unidadMedida", qualifiedByName = "mapUnidadId")
     @Mapping(target = "unidad", source = "unidadMedida", qualifiedByName = "mapUnidadNombre")


### PR DESCRIPTION
### Motivation
- Expose the underlying insumo identifier in the BOM detalle response so frontend can validate and bind form state using `insumoId` without breaking existing response fields.

### Description
- Add a new `public Long insumoId;` field to `DetalleFormulaResponse` to include the insumo identifier in API responses.
- Map `insumoId` in `BomMapper` by adding `@Mapping(target = "insumoId", source = "insumo", qualifiedByName = "mapProductoId")` to the `toResponseDTO(DetalleFormula)` mapping, reusing the existing `mapProductoId` helper for null-safe conversion.

### Testing
- Ran `mvn -q test` to execute project tests, but the run produced JVM/Guice warnings and was manually interrupted (exit code 130), so no test results were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fe20b47048333b372dc88b15a2033)