### PR TITLE
Extend BOM formula listing with audit fields and enforce single active formula on approval

### DIFF
--- a/docs/bom/formula-activo-unico-ddl.md
+++ b/docs/bom/formula-activo-unico-ddl.md
@@ -1,0 +1,17 @@
+# DDL recomendado: solo una fórmula activa por producto
+
+Para garantizar que exista **solo una fórmula activa por producto**, se puede usar una columna generada
+y un índice único basado en dicha columna. Esto evita múltiples registros `activo = 1` para el mismo
+`producto_id` en la tabla `formula_producto`.
+
+```sql
+ALTER TABLE formula_producto
+    ADD COLUMN activo_unico BIGINT
+        GENERATED ALWAYS AS (CASE WHEN activo = 1 THEN producto_id ELSE NULL END) STORED;
+
+CREATE UNIQUE INDEX uq_formula_producto_activo
+    ON formula_producto (activo_unico);
+```
+
+> Nota: la columna generada permite que múltiples filas con `activo = 0` compartan el valor `NULL`,
+> mientras que solo una fila con `activo = 1` pueda existir por `producto_id`.

--- a/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoSelectorDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoSelectorDTO.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.bom.dto;
 
 import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import java.time.LocalDateTime;
 
 public class FormulaProductoSelectorDTO {
     public Long formulaId;
@@ -9,6 +10,11 @@ public class FormulaProductoSelectorDTO {
     public Long productoId;
     public String productoSku;
     public String productoNombre;
+    public boolean activo;
+    public LocalDateTime fechaActualizacion;
+    public String actualizadoPorNombre;
+    public LocalDateTime fechaCreacion;
+    public String creadoPorNombre;
 
     public FormulaProductoSelectorDTO(Long formulaId,
                                       String version,
@@ -22,6 +28,30 @@ public class FormulaProductoSelectorDTO {
         this.productoId = productoId;
         this.productoSku = productoSku;
         this.productoNombre = productoNombre;
+    }
+
+    public FormulaProductoSelectorDTO(Long formulaId,
+                                      String version,
+                                      EstadoFormula estado,
+                                      Long productoId,
+                                      String productoSku,
+                                      String productoNombre,
+                                      boolean activo,
+                                      LocalDateTime fechaActualizacion,
+                                      String actualizadoPorNombre,
+                                      LocalDateTime fechaCreacion,
+                                      String creadoPorNombre) {
+        this.formulaId = formulaId;
+        this.version = version;
+        this.estado = estado != null ? estado.name() : null;
+        this.productoId = productoId;
+        this.productoSku = productoSku;
+        this.productoNombre = productoNombre;
+        this.activo = activo;
+        this.fechaActualizacion = fechaActualizacion;
+        this.actualizadoPorNombre = actualizadoPorNombre;
+        this.fechaCreacion = fechaCreacion;
+        this.creadoPorNombre = creadoPorNombre;
     }
 
     public FormulaProductoSelectorDTO(Long formulaId,

--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -70,9 +70,12 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
     List<FormulaProducto> findAllForResumen(@Param("estado") EstadoFormula estado, @Param("producto") String producto);
 
     @Query("select new com.willyes.clemenintegra.bom.dto.FormulaProductoSelectorDTO(" +
-            "f.id, f.version, f.estado, p.id, p.codigoSku, p.nombre) " +
+            "f.id, f.version, f.estado, p.id, p.codigoSku, p.nombre, f.activo, " +
+            "f.fechaActualizacion, ap.nombreCompleto, f.fechaCreacion, cp.nombreCompleto) " +
             "from FormulaProducto f " +
             "join f.producto p " +
+            "left join f.actualizadoPor ap " +
+            "left join f.creadoPor cp " +
             "where (:estado is null or f.estado = :estado) " +
             "and (:producto is null or lower(p.codigoSku) like lower(concat('%', :producto, '%')) " +
             "or lower(p.nombre) like lower(concat('%', :producto, '%'))) " +
@@ -82,6 +85,11 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
                                                        Pageable pageable);
 
     @Modifying(clearAutomatically = true)
-    @Query("update FormulaProducto f set f.activo = false where f.producto = :producto and f.id <> :id")
-    void desactivarOtrasFormulasDelProducto(@Param("producto") Producto producto, @Param("id") Long id);
+    @Query("update FormulaProducto f " +
+            "set f.activo = false, f.fechaActualizacion = :fechaActualizacion, f.actualizadoPor = :usuario " +
+            "where f.producto = :producto and f.id <> :id")
+    void desactivarOtrasFormulasDelProducto(@Param("producto") Producto producto,
+                                            @Param("id") Long id,
+                                            @Param("usuario") com.willyes.clemenintegra.shared.model.Usuario usuario,
+                                            @Param("fechaActualizacion") java.time.LocalDateTime fechaActualizacion);
 }

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -115,19 +115,24 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                 .orElseThrow(() -> new CustomBusinessException(ApiErrorCode.RECURSO_NO_ENCONTRADO,
                         "Usuario no encontrado para actualizar la fórmula"));
 
+        LocalDateTime fechaActualizacion = LocalDateTime.now();
+
         if (nuevoEstado == EstadoFormula.APROBADA) {
             if (formula.getProducto() == null) {
                 throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
                         "La fórmula aprobada debe contar con un producto asociado");
             }
-            formulaRepository.desactivarOtrasFormulasDelProducto(formula.getProducto(), formula.getId());
+            formulaRepository.desactivarOtrasFormulasDelProducto(formula.getProducto(),
+                    formula.getId(),
+                    usuario,
+                    fechaActualizacion);
             formula.setActivo(true);
         } else {
             formula.setActivo(false);
         }
 
         formula.setEstado(nuevoEstado);
-        formula.setFechaActualizacion(LocalDateTime.now());
+        formula.setFechaActualizacion(fechaActualizacion);
         formula.setActualizadoPor(usuario);
 
         return formulaRepository.save(formula);

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoListadoIntegrationTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -117,13 +118,17 @@ class FormulaProductoListadoIntegrationTest extends IntegrationTestMySqlContaine
                 .activo(true)
                 .build());
 
+        LocalDateTime actualizacion = LocalDateTime.now().minusHours(2);
+
         FormulaProducto formulaUno = FormulaProducto.builder()
                 .producto(productoUno)
                 .version("V1")
                 .estado(EstadoFormula.BORRADOR)
                 .fechaCreacion(LocalDateTime.now().minusDays(1))
+                .fechaActualizacion(actualizacion)
                 .activo(true)
                 .creadoPor(usuario)
+                .actualizadoPor(usuario)
                 .build();
 
         FormulaProducto formulaDos = FormulaProducto.builder()
@@ -143,6 +148,11 @@ class FormulaProductoListadoIntegrationTest extends IntegrationTestMySqlContaine
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[*].productoId", hasItems(productoUno.getId(), productoDos.getId())))
                 .andExpect(jsonPath("$.content[*].productoSku", hasItems("SKU-SEL-1", "SKU-SEL-2")))
-                .andExpect(jsonPath("$.content[*].productoNombre", hasItems("Producto Selector Uno", "Producto Selector Dos")));
+                .andExpect(jsonPath("$.content[*].productoNombre", hasItems("Producto Selector Uno", "Producto Selector Dos")))
+                .andExpect(jsonPath("$.content[*].activo", hasItems(true)))
+                .andExpect(jsonPath("$.content[*].fechaActualizacion", hasItems(notNullValue())))
+                .andExpect(jsonPath("$.content[*].actualizadoPorNombre", hasItems("Usuario BOM Listado")))
+                .andExpect(jsonPath("$.content[*].fechaCreacion", hasItems(notNullValue())))
+                .andExpect(jsonPath("$.content[*].creadoPorNombre", hasItems("Usuario BOM Listado")));
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoAprobacionIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoAprobacionIntegrationTest.java
@@ -1,0 +1,121 @@
+package com.willyes.clemenintegra.bom.service;
+
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class FormulaProductoAprobacionIntegrationTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private FormulaProductoService formulaProductoService;
+
+    @Autowired
+    private FormulaProductoRepository formulaProductoRepository;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Test
+    void aprobarFormulaActivaUnicaPorProducto() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("bom-aprobador")
+                .clave("secret")
+                .nombreCompleto("Usuario Aprobador")
+                .correo("bom-aprobador@example.com")
+                .rol(RolUsuario.ROL_JEFE_CALIDAD)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad BOM Aprobacion")
+                .simbolo("UBA")
+                .codigo("UBA")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria BOM Aprobacion")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-AP-1")
+                .nombre("Producto Aprobacion")
+                .descripcionProducto("Producto para aprobación")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        FormulaProducto formulaAnterior = formulaProductoRepository.save(FormulaProducto.builder()
+                .producto(producto)
+                .version("V1")
+                .estado(EstadoFormula.APROBADA)
+                .fechaCreacion(LocalDateTime.now().minusDays(2))
+                .fechaActualizacion(LocalDateTime.now().minusDays(1))
+                .activo(true)
+                .creadoPor(usuario)
+                .actualizadoPor(usuario)
+                .build());
+
+        FormulaProducto formulaNueva = formulaProductoRepository.save(FormulaProducto.builder()
+                .producto(producto)
+                .version("V2")
+                .estado(EstadoFormula.EN_REVISION)
+                .fechaCreacion(LocalDateTime.now().minusDays(1))
+                .activo(false)
+                .creadoPor(usuario)
+                .build());
+
+        formulaProductoService.cambiarEstado(formulaNueva.getId(), EstadoFormula.APROBADA, usuario.getId());
+
+        FormulaProducto formulaAnteriorActualizada = formulaProductoRepository.findById(formulaAnterior.getId()).orElseThrow();
+        FormulaProducto formulaNuevaActualizada = formulaProductoRepository.findById(formulaNueva.getId()).orElseThrow();
+
+        assertThat(formulaNuevaActualizada.isActivo()).isTrue();
+        assertThat(formulaNuevaActualizada.getEstado()).isEqualTo(EstadoFormula.APROBADA);
+        assertThat(formulaNuevaActualizada.getFechaActualizacion()).isNotNull();
+        assertThat(formulaNuevaActualizada.getActualizadoPor()).isNotNull();
+
+        assertThat(formulaAnteriorActualizada.isActivo()).isFalse();
+        assertThat(formulaAnteriorActualizada.getFechaActualizacion()).isNotNull();
+        assertThat(formulaAnteriorActualizada.getActualizadoPor()).isNotNull();
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -94,7 +94,7 @@ class FormulaProductoServiceImplTest {
         assertThat(resultado.isActivo()).isFalse();
         assertThat(resultado.getActualizadoPor()).isEqualTo(usuario);
         assertThat(resultado.getFechaActualizacion()).isNotNull();
-        verify(formulaRepository, never()).desactivarOtrasFormulasDelProducto(any(), any());
+        verify(formulaRepository, never()).desactivarOtrasFormulasDelProducto(any(), any(), any(), any());
         verify(formulaRepository).save(formula);
     }
 
