### PR TITLE
Fix tests: align plan repo stub, add H2 column, and make fixtures unique

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/calidad/controller/VidaUtilProductoControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/calidad/controller/VidaUtilProductoControllerIntegrationTest.java
@@ -59,15 +59,16 @@ class VidaUtilProductoControllerIntegrationTest extends IntegrationTestH2 {
 
     private CategoriaProducto categoriaPt;
     private CategoriaProducto categoriaPs;
+    private String skuPt;
+    private String skuPs;
+    private String nombreBase;
 
     @BeforeEach
     void setUp() {
-        productoRepository.deleteAll();
-        categoriaProductoRepository.deleteAll();
-        unidadMedidaRepository.deleteAll();
-        usuarioRepository.deleteAll();
-
         String suffix = UUID.randomUUID().toString().substring(0, 8);
+        skuPt = "PT" + suffix;
+        skuPs = "PS" + suffix;
+        nombreBase = "Citrato " + suffix;
         Usuario usuario = usuarioRepository.save(Usuario.builder()
                 .nombreUsuario("tester-vida-util-" + suffix)
                 .clave("secret")
@@ -80,8 +81,8 @@ class VidaUtilProductoControllerIntegrationTest extends IntegrationTestH2 {
 
         UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
                 .nombre("Unidad Vida Util " + suffix)
-                .simbolo("UV")
-                .codigo("UV1")
+                .simbolo(("UV" + suffix).substring(0, 5))
+                .codigo(("U" + suffix).substring(0, 4))
                 .build());
 
         categoriaPt = categoriaProductoRepository.save(CategoriaProducto.builder()
@@ -99,33 +100,33 @@ class VidaUtilProductoControllerIntegrationTest extends IntegrationTestH2 {
                 .tipo(TipoCategoria.MATERIA_PRIMA)
                 .build());
 
-        productoRepository.save(crearProducto("PT0001", "Producto Citrato", usuario, unidad, categoriaPt));
-        productoRepository.save(crearProducto("PS0002", "Citrato Semielaborado", usuario, unidad, categoriaPs));
-        productoRepository.save(crearProducto("MP0001", "Citrato Materia Prima", usuario, unidad, categoriaMp));
-        productoRepository.save(crearProducto("PT0003", "Otro Producto", usuario, unidad, categoriaPt));
+        productoRepository.save(crearProducto(skuPt, nombreBase + " Producto", usuario, unidad, categoriaPt));
+        productoRepository.save(crearProducto(skuPs, nombreBase + " Semielaborado", usuario, unidad, categoriaPs));
+        productoRepository.save(crearProducto("MP" + suffix, "Materia Prima " + suffix, usuario, unidad, categoriaMp));
+        productoRepository.save(crearProducto("PTX" + suffix, "Otro Producto " + suffix, usuario, unidad, categoriaPt));
     }
 
     @Test
     void buscarPorSkuAplicaFiltroCaseInsensitive() throws Exception {
         mockMvc.perform(get("/api/calidad/vida-util/productos-terminados")
-                        .param("search", "PT0001")
+                        .param("search", skuPt.toLowerCase())
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalElements").value(1))
-                .andExpect(jsonPath("$.content[0].codigoSku").value("PT0001"));
+                .andExpect(jsonPath("$.content[0].codigoSku").value(skuPt));
     }
 
     @Test
     void buscarPorNombreAplicaFiltroContiene() throws Exception {
         mockMvc.perform(get("/api/calidad/vida-util/productos-terminados")
-                        .param("search", "citrat")
+                        .param("search", nombreBase.toLowerCase())
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalElements").value(2))
                 .andExpect(jsonPath("$.content[*].codigoSku",
-                        Matchers.containsInAnyOrder("PT0001", "PS0002")));
+                        Matchers.containsInAnyOrder(skuPt, skuPs)));
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
@@ -98,7 +98,7 @@ class PlanProduccionServiceImplTest {
                 .estado(EstadoPlanProduccion.BORRADOR)
                 .build();
 
-        when(planProduccionSemanalRepository.findById(20L)).thenReturn(Optional.of(existente));
+        when(planProduccionSemanalRepository.findWithDetallesById(20L)).thenReturn(Optional.of(existente));
         when(planProduccionSemanalRepository.save(any(PlanProduccionSemanal.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -131,7 +131,7 @@ class PlanProduccionServiceImplTest {
                 .estado(EstadoPlanProduccion.CONFIRMADO)
                 .build();
 
-        when(planProduccionSemanalRepository.findById(40L)).thenReturn(Optional.of(existente));
+        when(planProduccionSemanalRepository.findWithDetallesById(40L)).thenReturn(Optional.of(existente));
 
         assertThrows(IllegalStateException.class, () -> service.confirmar(40L));
     }

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionListadoIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionListadoIntegrationTest.java
@@ -78,19 +78,20 @@ class OrdenProduccionListadoIntegrationTest extends IntegrationTestH2 {
                 .build());
 
         UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
-                .nombre("Unidad OP")
-                .simbolo("UOP")
-                .codigo("UOP")
+                .nombre("Unidad OP " + uniqueSuffix)
+                .simbolo(("UO" + uniqueSuffix).substring(0, 5))
+                .codigo(("U" + uniqueSuffix).substring(0, 4))
                 .build());
 
         CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
-                .nombre("Categoria OP")
+                .nombre("Categoria OP " + uniqueSuffix)
                 .tipo(TipoCategoria.PRODUCTO_TERMINADO)
                 .build());
 
+        String nombreProducto = "Producto OP " + uniqueSuffix;
         Producto producto = productoRepository.save(Producto.builder()
-                .codigoSku("SKU-OP")
-                .nombre("Producto OP")
+                .codigoSku("SKU-" + uniqueSuffix)
+                .nombre(nombreProducto)
                 .descripcionProducto("Producto para orden")
                 .stockMinimo(BigDecimal.ZERO)
                 .unidadMedida(unidad)
@@ -119,7 +120,7 @@ class OrdenProduccionListadoIntegrationTest extends IntegrationTestH2 {
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].nombreProducto").value("Producto OP"))
+                .andExpect(jsonPath("$.content[0].nombreProducto").value(nombreProducto))
                 .andExpect(jsonPath("$.content[0].nombreResponsable").value("Responsable OP"));
     }
 }

--- a/src/test/resources/sql/vida-util-schema.sql
+++ b/src/test/resources/sql/vida-util-schema.sql
@@ -17,7 +17,8 @@ CREATE TABLE usuarios (
     codigo_2fa VARCHAR(6),
     codigo_2fa_expira_en TIMESTAMP,
     session_version BIGINT NOT NULL DEFAULT 0,
-    ultima_actividad TIMESTAMP
+    ultima_actividad TIMESTAMP,
+    nivel_acceso_admin VARCHAR(50)
 );
 
 CREATE TABLE categorias_producto (


### PR DESCRIPTION
### Motivation
- Restore failing tests with the smallest changes by aligning test stubs with current repository methods and fixing H2 test schema mismatches that caused SQL errors and cross-test collisions.
- Avoid touching production code or disabling tests; make only test-side and test-schema adjustments to keep contracts intact.

### Description
- Adjusted `PlanProduccionServiceImplTest` to stub the repository method used by the service (`findWithDetallesById` instead of `findById`) so confirmation flows return the expected entities and exceptions.
- Added `nivel_acceso_admin VARCHAR(50)` to the H2 test schema used by vida util tests (`src/test/resources/sql/vida-util-schema.sql`) so `INSERT` statements from Hibernate succeed in H2.
- Made integration test fixtures deterministic/unique by generating per-test suffixes and using unique SKUs/names/unidad codes in `VidaUtilProductoControllerIntegrationTest` and `OrdenProduccionListadoIntegrationTest` to avoid unique-constraint collisions across runs and to align assertions with generated values.
- Changes are limited to test files and test SQL schema and do not modify production logic.

### Testing
- Ran `mvn -Dtest=PlanProduccionServiceImplTest test` which completed successfully (tests run: 13, failures: 0).
- Ran `mvn -Dtest=VidaUtilProductoRepositoryTest test` which completed successfully (tests run: 1, failures: 0).
- Ran the full suite with `mvn test` which completed successfully (build reported `BUILD SUCCESS`).
- Created the package with `mvn clean package` which completed successfully (`BUILD SUCCESS`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697282b247188333b2b302c4e7daa248)