### PR TITLE
Registrar bitácora para movimientos críticos (no bloqueante)

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioFiltroDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO.SolicitudDetalleAtencionDTO;
+import com.willyes.clemenintegra.inventario.dto.BitacoraCambiosInventarioDTO;
 import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.model.enums.CausaDevolucionPT;
@@ -103,6 +104,18 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             RolUsuario.ROL_ALMACENISTA,
             RolUsuario.ROL_SUPER_ADMIN
     );
+    private static final Set<Long> MOTIVOS_MOVIMIENTO_CRITICOS = Set.of(
+            1L,
+            2L,
+            4L,
+            5L,
+            9L,
+            14L,
+            15L,
+            16L
+    );
+    private static final int MAX_BITACORA_VALOR_NUEVO = 255;
+    private static final int MAX_BITACORA_OBSERVACION = 500;
 
     static final record MovimientoLoteDetalle(LoteProducto lote, BigDecimal cantidad) { }
 
@@ -142,6 +155,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     private final TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
     private final MovimientoInventarioRepository repository;
     private final MovimientoInventarioMapper mapper;
+    private final BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
     private final UsuarioService usuarioService;
     private final SolicitudMovimientoRepository solicitudMovimientoRepository;
     private final SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
@@ -906,6 +920,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         }
 
         MovimientoInventario guardado = repository.save(movimiento);
