### PR TITLE
Permitir lectura de solicitudes para ROL_PLANEADOR

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudPorOrdenController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudPorOrdenController.java
@@ -37,7 +37,7 @@ public class SolicitudPorOrdenController {
     private final SolicitudMovimientoService service;
 
     @GetMapping({"/por-orden", "/ordenes"})
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     @Operation(summary = "Listar solicitudes agrupadas por orden de producción")
     public ResponseEntity<Page<SolicitudesPorOrdenDTO>> listarPorOrden(
             @Parameter(description = "Estado de las solicitudes. Si se omite, se usa PENDIENTE por defecto")
@@ -79,13 +79,13 @@ public class SolicitudPorOrdenController {
     }
 
     @GetMapping("/orden/{ordenId}")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<SolicitudesPorOrdenDTO> obtenerPorOrden(@PathVariable Long ordenId) {
         return ResponseEntity.ok(service.obtenerPorOrden(ordenId));
     }
 
     @GetMapping("/orden/{ordenId}/picklist")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> generarPicklist(@PathVariable Long ordenId,
                                                   @RequestParam(defaultValue = "false") boolean incluirAprobadas) {
         PicklistDTO dto = service.generarPicklist(ordenId, incluirAprobadas);

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoControllerSecurityTest.java
@@ -1,0 +1,127 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.service.SolicitudMovimientoService;
+import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
+import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.SuperAdminSoloLecturaWriteBlockFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {SolicitudPorOrdenController.class, SolicitudMovimientoController.class})
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, SolicitudMovimientoControllerSecurityTest.MethodSecurityConfig.class})
+@ImportAutoConfiguration({SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
+class SolicitudMovimientoControllerSecurityTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    @org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity(prePostEnabled = true)
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SolicitudMovimientoService solicitudMovimientoService;
+    @MockBean
+    private UsuarioService usuarioService;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private RequestTimingFilter requestTimingFilter;
+    @MockBean
+    private RequestIdFilter requestIdFilter;
+    @MockBean
+    private SuperAdminSoloLecturaWriteBlockFilter superAdminSoloLecturaWriteBlockFilter;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void configureFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestTimingFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestIdFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(superAdminSoloLecturaWriteBlockFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    void planeadorPuedeListarSolicitudesPorOrden() throws Exception {
+        when(solicitudMovimientoService.listGroupByOrden(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/inventarios/solicitudes/por-orden")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(SecurityMockMvcRequestPostProcessors.user("planeador")
+                                .authorities(() -> "ROL_PLANEADOR")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void planeadorNoPuedeAprobarSolicitudes() throws Exception {
+        mockMvc.perform(put("/api/inventarios/solicitudes/1/aprobar")
+                        .with(SecurityMockMvcRequestPostProcessors.user("planeador")
+                                .authorities(() -> "ROL_PLANEADOR")))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
### Motivation
- El frontend en `/planeador/inventario/solicitudes` devolvía lista vacía y `403` en el endpoint por-orden porque el rol `ROL_PLANEADOR` no estaba autorizado en algunos controladores GET.  
- Se busca habilitar solo permisos de lectura para `ROL_PLANEADOR` sin otorgar acceso a endpoints de escritura (aprobar/rechazar/autorizar/revertir).

### Description
- Se añadió `ROL_PLANEADOR` a las anotaciones `@PreAuthorize` de los endpoints GET en `SolicitudPorOrdenController` (`/por-orden`, `/orden/{ordenId}`, `/orden/{ordenId}/picklist`).
- Ya existían permisos de solo lectura para planeador en `SolicitudMovimientoController` y en `SecurityConfig`; no se cambiaron los endpoints de escritura ni sus autorizaciones.  
- Se agregó la prueba `SolicitudMovimientoControllerSecurityTest` que valida con `MockMvc` que un usuario con `ROL_PLANEADOR` obtiene `200` en `GET /api/inventarios/solicitudes/por-orden` y `403` al intentar `PUT /api/inventarios/solicitudes/{id}/aprobar`.

### Testing
- Se ejecutó la suite con `mvn test` y la compilación de pruebas finalizó correctamente con `BUILD SUCCESS` y sin fallos (tests ejecutados: 624, failures: 0, errors: 0, skipped: 2).  
- La nueva prueba `SolicitudMovimientoControllerSecurityTest` se ejecutó dentro del pipeline de pruebas y pasó, validando lectura permitida y bloqueo de escritura para `ROL_PLANEADOR`.
- No se modificaron pruebas existentes y no se introdujeron cambios que abran endpoints `POST/PUT/PATCH/DELETE` para `ROL_PLANEADOR`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e410ec248333b9989eaa3abd20bc)