@@ -121,7 +121,7 @@ class FormulaProductoServiceImplTest {
 
         assertThat(resultado.getEstado()).isEqualTo(EstadoFormula.APROBADA);
         assertThat(resultado.isActivo()).isTrue();
-        verify(formulaRepository).desactivarOtrasFormulasDelProducto(producto, 3L);
+        verify(formulaRepository).desactivarOtrasFormulasDelProducto(eq(producto), eq(3L), eq(usuario), any());
         verify(formulaRepository).save(formula);
     }
 
@@ -145,7 +145,7 @@ class FormulaProductoServiceImplTest {
 
         assertThat(resultado.getEstado()).isEqualTo(EstadoFormula.RECHAZADA);
         assertThat(resultado.isActivo()).isFalse();
-        verify(formulaRepository, never()).desactivarOtrasFormulasDelProducto(any(), any());
+        verify(formulaRepository, never()).desactivarOtrasFormulasDelProducto(any(), any(), any(), any());
     }
 
     @Test
@@ -183,7 +183,12 @@ class FormulaProductoServiceImplTest {
                 EstadoFormula.BORRADOR,
                 1L,
                 "PR-001",
-                "Producto Test");
+                "Producto Test",
+                true,
+                LocalDateTime.of(2024, 1, 10, 8, 30),
+                "Usuario Responsable",
+                LocalDateTime.of(2024, 1, 9, 8, 30),
+                "Usuario Creador");
 
         when(formulaRepository.findAllForSelector(isNull(), isNull(), any(PageRequest.class)))
                 .thenReturn(new PageImpl<>(List.of(selector)));
