### PR TITLE
Fix MRP tests: add UnidadMedida fixtures and stabilize OrdenCompra security slice

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerSecurityTest.java
@@ -13,6 +13,7 @@ import com.willyes.clemenintegra.inventario.mapper.RecepcionOCMapper;
 import com.willyes.clemenintegra.inventario.service.HistorialEstadoOrdenService;
 import com.willyes.clemenintegra.inventario.service.OrdenCompraPdfService;
 import com.willyes.clemenintegra.inventario.service.OrdenCompraService;
+import com.willyes.clemenintegra.inventario.service.RecepcionOCService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -60,6 +61,8 @@ class OrdenCompraControllerSecurityTest {
     private OrdenCompraService ordenCompraService;
     @MockBean
     private HistorialEstadoOrdenService historialEstadoOrdenService;
+    @MockBean
+    private RecepcionOCService recepcionOCService;
     @MockBean
     private RecepcionOCRepository recepcionOCRepository;
     @MockBean

--- a/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.planeacion.controller;
 
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.planeacion.dto.CorridaMrpResponseDTO;
 import com.willyes.clemenintegra.planeacion.model.CorridaMrp;
 import com.willyes.clemenintegra.planeacion.model.DetalleCorridaMrp;
@@ -31,6 +32,13 @@ import static org.mockito.Mockito.when;
 
 class MrpControllerTest {
 
+    private static final UnidadMedida UNIDAD_MEDIDA_BASE = UnidadMedida.builder()
+            .id(1L)
+            .codigo("UND")
+            .nombre("UNIDAD")
+            .simbolo("UND")
+            .build();
+
     @Test
     void toDtoShouldCalculateCriticidadPerRules() {
         MrpController controller = new MrpController(
@@ -49,6 +57,7 @@ class MrpControllerTest {
                 .codigoSku("SKU-1")
                 .nombre("Insumo 1")
                 .categoriaProducto(categoria)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
 
         DetalleCorridaMrp criticidadBaja = DetalleCorridaMrp.builder()
@@ -128,6 +137,7 @@ class MrpControllerTest {
                 .nombre("Producto Semielaborado")
                 .categoriaProducto(categoria)
                 .leadTimeCompraDias(7)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
 
         CorridaMrp corrida = CorridaMrp.builder()
@@ -203,6 +213,7 @@ class MrpControllerTest {
                 .nombre("Producto Alto")
                 .categoriaProducto(categoria)
                 .leadTimeCompraDias(7)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         DetalleCorridaMrp detalleAlto = DetalleCorridaMrp.builder()
                 .id(101L)
@@ -221,6 +232,7 @@ class MrpControllerTest {
                 .nombre("Producto Critico")
                 .categoriaProducto(categoria)
                 .leadTimeCompraDias(21)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         DetalleCorridaMrp detalleCritico = DetalleCorridaMrp.builder()
                 .id(102L)

--- a/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.CategoriaProducto;
+import com.willyes.clemenintegra.inventario.model.UnidadMedida;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
@@ -49,6 +50,13 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MrpServiceImplTest {
 
+    private static final UnidadMedida UNIDAD_MEDIDA_BASE = UnidadMedida.builder()
+            .id(1L)
+            .codigo("UND")
+            .nombre("UNIDAD")
+            .simbolo("UND")
+            .build();
+
     @Mock
     private FormulaProductoRepository formulaProductoRepository;
 
@@ -85,7 +93,7 @@ class MrpServiceImplTest {
 
     @Test
     void calculaRequerimientoNetoEnCeroCuandoInventarioCubreBruto() {
-        Producto producto = Producto.builder().id(1).build();
+        Producto producto = Producto.builder().id(1).unidadMedida(UNIDAD_MEDIDA_BASE).build();
         Map<Producto, BigDecimal> requerimientos = Map.of(producto, BigDecimal.TEN);
 
         mockInventarioDisponible(BigDecimal.valueOf(15));
@@ -100,7 +108,7 @@ class MrpServiceImplTest {
 
     @Test
     void calculaRequerimientoNetoPositivoCuandoInventarioInsuficiente() {
-        Producto producto = Producto.builder().id(2).build();
+        Producto producto = Producto.builder().id(2).unidadMedida(UNIDAD_MEDIDA_BASE).build();
         Map<Producto, BigDecimal> requerimientos = Map.of(producto, BigDecimal.TEN);
 
         mockInventarioDisponible(BigDecimal.valueOf(2));
@@ -114,7 +122,7 @@ class MrpServiceImplTest {
 
     @Test
     void descuentaRecepcionesProgramadasDelNeto() {
-        Producto producto = Producto.builder().id(3).build();
+        Producto producto = Producto.builder().id(3).unidadMedida(UNIDAD_MEDIDA_BASE).build();
         Map<Producto, BigDecimal> requerimientos = Map.of(producto, BigDecimal.TEN);
 
         mockInventarioDisponible(BigDecimal.ONE);
@@ -132,14 +140,17 @@ class MrpServiceImplTest {
         Producto productoTerminado = Producto.builder()
                 .id(10)
                 .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.PRODUCTO_TERMINADO).build())
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         Producto semiElaborado = Producto.builder()
                 .id(20)
                 .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO).build())
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         Producto insumoFinal = Producto.builder()
                 .id(30)
                 .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.MATERIA_PRIMA).build())
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
 
         PlanProduccionSemanal plan = PlanProduccionSemanal.builder()
@@ -211,6 +222,7 @@ class MrpServiceImplTest {
                 .id(30)
                 .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.MATERIA_PRIMA).build())
                 .leadTimeCompraDias(7)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         CorridaMrp corrida = CorridaMrp.builder()
                 .horizonteInicio(LocalDate.of(2024, 1, 1))
@@ -243,6 +255,7 @@ class MrpServiceImplTest {
                 .id(40)
                 .categoriaProducto(CategoriaProducto.builder().tipo(TipoCategoria.MATERIA_PRIMA).build())
                 .leadTimeCompraDias(21)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         CorridaMrp corrida = CorridaMrp.builder()
                 .horizonteInicio(LocalDate.of(2024, 1, 1))
@@ -278,10 +291,10 @@ class MrpServiceImplTest {
                 .semanaFin(LocalDate.of(2024, 1, 7))
                 .build();
 
-        Producto insumoNuevo = Producto.builder().id(1).build();
-        Producto insumoAumenta = Producto.builder().id(2).build();
-        Producto insumoReduce = Producto.builder().id(3).build();
-        Producto insumoIgual = Producto.builder().id(4).build();
+        Producto insumoNuevo = Producto.builder().id(1).unidadMedida(UNIDAD_MEDIDA_BASE).build();
+        Producto insumoAumenta = Producto.builder().id(2).unidadMedida(UNIDAD_MEDIDA_BASE).build();
+        Producto insumoReduce = Producto.builder().id(3).unidadMedida(UNIDAD_MEDIDA_BASE).build();
+        Producto insumoIgual = Producto.builder().id(4).unidadMedida(UNIDAD_MEDIDA_BASE).build();
 
         DetalleCorridaMrp detalleAnteriorAumenta = DetalleCorridaMrp.builder()
                 .producto(insumoAumenta)
@@ -341,6 +354,7 @@ class MrpServiceImplTest {
         Producto producto = Producto.builder()
                 .id(1)
                 .leadTimeCompraDias(14)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
                 .corrida(corrida)
@@ -373,6 +387,7 @@ class MrpServiceImplTest {
         Producto producto = Producto.builder()
                 .id(2)
                 .leadTimeCompraDias(7)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
                 .corrida(corrida)
@@ -405,6 +420,7 @@ class MrpServiceImplTest {
         Producto producto = Producto.builder()
                 .id(105)
                 .leadTimeCompraDias(7)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
                 .corrida(corrida)
@@ -437,6 +453,7 @@ class MrpServiceImplTest {
         Producto producto = Producto.builder()
                 .id(83)
                 .leadTimeCompraDias(14)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         Map<Producto, BigDecimal> requerimientos = Map.of(producto, BigDecimal.valueOf(1000));
 
@@ -465,6 +482,7 @@ class MrpServiceImplTest {
         Producto producto = Producto.builder()
                 .id(99)
                 .leadTimeCompraDias(7)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
                 .corrida(corrida)
@@ -491,6 +509,7 @@ class MrpServiceImplTest {
         Producto producto = Producto.builder()
                 .id(3)
                 .leadTimeCompraDias(7)
+                .unidadMedida(UNIDAD_MEDIDA_BASE)
                 .build();
         DetalleCorridaMrp detalle = DetalleCorridaMrp.builder()
                 .corrida(corrida)


### PR DESCRIPTION
### Motivation
- MRP logic requires every `Producto` to have a configured `UnidadMedida`, and several unit tests created `Producto` instances without it causing business-validation failures. 
- The `OrdenCompraControllerSecurityTest` ApplicationContext failed due to a missing controller dependency in the slice (`RecepcionOCService`) and needed a mock to load cleanly.

### Description
- Added a shared `UNIDAD_MEDIDA_BASE` test fixture and assigned it to all `Producto` instances used by MRP tests to ensure `unidadMedida` is always present (files modified: `MrpServiceImplTest.java`, `MrpControllerTest.java`).
- Mocked the missing `RecepcionOCService` in the `OrdenCompraControllerSecurityTest` security slice so the controller context can load reliably (file modified: `OrdenCompraControllerSecurityTest.java`).
- Changes were restricted to test code and fixtures only and preserve production MRP validation (no production logic changes).

### Testing
- Ran the focused tests with `mvn -Dtest=MrpControllerTest,MrpServiceImplTest,OrdenCompraControllerSecurityTest test` and they passed (no failures).
- Ran the full test suite with `mvn test` and the build completed successfully with all tests green.
- Modified files: `src/test/java/com/willyes/clemenintegra/planeacion/service/impl/MrpServiceImplTest.java`, `src/test/java/com/willyes/clemenintegra/planeacion/controller/MrpControllerTest.java`, `src/test/java/com/willyes/clemenintegra/inventario/controller/OrdenCompraControllerSecurityTest.java`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974033a1020833385d323401ab63662)