### PR TITLE
Add idempotent Flyway migration V20260128 to patch PROD permissions and role assignments

### DIFF
--- a/src/main/resources/db/migration/inventario/V20260128__rbac_produccion_permissions_patch.sql
+++ b/src/main/resources/db/migration/inventario/V20260128__rbac_produccion_permissions_patch.sql
@@ -1,0 +1,177 @@
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select v.codigo, v.modulo, v.accion, v.descripcion, v.activo
+from (
+    select 'PROD_OP_READ' as codigo, 'PROD' as modulo, 'READ' as accion, 'Lectura de ordenes de produccion' as descripcion, b'1' as activo
+    union all
+    select 'PROD_OP_CREATE', 'PROD', 'CREATE', 'Creacion de ordenes de produccion', b'1'
+    union all
+    select 'PROD_OP_EDIT', 'PROD', 'EDIT', 'Edicion de ordenes de produccion', b'1'
+    union all
+    select 'PROD_OP_WORKFLOW_CANCEL', 'PROD', 'WORKFLOW_CANCEL', 'Cancelacion de ordenes de produccion', b'1'
+    union all
+    select 'PROD_OP_WORKFLOW_FINALIZE', 'PROD', 'WORKFLOW_FINALIZE', 'Finalizacion de ordenes de produccion', b'1'
+    union all
+    select 'PROD_ETAPA_CHECKLIST_READ', 'PROD', 'READ', 'Lectura de checklist de etapa', b'1'
+    union all
+    select 'PROD_ETAPA_CHECKLIST_WRITE', 'PROD', 'WRITE', 'Actualizacion de checklist de etapa', b'1'
+    union all
+    select 'PROD_BATCH_RECORD_READ', 'PROD', 'READ', 'Lectura de batch record', b'1'
+    union all
+    select 'PROD_BATCH_RECORD_WRITE', 'PROD', 'WRITE', 'Actualizacion de batch record', b'1'
+    union all
+    select 'PROD_BATCH_RECORD_EXPORT', 'PROD', 'EXPORT', 'Exportacion de batch record', b'1'
+    union all
+    select 'PROD_BATCH_RECORD_DECIDE', 'PROD', 'DECIDE', 'Decision de calidad en batch record', b'1'
+    union all
+    select 'PROD_ETAPA_CLONE', 'PROD', 'CLONE', 'Clonar etapas de ordenes de produccion', b'1'
+    union all
+    select 'PROD_ETAPA_START', 'PROD', 'START', 'Iniciar etapa de produccion', b'1'
+    union all
+    select 'PROD_ETAPA_FINISH', 'PROD', 'FINISH', 'Finalizar etapa de produccion', b'1'
+    union all
+    select 'PROD_OP_EXPORT', 'PROD', 'EXPORT', 'Exportacion de ordenes de produccion', b'1'
+    union all
+    select 'PROD_REPORTS_READ', 'PROD', 'READ', 'Lectura de reportes de produccion', b'1'
+    union all
+    select 'PROD_INDICADORES_READ', 'PROD', 'READ', 'Lectura de indicadores de produccion', b'1'
+    union all
+    select 'PROD_INDICADORES_EXPORT', 'PROD', 'EXPORT', 'Exportacion de indicadores de produccion', b'1'
+    union all
+    select 'PROD_ALERTAS_READ', 'PROD', 'READ', 'Lectura de alertas de produccion', b'1'
+) v
+left join permisos p on p.codigo = v.codigo
+where p.id is null;
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'PROD_OP_READ',
+    'PROD_OP_CREATE',
+    'PROD_OP_EDIT',
+    'PROD_OP_WORKFLOW_CANCEL',
+    'PROD_OP_WORKFLOW_FINALIZE',
+    'PROD_ETAPA_CHECKLIST_READ',
+    'PROD_ETAPA_CHECKLIST_WRITE',
+    'PROD_BATCH_RECORD_READ',
+    'PROD_BATCH_RECORD_WRITE',
+    'PROD_BATCH_RECORD_EXPORT',
+    'PROD_BATCH_RECORD_DECIDE',
+    'PROD_ETAPA_CLONE',
+    'PROD_ETAPA_START',
+    'PROD_ETAPA_FINISH',
+    'PROD_OP_EXPORT',
+    'PROD_REPORTS_READ',
+    'PROD_INDICADORES_READ',
+    'PROD_INDICADORES_EXPORT',
+    'PROD_ALERTAS_READ'
+)
+where r.codigo = 'ROL_SUPER_ADMIN'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'PROD_OP_READ',
+    'PROD_OP_CREATE',
+    'PROD_OP_EDIT',
+    'PROD_OP_WORKFLOW_CANCEL',
+    'PROD_OP_WORKFLOW_FINALIZE',
+    'PROD_ETAPA_CHECKLIST_READ',
+    'PROD_ETAPA_CHECKLIST_WRITE',
+    'PROD_BATCH_RECORD_READ',
+    'PROD_BATCH_RECORD_WRITE',
+    'PROD_BATCH_RECORD_EXPORT',
+    'PROD_ETAPA_CLONE',
+    'PROD_ETAPA_START',
+    'PROD_ETAPA_FINISH',
+    'PROD_OP_EXPORT',
+    'PROD_REPORTS_READ',
+    'PROD_INDICADORES_READ',
+    'PROD_INDICADORES_EXPORT',
+    'PROD_ALERTAS_READ'
+)
+where r.codigo = 'ROL_JEFE_PRODUCCION'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'PROD_OP_READ',
+    'PROD_OP_CREATE',
+    'PROD_OP_EDIT',
+    'PROD_OP_WORKFLOW_CANCEL',
+    'PROD_OP_WORKFLOW_FINALIZE',
+    'PROD_ETAPA_CHECKLIST_READ',
+    'PROD_ETAPA_CHECKLIST_WRITE',
+    'PROD_BATCH_RECORD_READ',
+    'PROD_BATCH_RECORD_WRITE',
+    'PROD_BATCH_RECORD_EXPORT',
+    'PROD_ETAPA_CLONE',
+    'PROD_ETAPA_START',
+    'PROD_ETAPA_FINISH',
+    'PROD_OP_EXPORT',
+    'PROD_REPORTS_READ',
+    'PROD_INDICADORES_READ',
+    'PROD_INDICADORES_EXPORT',
+    'PROD_ALERTAS_READ'
+)
+where r.codigo = 'ROL_PLANEADOR'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'PROD_OP_READ',
+    'PROD_BATCH_RECORD_READ',
+    'PROD_BATCH_RECORD_EXPORT',
+    'PROD_BATCH_RECORD_DECIDE',
+    'PROD_ALERTAS_READ'
+)
+where r.codigo = 'ROL_JEFE_CALIDAD'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'PROD_OP_READ',
+    'PROD_BATCH_RECORD_READ',
+    'PROD_BATCH_RECORD_EXPORT',
+    'PROD_ALERTAS_READ'
+)
+where r.codigo = 'ROL_ANALISTA_CALIDAD'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'PROD_OP_READ',
+    'PROD_BATCH_RECORD_READ',
+    'PROD_BATCH_RECORD_EXPORT',
+    'PROD_ALERTAS_READ'
+)
+where r.codigo = 'ROL_MICROBIOLOGO'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );


### PR DESCRIPTION
### Motivation
- Flyway reported a checksum mismatch for an already-applied migration, so the fix must not modify applied migrations or require `flyway repair` in production.
- Provide a safe, additive patch that inserts any missing PROD permissions and assigns them to the appropriate roles without changing historic migration files.

### Description
- Added a new Flyway migration `src/main/resources/db/migration/inventario/V20260128__rbac_produccion_permissions_patch.sql` that inserts missing `permisos` entries using a `LEFT JOIN` / `where p.id is null` anti-join to be fully idempotent.
- The migration inserts the full set of `PROD_*` permissions and creates `roles_permisos` assignments for `ROL_SUPER_ADMIN`, `ROL_JEFE_PRODUCCION`, `ROL_PLANEADOR`, `ROL_JEFE_CALIDAD`, `ROL_ANALISTA_CALIDAD` and `ROL_MICROBIOLOGO` using `NOT EXISTS` checks so reapplying is safe.
- Minor cleanup in the new migration removed duplicate permission references from the `ROL_PLANEADOR` assignment list so the SQL is consistent and deterministic.

### Testing
- Ran the full test suite with `mvn test`, which completed successfully (`BUILD SUCCESS`) with 636 tests run, 0 failures, 0 errors and 2 skipped.
- All automated unit and integration tests in the repository passed under the test profile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b6bb78b083339d00b8cce5776503)