### PR TITLE
Add numeric versioning for BOM formulas (V{major}.{minor} with minor rollover)

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/model/FormulaProducto.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/model/FormulaProducto.java
@@ -22,6 +22,12 @@ public class FormulaProducto {
 
     private String version;
 
+    @Column(name = "version_major")
+    private Integer versionMajor;
+
+    @Column(name = "version_minor")
+    private Integer versionMinor;
+
     @Enumerated(EnumType.STRING)
     private EstadoFormula estado;
 
@@ -52,8 +58,17 @@ public class FormulaProducto {
     public void setId(Long id) {this.id = id;}
     public Producto getProducto() {return producto;}
     public void setProducto(Producto producto) {this.producto = producto;}
-    public String getVersion() {return version;}
+    public String getVersion() {
+        if (versionMajor != null && versionMinor != null) {
+            return String.format("V%d.%d", versionMajor, versionMinor);
+        }
+        return version;
+    }
     public void setVersion(String version) {this.version = version;}
+    public Integer getVersionMajor() {return versionMajor;}
+    public void setVersionMajor(Integer versionMajor) {this.versionMajor = versionMajor;}
+    public Integer getVersionMinor() {return versionMinor;}
+    public void setVersionMinor(Integer versionMinor) {this.versionMinor = versionMinor;}
     public EstadoFormula getEstado() {return estado;}
     public void setEstado(EstadoFormula estado) {this.estado = estado;}
     public LocalDateTime getFechaCreacion() {return fechaCreacion;}
@@ -73,4 +88,3 @@ public class FormulaProducto {
     public Usuario getActualizadoPor() {return actualizadoPor;}
     public void setActualizadoPor(Usuario actualizadoPor) {this.actualizadoPor = actualizadoPor;}
 }
-

--- a/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/repository/FormulaProductoRepository.java
@@ -56,8 +56,9 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
     @Query("select f from FormulaProducto f where f.id = :id")
     Optional<FormulaProducto> findByIdWithDocumentos(@Param("id") Long id);
 
-
     List<FormulaProducto> findAllByProductoId(Long productoId);
+
+    Optional<FormulaProducto> findTopByProductoIdOrderByVersionMajorDescVersionMinorDesc(Long productoId);
 
     @Query("select f from FormulaProducto f " +
             "join fetch f.producto p " +
@@ -70,7 +71,11 @@ public interface FormulaProductoRepository extends JpaRepository<FormulaProducto
     List<FormulaProducto> findAllForResumen(@Param("estado") EstadoFormula estado, @Param("producto") String producto);
 
     @Query("select new com.willyes.clemenintegra.bom.dto.FormulaProductoSelectorDTO(" +
-            "f.id, f.version, f.estado, p.id, p.codigoSku, p.nombre, f.activo, " +
+            "f.id, " +
+            "case when f.versionMajor is not null and f.versionMinor is not null " +
+            "then concat(concat('V', f.versionMajor), concat('.', f.versionMinor)) " +
+            "else f.version end, " +
+            "f.estado, p.id, p.codigoSku, p.nombre, f.activo, " +
             "f.fechaActualizacion, ap.nombreCompleto, f.fechaCreacion, cp.nombreCompleto) " +
             "from FormulaProducto f " +
             "join f.producto p " +

--- a/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImpl.java
@@ -27,7 +27,6 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -36,6 +35,8 @@ import java.util.stream.Collectors;
 public class FormulaProductoServiceImpl implements FormulaProductoService {
 
     private static final Logger log = LoggerFactory.getLogger(FormulaProductoServiceImpl.class);
+    private static final int MAX_VERSION_MINOR = 9;
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^V?(\\d+)(?:\\.(\\d+))?$", Pattern.CASE_INSENSITIVE);
 
     private final FormulaProductoRepository formulaRepository;
     private final BomMapper bomMapper;
@@ -82,6 +83,7 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
         if (formula.getEstado() == EstadoFormula.APROBADA) {
             formula.setActivo(true);
         }
+        normalizarVersion(formula);
         return formulaRepository.save(formula);
     }
 
@@ -155,20 +157,18 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
                         "Usuario no encontrado para clonar la fórmula"));
 
         Long productoId = origen.getProducto().getId().longValue();
-        List<FormulaProducto> formulasProducto = formulaRepository.findAllByProductoId(productoId);
-
-        int nuevaVersionNumerica = formulasProducto.stream()
-                .map(FormulaProducto::getVersion)
-                .map(this::parseNumeroVersion)
-                .max(Integer::compareTo)
-                .orElse(0) + 1;
-
-        String nuevaVersion = construirValorVersion(origen.getVersion(), nuevaVersionNumerica);
+        VersionParts ultimaVersion = formulaRepository.findTopByProductoIdOrderByVersionMajorDescVersionMinorDesc(productoId)
+                .map(this::resolverVersionParts)
+                .orElse(null);
+        VersionParts siguienteVersion = calcularSiguienteVersion(ultimaVersion);
+        String nuevaVersion = formatearVersion(siguienteVersion);
         LocalDateTime ahora = LocalDateTime.now();
 
         FormulaProducto clon = new FormulaProducto();
         clon.setProducto(origen.getProducto());
         clon.setVersion(nuevaVersion);
+        clon.setVersionMajor(siguienteVersion.major());
+        clon.setVersionMinor(siguienteVersion.minor());
         clon.setEstado(EstadoFormula.BORRADOR);
         clon.setActivo(false);
         clon.setObservacion(origen.getObservacion());
@@ -209,35 +209,76 @@ public class FormulaProductoServiceImpl implements FormulaProductoService {
         return formulaRepository.save(clon);
     }
 
-    private int parseNumeroVersion(String version) {
+    static VersionParts calcularSiguienteVersion(VersionParts versionActual) {
+        if (versionActual == null) {
+            return new VersionParts(1, 0);
+        }
+        if (versionActual.minor() < MAX_VERSION_MINOR) {
+            return new VersionParts(versionActual.major(), versionActual.minor() + 1);
+        }
+        return new VersionParts(versionActual.major() + 1, 0);
+    }
+
+    static String formatearVersion(VersionParts version) {
+        if (version == null) {
+            return null;
+        }
+        return String.format("V%d.%d", version.major(), version.minor());
+    }
+
+    static VersionParts parsearVersion(String version) {
         if (version == null || version.isBlank()) {
-            return 0;
+            return null;
         }
-        String digitos = version.replaceAll("[^0-9]", "");
-        if (digitos.isEmpty()) {
-            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
-                    "La versión registrada no contiene componentes numéricos");
-        }
-        try {
-            return Integer.parseInt(digitos);
-        } catch (NumberFormatException ex) {
+        var matcher = VERSION_PATTERN.matcher(version.trim());
+        if (!matcher.matches()) {
             throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
                     "Formato de versión inválido para la fórmula");
         }
+        int major = Integer.parseInt(matcher.group(1));
+        int minor = matcher.group(2) != null ? Integer.parseInt(matcher.group(2)) : 0;
+        return new VersionParts(major, minor);
     }
 
-    private String construirValorVersion(String versionBase, int numeroVersion) {
-        if (versionBase == null || versionBase.isBlank()) {
-            return String.valueOf(numeroVersion);
+    private VersionParts resolverVersionParts(FormulaProducto formula) {
+        if (formula == null) {
+            return null;
         }
-        Pattern patron = Pattern.compile("^(\\D*)(\\d+)(.*)$");
-        Matcher matcher = patron.matcher(versionBase);
-        if (matcher.matches()) {
-            String prefijo = matcher.group(1);
-            String sufijo = matcher.group(3);
-            return prefijo + numeroVersion + (sufijo != null ? sufijo : "");
+        if (formula.getVersionMajor() != null && formula.getVersionMinor() != null) {
+            return new VersionParts(formula.getVersionMajor(), formula.getVersionMinor());
         }
-        return String.valueOf(numeroVersion);
+        return parsearVersion(formula.getVersion());
+    }
+
+    private void normalizarVersion(FormulaProducto formula) {
+        if (formula == null) {
+            return;
+        }
+        VersionParts parts = resolverVersionParts(formula);
+        if (parts == null) {
+            return;
+        }
+        formula.setVersionMajor(parts.major());
+        formula.setVersionMinor(parts.minor());
+        formula.setVersion(formatearVersion(parts));
+    }
+
+    static class VersionParts {
+        private final int major;
+        private final int minor;
+
+        VersionParts(int major, int minor) {
+            this.major = major;
+            this.minor = minor;
+        }
+
+        int major() {
+            return major;
+        }
+
+        int minor() {
+            return minor;
+        }
     }
 
     private FormulaProductoDetalleDTO mapDetalleFormula(FormulaProducto formula, List<DocumentoFormula> documentos) {

--- a/src/main/resources/db/migration/inventario/V20251242__bom_formula_version_numerica.sql
+++ b/src/main/resources/db/migration/inventario/V20251242__bom_formula_version_numerica.sql
@@ -1,0 +1,17 @@
+alter table formula_producto add column version_major int null;
+alter table formula_producto add column version_minor int null;
+
+update formula_producto
+set version_major = case
+    when version is null or trim(version) = '' then null
+    else cast(substring_index(replace(upper(version), 'V', ''), '.', 1) as unsigned)
+end,
+version_minor = case
+    when version is null or trim(version) = '' then null
+    when locate('.', replace(upper(version), 'V', '')) > 0
+        then cast(substring_index(replace(upper(version), 'V', ''), '.', -1) as unsigned)
+    else 0
+end
+where version is not null and (version_major is null or version_minor is null);
+
+create index idx_formula_producto_version on formula_producto (producto_id, version_major, version_minor);

--- a/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java
@@ -506,17 +506,14 @@ class FormulaProductoServiceImplTest {
         FormulaProducto origen = new FormulaProducto();
         origen.setId(7L);
         origen.setProducto(producto);
-        origen.setVersion("v3");
+        origen.setVersionMajor(1);
+        origen.setVersionMinor(9);
+        origen.setVersion("V1.9");
         origen.setObservacion("Observación previa");
         origen.setDetalles(List.of(detalleOriginal));
         origen.setDocumentos(List.of(documentoOriginal));
         detalleOriginal.setFormula(origen);
         documentoOriginal.setFormula(origen);
-
-        FormulaProducto versionAnterior = new FormulaProducto();
-        versionAnterior.setId(4L);
-        versionAnterior.setProducto(producto);
-        versionAnterior.setVersion("v2");
 
         Usuario usuario = new Usuario();
         usuario.setId(3L);
@@ -524,7 +521,8 @@ class FormulaProductoServiceImplTest {
 
         when(formulaRepository.findById(7L)).thenReturn(Optional.of(origen));
         when(usuarioRepository.findById(3L)).thenReturn(Optional.of(usuario));
-        when(formulaRepository.findAllByProductoId(5L)).thenReturn(List.of(versionAnterior, origen));
+        when(formulaRepository.findTopByProductoIdOrderByVersionMajorDescVersionMinorDesc(5L))
+                .thenReturn(Optional.of(origen));
         when(formulaRepository.save(any(FormulaProducto.class))).thenAnswer(invocation -> {
             FormulaProducto guardado = invocation.getArgument(0);
             guardado.setId(11L);
@@ -535,7 +533,9 @@ class FormulaProductoServiceImplTest {
 
         assertThat(clon.getId()).isEqualTo(11L);
         assertThat(clon.getProducto()).isEqualTo(producto);
-        assertThat(clon.getVersion()).isEqualTo("v4");
+        assertThat(clon.getVersion()).isEqualTo("V2.0");
+        assertThat(clon.getVersionMajor()).isEqualTo(2);
+        assertThat(clon.getVersionMinor()).isEqualTo(0);
         assertThat(clon.getEstado()).isEqualTo(EstadoFormula.BORRADOR);
         assertThat(clon.isActivo()).isFalse();
         assertThat(clon.getCreadoPor()).isEqualTo(usuario);
@@ -560,6 +560,25 @@ class FormulaProductoServiceImplTest {
         assertThat(documentoClonado.getTipoDocumento()).isEqualTo(TipoDocumento.PROCEDIMIENTO);
         assertThat(documentoClonado.getNombreArchivo()).isEqualTo("doc.pdf");
         assertThat(documentoClonado.getRutaArchivo()).isEqualTo("/files/doc.pdf");
+    }
+
+    @Test
+    @DisplayName("versionado calcula y formatea la siguiente versión con rollover")
+    void versionadoCalculaSiguienteVersion() {
+        FormulaProductoServiceImpl.VersionParts actual = FormulaProductoServiceImpl.parsearVersion("V3.9");
+        FormulaProductoServiceImpl.VersionParts siguiente = FormulaProductoServiceImpl.calcularSiguienteVersion(actual);
+
+        assertThat(FormulaProductoServiceImpl.formatearVersion(siguiente)).isEqualTo("V4.0");
+        assertThat(siguiente.major()).isEqualTo(4);
+        assertThat(siguiente.minor()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("versionado formatea versión cuando solo existe el string")
+    void versionadoFormateaVersion() {
+        FormulaProductoServiceImpl.VersionParts version = FormulaProductoServiceImpl.parsearVersion("V11.2");
+
+        assertThat(FormulaProductoServiceImpl.formatearVersion(version)).isEqualTo("V11.2");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Introduce numeric major/minor versioning for BOM formulas so versions follow `V{major}.{minor}` semantics with a minor rollover 0..9.
- Preserve existing API compatibility by keeping the `version` string in responses formatted as `V{major}.{minor}`.

### Description
- Add `versionMajor` and `versionMinor` fields to `FormulaProducto` and make `getVersion()` return `V{major}.{minor}` when both numeric parts exist, while retaining the original `version` string field.
- Add a Flyway migration `V20251242__bom_formula_version_numerica.sql` that adds `version_major`/`version_minor`, backfills them from existing `version` values, and creates an index on `(producto_id, version_major, version_minor)`.
- Implement parsing, normalization and next-version logic in `FormulaProductoServiceImpl` including `parsearVersion`, `calcularSiguienteVersion` (rollover when minor == 9), `formatearVersion`, and `normalizarVersion`, and use numeric ordering via `findTopByProductoIdOrderByVersionMajorDescVersionMinorDesc` when creating clones in `clonarFormula`.
- Update repository selector to emit formatted version (`case when f.versionMajor is not null ... then 'V{major}.{minor}' else f.version end`) so lists continue returning a consistent `version` string, and add `findTopByProductoIdOrderByVersionMajorDescVersionMinorDesc` to look up the latest numeric version.
- Add unit tests in `FormulaProductoServiceImplTest` to validate clone behavior with numeric versions and versioning helpers (`parsearVersion`, `calcularSiguienteVersion`, `formatearVersion`).

### Testing
- Added unit tests in `src/test/java/com/willyes/clemenintegra/bom/service/FormulaProductoServiceImplTest.java` covering clone/version rollover and formatting, but no automated tests were executed in this rollout.
- Manual compilation/build was not performed as part of this change set and CI was not run during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972338737b483338a2496aba8bef6f9)