### PR TITLE
Add RBAC schema, entities, authorities and /api/auth/me endpoint

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/shared/dto/auth/AuthMeResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/dto/auth/AuthMeResponseDTO.java
@@ -1,0 +1,6 @@
+package com.willyes.clemenintegra.shared.dto.auth;
+
+import java.util.List;
+
+public record AuthMeResponseDTO(Long usuarioId, String username, String nombre, String rol, List<String> permisos) {
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/model/rbac/PermisoEntity.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/model/rbac/PermisoEntity.java
@@ -1,0 +1,50 @@
+package com.willyes.clemenintegra.shared.model.rbac;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "permisos")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PermisoEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "codigo", nullable = false, length = 120, unique = true)
+    private String codigo;
+
+    @Column(name = "modulo", nullable = false, length = 40)
+    private String modulo;
+
+    @Column(name = "accion", nullable = false, length = 40)
+    private String accion;
+
+    @Column(name = "descripcion", length = 255)
+    private String descripcion;
+
+    @Column(name = "activo", nullable = false)
+    private boolean activo;
+
+    @ManyToMany(mappedBy = "permisos", fetch = FetchType.LAZY)
+    @Builder.Default
+    private Set<RolEntity> roles = new HashSet<>();
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/model/rbac/RolEntity.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/model/rbac/RolEntity.java
@@ -1,0 +1,52 @@
+package com.willyes.clemenintegra.shared.model.rbac;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "roles")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RolEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "codigo", nullable = false, length = 80, unique = true)
+    private String codigo;
+
+    @Column(name = "nombre", length = 120)
+    private String nombre;
+
+    @Column(name = "activo", nullable = false)
+    private boolean activo;
+
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(
+            name = "roles_permisos",
+            joinColumns = @JoinColumn(name = "rol_id"),
+            inverseJoinColumns = @JoinColumn(name = "permiso_id")
+    )
+    @Builder.Default
+    private Set<PermisoEntity> permisos = new HashSet<>();
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/repository/PermisoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/repository/PermisoRepository.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.shared.repository;
+
+import com.willyes.clemenintegra.shared.model.rbac.PermisoEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PermisoRepository extends JpaRepository<PermisoEntity, Long> {
+
+    List<PermisoEntity> findByRolesCodigoAndActivoTrue(String codigo);
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/repository/RolRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/repository/RolRepository.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.shared.repository;
+
+import com.willyes.clemenintegra.shared.model.rbac.RolEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RolRepository extends JpaRepository<RolEntity, Long> {
+
+    Optional<RolEntity> findByCodigoAndActivoTrue(String codigo);
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/security/CustomUserDetailsService.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/CustomUserDetailsService.java
@@ -3,27 +3,25 @@ package com.willyes.clemenintegra.shared.security;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
+import com.willyes.clemenintegra.shared.security.service.UsuarioAuthoritiesService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.*;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UsuarioRepository usuarioRepository;
+    private final UsuarioAuthoritiesService usuarioAuthoritiesService;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Usuario usuario = usuarioRepository.findByNombreUsuario(username)
                 .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado"));
 
-        return new CustomUserDetails(usuario);  // ✅ Usa tu clase personalizada
+        return new CustomUserDetails(usuario, usuarioAuthoritiesService.buildAuthorities(usuario));
     }
 }
-
-