@@ -198,6 +203,11 @@ class FormulaProductoServiceImplTest {
         assertThat(dto.productoNombre).isEqualTo("Producto Test");
         assertThat(dto.version).isEqualTo("v1");
         assertThat(dto.estado).isEqualTo("BORRADOR");
+        assertThat(dto.activo).isTrue();
+        assertThat(dto.fechaActualizacion).isNotNull();
+        assertThat(dto.actualizadoPorNombre).isEqualTo("Usuario Responsable");
+        assertThat(dto.fechaCreacion).isNotNull();
+        assertThat(dto.creadoPorNombre).isEqualTo("Usuario Creador");
     }
 
     @Test
@@ -209,7 +219,12 @@ class FormulaProductoServiceImplTest {
                 EstadoFormula.BORRADOR,
                 2L,
                 "PR-002",
-                "Producto Borrador");
+                "Producto Borrador",
+                false,
+                null,
+                null,
+                LocalDateTime.of(2024, 1, 12, 10, 0),
+                "Usuario Creador");
 
         when(formulaRepository.findAllForSelector(eq(EstadoFormula.BORRADOR), isNull(), any(PageRequest.class)))
                 .thenReturn(new PageImpl<>(List.of(selector)));
@@ -232,7 +247,12 @@ class FormulaProductoServiceImplTest {
                 EstadoFormula.APROBADA,
                 3L,
                 "PT-0311",
-                "CVC-COMPRIMIDO VITAMINA C 500 MG");
+                "CVC-COMPRIMIDO VITAMINA C 500 MG",
+                true,
+                LocalDateTime.of(2024, 1, 15, 10, 0),
+                "Usuario Responsable",
+                LocalDateTime.of(2024, 1, 14, 10, 0),
+                "Usuario Creador");
 
         when(formulaRepository.findAllForSelector(any(), any(), any(PageRequest.class)))
                 .thenReturn(new PageImpl<>(List.of(selector)));


