### PR TITLE
Return 204 on orden de producción cancel endpoint

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -156,10 +156,10 @@ public class OrdenProduccionController {
     @PostMapping("/{id}/cancelar")
     @PreAuthorize("hasAnyAuthority('PROD_OP_WORKFLOW_CANCEL','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
             "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
-    public ResponseEntity<OrdenProduccionResponseDTO> cancelar(@PathVariable Long id,
-                                                               @RequestBody(required = false) CancelarOrdenRequestDTO request) {
-        OrdenProduccion orden = service.cancelarOrden(id, request != null ? request.getMotivo() : null);
-        return ResponseEntity.ok(ProduccionMapper.toResponse(orden));
+    public ResponseEntity<Void> cancelar(@PathVariable Long id,
+                                         @RequestBody(required = false) CancelarOrdenRequestDTO request) {
+        service.cancelarOrden(id, request != null ? request.getMotivo() : null);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/{id}/cierres")

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionService.java
@@ -70,7 +70,7 @@ public interface OrdenProduccionService {
                                  LocalDateTime fechaInicio,
                                  LocalDateTime fechaFin);
 
-    OrdenProduccion cancelarOrden(Long ordenProduccionId, @Nullable String motivo);
+    void cancelarOrden(Long ordenProduccionId, @Nullable String motivo);
 
     com.willyes.clemenintegra.produccion.dto.ProduccionTrazabilidadResponseDTO obtenerTrazabilidad(Long ordenProduccionId);
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -2044,7 +2044,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
     @Override
     @Transactional
-    public OrdenProduccion cancelarOrden(Long ordenProduccionId, @Nullable String motivo) {
+    public void cancelarOrden(Long ordenProduccionId, @Nullable String motivo) {
         OrdenProduccion orden = repository.findByIdForUpdate(ordenProduccionId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ORDEN_NO_ENCONTRADA"));
 
@@ -2110,7 +2110,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             orden.setFechaFin(LocalDateTime.now());
         }
 
-        return repository.save(orden);
+        repository.save(orden);
     }
 
     @Transactional

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.produccion.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.willyes.clemenintegra.produccion.dto.InsumoFaltanteDTO;
 import com.willyes.clemenintegra.produccion.dto.InsumoOPDTO;
+import com.willyes.clemenintegra.produccion.dto.CancelarOrdenRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.OrdenProduccionRequestDTO;
 import com.willyes.clemenintegra.produccion.dto.OrdenProduccionResponseDTO;
 import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
@@ -50,6 +51,7 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -165,6 +167,23 @@ class OrdenProduccionControllerTest {
                 .andExpect(status().isOk());
 
         verify(ordenProduccionService).listarInsumos(10L);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("POST /api/produccion/ordenes/{id}/cancelar retorna 204 para cancelación exitosa")
+    void cancelarOrden_respondeNoContent() throws Exception {
+        CancelarOrdenRequestDTO request = new CancelarOrdenRequestDTO();
+        request.setMotivo("Motivo de cancelación");
+
+        doNothing().when(ordenProduccionService).cancelarOrden(10L, "Motivo de cancelación");
+
+        mockMvc.perform(post("/api/produccion/ordenes/{id}/cancelar", 10L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+
+        verify(ordenProduccionService).cancelarOrden(10L, "Motivo de cancelación");
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCancelarTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceCancelarTest.java
@@ -92,10 +92,10 @@ class OrdenProduccionServiceCancelarTest {
             return op;
         });
 
-        OrdenProduccion resultado = service.cancelarOrden(1L, "ajuste formula");
+        service.cancelarOrden(1L, "ajuste formula");
 
-        assertThat(resultado.getEstado()).isEqualTo(EstadoProduccion.CANCELADA);
-        assertThat(resultado.getFechaFin()).isNotNull();
+        assertThat(orden.getEstado()).isEqualTo(EstadoProduccion.CANCELADA);
+        assertThat(orden.getFechaFin()).isNotNull();
         assertThat(detalle.getEstado()).isEqualTo(EstadoSolicitudMovimientoDetalle.CANCELADO);
         assertThat(solicitud.getEstado()).isEqualTo(EstadoSolicitudMovimiento.CANCELADA);
         verify(reservaLoteService, times(1)).liberarReservasPorOrden(1L);
@@ -128,4 +128,3 @@ class OrdenProduccionServiceCancelarTest {
                 .hasFieldOrPropertyWithValue("statusCode", HttpStatus.CONFLICT);
     }
 }
-

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -178,16 +179,13 @@ class OrdenProduccionControllerSecurityTest {
     @Test
     @WithMockUser(authorities = "ROL_PLANEADOR")
     @DisplayName("POST /api/produccion/ordenes/{id}/cancelar permite workflow con rol planeador")
-    void cancelarOrden_conRolPlaneador_devuelve200() throws Exception {
-        OrdenProduccion orden = new OrdenProduccion();
-        orden.setId(1L);
-        orden.setEstado(EstadoProduccion.CREADA);
-        when(ordenProduccionService.cancelarOrden(any(), any())).thenReturn(orden);
+    void cancelarOrden_conRolPlaneador_devuelve204() throws Exception {
+        doNothing().when(ordenProduccionService).cancelarOrden(any(), any());
 
         mockMvc.perform(post("/api/produccion/ordenes/{id}/cancelar", 1L)
                         .contentType("application/json")
                         .content("{}"))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Cancelling an Orden de Producción was causing a `LazyInitializationException` during response mapping because the controller returned an entity/DTO that traversed lazy relations outside a session.  
- Provide a minimal, safe fix that avoids serializing lazy associations and does not change entity fetch strategies or business logic.  

### Description
- Change the `POST /api/produccion/ordenes/{id}/cancelar` controller to return `ResponseEntity.noContent()` (`204 No Content`) and stop returning the cancelled entity.  
- Change the service contract `OrdenProduccionService.cancelarOrden` from returning `OrdenProduccion` to `void` and adapt the implementation to keep the same cancellation logic but not return the entity.  
- Update unit tests and security controller tests to expect `204 No Content` on successful cancellation and adjust service tests to account for the `void` return (files updated: `OrdenProduccionController`, `OrdenProduccionService`, `OrdenProduccionServiceImpl`, `OrdenProduccionControllerTest`, `OrdenProduccionControllerSecurityTest`, `OrdenProduccionServiceCancelarTest`).  
- Preserved all existing cancellation behavior (reservations release, solicitud movement updates, state changes, fechaFin update and persistence) and did not use `EAGER` fetch or `Hibernate.initialize()` patches.  

### Testing
- Ran the controller test suite with `mvn -Dtest=OrdenProduccionControllerTest test`, and the targeted tests completed successfully (tests passed).  
- Adjusted and ran related unit tests (`OrdenProduccionControllerSecurityTest` and `OrdenProduccionServiceCancelarTest`) as part of the local test iteration to validate the new `204` behavior and service contract changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c242abe48333bf4ddf9a6e28b949)