### PR TITLE
Enforce EtapaPlantilla uniqueness via DB constraints

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaPlantillaRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaPlantillaRepository.java
@@ -12,13 +12,5 @@ public interface EtapaPlantillaRepository extends JpaRepository<EtapaPlantilla, 
 
     Optional<EtapaPlantilla> findFirstByProductoIdAndSecuencia(Integer productoId, Integer secuencia);
 
-    boolean existsByProductoIdAndSecuencia(Integer productoId, Integer secuencia);
-
-    boolean existsByProductoIdAndNombreIgnoreCase(Integer productoId, String nombre);
-
-    boolean existsByProductoIdAndSecuenciaAndIdNot(Integer productoId, Integer secuencia, Long id);
-
-    boolean existsByProductoIdAndNombreIgnoreCaseAndIdNot(Integer productoId, String nombre, Long id);
-
     Optional<EtapaPlantilla> findFirstByProductoIdAndNombreIgnoreCase(Integer productoId, String nombre);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/EtapaPlantillaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/EtapaPlantillaServiceImpl.java
@@ -3,7 +3,6 @@ package com.willyes.clemenintegra.produccion.service;
 import com.willyes.clemenintegra.produccion.dto.EtapaPlantillaReordenRequest;
 import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
 import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
-import com.willyes.clemenintegra.produccion.service.ChecklistEtapaTemplateService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,24 +20,6 @@ public class EtapaPlantillaServiceImpl implements EtapaPlantillaService {
     private final EtapaPlantillaRepository repository;
     private final ChecklistEtapaTemplateService checklistTemplateService;
 
-    private void validarUnicidad(Integer productoId, String nombre, Integer secuencia, Long id) {
-        if (id == null) {
-            if (repository.existsByProductoIdAndSecuencia(productoId, secuencia)) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Secuencia ya usada");
-            }
-            if (repository.existsByProductoIdAndNombreIgnoreCase(productoId, nombre)) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Nombre ya usado");
-            }
-        } else {
-            if (repository.existsByProductoIdAndSecuenciaAndIdNot(productoId, secuencia, id)) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Secuencia ya usada");
-            }
-            if (repository.existsByProductoIdAndNombreIgnoreCaseAndIdNot(productoId, nombre, id)) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Nombre ya usado");
-            }
-        }
-    }
-
     @Override
     public List<EtapaPlantilla> listarPorProducto(Integer productoId) {
         return repository.findByProductoIdOrderBySecuenciaAsc(productoId);
@@ -51,8 +32,6 @@ public class EtapaPlantillaServiceImpl implements EtapaPlantillaService {
 
     @Override
     public EtapaPlantilla crear(EtapaPlantilla etapa) {
-        Integer productoId = etapa.getProducto().getId();
-        validarUnicidad(productoId, etapa.getNombre(), etapa.getSecuencia(), null);
         EtapaPlantilla guardada = repository.save(etapa);
         checklistTemplateService.crearPlaceholderPorDefectoSiNoExiste(guardada);
         return guardada;
@@ -62,8 +41,6 @@ public class EtapaPlantillaServiceImpl implements EtapaPlantillaService {
     public EtapaPlantilla actualizar(Long id, EtapaPlantilla etapa) {
         EtapaPlantilla existente = repository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Etapa no encontrada"));
-        Integer productoId = existente.getProducto().getId();
-        validarUnicidad(productoId, etapa.getNombre(), etapa.getSecuencia(), id);
         existente.setNombre(etapa.getNombre());
         existente.setSecuencia(etapa.getSecuencia());
         existente.setActivo(etapa.getActivo());

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaExcep
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -156,6 +157,15 @@ public class GlobalExceptionHandler {
                                                                HttpServletRequest request) {
         return buildResponse(ApiErrorCode.ROL_INSUFICIENTE,
                 "Acceso denegado. Contacte a un administrador para solicitar el rol adecuado.",
+                null);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponseDTO> handleDataIntegrityViolation(DataIntegrityViolationException ex,
+                                                                         HttpServletRequest request) {
+        return buildResponse(HttpStatus.CONFLICT,
+                "CONFLICTO_INTEGRIDAD",
+                "Conflicto de integridad en la operación solicitada.",
                 null);
     }
 

--- a/src/main/resources/db/migration/inventario/V20251234__etapa_plantilla_unique_constraints.sql
+++ b/src/main/resources/db/migration/inventario/V20251234__etapa_plantilla_unique_constraints.sql
@@ -1,0 +1,5 @@
+alter table etapa_plantilla
+    add constraint uk_etapa_plantilla_producto_secuencia unique (producto_id, secuencia);
+
+alter table etapa_plantilla
+    add constraint uk_etapa_plantilla_producto_nombre unique (producto_id, nombre);


### PR DESCRIPTION
### Motivation

- Remove application-level uniqueness checks that used `existsBy*` during create/update and rely on the database as source of truth for uniqueness.
- Avoid prolonged locks and race conditions caused by pre-checks inside transactional flows by delegating enforcement to DB constraints.
- Map DB integrity errors to a functional HTTP response so constraint violations result in a clear `409 CONFLICT` and leave transaction management to Spring/JPA (commit/rollback handled by the framework).

### Description

- Removed the `validarUnicidad` checks and their calls from `EtapaPlantillaServiceImpl` so create/update now call `repository.save` directly (removed pre-checks with `existsBy*`).
- Deleted the unused `existsByProductoIdAnd*` repository methods from `EtapaPlantillaRepository`.
- Added a global exception handler for `DataIntegrityViolationException` in `GlobalExceptionHandler` that returns HTTP `409 CONFLICT` with code `CONFLICTO_INTEGRIDAD`.
- Added a Flyway migration `V20251234__etapa_plantilla_unique_constraints.sql` that creates unique constraints on `etapa_plantilla` for `(producto_id, secuencia)` and `(producto_id, nombre)`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971670d21e4833396aa37c23326d861)