--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationFilter.java
@@ -29,7 +29,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final AuthenticationEntryPoint authenticationEntryPoint;
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
     private final List<String> publicMatchers = List.of(
-            "/api/auth/**",
+            "/api/auth/login",
+            "/api/auth/verificar",
             "/api/public/**",
             "/api/health",
             "/api/health/**",

--- a/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProvider.java
@@ -9,6 +9,7 @@ import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaAuthe
 import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
 import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
 import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
+import com.willyes.clemenintegra.shared.security.service.UsuarioAuthoritiesService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -35,6 +36,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
     private final JwtTokenService jwtTokenService;
     private final UsuarioRepository usuarioRepository;
+    private final UsuarioAuthoritiesService usuarioAuthoritiesService;
 
     @Value("${security.session.max-idle-minutes:20}")
     private long maxIdleMinutes;
@@ -51,7 +53,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
             validarSesion(claims, usuario);
 
-            CustomUserDetails principal = new CustomUserDetails(usuario);
+            CustomUserDetails principal = new CustomUserDetails(usuario, usuarioAuthoritiesService.buildAuthorities(usuario));
             UsernamePasswordAuthenticationToken authenticated = new UsernamePasswordAuthenticationToken(
                     principal, token, principal.getAuthorities()
             );

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.willyes.clemenintegra.shared.security.model.UsuarioPrincipal;
+import com.willyes.clemenintegra.shared.security.service.UsuarioAuthoritiesService;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -19,6 +20,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -30,6 +32,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -95,7 +98,8 @@ public class SecurityConfig {
                             "/api/health",
                             "/api/health/**",
                             "/auth/login",
-                            "/api/auth/**",
+                            "/api/auth/login",
+                            "/api/auth/verificar",
                             "/v3/api-docs/**",
                             "/swagger-ui.html",
                             "/swagger-ui/**",
@@ -476,10 +480,18 @@ public class SecurityConfig {
     }
 
     @Bean
-    public UserDetailsService userDetailsService(UsuarioRepository usuarioRepository) {
+    public UserDetailsService userDetailsService(UsuarioRepository usuarioRepository,
+                                                 ObjectProvider<UsuarioAuthoritiesService> usuarioAuthoritiesServiceProvider) {
         return username -> usuarioRepository
                 .findByNombreUsuario(username.trim())
-                .map(UsuarioPrincipal::new) // usa tu clase que implementa UserDetails
+                .map(usuario -> {
+                    UsuarioAuthoritiesService usuarioAuthoritiesService = usuarioAuthoritiesServiceProvider.getIfAvailable();
+                    if (usuarioAuthoritiesService == null) {
+                        return new UsuarioPrincipal(usuario,
+                                List.of(new SimpleGrantedAuthority(usuario.getRol().name())));
+                    }
+                    return new UsuarioPrincipal(usuario, usuarioAuthoritiesService.buildAuthorities(usuario));
+                })
                 .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado"));
     }
 }

--- a/src/main/java/com/willyes/clemenintegra/shared/security/controller/AuthController.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/controller/AuthController.java
@@ -1,11 +1,18 @@
 package com.willyes.clemenintegra.shared.security.controller;
 
+import com.willyes.clemenintegra.shared.dto.auth.AuthMeResponseDTO;
 import com.willyes.clemenintegra.shared.dto.auth.AuthResponseDTO;
 import com.willyes.clemenintegra.shared.dto.auth.Codigo2FARequestDTO;
 import com.willyes.clemenintegra.shared.dto.auth.LoginRequestDTO;
+import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.security.service.AuthService;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import java.util.List;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final UsuarioService usuarioService;
 
     @PostMapping("/login")
     public ResponseEntity<String> login(@RequestBody LoginRequestDTO dto) {
@@ -28,5 +36,23 @@ public class AuthController {
     public ResponseEntity<AuthResponseDTO> verificarCodigo(@RequestBody Codigo2FARequestDTO dto) {
         return ResponseEntity.ok(authService.verificarCodigo2FA(dto));
     }
-}
 
+    @GetMapping("/me")
+    public ResponseEntity<AuthMeResponseDTO> me(Authentication authentication) {
+        Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
+        List<String> permisos = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(authority -> !authority.startsWith("ROL_"))
+                .sorted()
+                .toList();
+
+        AuthMeResponseDTO response = new AuthMeResponseDTO(
+                usuario.getId(),
+                usuario.getNombreUsuario(),
+                usuario.getNombreCompleto(),
+                usuario.getRol() != null ? usuario.getRol().name() : null,
+                permisos
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/shared/security/model/UsuarioPrincipal.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/model/UsuarioPrincipal.java
@@ -14,9 +14,15 @@ import java.util.List;
 public class UsuarioPrincipal implements UserDetails {
 
     private final Usuario usuario;
+    private final Collection<? extends GrantedAuthority> authorities;
 
     public UsuarioPrincipal(Usuario usuario) {
+        this(usuario, List.of(new SimpleGrantedAuthority(usuario.getRol().name())));
+    }
+
+    public UsuarioPrincipal(Usuario usuario, Collection<? extends GrantedAuthority> authorities) {
         this.usuario = usuario;
+        this.authorities = authorities;
     }
 
     public Usuario getUsuario() {
@@ -25,8 +31,7 @@ public class UsuarioPrincipal implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // Convertimos el rol del usuario en un GrantedAuthority
-        return List.of(new SimpleGrantedAuthority(usuario.getRol().name()));
+        return authorities;
     }
 
     @Override
@@ -59,4 +64,3 @@ public class UsuarioPrincipal implements UserDetails {
         return usuario.isActivo();
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/shared/security/service/CustomUserDetails.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/service/CustomUserDetails.java
@@ -11,9 +11,15 @@ import java.util.Collections;
 public class CustomUserDetails implements UserDetails {
 
     private final Usuario usuario;
+    private final Collection<? extends GrantedAuthority> authorities;
 
     public CustomUserDetails(Usuario usuario) {
+        this(usuario, Collections.singletonList(new SimpleGrantedAuthority(usuario.getRol().name())));
+    }
+
+    public CustomUserDetails(Usuario usuario, Collection<? extends GrantedAuthority> authorities) {
         this.usuario = usuario;
+        this.authorities = authorities;
     }
 
     // Este es el método que usarás en tu UsuarioService
@@ -27,8 +33,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // Convertimos tu Enum RolUsuario a GrantedAuthority
-        return Collections.singletonList(new SimpleGrantedAuthority(usuario.getRol().name()));
+        return authorities;
     }
 
     @Override
@@ -61,4 +66,3 @@ public class CustomUserDetails implements UserDetails {
         return usuario.isActivo();
     }
 }
-

--- a/src/main/java/com/willyes/clemenintegra/shared/security/service/UsuarioAuthoritiesService.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/service/UsuarioAuthoritiesService.java
@@ -1,0 +1,40 @@
+package com.willyes.clemenintegra.shared.security.service;
+
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.rbac.PermisoEntity;
+import com.willyes.clemenintegra.shared.repository.PermisoRepository;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UsuarioAuthoritiesService {
+
+    private final PermisoRepository permisoRepository;
+
+    public Collection<? extends GrantedAuthority> buildAuthorities(Usuario usuario) {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        if (usuario == null || usuario.getRol() == null) {
+            return authorities;
+        }
+
+        authorities.add(new SimpleGrantedAuthority(usuario.getRol().name()));
+
+        List<GrantedAuthority> permisos = permisoRepository.findByRolesCodigoAndActivoTrue(usuario.getRol().name()).stream()
+                .map(PermisoEntity::getCodigo)
+                .filter(Objects::nonNull)
+                .distinct()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+        authorities.addAll(permisos);
+
+        return authorities;
+    }
+}

--- a/src/main/resources/db/migration/inventario/V20260126__rbac_roles_permisos.sql
+++ b/src/main/resources/db/migration/inventario/V20260126__rbac_roles_permisos.sql
@@ -1,0 +1,31 @@
+create table roles (
+    id bigint not null auto_increment,
+    codigo varchar(80) not null,
+    nombre varchar(120) null,
+    activo bit(1) not null default b'1',
+    primary key (id),
+    unique key uk_roles_codigo (codigo)
+) ENGINE=InnoDB;
+
+create table permisos (
+    id bigint not null auto_increment,
+    codigo varchar(120) not null,
+    modulo varchar(40) not null,
+    accion varchar(40) not null,
+    descripcion varchar(255) null,
+    activo bit(1) not null default b'1',
+    primary key (id),
+    unique key uk_permisos_codigo (codigo)
+) ENGINE=InnoDB;
+
+create table roles_permisos (
+    rol_id bigint not null,
+    permiso_id bigint not null,
+    primary key (rol_id, permiso_id),
+    constraint fk_roles_permisos_rol
+        foreign key (rol_id) references roles (id)
+        on delete cascade,
+    constraint fk_roles_permisos_permiso
+        foreign key (permiso_id) references permisos (id)
+        on delete cascade
+) ENGINE=InnoDB;

--- a/src/main/resources/db/migration/inventario/V20260127__rbac_seed_roles_permisos.sql
+++ b/src/main/resources/db/migration/inventario/V20260127__rbac_seed_roles_permisos.sql
@@ -1,0 +1,167 @@
+insert into roles (codigo, nombre, activo)
+select 'ROL_MICROBIOLOGO', 'Microbiologo', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_MICROBIOLOGO');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_JEFE_CALIDAD', 'Jefe Calidad', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_JEFE_CALIDAD');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_ANALISTA_CALIDAD', 'Analista Calidad', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_ANALISTA_CALIDAD');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_JEFE_ALMACENES', 'Jefe Almacenes', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_JEFE_ALMACENES');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_ALMACENISTA', 'Almacenista', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_ALMACENISTA');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_JEFE_PRODUCCION', 'Jefe Produccion', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_JEFE_PRODUCCION');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_LIDER_HOMEOPATICOS', 'Lider Homeopaticos', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_LIDER_HOMEOPATICOS');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_LIDER_ALIMENTOS', 'Lider Alimentos', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_LIDER_ALIMENTOS');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_CONTADOR', 'Contador', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_CONTADOR');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_COMPRADOR', 'Comprador', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_COMPRADOR');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_PLANEADOR', 'Planeador', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_PLANEADOR');
+
+insert into roles (codigo, nombre, activo)
+select 'ROL_SUPER_ADMIN', 'Super Admin', b'1'
+where not exists (select 1 from roles where codigo = 'ROL_SUPER_ADMIN');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_OP_READ', 'PROD', 'READ', 'Lectura de ordenes de produccion', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_OP_READ');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_OP_CREATE', 'PROD', 'CREATE', 'Creacion de ordenes de produccion', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_OP_CREATE');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_OP_EDIT', 'PROD', 'EDIT', 'Edicion de ordenes de produccion', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_OP_EDIT');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_OP_WORKFLOW_CANCEL', 'PROD', 'WORKFLOW_CANCEL', 'Cancelacion de ordenes de produccion', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_OP_WORKFLOW_CANCEL');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_OP_WORKFLOW_FINALIZE', 'PROD', 'WORKFLOW_FINALIZE', 'Finalizacion de ordenes de produccion', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_OP_WORKFLOW_FINALIZE');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_ETAPA_CHECKLIST_READ', 'PROD', 'READ', 'Lectura de checklist de etapa', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_ETAPA_CHECKLIST_READ');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_ETAPA_CHECKLIST_WRITE', 'PROD', 'WRITE', 'Actualizacion de checklist de etapa', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_ETAPA_CHECKLIST_WRITE');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_BATCH_RECORD_READ', 'PROD', 'READ', 'Lectura de batch record', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_BATCH_RECORD_READ');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_BATCH_RECORD_WRITE', 'PROD', 'WRITE', 'Actualizacion de batch record', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_BATCH_RECORD_WRITE');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PROD_BATCH_RECORD_EXPORT', 'PROD', 'EXPORT', 'Exportacion de batch record', b'1'
+where not exists (select 1 from permisos where codigo = 'PROD_BATCH_RECORD_EXPORT');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'INV_PRODUCT_READ', 'INV', 'READ', 'Lectura de productos', b'1'
+where not exists (select 1 from permisos where codigo = 'INV_PRODUCT_READ');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'INV_MOV_READ', 'INV', 'READ', 'Lectura de movimientos de inventario', b'1'
+where not exists (select 1 from permisos where codigo = 'INV_MOV_READ');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'INV_REPORTES_EXPORT', 'INV', 'EXPORT', 'Exportacion de reportes de inventario', b'1'
+where not exists (select 1 from permisos where codigo = 'INV_REPORTES_EXPORT');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'INV_LOTES_READ', 'INV', 'READ', 'Lectura de lotes', b'1'
+where not exists (select 1 from permisos where codigo = 'INV_LOTES_READ');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'BOM_FORMULA_READ', 'BOM', 'READ', 'Lectura de formulas BOM', b'1'
+where not exists (select 1 from permisos where codigo = 'BOM_FORMULA_READ');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'QC_ALERTAS_READ', 'QC', 'READ', 'Lectura de alertas de calidad', b'1'
+where not exists (select 1 from permisos where codigo = 'QC_ALERTAS_READ');
+
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'PO_PLAN_SEMANAL_READ', 'PO', 'READ', 'Lectura de plan semanal', b'1'
+where not exists (select 1 from permisos where codigo = 'PO_PLAN_SEMANAL_READ');
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'PROD_OP_READ',
+    'PROD_OP_CREATE',
+    'PROD_OP_EDIT',
+    'PROD_OP_WORKFLOW_CANCEL',
+    'PROD_OP_WORKFLOW_FINALIZE',
+    'PROD_ETAPA_CHECKLIST_READ',
+    'PROD_ETAPA_CHECKLIST_WRITE',
+    'PROD_BATCH_RECORD_READ',
+    'PROD_BATCH_RECORD_WRITE',
+    'PROD_BATCH_RECORD_EXPORT',
+    'INV_PRODUCT_READ',
+    'INV_MOV_READ',
+    'INV_REPORTES_EXPORT',
+    'INV_LOTES_READ',
+    'BOM_FORMULA_READ',
+    'QC_ALERTAS_READ',
+    'PO_PLAN_SEMANAL_READ'
+)
+where r.codigo = 'ROL_SUPER_ADMIN'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'PROD_OP_READ',
+    'PROD_OP_CREATE',
+    'PROD_OP_EDIT',
+    'PROD_OP_WORKFLOW_CANCEL',
+    'PROD_OP_WORKFLOW_FINALIZE',
+    'PROD_ETAPA_CHECKLIST_READ',
+    'PROD_ETAPA_CHECKLIST_WRITE',
+    'PROD_BATCH_RECORD_READ',
+    'PROD_BATCH_RECORD_WRITE',
+    'PROD_BATCH_RECORD_EXPORT',
+    'PO_PLAN_SEMANAL_READ',
+    'INV_PRODUCT_READ',
+    'INV_LOTES_READ'
+)
+where r.codigo = 'ROL_PLANEADOR'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );

