### PR TITLE
Add ROL_PLANEADOR role and fine-grained read/write permissions

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/AlertasCalidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/AlertasCalidadController.java
@@ -18,7 +18,8 @@ public class AlertasCalidadController {
     private final AlertasCalidadService alertasCalidadService;
 
     @GetMapping("/resumen")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO'," +
+            "'ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ResumenAlertasCalidadDTO> obtenerResumen(@RequestParam(defaultValue = "30") int diasUmbral) {
         return ResponseEntity.ok(alertasCalidadService.obtenerAlertas(diasUmbral));
     }

--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/VidaUtilProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/VidaUtilProductoController.java
@@ -22,7 +22,8 @@ public class VidaUtilProductoController {
     private final VidaUtilProductoService vidaUtilProductoService;
 
     @GetMapping("/producto-terminado/{productoId}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO'," +
+            "'ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<VidaUtilProductoDTO> obtenerPorProducto(@PathVariable Integer productoId) {
         return vidaUtilProductoService.buscarPorProductoId(productoId)
                 .map(vida -> ResponseEntity.ok(mapToDto(vida)))
@@ -30,7 +31,8 @@ public class VidaUtilProductoController {
     }
 
     @GetMapping("/productos-terminados")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO'," +
+            "'ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<Page<VidaUtilProductoDTO>> listar(
             @RequestParam(required = false) String filtro,
             @RequestParam(name = "search", required = false) String search,

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/AlertaInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/AlertaInventarioController.java
@@ -17,27 +17,27 @@ public class AlertaInventarioController {
     private final AlertaInventarioService alertaService;
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA')")
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_PLANEADOR')")
     public ResponseEntity<List<AlertaInventarioResponseDTO>> obtenerAlertas(
             @RequestParam(value = "diasVencimiento", required = false, defaultValue = "30") Integer diasVencimiento) {
         return ResponseEntity.ok(alertaService.obtenerAlertasInventario(diasVencimiento));
     }
 
     @GetMapping("/stock-bajo")
-    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA')")
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_PLANEADOR')")
     public ResponseEntity<List<ProductoAlertaResponseDTO>> obtenerProductosConStockBajo() {
         List<ProductoAlertaResponseDTO> alertas = alertaService.obtenerProductosConStockBajo();
         return ResponseEntity.ok(alertas);
     }
 
     @GetMapping("/productos-vencidos")
-    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA')")
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_PLANEADOR')")
     public ResponseEntity<List<LoteAlertaResponseDTO>> obtenerProductosVencidos() {
         return ResponseEntity.ok(alertaService.obtenerLotesVencidos());
     }
 
     @GetMapping("/lotes-retenidos-prolongados")
-    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA')")
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_PLANEADOR')")
     public ResponseEntity<List<LoteEstadoProlongadoResponseDTO>> obtenerLotesEnCuarentenaORetenidosProlongados() {
         return ResponseEntity.ok(alertaService.obtenerLotesRetenidosOCuarentenaProlongados());
     }

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/KardexController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/KardexController.java
@@ -33,6 +33,7 @@ public class KardexController {
             "'ROL_LIDER_ALIMENTOS'," +
             "'ROL_LIDER_HOMEOPATICOS'," +
             "'ROL_JEFE_CALIDAD'," +
+            "'ROL_PLANEADOR'," +
             "'ROL_SUPER_ADMIN'" +
             ")")
     public ResponseEntity<List<KardexItemDTO>> obtenerKardex(

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/LoteProductoController.java
@@ -44,14 +44,16 @@ public class LoteProductoController {
     }
 
     @GetMapping("/estado/{estado}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_JEFE_CALIDAD', 'ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_JEFE_CALIDAD'," +
+            " 'ROL_PLANEADOR', 'ROL_SUPER_ADMIN')")
     public ResponseEntity<List<LoteProductoResponseDTO>> listarPorEstado(@PathVariable String estado) {
         List<LoteProductoResponseDTO> lotes = service.obtenerLotesPorEstado(estado);
         return ResponseEntity.ok(lotes);
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_SUPER_ADMIN'," +
+            " 'ROL_JEFE_CALIDAD', 'ROL_PLANEADOR')")
     public ResponseEntity<Page<LoteProductoResponseDTO>> listar(
             @RequestParam(required = false) String producto,
             @RequestParam(required = false) String estado,

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -275,7 +275,8 @@ public class MovimientoInventarioController {
     @Operation(summary = "Consultar movimientos de inventario con filtros opcionales")
     @ApiResponse(responseCode = "200", description = "Consulta exitosa")
     @GetMapping("/filtrar")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_JEFE_PRODUCCION', 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_JEFE_PRODUCCION'," +
+            " 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD', 'ROL_PLANEADOR')")
     public ResponseEntity<Page<MovimientoInventarioResponseDTO>> filtrar(
             @RequestParam(required = false) Long productoId,
             @RequestParam(required = false) Long almacenId,
@@ -305,6 +306,8 @@ public class MovimientoInventarioController {
     }
 
     @GetMapping("/buscar")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_JEFE_PRODUCCION'," +
+            " 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD', 'ROL_PLANEADOR')")
     public ResponseEntity<List<MovimientoInventarioResponseDTO>> consultar(
             @RequestParam(required = false) Long productoId,
             @RequestParam(required = false) Long almacenId,
@@ -333,6 +336,8 @@ public class MovimientoInventarioController {
     }
 
     @GetMapping
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_JEFE_PRODUCCION'," +
+            " 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD', 'ROL_PLANEADOR')")
     public ResponseEntity<Page<MovimientoInventarioResponseDTO>> listarTodos(
             @RequestParam(required = false) String codigoRecepcion,
             @RequestParam(required = false, name = "tipoMovimiento") TipoMovimiento tipoMovimiento,

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -195,6 +195,7 @@ public class OrdenCompraController {
     }
 
     @PutMapping("/{id}/estado")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<HistorialEstadoOrdenResponse> cambiarEstado(
             @PathVariable Long id,
             @RequestBody CambioEstadoOrdenRequest request,

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -41,7 +41,7 @@ public class ProductoController {
 
     @GetMapping("/buscar")
     @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
-            "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD')")
+            "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoOptionDTO>> buscarProductos(
             @RequestParam(name = "q", required = false) String q,
             @RequestParam(name = "term", required = false) String term,
@@ -54,7 +54,7 @@ public class ProductoController {
     }
 
     @GetMapping("/buscar-insumos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoResumenDTO>> buscarInsumos(
             @RequestParam(name = "term") String term,
             @PageableDefault(size = 20, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {
@@ -64,7 +64,7 @@ public class ProductoController {
     }
 
     @GetMapping("/buscar-pt")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoResumenDTO>> buscarProductosTerminados(
             @RequestParam(name = "term") String term,
             @PageableDefault(size = 20, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {
@@ -74,7 +74,7 @@ public class ProductoController {
     }
 
     @GetMapping("/buscar-fabricables")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoAutocompleteDTO>> buscarProductosFabricablesAutocomplete(
             @RequestParam("term") String term,
             Pageable pageable
@@ -84,6 +84,8 @@ public class ProductoController {
     }
 
     @GetMapping("/categoria/{nombre}")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
+            "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<List<ProductoResponseDTO>> buscarPorCategoria(
             @PathVariable String nombre) {
         List<ProductoResponseDTO> productos = productoService.buscarPorCategoria(nombre);
@@ -94,20 +96,20 @@ public class ProductoController {
     }
 
     @GetMapping("/fabricables")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<List<ProductoResponseDTO>> getProductosFabricables() {
         List<ProductoResponseDTO> productos = productoService.findProductosFabricables();
         return ResponseEntity.ok(productos);
     }
 
     @GetMapping("/producto-terminado")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public List<ProductoResponseDTO> getProductosTerminados() {
         return productoService.findByCategoriaTipo("PRODUCTO_TERMINADO");
     }
 
     @GetMapping("/insumos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public List<ProductoResponseDTO> getProductosInsumo() {
         return productoService.findByCategoriaTipoIn(List.of(
                 "MATERIA_PRIMA",
@@ -118,7 +120,7 @@ public class ProductoController {
     }
 
     @GetMapping("/insumos/autocomplete")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<Page<InsumoAutocompleteDTO>> buscarInsumosAutocomplete(
             @RequestParam("term") String term,
             Pageable pageable
@@ -154,6 +156,8 @@ public class ProductoController {
     }
 
     @GetMapping("/{id:[0-9]+}")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
+            "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<ProductoResponseDTO> obtenerPorId(@PathVariable Long id) {
         ProductoResponseDTO producto = productoService.obtenerPorId(id);
         return ResponseEntity.ok(producto);
@@ -194,6 +198,7 @@ public class ProductoController {
     // PROD-INACTIVAR END
 
     @PutMapping("/{id}/unidad-medida")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_SUPER_ADMIN')")
     public ResponseEntity<?> cambiarUnidadMedida(
             @PathVariable Long id,
             @RequestBody @Valid UnidadMedidaRequestDTO dto) {
@@ -225,6 +230,8 @@ public class ProductoController {
     }
 
     @GetMapping("/con-lotes")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
+            "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<List<ProductoConEstadoLoteDTO>> productosConLotesPorEstado(
             @RequestParam String estado) {
         try {
@@ -236,6 +243,8 @@ public class ProductoController {
     }
 
     @GetMapping("/agrupado-por-lotes")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
+            "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<List<ProductoConLotesDTO>> productosAgrupadosPorLotesEnEstado(
             @RequestParam String estado) {
         try {
@@ -247,7 +256,8 @@ public class ProductoController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD', 'ROL_JEFE_PRODUCCION')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD'," +
+            " 'ROL_JEFE_PRODUCCION','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoResponseDTO>> obtenerTodos(
             @RequestParam(required = false) String nombre,
             @RequestParam(required = false) String sku,

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioController.java
@@ -41,7 +41,7 @@ public class ReporteInventarioController {
             MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
 
     @GetMapping("/alta-rotacion")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR','ROL_PLANEADOR')")
     public ResponseEntity<byte[]> altaRotacion(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin
@@ -57,7 +57,7 @@ public class ReporteInventarioController {
     }
 
     @GetMapping("/baja-rotacion")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR','ROL_PLANEADOR')")
     public ResponseEntity<byte[]> bajaRotacion(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin
@@ -73,7 +73,7 @@ public class ReporteInventarioController {
     }
 
     @GetMapping("/mas-costosos")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<byte[]> productosMasCostosos(
             @RequestParam(required = false) String categoria
     ) throws IOException {
@@ -88,7 +88,7 @@ public class ReporteInventarioController {
     }
 
     @GetMapping("/trazabilidad-lote")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<byte[]> exportarTrazabilidadPorLote(@RequestParam String codigoLote) throws IOException {
         Workbook workbook = service.generarReporteTrazabilidadLote(codigoLote);
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -153,7 +153,7 @@ public class ReporteInventarioController {
     }
 
     @GetMapping(value = "/stock-disponible", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<byte[]> exportarStockDisponible() {
         log.info("Generando reporte de stock disponible");
         try (Workbook workbook = productoService.generarReporteStockDisponibleExcel();
@@ -173,7 +173,8 @@ public class ReporteInventarioController {
     }
 
     @GetMapping(value = "/productos-por-vencer", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD'," +
+            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<byte[]> exportarLotesPorVencer(
             @RequestParam(name = "fechaInicio", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam(name = "fechaFin", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin
@@ -200,7 +201,8 @@ public class ReporteInventarioController {
 
     @GetMapping(value = "/productos-vencidos",
             produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD'," +
+            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<byte[]> exportProductosVencidos(
             @RequestParam(name = "producto", required = false) Long productoId,
             @RequestParam(name = "almacen", required = false) Long almacenId) {
@@ -221,7 +223,8 @@ public class ReporteInventarioController {
     }
 
     @GetMapping("/alertas-inventario")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD'," +
+            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<byte[]> exportarAlertasInventario() {
         ByteArrayOutputStream stream = loteProductoService.generarReporteAlertasActivasExcel();
         return ResponseEntity.ok()
@@ -231,7 +234,8 @@ public class ReporteInventarioController {
     }
 
     @GetMapping(value = "/movimientos", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION'," +
+            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<byte[]> exportarReporteMovimientos(
             @RequestParam(name = "fechaInicio", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam(name = "fechaFin", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin

--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
@@ -34,12 +34,14 @@ public class SolicitudMovimientoController {
     private final UsuarioService usuarioService;
 
     @PostMapping
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<SolicitudMovimientoResponseDTO> crear(@RequestBody SolicitudMovimientoRequestDTO dto) {
         return new ResponseEntity<>(service.registrarSolicitud(dto), HttpStatus.CREATED);
     }
 
     @GetMapping
     // endpoint que lista las solicitudes de movimiento con paginación
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<Page<SolicitudMovimientoListadoDTO>> listar(
             @PageableDefault(size = 10, sort = "fechaSolicitud", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) EstadoSolicitudMovimiento estado,
@@ -80,7 +82,7 @@ public class SolicitudMovimientoController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<SolicitudMovimientoResponseDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerSolicitud(id));
     }

--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
@@ -35,7 +35,7 @@ public class MrpController {
     private final MrpReporteService mrpReporteService;
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<CorridaMrpResponseDTO> ejecutar(@RequestBody CorridaMrpRequest request) {
         Optional<PlanProduccionSemanal> plan = planProduccionService.buscarPorId(request.getPlanSemanalId());
         if (plan.isEmpty()) {
@@ -46,7 +46,7 @@ public class MrpController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<?> obtener(@PathVariable Long id) {
         try {
             CorridaMrp corrida = mrpService.obtenerCorrida(id);
@@ -57,7 +57,7 @@ public class MrpController {
     }
 
     @GetMapping("/{id}/excel")
-    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<?> exportarExcel(@PathVariable Long id) {
         try {
             byte[] excel = mrpReporteService.generarExcelCorrida(id);

--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
@@ -34,7 +34,7 @@ public class PlanProduccionController {
     private final PlanProduccionService planProduccionService;
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<PlanProduccionSemanalDTO> crearOActualizar(@RequestBody PlanProduccionSemanalDTO dto,
                                                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
         if (dto.getCreadoPorId() == null && userDetails != null) {
@@ -45,21 +45,21 @@ public class PlanProduccionController {
     }
 
     @PostMapping("/{id}/confirmar")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<PlanProduccionSemanalDTO> confirmar(@PathVariable Long id) {
         PlanProduccionSemanal plan = planProduccionService.confirmar(id);
         return ResponseEntity.ok(toDto(plan));
     }
 
     @PostMapping("/{id}/cerrar")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<PlanProduccionSemanalDTO> cerrar(@PathVariable Long id) {
         PlanProduccionSemanal plan = planProduccionService.cerrar(id);
         return ResponseEntity.ok(toDto(plan));
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<Page<PlanProduccionResumenDTO>> listar(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate semanaInicioDesde,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate semanaInicioHasta,
@@ -70,7 +70,7 @@ public class PlanProduccionController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<PlanProduccionSemanalDTO> obtener(@PathVariable Long id) {
         return planProduccionService.buscarPorId(id)
                 .map(plan -> ResponseEntity.ok(toDto(plan)))

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/IndicadoresProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/IndicadoresProduccionController.java
@@ -26,7 +26,8 @@ public class IndicadoresProduccionController {
     private final ReporteIndicadoresProduccionService reporteIndicadoresProduccionService;
 
     @GetMapping("/indicadores")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS'," +
+            "'ROL_LIDER_HOMEOPATICOS','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<IndicadoresProduccionResponseDTO> obtenerIndicadores(
             @RequestParam LocalDate fechaInicio,
             @RequestParam LocalDate fechaFin,
@@ -35,7 +36,8 @@ public class IndicadoresProduccionController {
     }
 
     @GetMapping("/ordenes/alertas")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION'," +
+            "'ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<List<AlertaOrdenProduccionDTO>> obtenerAlertas(
             @RequestParam(required = false) LocalDate fechaReferencia,
             @RequestParam(required = false, defaultValue = "3") Integer diasVentana) {
@@ -43,7 +45,8 @@ public class IndicadoresProduccionController {
     }
 
     @GetMapping(value = "/indicadores/export/excel", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_AUXILIAR_PRODUCCION','ROL_LIDER_ALIMENTOS'," +
+            "'ROL_LIDER_HOMEOPATICOS','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportarIndicadoresExcel(
             @RequestParam LocalDate fechaInicio,
             @RequestParam LocalDate fechaFin,

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -46,7 +46,8 @@ public class OrdenProduccionController {
 
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public Page<OrdenProduccionResponseDTO> listar(
             @RequestParam(required = false) String codigo,
             @RequestParam(required = false) EstadoProduccion estado,
@@ -58,7 +59,8 @@ public class OrdenProduccionController {
     }
 
     @GetMapping(value = "/export/excel", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportarExcel(
             @RequestParam(required = false) String codigo,
             @RequestParam(required = false) EstadoProduccion estado,
@@ -74,7 +76,8 @@ public class OrdenProduccionController {
     }
 
     @GetMapping(value = "/export/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportarPdf(
             @RequestParam(required = false) String codigo,
             @RequestParam(required = false) EstadoProduccion estado,
@@ -90,7 +93,8 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> obtenerPorId(@PathVariable Long id) {
         return service.buscarPorId(id)
                 .map(ProduccionMapper::toResponse)
@@ -99,13 +103,14 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{id}/trazabilidad")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ProduccionTrazabilidadResponseDTO> obtenerTrazabilidad(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerTrazabilidad(id));
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ResultadoValidacionOrdenDTO> crear(@RequestBody OrdenProduccionRequestDTO request) {
         ResultadoValidacionOrdenDTO resultado = service.crearOrden(request);
         HttpStatus status = resultado.isEsValida() ? HttpStatus.CREATED : HttpStatus.BAD_REQUEST;
@@ -116,7 +121,7 @@ public class OrdenProduccionController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ResultadoValidacionOrdenDTO> actualizar(@PathVariable Long id, @RequestBody OrdenProduccionRequestDTO request) {
         return service.buscarPorId(id)
                 .map(existente -> {
@@ -165,14 +170,16 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{id}/cierres")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public Page<CierreProduccionResponseDTO> listarCierres(@PathVariable Long id,
                                                           @PageableDefault(size = 10, sort = "fechaCierre", direction = Sort.Direction.DESC) Pageable pageable) {
         return service.listarCierres(id, pageable);
     }
 
     @GetMapping("/{id}/etapas")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public List<EtapaProduccionResponse> listarEtapas(@PathVariable Long id) {
         return service.listarEtapas(id);
     }
@@ -203,13 +210,15 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{id}/insumos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public List<InsumoOPDTO> listarInsumos(@PathVariable Long id) {
         return service.listarInsumos(id);
     }
 
     @GetMapping("/{id}/movimientos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public Page<MovimientoInventarioResponseDTO> listarMovimientos(@PathVariable Long id,
                                                                    @RequestParam(name = "etapaId", required = false) Long etapaId,
                                                                    Pageable pageable) {
@@ -217,7 +226,8 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{ordenId}/etapas/{etapaId}/consumos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<List<MovimientoInventarioResponseDTO>> listarConsumosPorEtapa(@PathVariable Long ordenId,
                                                                                         @PathVariable Long etapaId,
                                                                                         @RequestParam(name = "clasificacion", required = false) ClasificacionMovimientoInventario clasificacion) {
@@ -225,7 +235,8 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{ordenId}/etapas/{etapaId}/movimientos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<List<MovimientoInventarioResponseDTO>> listarMovimientosPorEtapa(@PathVariable Long ordenId,
                                                                                            @PathVariable Long etapaId,
                                                                                            @RequestParam(name = "clasificacion", required = false) ClasificacionMovimientoInventario clasificacion) {
@@ -233,7 +244,8 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{ordenId}/etapas/{etapaId}/checklist")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistEtapaDTO> obtenerChecklistPorEtapa(@PathVariable Long ordenId,
                                                                       @PathVariable Long etapaId) {
         log.info("ChecklistEtapa - GET ordenId={}, etapaId={}", ordenId, etapaId);
@@ -241,7 +253,8 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{ordenId}/etapas/{etapaId}/checklist")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistEtapaDTO> actualizarChecklistPorEtapa(@PathVariable Long ordenId,
                                                                          @PathVariable Long etapaId,
                                                                          @RequestBody List<ChecklistItemDTO> items) {

--- a/src/main/java/com/willyes/clemenintegra/shared/model/enums/RolUsuario.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/model/enums/RolUsuario.java
@@ -11,6 +11,6 @@ public enum RolUsuario {
     ROL_LIDER_ALIMENTOS,
     ROL_CONTADOR,
     ROL_COMPRADOR,
+    ROL_PLANEADOR,
     ROL_SUPER_ADMIN
 }
-

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -129,6 +129,7 @@ public class SecurityConfig {
                             "/api/produccion/ordenes/alertas/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_LIDER_ALIMENTOS.name(),
                             RolUsuario.ROL_LIDER_HOMEOPATICOS.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
@@ -150,6 +151,7 @@ public class SecurityConfig {
                             RolUsuario.ROL_ANALISTA_CALIDAD.name(),
                             RolUsuario.ROL_MICROBIOLOGO.name(),
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
@@ -163,6 +165,22 @@ public class SecurityConfig {
                             RolUsuario.ROL_COMPRADOR.name(),
                             RolUsuario.ROL_JEFE_ALMACENES.name(),
                             RolUsuario.ROL_ALMACENISTA.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers(HttpMethod.GET, "/api/movimientos/**").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_ALMACENISTA.name(),
+                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers(HttpMethod.GET, "/api/inventario/alertas/**").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_ALMACENISTA.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
@@ -183,11 +201,19 @@ public class SecurityConfig {
                     auth.requestMatchers(HttpMethod.GET, "/api/planeacion/planes-semanales/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
                             RolUsuario.ROL_COMPRADOR.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
                     // 2) Resto de operaciones de planeación (crear/editar/eliminar):
                     auth.requestMatchers("/api/planeacion/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers(HttpMethod.GET, "/api/mrp/**").hasAnyAuthority(
+                            RolUsuario.ROL_COMPRADOR.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
@@ -222,6 +248,17 @@ public class SecurityConfig {
                     ).hasAnyAuthority(
                             RolUsuario.ROL_MICROBIOLOGO.name(),
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers(HttpMethod.GET,
+                            "/api/calidad/alertas/**",
+                            "/api/calidad/vida-util/**").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_ANALISTA_CALIDAD.name(),
+                            RolUsuario.ROL_MICROBIOLOGO.name(),
+                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
@@ -262,6 +299,7 @@ public class SecurityConfig {
                             RolUsuario.ROL_LIDER_ALIMENTOS.name(),
                             RolUsuario.ROL_LIDER_HOMEOPATICOS.name(),
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
@@ -269,6 +307,7 @@ public class SecurityConfig {
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
                             RolUsuario.ROL_LIDER_ALIMENTOS.name(),
                             RolUsuario.ROL_LIDER_HOMEOPATICOS.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
@@ -290,10 +329,22 @@ public class SecurityConfig {
                             RolUsuario.ROL_ANALISTA_CALIDAD.name(),
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
                     auth.requestMatchers("/actuator/metrics/**").hasAnyAuthority(
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers(HttpMethod.GET,
+                            "/api/inventarios/solicitudes/**",
+                            "/api/inventario/solicitudes/**"
+                    ).hasAnyAuthority(
+                            RolUsuario.ROL_ALMACENISTA.name(),
+                            RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 

--- a/src/main/resources/db/migration/inventario/V20260110__add_rol_planeador.sql
+++ b/src/main/resources/db/migration/inventario/V20260110__add_rol_planeador.sql
@@ -1,0 +1,16 @@
+-- Extiende el ENUM de usuarios.rol para incluir ROL_PLANEADOR
+ALTER TABLE usuarios
+    MODIFY COLUMN rol ENUM(
+        'ROL_MICROBIOLOGO',
+        'ROL_JEFE_CALIDAD',
+        'ROL_ANALISTA_CALIDAD',
+        'ROL_JEFE_ALMACENES',
+        'ROL_ALMACENISTA',
+        'ROL_JEFE_PRODUCCION',
+        'ROL_LIDER_HOMEOPATICOS',
+        'ROL_LIDER_ALIMENTOS',
+        'ROL_CONTADOR',
+        'ROL_COMPRADOR',
+        'ROL_PLANEADOR',
+        'ROL_SUPER_ADMIN'
+    ) NOT NULL;

--- a/src/test/java/com/willyes/clemenintegra/shared/security/PlaneadorRoleSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/PlaneadorRoleSecurityTest.java
@@ -1,0 +1,190 @@
+package com.willyes.clemenintegra.shared.security;
+
+import com.willyes.clemenintegra.inventario.controller.ProductoController;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.ProductoService;
+import com.willyes.clemenintegra.planeacion.controller.MrpController;
+import com.willyes.clemenintegra.planeacion.controller.PlanProduccionController;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
+import com.willyes.clemenintegra.planeacion.service.MrpReporteService;
+import com.willyes.clemenintegra.planeacion.service.MrpService;
+import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
+import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
+import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.PageImpl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {
+        ProductoController.class,
+        PlanProduccionController.class,
+        MrpController.class
+})
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, PlaneadorRoleSecurityTest.MethodSecurityConfig.class})
+@ImportAutoConfiguration({SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
+class PlaneadorRoleSecurityTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    @org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity(prePostEnabled = true)
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProductoService productoService;
+    @MockBean
+    private ProductoRepository productoRepository;
+    @MockBean
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @MockBean
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+    @MockBean
+    private PlanProduccionService planProduccionService;
+    @MockBean
+    private MrpService mrpService;
+    @MockBean
+    private MrpReporteService mrpReporteService;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private RequestTimingFilter requestTimingFilter;
+    @MockBean
+    private RequestIdFilter requestIdFilter;
+    @MockBean
+    private SuperAdminSoloLecturaWriteBlockFilter superAdminSoloLecturaWriteBlockFilter;
+
+    @BeforeEach
+    void configureFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestTimingFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestIdFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(superAdminSoloLecturaWriteBlockFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    void planeadorPuedeBuscarProductos() throws Exception {
+        when(productoService.buscarOpciones(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/productos/buscar")
+                        .param("q", "CA")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    void planeadorNoPuedeCrearProducto() throws Exception {
+        mockMvc.perform(post("/api/productos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "sku": "PT-001",
+                                  "nombre": "Producto de prueba",
+                                  "stockMinimo": 1,
+                                  "unidadMedidaId": 1,
+                                  "categoriaProductoId": 1
+                                }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    void planeadorPuedeCrearPlanSemanal() throws Exception {
+        PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
+                .id(1L)
+                .semanaInicio(LocalDate.of(2024, 1, 1))
+                .semanaFin(LocalDate.of(2024, 1, 7))
+                .detalles(new ArrayList<>())
+                .build();
+        when(planProduccionService.crearOActualizar(any())).thenReturn(plan);
+
+        mockMvc.perform(post("/api/planeacion/planes-semanales")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "semanaInicio": "2024-01-01",
+                                  "semanaFin": "2024-01-07",
+                                  "detalles": []
+                                }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    void planeadorNoPuedeEjecutarMrp() throws Exception {
+        mockMvc.perform(post("/api/mrp/corridas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"planSemanalId\": 1}"))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a new role `ROL_PLANEADOR` and map it into the security model so planning users can have read-only access to inventory/MRP/quality where appropriate and write access where allowed by the matrix. 
- Close authorization gaps where write endpoints were reachable via broad matchers (notably unit-of-measure change, order-state change and movement requests) and explicitly separate READ vs WRITE. 
- Add minimal automated tests to assert the expected allow/deny behaviour for the new role.

### Description
- Add `ROL_PLANEADOR` to the roles enum at `src/main/java/com/willyes/clemenintegra/shared/model/enums/RolUsuario.java` and provide a Flyway migration `V20260110__add_rol_planeador.sql` to extend the `usuarios.rol` ENUM. 
- Update HTTP security matchers in `SecurityConfig` to grant `ROL_PLANEADOR` read-only access where required (inventory movements, inventory alerts, planeación GETs, MRP GETs, calidad reads, report exports, solicitudes GETs, produccion reads, reportes, etc.) while keeping write matchers restricted. 
- Add or tighten `@PreAuthorize` annotations in controllers to reflect READ vs WRITE separation and to prevent the planeador role from performing writes where not allowed; modified controllers include `ProductoController`, `MovimientoInventarioController`, `KardexController`, `SolicitudMovimientoController`, `OrdenCompraController`, `LoteProductoController`, `AlertaInventarioController`, `ReporteInventarioController`, `PlanProduccionController`, `MrpController`, `IndicadoresProduccionController`, `OrdenProduccionController`, `AlertasCalidadController`, and `VidaUtilProductoController`. 
- Fix the specific gaps reported: added `@PreAuthorize` on `ProductoController#cambiarUnidadMedida`, `OrdenCompraController#cambiarEstado`, and separated `SolicitudMovimientoController` `POST` vs `GET` access so `ROL_PLANEADOR` can list/obtain but not create. 
- Add unit tests `PlaneadorRoleSecurityTest` (MockMvc) to cover positive and negative cases for the new role and adjust the test payload to exercise validation and authorization properly.

### Testing
- Ran a full `mvn test` during development which surfaced an initial failing security assertion (the test sent an empty payload and returned `400` instead of `403`); the test and controller validation were then corrected. 
- Ran the targeted security test with `mvn -Dtest=PlaneadorRoleSecurityTest test` and it passed (all assertions in `PlaneadorRoleSecurityTest` succeeded). 
- The PR includes the added Flyway migration `src/main/resources/db/migration/inventario/V20260110__add_rol_planeador.sql` and the new test `src/test/java/com/willyes/clemenintegra/shared/security/PlaneadorRoleSecurityTest.java`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697382e3cef08333bfd044f12b076754)