+        registrarBitacoraMovimientoCritico(guardado, usuario, idempotencyKey);
 
         if (solicitud != null) {
             if (detalleRespuesta == null || detalleRespuesta.isEmpty()) {
@@ -953,6 +968,108 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             respuesta.setDetallesSolicitud(detalles);
         }
         return respuesta;
+    }
+
+    private void registrarBitacoraMovimientoCritico(MovimientoInventario movimiento,
+                                                    Usuario usuario,
+                                                    String idempotencyKey) {
+        if (movimiento == null) {
+            return;
+        }
+        MotivoMovimiento motivoMovimiento = movimiento.getMotivoMovimiento();
+        Long motivoId = motivoMovimiento != null ? motivoMovimiento.getId() : null;
+        if (motivoId == null || !MOTIVOS_MOVIMIENTO_CRITICOS.contains(motivoId)) {
+            return;
+        }
+        if (usuario == null || usuario.getId() == null) {
+            log.warn("BITACORA_MOVIMIENTO_OMITIDA: usuario no disponible para movimientoId={}",
+                    movimiento.getId());
+            return;
+        }
+        String valorNuevo = buildResumenMovimiento(movimiento, motivoId);
+        String observacion = buildObservacionMovimiento(movimiento.getDocReferencia(), idempotencyKey);
+        try {
+            bitacoraCambiosInventarioService.crear(BitacoraCambiosInventarioDTO.builder()
+                    .tablaAfectada("movimientos_inventario")
+                    .registroId(movimiento.getId() != null ? movimiento.getId() : 0L)
+                    .campoModificado("movimiento")
+                    .valorAnt("N/A")
+                    .valorNuevo(valorNuevo)
+                    .accion("MOVIMIENTO_CRITICO_REGISTRADO")
+                    .observacion(observacion)
+                    .fechaCambio(LocalDateTime.now())
+                    .usuarioId(usuario.getId())
+                    .usuarioNombre(resolveNombreUsuario(usuario))
+                    .build());
+        } catch (Exception ex) {
+            log.warn("BITACORA_MOVIMIENTO_ERROR: movimientoId={} motivoId={} msg={}",
+                    movimiento.getId(), motivoId, ex.getMessage(), ex);
+        }
+    }
+
+    private String buildResumenMovimiento(MovimientoInventario movimiento, Long motivoId) {
+        String cantidad = movimiento.getCantidad() != null ? movimiento.getCantidad().toPlainString() : "N/A";
+        String loteId = movimiento.getLote() != null && movimiento.getLote().getId() != null
+                ? movimiento.getLote().getId().toString()
+                : "N/A";
+        String almacenOrigenId = movimiento.getAlmacenOrigen() != null && movimiento.getAlmacenOrigen().getId() != null
+                ? movimiento.getAlmacenOrigen().getId().toString()
+                : "N/A";
+        String almacenDestinoId = movimiento.getAlmacenDestino() != null && movimiento.getAlmacenDestino().getId() != null
+                ? movimiento.getAlmacenDestino().getId().toString()
+                : "N/A";
+        String tipoDetId = movimiento.getTipoMovimientoDetalle() != null
+                && movimiento.getTipoMovimientoDetalle().getId() != null
+                ? movimiento.getTipoMovimientoDetalle().getId().toString()
+                : "N/A";
+        String motivoValue = motivoId != null ? motivoId.toString() : "N/A";
+        String resumen = String.format(
+                "cant=%s, loteId=%s, orig=%s, dest=%s, tipoDetId=%s, motivoId=%s",
+                cantidad,
+                loteId,
+                almacenOrigenId,
+                almacenDestinoId,
+                tipoDetId,
+                motivoValue
+        );
+        return truncate(resumen, MAX_BITACORA_VALOR_NUEVO);
+    }
+
+    private String buildObservacionMovimiento(String docReferencia, String idempotencyKey) {
+        String docRef = safeTexto(docReferencia);
+        String idempotencia = safeTexto(idempotencyKey);
+        String observacion = docRef + " | " + idempotencia;
+        return truncate(observacion, MAX_BITACORA_OBSERVACION);
+    }
+
+    private String safeTexto(String value) {
+        if (StringUtils.hasText(value)) {
+            return value.trim();
+        }
+        return "N/A";
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) {
+            return "N/A";
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+
+    private String resolveNombreUsuario(Usuario usuario) {
+        if (usuario == null) {
+            return "N/A";
+        }
+        if (StringUtils.hasText(usuario.getNombreCompleto())) {
+            return usuario.getNombreCompleto().trim();
+        }
+        if (StringUtils.hasText(usuario.getNombreUsuario())) {
+            return usuario.getNombreUsuario().trim();
+        }
+        return "N/A";
     }
 
     private boolean esContextoOrdenProduccion(MovimientoInventarioDTO dto, SolicitudMovimiento solicitud) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceAlmacenOrigenTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceAlmacenOrigenTest.java
@@ -77,6 +77,8 @@ class MovimientoInventarioServiceAlmacenOrigenTest {
     @Mock
     private MovimientoInventarioMapper mapper;
     @Mock
+    private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
+    @Mock
     private UsuarioService usuarioService;
     @Mock
     private SolicitudMovimientoRepository solicitudMovimientoRepository;

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
@@ -61,6 +61,8 @@ class MovimientoInventarioServiceConsumoEtapaTest {
     @Mock
     private MovimientoInventarioMapper mapper;
     @Mock
+    private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
+    @Mock
     private UsuarioService usuarioService;
     @Mock
     private SolicitudMovimientoRepository solicitudMovimientoRepository;

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDevolucionClienteTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDevolucionClienteTest.java
@@ -81,6 +81,8 @@ class MovimientoInventarioServiceDevolucionClienteTest {
     @Mock
     private MovimientoInventarioMapper mapper;
     @Mock
+    private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
+    @Mock
     private UsuarioService usuarioService;
     @Mock
     private SolicitudMovimientoRepository solicitudMovimientoRepository;

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDuplicarMovimientoBaseTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceDuplicarMovimientoBaseTest.java
@@ -32,6 +32,7 @@ class MovimientoInventarioServiceDuplicarMovimientoBaseTest {
     @Mock private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
     @Mock private MovimientoInventarioRepository repository;
     @Mock private MovimientoInventarioMapper mapper;
+    @Mock private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
     @Mock private UsuarioService usuarioService;
     @Mock private SolicitudMovimientoRepository solicitudMovimientoRepository;
     @Mock private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceFefoTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceFefoTest.java
@@ -53,6 +53,8 @@ class MovimientoInventarioServiceFefoTest {
     @Mock
     private MovimientoInventarioMapper mapper;
     @Mock
+    private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
+    @Mock
     private UsuarioService usuarioService;
     @Mock
     private SolicitudMovimientoRepository solicitudMovimientoRepository;

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSalidaPtTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSalidaPtTest.java
@@ -72,6 +72,8 @@ class MovimientoInventarioServiceSalidaPtTest {
     @Mock
     private MovimientoInventarioMapper mapper;
     @Mock
+    private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
+    @Mock
     private UsuarioService usuarioService;
     @Mock
     private SolicitudMovimientoRepository solicitudMovimientoRepository;

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -68,6 +68,8 @@ class MovimientoInventarioServiceSolicitudOpTest {
     @Mock
     private MovimientoInventarioMapper mapper;
     @Mock
+    private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
+    @Mock
     private UsuarioService usuarioService;
     @Mock
     private SolicitudMovimientoRepository solicitudMovimientoRepository;

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
@@ -1,10 +1,12 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.dto.BitacoraCambiosInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.MovimientoInventarioMapper;
 import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MotivoMovimiento;
 import com.willyes.clemenintegra.inventario.model.MovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.TipoMovimientoDetalle;
@@ -16,6 +18,7 @@ import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository;
 import jakarta.persistence.EntityManager;
@@ -41,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.doThrow;
@@ -70,6 +74,8 @@ class MovimientoInventarioServiceTransferenciaTest {
     private MovimientoInventarioRepository movimientoInventarioRepository;
     @Mock
     private MovimientoInventarioMapper mapper;
+    @Mock
+    private BitacoraCambiosInventarioService bitacoraCambiosInventarioService;
     @Mock
     private UsuarioService usuarioService;
     @Mock
@@ -423,6 +429,146 @@ class MovimientoInventarioServiceTransferenciaTest {
                 .isInstanceOfSatisfying(CustomBusinessException.class, ex -> {
                     assertThat(ex.getCode()).isEqualTo(ApiErrorCode.UBICACION_NO_PERTENECE_ALMACEN);
                 });
+    }
+
+    @Test
+    void registrarMovimiento_registraBitacoraParaMotivoCritico() {
+        Producto producto = crearProducto(21, 2);
+        LoteProducto lote = crearLote(50L, producto, 1, EstadoLote.LIBERADO,
+                new BigDecimal("4000"), BigDecimal.ZERO, false);
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("1000"),
+                TipoMovimiento.TRANSFERENCIA,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_GENERAL,
+                "DOC-123",
+                null,
+                null,
+                null,
+                null,
+                producto.getId(),
+                lote.getId(),
+                1,
+                6,
+                null,
+                null,
+                1L,
+                5L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                null,
+                Boolean.FALSE,
+                null
+        );
+
+        configurarMocksBasicos(producto, lote);
+        given(usuarioService.obtenerUsuarioAutenticado())
+                .willReturn(Usuario.builder().id(1L).nombreCompleto("Tester").build());
+        given(movimientoInventarioRepository.findByIdempotencyKey("idem-1"))
+                .willReturn(Optional.empty());
+        MotivoMovimiento motivo = new MotivoMovimiento();
+        motivo.setId(1L);
+        motivo.setMotivo(ClasificacionMovimientoInventario.AJUSTE_NEGATIVO);
+        given(motivoMovimientoRepository.findById(1L)).willReturn(Optional.of(motivo));
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(dto.tipoMovimiento());
+        movimientoEntidad.setClasificacion(dto.clasificacionMovimientoInventario());
+        movimientoEntidad.setCantidad(dto.cantidad());
+        movimientoEntidad.setDocReferencia(dto.docReferencia());
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(300L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willReturn(MovimientoInventarioResponseDTO.builder().id(300L).build());
+
+        service.registrarMovimiento(dto, "idem-1");
+
+        ArgumentCaptor<BitacoraCambiosInventarioDTO> bitacoraCaptor =
+                ArgumentCaptor.forClass(BitacoraCambiosInventarioDTO.class);
+        verify(bitacoraCambiosInventarioService).crear(bitacoraCaptor.capture());
+        assertThat(bitacoraCaptor.getValue().getValorNuevo()).isNotNull();
+        assertThat(bitacoraCaptor.getValue().getValorNuevo().length()).isLessThanOrEqualTo(255);
+    }
+
+    @Test
+    void registrarMovimiento_noRegistraBitacoraParaMotivoNoCritico() {
+        Producto producto = crearProducto(22, 2);
+        LoteProducto lote = crearLote(51L, producto, 1, EstadoLote.LIBERADO,
+                new BigDecimal("4000"), BigDecimal.ZERO, false);
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("1000"),
+                TipoMovimiento.TRANSFERENCIA,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_GENERAL,
+                "DOC-456",
+                null,
+                null,
+                null,
+                null,
+                producto.getId(),
+                lote.getId(),
+                1,
+                6,
+                null,
+                null,
+                11L,
+                5L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                null,
+                Boolean.FALSE,
+                null
+        );
+
+        configurarMocksBasicos(producto, lote);
+        given(usuarioService.obtenerUsuarioAutenticado())
+                .willReturn(Usuario.builder().id(2L).nombreCompleto("Tester").build());
+        given(movimientoInventarioRepository.findByIdempotencyKey("idem-2"))
+                .willReturn(Optional.empty());
+        MotivoMovimiento motivo = new MotivoMovimiento();
+        motivo.setId(11L);
+        motivo.setMotivo(ClasificacionMovimientoInventario.SALIDA_PRODUCCION);
+        given(motivoMovimientoRepository.findById(11L)).willReturn(Optional.of(motivo));
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(dto.tipoMovimiento());
+        movimientoEntidad.setClasificacion(dto.clasificacionMovimientoInventario());
+        movimientoEntidad.setCantidad(dto.cantidad());
+        movimientoEntidad.setDocReferencia(dto.docReferencia());
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(301L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willReturn(MovimientoInventarioResponseDTO.builder().id(301L).build());
+
+        service.registrarMovimiento(dto, "idem-2");
+
+        verify(bitacoraCambiosInventarioService, never()).crear(any());
     }
 
     private void configurarMocksBasicos(Producto producto, LoteProducto lote) {


### PR DESCRIPTION
### Motivation
- Evitar crecimiento innecesario de la bitácora registrando solo movimientos críticos definidos por motivos específicos. 
- Asegurar que los inserts a `bitacora_cambios_inventario` no provoquen rollback del movimiento cuando fallen. 

### Description
- Se agregó la inyección de `BitacoraCambiosInventarioService` y constantes con el conjunto de motivos críticos `MOTIVOS_MOVIMIENTO_CRITICOS` y longitudes máximas para campos de bitácora. 
- Después de `repository.save(movimiento)` se invoca `registrarBitacoraMovimientoCritico(...)` que construye un `BitacoraCambiosInventarioDTO` con campos no nulos (`"N/A"` por defecto), `tablaAfectada="movimientos_inventario"`, `campoModificado="movimiento"`, `accion="MOVIMIENTO_CRITICO_REGISTRADO"`, y `observacion` formada por `doc_referencia + " | " + idempotency_key` truncada según límites. 
- La creación de bitácora es resiliente: cualquier excepción durante la creación se captura y solo se registra el warning sin hacer rollback del movimiento. 
- Se añadieron helpers para construir/respetar la longitud del `valorNuevo` y `observacion`, y para resolver el nombre de usuario a partir del `Usuario` autenticado. 
- Tests unitarios: se añadieron dos tests en `MovimientoInventarioServiceTransferenciaTest` que verifican que se cree la bitácora para un motivo crítico y que no se cree para un motivo excluido, y se actualizaron varios tests para mockear la nueva dependencia. 

### Testing
- Ejecutado el test modificado con `mvn -q -Dtest=MovimientoInventarioServiceTransferenciaTest test` y la suite de esa clase pasó exitosamente. 
- Los nuevos tests cubren: `registrarMovimiento_registraBitacoraParaMotivoCritico` (verifica llamada a `bitacoraCambiosInventarioService.crear` y longitud `valorNuevo <= 255`) y `registrarMovimiento_noRegistraBitacoraParaMotivoNoCritico` (verifica que no se invoque la bitácora). 
- Se actualizaron otros tests para inyectar `BitacoraCambiosInventarioService` como mock para mantener compatibilidad con la clase modificada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977995b16d08333ae3c9aed08b4fa5e)