--- a/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/JwtAuthenticationProviderTest.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.shared.security.exception.SesionExpiradaAuthent
 import com.willyes.clemenintegra.shared.security.exception.SesionInvalidadaAuthenticationException;
 import com.willyes.clemenintegra.shared.security.service.JwtAuthenticationToken;
 import com.willyes.clemenintegra.shared.security.service.JwtTokenService;
+import com.willyes.clemenintegra.shared.security.service.UsuarioAuthoritiesService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.impl.DefaultClaims;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -31,13 +33,18 @@ class JwtAuthenticationProviderTest {
     private JwtTokenService jwtTokenService;
     @Mock
     private UsuarioRepository usuarioRepository;
+    @Mock
+    private UsuarioAuthoritiesService usuarioAuthoritiesService;
 
     private JwtAuthenticationProvider provider;
 
     @BeforeEach
     void setUp() {
-        provider = new JwtAuthenticationProvider(jwtTokenService, usuarioRepository);
+        provider = new JwtAuthenticationProvider(jwtTokenService, usuarioRepository, usuarioAuthoritiesService);
         ReflectionTestUtils.setField(provider, "maxIdleMinutes", 20L);
+        java.util.Collection<? extends org.springframework.security.core.GrantedAuthority> authorities =
+                java.util.List.of(new SimpleGrantedAuthority(RolUsuario.ROL_SUPER_ADMIN.name()));
+        lenient().doReturn(authorities).when(usuarioAuthoritiesService).buildAuthorities(any());
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/shared/security/controller/AuthControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/controller/AuthControllerTest.java
@@ -1,0 +1,71 @@
+package com.willyes.clemenintegra.shared.security.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.model.enums.RolUsuario;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.service.CustomUserDetails;
+import com.willyes.clemenintegra.shared.security.service.UsuarioAuthoritiesService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private UsuarioAuthoritiesService usuarioAuthoritiesService;
+
+    private Usuario usuarioPlaneador;
+
+    @BeforeEach
+    void setUp() {
+        usuarioPlaneador = usuarioRepository.findByNombreUsuario("planeador")
+                .orElseGet(() -> usuarioRepository.save(Usuario.builder()
+                        .nombreUsuario("planeador")
+                        .clave("secret")
+                        .nombreCompleto("Planeador Test")
+                        .correo("planeador@test.local")
+                        .rol(RolUsuario.ROL_PLANEADOR)
+                        .activo(true)
+                        .bloqueado(false)
+                        .build()));
+    }
+
+    @Test
+    void meRetornaRolYPermisosDelPlaneador() throws Exception {
+        CustomUserDetails principal = new CustomUserDetails(
+                usuarioPlaneador,
+                usuarioAuthoritiesService.buildAuthorities(usuarioPlaneador)
+        );
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                principal,
+                "N/A",
+                principal.getAuthorities()
+        );
+
+        mockMvc.perform(get("/api/auth/me").with(authentication(authentication)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rol").value("ROL_PLANEADOR"))
+                .andExpect(jsonPath("$.permisos").isArray())
+                .andExpect(jsonPath("$.permisos").value(org.hamcrest.Matchers.hasItem("PROD_OP_CREATE")));
+    }
+}


### PR DESCRIPTION
### Motivation
- Introducir infraestructura RBAC (rol único por usuario + permisos por rol) para permitir cargar permisos como authorities sin romper la seguridad basada en roles actual.
- Sembrar roles y permisos mínimos para los módulos iniciales (PROD, INV, BOM, QC, PO) y facilitar migración incremental por fases.

### Description
- Agregadas migraciones Flyway para esquema RBAC y seed idempotente: `V20260126__rbac_roles_permisos.sql` y `V20260127__rbac_seed_roles_permisos.sql` que crean `roles`, `permisos` y `roles_permisos` y realizan inserts protectivos si no existen.
- Nuevas entidades y repositorios JPA: `RolEntity`, `PermisoEntity`, `RolRepository`, `PermisoRepository` para mapear las nuevas tablas.
- Nueva capa `UsuarioAuthoritiesService` que consulta permisos por `rol.codigo` y construye `GrantedAuthority` (mantiene la autoridad del rol y agrega permisos como authorities).
- Integración con Spring Security: `CustomUserDetails`, `UsuarioPrincipal`, `CustomUserDetailsService`, y `JwtAuthenticationProvider` ahora usan `UsuarioAuthoritiesService` para incluir permisos en el `Authentication` (se preserva la autoridad del rol para compatibilidad).
- Ajustes en seguridad/filters: `SecurityConfig` y `JwtAuthenticationFilter` actualizados para exponer solo `/api/auth/login` y `/api/auth/verificar` como públicos (en lugar de todo `/api/auth/**`).
- Nuevo endpoint `GET /api/auth/me` que devuelve `AuthMeResponseDTO` con (`usuarioId`, `username`, `nombre`, `rol`, `permisos`) implementado en `AuthController`.
- Tests añadidos/ajustados: `AuthControllerTest` (integra `/api/auth/me`) y actualizaciones a `JwtAuthenticationProviderTest` para inyectar `UsuarioAuthoritiesService` y adaptar stubbings.

### Testing
- Ejecutado `mvn test` en el proyecto; el build ejecutó la suite completa (varias centenas de pruebas).
- Resultado final: build fallido con `Tests run: 635, Failures: 0, Errors: 10, Skipped: 2` por problemas de entorno y migración, no por la lógica RBAC añadida.
- Causas principales de bloqueo en CI/local tests: Flyway falla al aplicar una migración existente (`V20251010__calidad_retencion_nc_extensiones.sql`) debido a SQL MySQL-específico (`SET @c := ...`) que H2 no acepta durante tests, y algunos tests/integrations dependen de Testcontainers/Docker (no disponible en el entorno de CI usado aquí).
- Notas: las nuevas clases y el endpoint fueron compiladas y las pruebas unitarias relacionadas con la autenticación se ajustaron para pasar en el entorno de pruebas modificado; la falla global requiere corregir/aislar la migración MySQL-incompatible o ejecutar los tests en un entorno con Docker para completar la validación de la suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69780ebad82c83338170c39b35198059)