### PR TITLE
Soft-delete checklist templates and enforce non-null `activo`

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateAdminServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaTemplateAdminServiceImpl.java
@@ -7,11 +7,13 @@ import com.willyes.clemenintegra.produccion.model.EtapaPlantilla;
 import com.willyes.clemenintegra.produccion.repository.ChecklistEtapaTemplateRepository;
 import com.willyes.clemenintegra.produccion.repository.EtapaPlantillaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,7 +27,7 @@ public class ChecklistEtapaTemplateAdminServiceImpl implements ChecklistEtapaTem
     @Override
     public List<ChecklistEtapaTemplateResponse> listar(Long etapaPlantillaId) {
         EtapaPlantilla etapa = obtenerEtapa(etapaPlantillaId);
-        return repository.findByEtapaPlantillaIdOrderByOrdenAsc(etapa.getId()).stream()
+        return repository.findByEtapaPlantillaIdAndActivoTrueOrderByOrdenAsc(etapa.getId()).stream()
                 .map(this::toResponse)
                 .toList();
     }
@@ -60,6 +62,7 @@ public class ChecklistEtapaTemplateAdminServiceImpl implements ChecklistEtapaTem
     }
 
     @Override
+    @Transactional
     public void eliminar(Long id) {
         ChecklistEtapaTemplate existente = obtenerTemplate(id);
         existente.setActivo(false);
@@ -101,7 +104,7 @@ public class ChecklistEtapaTemplateAdminServiceImpl implements ChecklistEtapaTem
                         .build())
                 .toList();
         repository.saveAll(copias);
-        return repository.findByEtapaPlantillaIdOrderByOrdenAsc(destino.getId()).stream()
+        return repository.findByEtapaPlantillaIdAndActivoTrueOrderByOrdenAsc(destino.getId()).stream()
                 .map(this::toResponse)
                 .toList();
     }
@@ -139,6 +142,6 @@ public class ChecklistEtapaTemplateAdminServiceImpl implements ChecklistEtapaTem
 
     private ChecklistEtapaTemplate obtenerTemplate(Long id) {
         return repository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Checklist template no encontrado"));
+                .orElseThrow(() -> new EntityNotFoundException("Checklist template no encontrado"));
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.calidad.model.enums.MotivoRetencion;
 import com.willyes.clemenintegra.shared.dto.ErrorResponseDTO;
 import com.willyes.clemenintegra.shared.security.exception.SesionInactivaException;
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaException;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -125,6 +126,14 @@ public class GlobalExceptionHandler {
                 .build();
 
         return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponseDTO> handleEntityNotFound(EntityNotFoundException ex,
+                                                                 HttpServletRequest request) {
+        return buildResponse(ApiErrorCode.RECURSO_NO_ENCONTRADO,
+                ex.getMessage() != null ? ex.getMessage() : "Recurso no encontrado",
+                null);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/resources/db/migration/inventario/V20251243__checklist_etapa_template_activo_not_null.sql
+++ b/src/main/resources/db/migration/inventario/V20251243__checklist_etapa_template_activo_not_null.sql
@@ -1,0 +1,6 @@
+UPDATE checklist_etapa_template
+SET activo = b'1'
+WHERE activo IS NULL;
+
+ALTER TABLE checklist_etapa_template
+    MODIFY COLUMN activo BIT(1) NOT NULL DEFAULT b'1';

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/PlanProduccionServiceImplTest.java
@@ -98,7 +98,7 @@ class PlanProduccionServiceImplTest {
                 .estado(EstadoPlanProduccion.BORRADOR)
                 .build();
 
-        when(planProduccionSemanalRepository.findById(20L)).thenReturn(Optional.of(existente));
+        when(planProduccionSemanalRepository.findWithDetallesById(20L)).thenReturn(Optional.of(existente));
         when(planProduccionSemanalRepository.save(any(PlanProduccionSemanal.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -131,7 +131,7 @@ class PlanProduccionServiceImplTest {
                 .estado(EstadoPlanProduccion.CONFIRMADO)
                 .build();
 
-        when(planProduccionSemanalRepository.findById(40L)).thenReturn(Optional.of(existente));
+        when(planProduccionSemanalRepository.findWithDetallesById(40L)).thenReturn(Optional.of(existente));
 
         assertThrows(IllegalStateException.class, () -> service.confirmar(40L));
     }

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaTemplateControllerIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaTemplateControllerIntegrationTest.java
@@ -37,6 +37,7 @@ import java.time.LocalDateTime;
 import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -208,6 +209,10 @@ class ChecklistEtapaTemplateControllerIntegrationTest extends IntegrationTestMyS
         ChecklistEtapaTemplate eliminado = checklistEtapaTemplateRepository.findById(existente.getId()).orElseThrow();
         assertThat(eliminado.getActivo()).isFalse();
         assertThat(eliminado.getUpdatedAt()).isNotNull();
+
+        mockMvc.perform(get("/api/produccion/plantillas-etapas/{id}/checklist", etapaDestino.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Fix incorrect deletion behavior where `checklist_etapa_template.activo` could be `NULL` and deleted items reappeared in the UI.  
- Ensure soft-delete semantics (set `activo=false`) are applied consistently and listings only return active items.

### Description
- Add Flyway migration `src/main/resources/db/migration/inventario/V20251243__checklist_etapa_template_activo_not_null.sql` to normalize existing `activo` values and make the column `NOT NULL DEFAULT b'1'`.  
- Update `ChecklistEtapaTemplateAdminServiceImpl` to list only active templates (`findByEtapaPlantillaIdAndActivoTrueOrderByOrdenAsc`), perform soft-delete inside a `@Transactional` `eliminar` (set `activo=false`), and return only active items after copy operations.  
- Change template not-found behavior to throw `EntityNotFoundException` and add a global handler for it in `GlobalExceptionHandler` mapping it to `ApiErrorCode.RECURSO_NO_ENCONTRADO`.  
- Adjust tests: extend `ChecklistEtapaTemplateControllerIntegrationTest` to assert deleted templates are excluded from listing, and align `PlanProduccionServiceImplTest` mocks to use `findWithDetallesById` where appropriate.

### Testing
- Ran `mvn test`; test execution completed but the build failed due to unrelated existing integration/unit test errors (examples: `VidaUtilProductoControllerIntegrationTest`, `VidaUtilProductoRepositoryTest`, and `OrdenProduccionListadoIntegrationTest`) that pre-existed and are not caused by these changes.  
- Ran `mvn clean package`; packaging also failed for the same unrelated test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697289259a448333b12cb830e1c06634)