### PR TITLE
Permitir ROL_PLANEADOR en fórmulas activa legacy

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java
@@ -180,7 +180,7 @@ public class FormulaProductoController {
     }
 
     @GetMapping("/activa")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<FormulaProductoResponse> obtenerFormulaActiva(@RequestParam Long productoId,
                                                                         @RequestParam(defaultValue = "1") BigDecimal cantidad) {
         // LÍNEA CODEx: endpoint consultado por Producción para validar disponibilidad de insumos

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -330,6 +330,13 @@ public class SecurityConfig {
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
+                    auth.requestMatchers(HttpMethod.GET, "/api/bom/formulas/activa").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
                     auth.requestMatchers("/api/bom/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
                             RolUsuario.ROL_JEFE_CALIDAD.name(),

--- a/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoActivaSecurityIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoActivaSecurityIntegrationTest.java
@@ -1,0 +1,146 @@
+package com.willyes.clemenintegra.bom.controller;
+
+import com.willyes.clemenintegra.bom.model.DetalleFormula;
+import com.willyes.clemenintegra.bom.model.FormulaProducto;
+import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
+import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
+import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
+import com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.repository.CategoriaProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class FormulaProductoActivaSecurityIntegrationTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private FormulaProductoRepository formulaProductoRepository;
+
+    @MockBean
+    private InventoryCatalogResolver inventoryCatalogResolver;
+
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @Test
+    void obtenerFormulaActiva_permiteRolPlaneador() throws Exception {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("planeador-user")
+                .clave("secret")
+                .nombreCompleto("Usuario Planeador")
+                .correo("planeador-user@example.com")
+                .rol(RolUsuario.ROL_PLANEADOR)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Kilogramo Planeador")
+                .simbolo("KPL")
+                .codigo("KPL")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("Categoria Planeador")
+                .tipo(TipoCategoria.PRODUCTO_TERMINADO)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-FORM-PLAN")
+                .nombre("Producto Formula Planeador")
+                .descripcionProducto("Producto formula planeador")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        Producto insumo = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-INS-PLAN")
+                .nombre("Insumo Formula Planeador")
+                .descripcionProducto("Insumo planeador")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .activo(true)
+                .build());
+
+        FormulaProducto formula = FormulaProducto.builder()
+                .producto(producto)
+                .version("V1")
+                .estado(EstadoFormula.APROBADA)
+                .fechaCreacion(LocalDateTime.now())
+                .activo(true)
+                .creadoPor(usuario)
+                .detalles(List.of())
+                .documentos(List.of())
+                .build();
+
+        DetalleFormula detalle = DetalleFormula.builder()
+                .formula(formula)
+                .insumo(insumo)
+                .unidadMedida(unidad)
+                .cantidadNecesaria(BigDecimal.ONE)
+                .obligatorio(true)
+                .build();
+
+        formula.setDetalles(List.of(detalle));
+        formulaProductoRepository.save(formula);
+
+        mockMvc.perform(get("/api/bom/formulas/activa")
+                        .with(user("planeador").authorities(new SimpleGrantedAuthority("ROL_PLANEADOR")))
+                        .param("productoId", formula.getProducto().getId().toString()))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
### Motivation
- Evitar 403 para el rol `ROL_PLANEADOR` en el endpoint legacy `GET /api/bom/formulas/activa` sin abrir permisos de escritura y manteniendo el endpoint nuevo con su configuración actual.

### Description
- Se añadió `ROL_PLANEADOR` al `@PreAuthorize` del método `obtenerFormulaActiva` en `src/main/java/com/willyes/clemenintegra/bom/controller/FormulaProductoController.java` (líneas 182–188). 
- Se agregó un `requestMatcher` específico en `SecurityConfig` permitiendo `ROL_PLANEADOR` para `HttpMethod.GET /api/bom/formulas/activa` (archivo `src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java`, líneas ~333–339). 
- Se preservaron los roles existentes y la política general `auth.requestMatchers("/api/bom/**")` sigue aplicando para los demás métodos. 
- Se agregó una prueba de integración MockMvc `FormulaProductoActivaSecurityIntegrationTest` en `src/test/java/com/willyes/clemenintegra/bom/controller/FormulaProductoActivaSecurityIntegrationTest.java` que crea datos mínimos y valida que un usuario con autoridad `ROL_PLANEADOR` obtiene `200 OK` al llamar a `GET /api/bom/formulas/activa?productoId=...`.

### Testing
- Se ejecutó la suite completa con `mvn test` y el build finalizó con `BUILD SUCCESS` (tests ejecutados: 622, fallos: 0, errores: 0, omitidos: 2). 
- La nueva prueba `FormulaProductoActivaSecurityIntegrationTest` pasó correctamente como parte de la ejecución.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973de4ffd48833381baf0fa199b1090)