### PR TITLE
Permitir ROL_PLANEADOR en flujo de órdenes de producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
@@ -50,13 +50,15 @@ public class BatchRecordController {
     private final ReporteBatchRecordService reporteBatchRecordService;
 
     @GetMapping("/produccion/batch-record/{ordenProduccionId}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<BatchRecordDTO> obtener(@PathVariable Long ordenProduccionId) {
         return ResponseEntity.ok(batchRecordService.buildByOrdenProduccion(ordenProduccionId));
     }
 
     @PostMapping("/produccion/batch-record/{ordenProduccionId}/controles-proceso")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<List<BatchRecordDTO.ControlProcesoDTO>> guardarControlesProceso(
             @PathVariable Long ordenProduccionId,
@@ -86,7 +88,8 @@ public class BatchRecordController {
     }
 
     @PostMapping("/produccion/batch-record/{ordenProduccionId}/controles-empaque")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<List<BatchRecordDTO.ControlEmpaqueDTO>> guardarControlesEmpaque(
             @PathVariable Long ordenProduccionId,
@@ -115,7 +118,8 @@ public class BatchRecordController {
     }
 
     @PostMapping("/produccion/batch-record/{ordenProduccionId}/observaciones")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<List<BatchRecordDTO.ObservacionProcesoDTO>> guardarObservaciones(
             @PathVariable Long ordenProduccionId,
@@ -141,7 +145,7 @@ public class BatchRecordController {
     }
 
     @GetMapping(value = "/produccion/batch-record/{ordenProduccionId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportarPdf(@PathVariable Long ordenProduccionId) {
         try {
             BatchRecordDTO batchRecordDTO = batchRecordService.buildByOrdenProduccion(ordenProduccionId);

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaController.java
@@ -20,20 +20,23 @@ public class ChecklistEtapaController {
     private final ChecklistEtapaService checklistEtapaService;
 
     @GetMapping("/{etapaId}/checklist")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistEtapaDTO> obtener(@PathVariable Long etapaId) {
         return ResponseEntity.ok(checklistEtapaService.obtenerPorEtapa(etapaId));
     }
 
     @PutMapping("/{etapaId}/checklist")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistEtapaDTO> actualizar(@PathVariable Long etapaId,
                                                         @RequestBody List<ChecklistItemDTO> items) {
         return ResponseEntity.ok(checklistEtapaService.actualizar(etapaId, items));
     }
 
     @GetMapping(value = "/orden/{ordenId}/checklist/export", produces = "text/csv")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> exportar(@PathVariable Long ordenId) {
         byte[] csv = checklistEtapaService.exportCsvPorOrden(ordenId);
         return ResponseEntity.ok()

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/DetalleEtapaController.java
@@ -25,7 +25,8 @@ public class DetalleEtapaController {
     private final com.willyes.clemenintegra.shared.service.UsuarioService usuarioService;
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public List<DetalleEtapaResponse> listarTodas() {
         return service.listarTodas().stream()
                 .map(ProduccionMapper::toResponse)
@@ -33,7 +34,8 @@ public class DetalleEtapaController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<DetalleEtapaResponse> obtenerPorId(@PathVariable Long id) {
         return service.buscarPorId(id)
                 .map(ProduccionMapper::toResponse)
@@ -42,7 +44,8 @@ public class DetalleEtapaController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<DetalleEtapaResponse> crear(@Valid @RequestBody DetalleEtapaRequest request) {
         normalizarRequest(request, null);
         EtapaProduccion etapa = new EtapaProduccion(); etapa.setId(request.etapaProduccionId);
@@ -53,7 +56,8 @@ public class DetalleEtapaController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<DetalleEtapaResponse> actualizar(@PathVariable Long id, @Valid @RequestBody DetalleEtapaRequest request) {
         return service.buscarPorId(id)
                 .map(existente -> {
@@ -69,7 +73,8 @@ public class DetalleEtapaController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {
         service.eliminar(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaProduccionController.java
@@ -36,7 +36,8 @@ public class EtapaProduccionController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaProduccionResponse> crear(@RequestBody EtapaProduccionRequest request) {
         OrdenProduccion orden = new OrdenProduccion(); orden.setId(request.ordenProduccionId);
         EtapaProduccion entidad = ProduccionMapper.toEntity(request, orden);
@@ -44,7 +45,7 @@ public class EtapaProduccionController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaProduccionResponse> actualizar(@PathVariable Long id, @RequestBody EtapaProduccionRequest request) {
         return service.buscarPorId(id)
                 .map(existente -> {
@@ -57,7 +58,7 @@ public class EtapaProduccionController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {
         service.eliminar(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -138,14 +138,15 @@ public class OrdenProduccionController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {
         service.eliminar(id);
         return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/{id}/finalizar")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> finalizar(@PathVariable Long id,
                                                                @RequestBody FinalizarOrdenRequestDTO request) {
         OrdenProduccion orden = service.finalizar(id, request.getCantidadProducida());
@@ -153,7 +154,8 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{id}/cancelar")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> cancelar(@PathVariable Long id,
                                                                @RequestBody(required = false) CancelarOrdenRequestDTO request) {
         OrdenProduccion orden = service.cancelarOrden(id, request != null ? request.getMotivo() : null);
@@ -161,7 +163,8 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{id}/cierres")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> registrarCierre(@PathVariable Long id,
                                                                      @Valid @RequestBody CierreProduccionRequestDTO request) {
         log.debug("Registrar cierre recibido: ordenId={}, payload={}", id, request);
@@ -185,14 +188,15 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{id}/etapas/clonar")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> clonarEtapas(@PathVariable Long id) {
         service.clonarEtapas(id);
         return ResponseEntity.noContent().build();
     }
 
     @RequestMapping(value = "/{ordenId}/etapas/{etapaId}/iniciar", method = {RequestMethod.PATCH, RequestMethod.POST})
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> iniciarEtapa(@PathVariable Long ordenId, @PathVariable Long etapaId) {
         service.iniciarEtapa(ordenId, etapaId);
         return service.buscarPorId(ordenId)
@@ -203,7 +207,8 @@ public class OrdenProduccionController {
 
     // Compatibilidad POST agregada porque el frontend usa POST
     @RequestMapping(value = "/{ordenId}/etapas/{etapaId}/finalizar", method = {RequestMethod.PATCH, RequestMethod.POST})
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaProduccionResponse> finalizarEtapa(@PathVariable Long ordenId, @PathVariable Long etapaId) {
         Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
         return ResponseEntity.ok(ProduccionMapper.toResponse(service.finalizarEtapa(ordenId, etapaId, usuario.getId())));
@@ -262,7 +267,8 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{ordenId}/etapas/{etapaId}/checklist/{itemId}/completar")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistItemDTO> completarChecklistItem(@PathVariable Long ordenId,
                                                                    @PathVariable Long etapaId,
                                                                    @PathVariable Long itemId,
@@ -272,7 +278,8 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{ordenId}/etapas/{etapaId}/checklist/{itemId}/no-aplica")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistItemDTO> marcarNoAplicaChecklistItem(@PathVariable Long ordenId,
                                                                         @PathVariable Long etapaId,
                                                                         @PathVariable Long itemId,
@@ -282,7 +289,7 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{ordenId}/etapas/{etapaId}/checklist/{itemId}/reabrir")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistItemDTO> reabrirChecklistItem(@PathVariable Long ordenId,
                                                                  @PathVariable Long etapaId,
                                                                  @PathVariable Long itemId) {
@@ -290,14 +297,15 @@ public class OrdenProduccionController {
     }
 
     @GetMapping("/{id}/lote")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<LoteProductoResponse> obtenerLote(@PathVariable Long id) {
         LoteProductoResponse lote = service.obtenerLote(id);
         return lote != null ? ResponseEntity.ok(lote) : ResponseEntity.notFound().build();
     }
 
     @PostMapping("/{ordenId}/backfill-salida")
-    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION')")
+    @PreAuthorize("hasAnyAuthority('ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_PLANEADOR')")
     public ResponseEntity<Map<String, Object>> backfillSalidaProduccion(@PathVariable Long ordenId) {
 
         // Obtener el usuario autenticado usando el mismo patrón del resto del backend

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/ProduccionReportesController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/ProduccionReportesController.java
@@ -23,13 +23,15 @@ public class ProduccionReportesController {
     private final ReportesProduccionService reportesProduccionService;
 
     @GetMapping("/{id}/consumo-real-vs-teorico")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ConsumoTeoricoRealResponseDTO> consumoRealVsTeorico(@PathVariable Long id) {
         return ResponseEntity.ok(consumoTeoricoRealService.obtenerConsumo(id));
     }
 
     @GetMapping(value = "/{id}/batch-record/excel", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
+            "'ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> descargarBatchRecordExcel(@PathVariable Long id) {
         byte[] excel = reportesProduccionService.generarBatchRecordExcel(id);
         HttpHeaders headers = new HttpHeaders();
@@ -39,7 +41,7 @@ public class ProduccionReportesController {
     }
 
     @GetMapping(value = "/{id}/batch-record/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_CALIDAD','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<byte[]> descargarBatchRecordPdf(@PathVariable Long id) {
         byte[] pdf = reportesProduccionService.generarBatchRecordPdf(id);
         HttpHeaders headers = new HttpHeaders();
@@ -48,4 +50,3 @@ public class ProduccionReportesController {
         return new ResponseEntity<>(pdf, headers, HttpStatus.OK);
     }
 }
-

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
@@ -2,6 +2,9 @@ package com.willyes.clemenintegra.produccion.web;
 
 import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import com.willyes.clemenintegra.produccion.controller.OrdenProduccionController;
+import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.service.ChecklistEtapaService;
 import com.willyes.clemenintegra.produccion.service.OrdenProduccionService;
 import com.willyes.clemenintegra.produccion.service.ReporteOrdenProduccionService;
@@ -121,6 +124,87 @@ class OrdenProduccionControllerSecurityTest {
     @DisplayName("POST /api/produccion/ordenes/{id}/cierres es rechazado para jefe de calidad")
     void registrarCierre_conRolJefeCalidad_devuelve403() throws Exception {
         mockMvc.perform(post("/api/produccion/ordenes/{id}/cierres", 5L)
+                        .contentType("application/json")
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("GET /api/produccion/ordenes permite listar con rol planeador")
+    void listarOrdenes_conRolPlaneador_devuelve200() throws Exception {
+        when(ordenProduccionService.listarPaginado(any(), any(), any(), any(), any(), any())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/produccion/ordenes"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("GET /api/produccion/ordenes/{id} permite ver detalle con rol planeador")
+    void obtenerOrden_conRolPlaneador_devuelve404SiNoExiste() throws Exception {
+        when(ordenProduccionService.buscarPorId(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/produccion/ordenes/{id}", 1L))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("POST /api/produccion/ordenes permite crear con rol planeador")
+    void crearOrden_conRolPlaneador_devuelve201() throws Exception {
+        when(ordenProduccionService.crearOrden(any()))
+                .thenReturn(ResultadoValidacionOrdenDTO.builder().esValida(true).build());
+
+        mockMvc.perform(post("/api/produccion/ordenes")
+                        .contentType("application/json")
+                        .content("{}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("PUT /api/produccion/ordenes/{id} permite actualizar con rol planeador")
+    void actualizarOrden_conRolPlaneador_devuelve404SiNoExiste() throws Exception {
+        when(ordenProduccionService.buscarPorId(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .put("/api/produccion/ordenes/{id}", 1L)
+                        .contentType("application/json")
+                        .content("{}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("POST /api/produccion/ordenes/{id}/cancelar permite workflow con rol planeador")
+    void cancelarOrden_conRolPlaneador_devuelve200() throws Exception {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(1L);
+        orden.setEstado(EstadoProduccion.CREADA);
+        when(ordenProduccionService.cancelarOrden(any(), any())).thenReturn(orden);
+
+        mockMvc.perform(post("/api/produccion/ordenes/{id}/cancelar", 1L)
+                        .contentType("application/json")
+                        .content("{}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    @DisplayName("POST /api/produccion/ordenes rechaza rol no autorizado")
+    void crearOrden_conRolAlmacenista_devuelve403() throws Exception {
+        mockMvc.perform(post("/api/produccion/ordenes")
+                        .contentType("application/json")
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    @DisplayName("POST /api/produccion/ordenes/{id}/cancelar rechaza rol no autorizado")
+    void cancelarOrden_conRolAlmacenista_devuelve403() throws Exception {
+        mockMvc.perform(post("/api/produccion/ordenes/{id}/cancelar", 1L)
                         .contentType("application/json")
                         .content("{}"))
                 .andExpect(status().isForbidden());


### PR DESCRIPTION
### Motivation
- El frontend habilitó acciones de PLANEADOR en el flujo de Órdenes de Producción y el backend debe autorizar ese rol para evitar 403 e inconsistencias al ejecutar CRUD y acciones de workflow (cancelar, checklist, cambios de estado, batch record, reportes). 

### Description
- Se agregó `ROL_PLANEADOR` en las expresiones `@PreAuthorize` de los controladores del módulo de Producción para autorizar operaciones de O.P., etapas, detalles y checklist; los ficheros modificados incluyen `OrdenProduccionController`, `EtapaProduccionController`, `DetalleEtapaController`, `ChecklistEtapaController`, `BatchRecordController` y `ProduccionReportesController`.
- En `OrdenProduccionController` se amplió autorización para endpoints de creación/edición/listado/borrado y acciones de workflow (`/finalizar`, `/cancelar`, `/cierres`, `/etapas/*/iniciar|finalizar`, checklist y utilidades como `/lote` y `/backfill-salida`).
- En `BatchRecordController` y `ProduccionReportesController` se añadió `ROL_PLANEADOR` para permitir ver/guardar controles, observaciones y descargar/exportar batch records y reportes relacionados con O.P.
- Se extendieron y añadieron tests de seguridad en `OrdenProduccionControllerSecurityTest` para comprobar que `ROL_PLANEADOR` puede listar/ver/crear/actualizar y ejecutar al menos una acción de workflow y que roles no autorizados (ej. `ROL_ALMACENISTA`) reciben `403`.

### Testing
- Ejecuté `mvn -Dtest=OrdenProduccionControllerSecurityTest test` y la suite objetivo terminó con `BUILD SUCCESS` y resultados `Tests run: 13, Failures: 0, Errors: 0, Skipped: 0`.
- Se verificó explícitamente en tests que `ROL_PLANEADOR` obtiene `200/201/404` según caso y que `ROL_ALMACENISTA` recibe `403` donde corresponde.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d980e2608333b20f29a26276c647)