### PR DESCRIPTION
### Motivation
- The BOM formula list DTO lacked `activo` and audit fields (`fechaActualizacion`/`actualizadoPorNombre`) required by the UI and there was no strong guarantee that only one approved formula is active per product.
- Approving a formula must deactivate other formulas of the same product and record audit timestamps and user in the same transaction.

### Description
- Added audit and active fields to the selector projection by extending `FormulaProductoSelectorDTO` with `activo`, `fechaActualizacion`, `actualizadoPorNombre`, `fechaCreacion` and `creadoPorNombre` and a matching constructor (`src/main/java/com/willyes/clemenintegra/bom/dto/FormulaProductoSelectorDTO.java`).
- Updated the repository selector query to populate the new projection fields and included left joins to `actualizadoPor` and `creadoPor` (`src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java`).
- Changed `desactivarOtrasFormulasDelProducto` to run an update that sets `activo = false` and also stamps `fechaActualizacion` and `actualizadoPor` so deactivations carry audit info (`FormulaProductoRepository.java`).
- Ensured the approval flow uses a single `LocalDateTime` and passes the `usuario` and `fechaActualizacion` into the repository update so all changes (deactivate others + activate approved + audit fields) occur in one transaction (`src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java`).
- Added integration tests to verify the approval behavior and that the listing returns audit/active fields, plus updated unit tests to reflect the new repository signature and additional DTO fields (`src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoAprobacionIntegrationTest.java`, `src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoListadoIntegrationTest.java`, `src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java`).
- Documented a recommended DDL to enforce "only one active formula per product" using a generated column + unique index (`docs/bom/formula-activo-unico-ddl.md`).
- Behaviorally affected endpoints: `GET /api/bom/formulas` now returns the new fields in the paginated selector, and `POST /api/bom/formulas/{id}/cambiar-estado` (approval) will deactivate other formulas of the same product and stamp audit info atomically.

### Testing
- Ran `mvn -q -Dtest=FormulaProductoServiceImplTest,FormulaProductoListadoIntegrationTest,FormulaProductoAprobacionIntegrationTest test` to exercise the unit and integration scenarios.
- The unit tests (`FormulaProductoServiceImplTest`) executed and passed in this environment; repository and service-level logic assertions were validated.
- Integration tests that use Testcontainers (`FormulaProductoListadoIntegrationTest`, `FormulaProductoAprobacionIntegrationTest`) could not start because Testcontainers could not find a Docker environment on the runner, so those tests did not complete here (see Testcontainers Docker environment warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697226273f548333a646e527a8475d13)