### PR TITLE
Prevent LazyInitializationException in /api/ordenes-compra/{id}/recepciones

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java
@@ -9,10 +9,7 @@ import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.OrdenCompraPdfService;
 import com.willyes.clemenintegra.inventario.service.OrdenCompraService;
 import com.willyes.clemenintegra.inventario.service.HistorialEstadoOrdenService;
-import com.willyes.clemenintegra.inventario.mapper.RecepcionOCMapper;
-import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
-import com.willyes.clemenintegra.inventario.dto.RecepcionOCResponseDTO;
-import com.willyes.clemenintegra.inventario.repository.RecepcionOCRepository;
+import com.willyes.clemenintegra.inventario.service.RecepcionOCService;
 import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -52,10 +49,7 @@ public class OrdenCompraController {
     private final ProductoRepository productoRepository;
     private final OrdenCompraService ordenCompraService;
     private final HistorialEstadoOrdenService historialEstadoOrdenService;
-    private final RecepcionOCRepository recepcionOCRepository;
-    private final MovimientoInventarioRepository movimientoInventarioRepository;
-    private final MovimientoInventarioMapper movimientoInventarioMapper;
-    private final RecepcionOCMapper recepcionOCMapper;
+    private final RecepcionOCService recepcionOCService;
     private final OrdenCompraPdfService ordenCompraPdfService;
     private final OrdenCompraMapper mapper;
 
@@ -273,15 +267,7 @@ public class OrdenCompraController {
 
     @GetMapping("/{id}/recepciones")
     public ResponseEntity<List<RecepcionOCResponseDTO>> recepcionesPorOrden(@PathVariable Long id) {
-        List<RecepcionOCResponseDTO> recepciones = recepcionOCRepository
-                .findAllByOrdenCompra_IdOrderByFechaRecepcionAsc(id)
-                .stream()
-                .map(r -> recepcionOCMapper.toResponse(r,
-                        movimientoInventarioRepository.findAllByRecepcionOcIdOrderByFechaIngresoAsc(r.getId())
-                                .stream()
-                                .map(movimientoInventarioMapper::safeToResponseDTO)
-                                .toList()))
-                .toList();
+        List<RecepcionOCResponseDTO> recepciones = recepcionOCService.listarRecepcionesPorOrden(id);
         return ResponseEntity.ok(recepciones);
     }
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -276,7 +276,10 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
 
     @EntityGraph(attributePaths = {
             "producto",
+            "producto.unidadMedida",
             "lote",
+            "lote.producto",
+            "lote.producto.unidadMedida",
             "almacenOrigen",
             "almacenDestino",
             "registradoPor",

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCService.java
@@ -4,6 +4,7 @@ import com.willyes.clemenintegra.inventario.dto.RecepcionOCResponseDTO;
 import com.willyes.clemenintegra.inventario.model.RecepcionOC;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface RecepcionOCService {
 
@@ -15,4 +16,6 @@ public interface RecepcionOCService {
                                      String observaciones);
 
     RecepcionOCResponseDTO obtenerRecepcionPorCodigo(String codigo);
+
+    List<RecepcionOCResponseDTO> listarRecepcionesPorOrden(Long ordenCompraId);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCServiceImpl.java
@@ -69,6 +69,24 @@ public class RecepcionOCServiceImpl implements RecepcionOCService {
         return recepcionOCMapper.toResponse(recepcion, movimientos);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<RecepcionOCResponseDTO> listarRecepcionesPorOrden(Long ordenCompraId) {
+        List<RecepcionOC> recepciones = recepcionOCRepository
+                .findAllByOrdenCompra_IdOrderByFechaRecepcionAsc(ordenCompraId);
+
+        return recepciones.stream()
+                .map(recepcion -> {
+                    List<MovimientoInventarioResponseDTO> movimientos = movimientoInventarioRepository
+                            .findAllByRecepcionOcIdOrderByFechaIngresoAsc(recepcion.getId())
+                            .stream()
+                            .map(movimientoInventarioMapper::safeToResponseDTO)
+                            .toList();
+                    return recepcionOCMapper.toResponse(recepcion, movimientos);
+                })
+                .toList();
+    }
+
     private RecepcionOC crearCabecera(Integer ordenCompraId,
                                       Integer almacenDestinoId,
                                       Integer proveedorId,

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerRecepcionesTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerRecepcionesTest.java
@@ -1,13 +1,12 @@
 package com.willyes.clemenintegra.inventario.controller;
 
 import com.willyes.clemenintegra.inventario.dto.RecepcionOCResponseDTO;
-import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.mapper.OrdenCompraMapper;
-import com.willyes.clemenintegra.inventario.mapper.RecepcionOCMapper;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.inventario.service.HistorialEstadoOrdenService;
 import com.willyes.clemenintegra.inventario.service.OrdenCompraPdfService;
 import com.willyes.clemenintegra.inventario.service.OrdenCompraService;
+import com.willyes.clemenintegra.inventario.service.RecepcionOCService;
 import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
 import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
 import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
@@ -22,10 +21,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.security.test.context.support.WithMockUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.LocalDate;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -54,13 +51,7 @@ class OrdenCompraControllerRecepcionesTest {
     @MockBean
     private HistorialEstadoOrdenService historialEstadoOrdenService;
     @MockBean
-    private RecepcionOCRepository recepcionOCRepository;
-    @MockBean
-    private MovimientoInventarioRepository movimientoInventarioRepository;
-    @MockBean
-    private MovimientoInventarioMapper movimientoInventarioMapper;
-    @MockBean
-    private RecepcionOCMapper recepcionOCMapper;
+    private RecepcionOCService recepcionOCService;
     @MockBean
     private OrdenCompraPdfService ordenCompraPdfService;
     @MockBean
@@ -75,17 +66,8 @@ class OrdenCompraControllerRecepcionesTest {
     @Test
     @WithMockUser(authorities = "ROL_SUPER_ADMIN")
     void recepcionesEndpointReturnsList() throws Exception {
-        var recepcion = com.willyes.clemenintegra.inventario.model.RecepcionOC.builder()
-                .id(20L)
-                .codigo("RC-001")
-                .fechaRecepcion(LocalDate.now())
-                .build();
-        when(recepcionOCRepository.findAllByOrdenCompra_IdOrderByFechaRecepcionAsc(1L))
-                .thenReturn(List.of(recepcion));
-        when(movimientoInventarioRepository.findAllByRecepcionOcIdOrderByFechaIngresoAsc(20L))
-                .thenReturn(List.of());
-        when(recepcionOCMapper.toResponse(any(), any()))
-                .thenReturn(RecepcionOCResponseDTO.builder().id(20L).codigo("RC-001").build());
+        when(recepcionOCService.listarRecepcionesPorOrden(1L))
+                .thenReturn(List.of(RecepcionOCResponseDTO.builder().id(20L).codigo("RC-001").build()));
 
         var result = mockMvc.perform(get("/api/ordenes-compra/1/recepciones")
                         .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraRecepcionesIntegrationTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraRecepcionesIntegrationTest.java
@@ -1,0 +1,214 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.model.*;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
+import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.support.IntegrationTestMySqlContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+class OrdenCompraRecepcionesIntegrationTest extends IntegrationTestMySqlContainer {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private AlmacenRepository almacenRepository;
+    @Autowired
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @Autowired
+    private CategoriaProductoRepository categoriaProductoRepository;
+    @Autowired
+    private ProductoRepository productoRepository;
+    @Autowired
+    private LoteProductoRepository loteProductoRepository;
+    @Autowired
+    private ProveedorRepository proveedorRepository;
+    @Autowired
+    private OrdenCompraRepository ordenCompraRepository;
+    @Autowired
+    private OrdenCompraDetalleRepository ordenCompraDetalleRepository;
+    @Autowired
+    private RecepcionOCRepository recepcionOCRepository;
+    @Autowired
+    private RecepcionOCDetalleRepository recepcionOCDetalleRepository;
+    @Autowired
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Autowired
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Autowired
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+
+    @MockBean
+    private com.willyes.clemenintegra.inventario.service.InventoryCatalogResolver inventoryCatalogResolver;
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    private OrdenCompra ordenCompra;
+    private RecepcionOC recepcionOC;
+    private MovimientoInventario movimientoInventario;
+
+    @BeforeEach
+    void setUp() {
+        Usuario usuario = usuarioRepository.save(Usuario.builder()
+                .nombreUsuario("comprador")
+                .clave("secret")
+                .nombreCompleto("Usuario Comprador")
+                .correo("comprador@example.com")
+                .rol(RolUsuario.ROL_COMPRADOR)
+                .activo(true)
+                .bloqueado(false)
+                .build());
+
+        Almacen almacen = almacenRepository.save(Almacen.builder()
+                .nombre("Principal")
+                .ubicacion("Zona A")
+                .categoria(TipoCategoria.MATERIA_PRIMA)
+                .tipo(com.willyes.clemenintegra.inventario.model.enums.TipoAlmacen.PRINCIPAL)
+                .build());
+
+        UnidadMedida unidad = unidadMedidaRepository.save(UnidadMedida.builder()
+                .nombre("Unidad")
+                .simbolo("u")
+                .build());
+
+        CategoriaProducto categoria = categoriaProductoRepository.save(CategoriaProducto.builder()
+                .nombre("MP")
+                .tipo(TipoCategoria.MATERIA_PRIMA)
+                .build());
+
+        Producto producto = productoRepository.save(Producto.builder()
+                .codigoSku("SKU-123")
+                .nombre("Producto Recepcion")
+                .descripcionProducto("Descripción")
+                .stockMinimo(BigDecimal.ZERO)
+                .unidadMedida(unidad)
+                .categoriaProducto(categoria)
+                .creadoPor(usuario)
+                .tipoAnalisis(com.willyes.clemenintegra.inventario.model.enums.TipoAnalisisCalidad.NINGUNO)
+                .activo(true)
+                .build());
+
+        LoteProducto lote = loteProductoRepository.save(LoteProducto.builder()
+                .codigoLote("LOTE-01")
+                .producto(producto)
+                .almacen(almacen)
+                .estado(EstadoLote.DISPONIBLE)
+                .stockLote(new BigDecimal("5.00"))
+                .stockReservado(BigDecimal.ZERO.setScale(6))
+                .agotado(false)
+                .build());
+
+        Proveedor proveedor = proveedorRepository.save(Proveedor.builder()
+                .nombre("Proveedor Test")
+                .identificacion("123456789")
+                .telefono("1234567")
+                .email("proveedor@example.com")
+                .direccion("Calle 123")
+                .nombreContacto("Contacto")
+                .activo(true)
+                .build());
+
+        ordenCompra = ordenCompraRepository.save(OrdenCompra.builder()
+                .codigoOrden("OC-001")
+                .fechaOrden(LocalDateTime.of(2023, 12, 31, 8, 0))
+                .proveedor(proveedor)
+                .estado(com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra.ENVIADA)
+                .observaciones("Orden de prueba")
+                .build());
+
+        OrdenCompraDetalle ordenCompraDetalle = ordenCompraDetalleRepository.save(OrdenCompraDetalle.builder()
+                .ordenCompra(ordenCompra)
+                .producto(producto)
+                .cantidad(new BigDecimal("10.000"))
+                .valorUnitario(new BigDecimal("2.000"))
+                .valorTotal(new BigDecimal("20.000"))
+                .iva(BigDecimal.ZERO.setScale(2))
+                .cantidadRecibida(BigDecimal.ZERO.setScale(3))
+                .build());
+
+        recepcionOC = recepcionOCRepository.save(RecepcionOC.builder()
+                .codigo("RC-20240101-01")
+                .fechaRecepcion(LocalDate.of(2024, 1, 1))
+                .ordenCompra(ordenCompra)
+                .almacenDestino(almacen)
+                .proveedor(proveedor)
+                .usuario(usuario)
+                .observaciones("Recepción de prueba")
+                .build());
+
+        RecepcionOCDetalle detalle = recepcionOCDetalleRepository.save(RecepcionOCDetalle.builder()
+                .recepcionOc(recepcionOC)
+                .ordenCompraDetalle(ordenCompraDetalle)
+                .producto(producto)
+                .lote(lote)
+                .cantidadRecibida(new BigDecimal("5.000"))
+                .build());
+        recepcionOC.getDetalles().add(detalle);
+
+        MotivoMovimiento motivo = motivoMovimientoRepository.save(MotivoMovimiento.builder()
+                .descripcion("Recepción de compra")
+                .motivo(ClasificacionMovimientoInventario.RECEPCION_COMPRA)
+                .build());
+
+        TipoMovimientoDetalle tipoDetalle = tipoMovimientoDetalleRepository.save(TipoMovimientoDetalle.builder()
+                .descripcion("Ingreso de recepción")
+                .build());
+
+        movimientoInventario = movimientoInventarioRepository.save(MovimientoInventario.builder()
+                .cantidad(new BigDecimal("5.00"))
+                .tipoMovimiento(TipoMovimiento.RECEPCION)
+                .clasificacion(ClasificacionMovimientoInventario.RECEPCION_COMPRA)
+                .registradoPor(usuario)
+                .producto(producto)
+                .lote(lote)
+                .almacenDestino(almacen)
+                .proveedor(proveedor)
+                .ordenCompra(ordenCompra)
+                .motivoMovimiento(motivo)
+                .tipoMovimientoDetalle(tipoDetalle)
+                .ordenCompraDetalle(ordenCompraDetalle)
+                .recepcionOc(recepcionOC)
+                .codigoRecepcion("RC-20240101-01")
+                .docReferencia("OC-001")
+                .build());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void recepcionesIncluyenUnidadMedidaEnMovimientos() throws Exception {
+        mockMvc.perform(get("/api/ordenes-compra/{id}/recepciones", ordenCompra.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(recepcionOC.getId()))
+                .andExpect(jsonPath("$[0].movimientos[0].id").value(movimientoInventario.getId()))
+                .andExpect(jsonPath("$[0].movimientos[0].unidad").value("Unidad"));
+    }
+}


### PR DESCRIPTION
### Motivation
- The endpoint was triggering `LazyInitializationException` because `Producto.unidadMedida` was accessed by the response mapper after the Hibernate session had closed. 
- The minimal fix is to fetch the needed association inside the read-only transactional boundary (via `@EntityGraph` fetch paths) and keep mapping/serialization inside that session instead of changing entity fetch types. 

### Description
- Added `producto.unidadMedida` (and related paths) to the `@EntityGraph` on `MovimientoInventarioRepository.findAllByRecepcionOcIdOrderByFechaIngresoAsc` to eager-load the unit before mapping. (`src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java`).
- Moved response assembly for the controller into a new service method `RecepcionOCService.listarRecepcionesPorOrden` implemented with `@Transactional(readOnly = true)` so mapping happens while the session is open. (`src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCService.java`, `src/main/java/com/willyes/clemenintegra/inventario/service/RecepcionOCServiceImpl.java`).
- Updated the controller to call the new service method instead of assembling entities in the controller. (`src/main/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraController.java`).
- Added an integration test that inserts an `OrdenCompra`/`RecepcionOC`/`MovimientoInventario` and asserts the returned JSON includes the movement's `unidad` field, and updated the existing WebMvc test to mock the new service API. (`src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraRecepcionesIntegrationTest.java`, `src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerRecepcionesTest.java`).

### Testing
- Ran `mvn -Dtest=OrdenCompraRecepcionesIntegrationTest test` which compiled the project and attempted to run the integration test, but Testcontainers could not find a Docker environment so no tests were executed and surefire reported `Tests run: 0`; the build finished successfully. 
- The `WebMvc` unit test `OrdenCompraControllerRecepcionesTest` was updated to mock the new `RecepcionOCService` and is present for CI; it was not executed in the above run. 
- Manual inspection and local reasoning confirm that `producto.unidadMedida` is now fetched inside the transactional service method and mapping uses the in-session entities, preventing the previous `LazyInitializationException` during serialization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ed842c4483339b801ca62dd471d2)