### PR TITLE
Initialize plan detalles on confirm to avoid LazyInitializationException

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImpl.java
@@ -88,7 +88,7 @@ public class PlanProduccionServiceImpl implements PlanProduccionService {
 
     @Override
     public PlanProduccionSemanal confirmar(Long id) {
-        PlanProduccionSemanal plan = planProduccionSemanalRepository.findById(id)
+        PlanProduccionSemanal plan = planProduccionSemanalRepository.findWithDetallesById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Plan semanal no encontrado"));
         if (plan.getEstado() != EstadoPlanProduccion.BORRADOR) {
             throw new IllegalStateException("Solo los planes en BORRADOR pueden confirmarse");

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionControllerIntegrationTest.java
@@ -190,4 +190,40 @@ class PlanProduccionControllerIntegrationTest extends IntegrationTestMySqlContai
                 .andExpect(jsonPath("$.detalles[0].producto.id").value(producto.getId().longValue()))
                 .andExpect(jsonPath("$.detalles[0].unidadMedida.id").value(producto.getUnidadMedida().getId()));
     }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    void confirmarPlanSemanalDevuelveDetallesYConfirma() throws Exception {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .semanaInicio(LocalDate.now())
+                .semanaFin(LocalDate.now().plusDays(6))
+                .estado(EstadoPlanProduccion.BORRADOR)
+                .creadoPor(usuario)
+                .build();
+
+        PlanProduccionDetalle detalle = PlanProduccionDetalle.builder()
+                .plan(plan)
+                .producto(producto)
+                .unidadMedida(producto.getUnidadMedida())
+                .cantidadPlanificada(new BigDecimal("5.00"))
+                .prioridad(1)
+                .origenDemanda("Test")
+                .observacion("Obs")
+                .creadoPor(usuario)
+                .fechaCreacion(LocalDateTime.now())
+                .build();
+        plan.getDetalles().add(detalle);
+
+        plan = planProduccionSemanalRepository.save(plan);
+
+        mockMvc.perform(post("/api/planeacion/planes-semanales/{id}/confirmar", plan.getId())
+                        .with(SecurityMockMvcRequestPostProcessors.user(new CustomUserDetails(usuario))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.estado").value(EstadoPlanProduccion.CONFIRMADO.name()))
+                .andExpect(jsonPath("$.detalles[0].producto.id").value(producto.getId().longValue()))
+                .andExpect(jsonPath("$.detalles[0].unidadMedida.id").value(producto.getUnidadMedida().getId()));
+
+        PlanProduccionSemanal confirmado = planProduccionSemanalRepository.findById(plan.getId()).orElseThrow();
+        assertThat(confirmado.getEstado()).isEqualTo(EstadoPlanProduccion.CONFIRMADO);
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure the controller can build the DTO after confirming a weekly plan without triggering a `LazyInitializationException` by returning an entity with initialized `detalles`.

### Description
- Replace `findById` with `planProduccionSemanalRepository.findWithDetallesById(id)` in `PlanProduccionServiceImpl.confirmar` so details are fetched before changing state and add an integration test `confirmarPlanSemanalDevuelveDetallesYConfirma` that asserts the POST `/api/planeacion/planes-semanales/{id}/confirmar` response includes `detalles` and that the plan state becomes `CONFIRMADO`.

### Testing
- Added integration test `PlanProduccionControllerIntegrationTest#confirmarPlanSemanalDevuelveDetallesYConfirma`, but no automated tests were executed in this PR; run it with `mvn test -Dtest=PlanProduccionControllerIntegrationTest` to validate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727b1a1d5883338233359b86921008)