### PR TITLE
Trim ROL_PLANEADOR production permissions and adjust controllers/tests

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/BatchRecordController.java
@@ -58,7 +58,7 @@ public class BatchRecordController {
 
     @PostMapping("/produccion/batch-record/{ordenProduccionId}/controles-proceso")
     @PreAuthorize("hasAnyAuthority('PROD_BATCH_RECORD_WRITE','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<List<BatchRecordDTO.ControlProcesoDTO>> guardarControlesProceso(
             @PathVariable Long ordenProduccionId,
@@ -89,7 +89,7 @@ public class BatchRecordController {
 
     @PostMapping("/produccion/batch-record/{ordenProduccionId}/controles-empaque")
     @PreAuthorize("hasAnyAuthority('PROD_BATCH_RECORD_WRITE','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<List<BatchRecordDTO.ControlEmpaqueDTO>> guardarControlesEmpaque(
             @PathVariable Long ordenProduccionId,
@@ -119,7 +119,7 @@ public class BatchRecordController {
 
     @PostMapping("/produccion/batch-record/{ordenProduccionId}/observaciones")
     @PreAuthorize("hasAnyAuthority('PROD_BATCH_RECORD_WRITE','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     @Transactional
     public ResponseEntity<List<BatchRecordDTO.ObservacionProcesoDTO>> guardarObservaciones(
             @PathVariable Long ordenProduccionId,

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/ChecklistEtapaController.java
@@ -28,7 +28,7 @@ public class ChecklistEtapaController {
 
     @PutMapping("/{etapaId}/checklist")
     @PreAuthorize("hasAnyAuthority('PROD_ETAPA_CHECKLIST_WRITE','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistEtapaDTO> actualizar(@PathVariable Long etapaId,
                                                         @RequestBody List<ChecklistItemDTO> items) {
         return ResponseEntity.ok(checklistEtapaService.actualizar(etapaId, items));

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/EtapaProduccionController.java
@@ -41,7 +41,7 @@ public class EtapaProduccionController {
 
     @PostMapping
     @PreAuthorize("hasAnyAuthority('PROD_OP_EDIT','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaProduccionResponse> crear(@RequestBody EtapaProduccionRequest request) {
         OrdenProduccion orden = new OrdenProduccion(); orden.setId(request.ordenProduccionId);
         EtapaProduccion entidad = ProduccionMapper.toEntity(request, orden);
@@ -49,7 +49,7 @@ public class EtapaProduccionController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('PROD_OP_EDIT','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('PROD_OP_EDIT','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaProduccionResponse> actualizar(@PathVariable Long id, @RequestBody EtapaProduccionRequest request) {
         return service.buscarPorId(id)
                 .map(existente -> {
@@ -62,7 +62,7 @@ public class EtapaProduccionController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('PROD_OP_EDIT','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('PROD_OP_EDIT','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {
         service.eliminar(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -121,7 +121,7 @@ public class OrdenProduccionController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('PROD_OP_EDIT','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('PROD_OP_EDIT','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<ResultadoValidacionOrdenDTO> actualizar(@PathVariable Long id, @RequestBody OrdenProduccionRequestDTO request) {
         return service.buscarPorId(id)
                 .map(existente -> {
@@ -138,7 +138,7 @@ public class OrdenProduccionController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('PROD_OP_EDIT','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('PROD_OP_EDIT','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> eliminar(@PathVariable Long id) {
         service.eliminar(id);
         return ResponseEntity.noContent().build();
@@ -146,7 +146,7 @@ public class OrdenProduccionController {
 
     @PutMapping("/{id}/finalizar")
     @PreAuthorize("hasAnyAuthority('PROD_OP_WORKFLOW_FINALIZE','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> finalizar(@PathVariable Long id,
                                                                @RequestBody FinalizarOrdenRequestDTO request) {
         OrdenProduccion orden = service.finalizar(id, request.getCantidadProducida());
@@ -155,7 +155,7 @@ public class OrdenProduccionController {
 
     @PostMapping("/{id}/cancelar")
     @PreAuthorize("hasAnyAuthority('PROD_OP_WORKFLOW_CANCEL','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> cancelar(@PathVariable Long id,
                                          @RequestBody(required = false) CancelarOrdenRequestDTO request) {
         service.cancelarOrden(id, request != null ? request.getMotivo() : null);
@@ -164,7 +164,7 @@ public class OrdenProduccionController {
 
     @PostMapping("/{id}/cierres")
     @PreAuthorize("hasAnyAuthority('PROD_OP_WORKFLOW_FINALIZE','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> registrarCierre(@PathVariable Long id,
                                                                      @Valid @RequestBody CierreProduccionRequestDTO request) {
         log.debug("Registrar cierre recibido: ordenId={}, payload={}", id, request);
@@ -188,7 +188,7 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{id}/etapas/clonar")
-    @PreAuthorize("hasAnyAuthority('PROD_ETAPA_CLONE','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('PROD_ETAPA_CLONE','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<Void> clonarEtapas(@PathVariable Long id) {
         service.clonarEtapas(id);
         return ResponseEntity.noContent().build();
@@ -196,7 +196,7 @@ public class OrdenProduccionController {
 
     @RequestMapping(value = "/{ordenId}/etapas/{etapaId}/iniciar", method = {RequestMethod.PATCH, RequestMethod.POST})
     @PreAuthorize("hasAnyAuthority('PROD_ETAPA_START','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<OrdenProduccionResponseDTO> iniciarEtapa(@PathVariable Long ordenId, @PathVariable Long etapaId) {
         service.iniciarEtapa(ordenId, etapaId);
         return service.buscarPorId(ordenId)
@@ -208,7 +208,7 @@ public class OrdenProduccionController {
     // Compatibilidad POST agregada porque el frontend usa POST
     @RequestMapping(value = "/{ordenId}/etapas/{etapaId}/finalizar", method = {RequestMethod.PATCH, RequestMethod.POST})
     @PreAuthorize("hasAnyAuthority('PROD_ETAPA_FINISH','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<EtapaProduccionResponse> finalizarEtapa(@PathVariable Long ordenId, @PathVariable Long etapaId) {
         Usuario usuario = usuarioService.obtenerUsuarioAutenticado();
         return ResponseEntity.ok(ProduccionMapper.toResponse(service.finalizarEtapa(ordenId, etapaId, usuario.getId())));
@@ -259,7 +259,7 @@ public class OrdenProduccionController {
 
     @PostMapping("/{ordenId}/etapas/{etapaId}/checklist")
     @PreAuthorize("hasAnyAuthority('PROD_ETAPA_CHECKLIST_WRITE','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistEtapaDTO> actualizarChecklistPorEtapa(@PathVariable Long ordenId,
                                                                          @PathVariable Long etapaId,
                                                                          @RequestBody List<ChecklistItemDTO> items) {
@@ -268,7 +268,7 @@ public class OrdenProduccionController {
 
     @PostMapping("/{ordenId}/etapas/{etapaId}/checklist/{itemId}/completar")
     @PreAuthorize("hasAnyAuthority('PROD_ETAPA_CHECKLIST_WRITE','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistItemDTO> completarChecklistItem(@PathVariable Long ordenId,
                                                                    @PathVariable Long etapaId,
                                                                    @PathVariable Long itemId,
@@ -279,7 +279,7 @@ public class OrdenProduccionController {
 
     @PostMapping("/{ordenId}/etapas/{etapaId}/checklist/{itemId}/no-aplica")
     @PreAuthorize("hasAnyAuthority('PROD_ETAPA_CHECKLIST_WRITE','ROL_JEFE_PRODUCCION','ROL_LIDER_ALIMENTOS','ROL_LIDER_HOMEOPATICOS'," +
-            "'ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+            "'ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistItemDTO> marcarNoAplicaChecklistItem(@PathVariable Long ordenId,
                                                                         @PathVariable Long etapaId,
                                                                         @PathVariable Long itemId,
@@ -289,7 +289,7 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{ordenId}/etapas/{etapaId}/checklist/{itemId}/reabrir")
-    @PreAuthorize("hasAnyAuthority('PROD_ETAPA_CHECKLIST_WRITE','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('PROD_ETAPA_CHECKLIST_WRITE','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public ResponseEntity<ChecklistItemDTO> reabrirChecklistItem(@PathVariable Long ordenId,
                                                                  @PathVariable Long etapaId,
                                                                  @PathVariable Long itemId) {
@@ -305,7 +305,7 @@ public class OrdenProduccionController {
     }
 
     @PostMapping("/{ordenId}/backfill-salida")
-    @PreAuthorize("hasAnyAuthority('PROD_OP_WORKFLOW_FINALIZE','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('PROD_OP_WORKFLOW_FINALIZE','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION')")
     public ResponseEntity<Map<String, Object>> backfillSalidaProduccion(@PathVariable Long ordenId) {
 
         // Obtener el usuario autenticado usando el mismo patrón del resto del backend

--- a/src/main/resources/db/migration/inventario/V20260129__rbac_planeador_permissions_trim.sql
+++ b/src/main/resources/db/migration/inventario/V20260129__rbac_planeador_permissions_trim.sql
@@ -1,0 +1,15 @@
+delete rp
+from roles_permisos rp
+join roles r on r.id = rp.rol_id
+join permisos p on p.id = rp.permiso_id
+where r.codigo = 'ROL_PLANEADOR'
+  and p.codigo in (
+    'PROD_BATCH_RECORD_WRITE',
+    'PROD_ETAPA_CHECKLIST_WRITE',
+    'PROD_ETAPA_START',
+    'PROD_ETAPA_FINISH',
+    'PROD_ETAPA_CLONE',
+    'PROD_OP_EDIT',
+    'PROD_OP_WORKFLOW_CANCEL',
+    'PROD_OP_WORKFLOW_FINALIZE'
+  );

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/BatchRecordControllerTest.java
@@ -112,6 +112,21 @@ class BatchRecordControllerTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("GET /api/produccion/batch-record/{id} permite consulta a planeador")
+    void obtenerBatchRecordRolPlaneador() throws Exception {
+        BatchRecordDTO dto = new BatchRecordDTO();
+        dto.op = new BatchRecordDTO.OpDTO();
+        dto.op.codigoOrden = "OP-3";
+        when(batchRecordService.buildByOrdenProduccion(3L)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/produccion/batch-record/{id}", 3L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.op.codigoOrden").value("OP-3"));
+    }
+
+    @Test
     @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     @DisplayName("GET /api/produccion/batch-record/{id} devuelve 404 cuando no existe")
     void obtenerBatchRecordNoExiste() throws Exception {
@@ -192,6 +207,16 @@ class BatchRecordControllerTest {
     @DisplayName("POST /api/produccion/batch-record/{id}/controles-proceso es rechazado para jefe de calidad")
     void guardarControlesProceso_conRolCalidad_devuelve403() throws Exception {
         mockMvc.perform(post("/api/produccion/batch-record/{id}/controles-proceso", 3L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[]"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("POST /api/produccion/batch-record/{id}/controles-proceso rechaza rol planeador")
+    void guardarControlesProceso_conRolPlaneador_devuelve403() throws Exception {
+        mockMvc.perform(post("/api/produccion/batch-record/{id}/controles-proceso", 4L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("[]"))
                 .andExpect(status().isForbidden());

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -170,7 +170,7 @@ class OrdenProduccionControllerTest {
     }
 
     @Test
-    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
     @DisplayName("POST /api/produccion/ordenes/{id}/cancelar retorna 204 para cancelación exitosa")
     void cancelarOrden_respondeNoContent() throws Exception {
         CancelarOrdenRequestDTO request = new CancelarOrdenRequestDTO();

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/ChecklistEtapaControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/ChecklistEtapaControllerSecurityTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ChecklistEtapaController.class)
@@ -83,15 +84,37 @@ class ChecklistEtapaControllerSecurityTest {
     }
 
     @Test
-    @WithMockUser(authorities = {"ROL_PLANEADOR", "PROD_ETAPA_CHECKLIST_WRITE"})
-    @DisplayName("Actualizar checklist permite permiso de escritura")
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("Checklist etapa permite lectura para planeador")
+    void obtenerChecklist_conRolPlaneador() throws Exception {
+        when(checklistEtapaService.obtenerPorEtapa(anyLong())).thenReturn(ChecklistEtapaDTO.builder().etapaId(2L).build());
+
+        mockMvc.perform(get("/api/produccion/etapas/{id}/checklist", 2L))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("Actualizar checklist permite rol de producción")
     void actualizarChecklist_conPermisoEscritura() throws Exception {
         when(checklistEtapaService.actualizar(anyLong(), org.mockito.ArgumentMatchers.anyList()))
                 .thenReturn(ChecklistEtapaDTO.builder().etapaId(1L).build());
 
         mockMvc.perform(put("/api/produccion/etapas/{id}/checklist", 1L)
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("[]"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("Actualizar checklist rechaza rol planeador")
+    void actualizarChecklist_conRolPlaneador_devuelve403() throws Exception {
+        mockMvc.perform(put("/api/produccion/etapas/{id}/checklist", 1L)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[]"))
+                .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/web/OrdenProduccionControllerSecurityTest.java
@@ -3,8 +3,6 @@ package com.willyes.clemenintegra.produccion.web;
 import com.willyes.clemenintegra.inventario.service.MovimientoInventarioService;
 import com.willyes.clemenintegra.produccion.controller.OrdenProduccionController;
 import com.willyes.clemenintegra.produccion.dto.ResultadoValidacionOrdenDTO;
-import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
-import com.willyes.clemenintegra.produccion.model.enums.EstadoProduccion;
 import com.willyes.clemenintegra.produccion.service.ChecklistEtapaService;
 import com.willyes.clemenintegra.produccion.service.OrdenProduccionService;
 import com.willyes.clemenintegra.produccion.service.ReporteOrdenProduccionService;
@@ -35,7 +33,6 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -165,27 +162,23 @@ class OrdenProduccionControllerSecurityTest {
 
     @Test
     @WithMockUser(authorities = "ROL_PLANEADOR")
-    @DisplayName("PUT /api/produccion/ordenes/{id} permite actualizar con rol planeador")
+    @DisplayName("PUT /api/produccion/ordenes/{id} rechaza actualizar con rol planeador")
     void actualizarOrden_conRolPlaneador_devuelve404SiNoExiste() throws Exception {
-        when(ordenProduccionService.buscarPorId(1L)).thenReturn(Optional.empty());
-
         mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
                         .put("/api/produccion/ordenes/{id}", 1L)
                         .contentType("application/json")
                         .content("{}"))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     @Test
     @WithMockUser(authorities = "ROL_PLANEADOR")
-    @DisplayName("POST /api/produccion/ordenes/{id}/cancelar permite workflow con rol planeador")
+    @DisplayName("POST /api/produccion/ordenes/{id}/cancelar rechaza workflow con rol planeador")
     void cancelarOrden_conRolPlaneador_devuelve204() throws Exception {
-        doNothing().when(ordenProduccionService).cancelarOrden(any(), any());
-
         mockMvc.perform(post("/api/produccion/ordenes/{id}/cancelar", 1L)
                         .contentType("application/json")
                         .content("{}"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -199,19 +192,42 @@ class OrdenProduccionControllerSecurityTest {
     }
 
     @Test
-    @WithMockUser(authorities = {"ROL_PLANEADOR", "PROD_ETAPA_START"})
-    @DisplayName("PATCH /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/iniciar permite iniciar etapa")
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("PATCH /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/iniciar rechaza rol planeador")
     void iniciarEtapa_conPermisoPlaneador_devuelve200() throws Exception {
-        OrdenProduccion orden = new OrdenProduccion();
-        orden.setId(1L);
-        orden.setEstado(EstadoProduccion.CREADA);
-
-        when(ordenProduccionService.buscarPorId(1L)).thenReturn(Optional.of(orden));
-        when(ordenProduccionService.iniciarEtapa(1L, 2L)).thenReturn(new com.willyes.clemenintegra.produccion.model.EtapaProduccion());
-
         mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
                         .patch("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/iniciar", 1L, 2L))
-                .andExpect(status().isOk());
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("PATCH /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/finalizar rechaza rol planeador")
+    void finalizarEtapa_conRolPlaneador_devuelve403() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .patch("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/finalizar", 1L, 2L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("POST /api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist rechaza rol planeador")
+    void actualizarChecklistPorEtapa_conRolPlaneador_devuelve403() throws Exception {
+        mockMvc.perform(post("/api/produccion/ordenes/{ordenId}/etapas/{etapaId}/checklist", 1L, 2L)
+                        .contentType("application/json")
+                        .content("[]"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_PLANEADOR")
+    @DisplayName("PUT /api/produccion/ordenes/{id}/finalizar rechaza finalizar con rol planeador")
+    void finalizarOrden_conRolPlaneador_devuelve403() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .put("/api/produccion/ordenes/{id}/finalizar", 1L)
+                        .contentType("application/json")
+                        .content("{\"cantidadProducida\":1}"))
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/shared/security/controller/AuthControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/controller/AuthControllerTest.java
@@ -1,5 +1,7 @@
 package com.willyes.clemenintegra.shared.security.controller;
 
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -76,6 +78,16 @@ class AuthControllerTest extends IntegrationTestH2 {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.rol").value("ROL_PLANEADOR"))
                 .andExpect(jsonPath("$.permisos").isArray())
-                .andExpect(jsonPath("$.permisos").value(org.hamcrest.Matchers.hasItem("PROD_OP_CREATE")));
+                .andExpect(jsonPath("$.permisos").value(hasItem("PROD_OP_CREATE")))
+                .andExpect(jsonPath("$.permisos").value(hasItem("PROD_OP_READ")))
+                .andExpect(jsonPath("$.permisos").value(hasItem("PROD_ETAPA_CHECKLIST_READ")))
+                .andExpect(jsonPath("$.permisos").value(hasItem("PROD_BATCH_RECORD_READ")))
+                .andExpect(jsonPath("$.permisos").value(not(hasItem("PROD_OP_EDIT"))))
+                .andExpect(jsonPath("$.permisos").value(not(hasItem("PROD_ETAPA_START"))))
+                .andExpect(jsonPath("$.permisos").value(not(hasItem("PROD_ETAPA_FINISH"))))
+                .andExpect(jsonPath("$.permisos").value(not(hasItem("PROD_ETAPA_CHECKLIST_WRITE"))))
+                .andExpect(jsonPath("$.permisos").value(not(hasItem("PROD_BATCH_RECORD_WRITE"))))
+                .andExpect(jsonPath("$.permisos").value(not(hasItem("PROD_OP_WORKFLOW_CANCEL"))))
+                .andExpect(jsonPath("$.permisos").value(not(hasItem("PROD_OP_WORKFLOW_FINALIZE"))));
     }
 }

--- a/src/test/resources/db/migration/test/V2__rbac_seed_planeador.sql
+++ b/src/test/resources/db/migration/test/V2__rbac_seed_planeador.sql
@@ -4,12 +4,32 @@ VALUES ('ROL_PLANEADOR', 'Planeador', TRUE);
 
 MERGE INTO permisos (codigo, modulo, accion, descripcion, activo)
 KEY (codigo)
-VALUES ('PROD_OP_CREATE', 'PRODUCCION', 'CREATE', 'Crear orden de producción', TRUE);
+VALUES ('PROD_OP_CREATE', 'PRODUCCION', 'CREATE', 'Crear orden de producción', TRUE),
+       ('PROD_OP_READ', 'PRODUCCION', 'READ', 'Leer orden de producción', TRUE),
+       ('PROD_ETAPA_CHECKLIST_READ', 'PRODUCCION', 'READ', 'Leer checklist de etapa', TRUE),
+       ('PROD_BATCH_RECORD_READ', 'PRODUCCION', 'READ', 'Leer batch record', TRUE),
+       ('PROD_OP_EXPORT', 'PRODUCCION', 'EXPORT', 'Exportar orden de producción', TRUE),
+       ('PROD_BATCH_RECORD_EXPORT', 'PRODUCCION', 'EXPORT', 'Exportar batch record', TRUE),
+       ('PROD_REPORTS_READ', 'PRODUCCION', 'READ', 'Leer reportes de producción', TRUE),
+       ('PROD_INDICADORES_READ', 'PRODUCCION', 'READ', 'Leer indicadores de producción', TRUE),
+       ('PROD_INDICADORES_EXPORT', 'PRODUCCION', 'EXPORT', 'Exportar indicadores de producción', TRUE),
+       ('PROD_ALERTAS_READ', 'PRODUCCION', 'READ', 'Leer alertas de producción', TRUE);
 
 INSERT INTO roles_permisos (rol_id, permiso_id)
 SELECT r.id, p.id
 FROM roles r
-JOIN permisos p ON p.codigo = 'PROD_OP_CREATE'
+JOIN permisos p ON p.codigo in (
+    'PROD_OP_CREATE',
+    'PROD_OP_READ',
+    'PROD_ETAPA_CHECKLIST_READ',
+    'PROD_BATCH_RECORD_READ',
+    'PROD_OP_EXPORT',
+    'PROD_BATCH_RECORD_EXPORT',
+    'PROD_REPORTS_READ',
+    'PROD_INDICADORES_READ',
+    'PROD_INDICADORES_EXPORT',
+    'PROD_ALERTAS_READ'
+)
 WHERE r.codigo = 'ROL_PLANEADOR'
   AND NOT EXISTS (
       SELECT 1


### PR DESCRIPTION
### Motivation
- Reduce permissions granted to `ROL_PLANEADOR` so planeador can create/read OP and read checklists/batch-records but cannot execute/finalize stages, write checklists/batch-records, cancel/finalize/edit OPs.
- Ensure RBAC seed and runtime security annotations match the intended role capabilities and tests validate the policy.

### Description
- Add a Flyway migration `V20260129__rbac_planeador_permissions_trim.sql` that removes the following `ROL_PLANEADOR` assignments: `PROD_BATCH_RECORD_WRITE`, `PROD_ETAPA_CHECKLIST_WRITE`, `PROD_ETAPA_START`, `PROD_ETAPA_FINISH`, `PROD_ETAPA_CLONE`, `PROD_OP_EDIT`, `PROD_OP_WORKFLOW_CANCEL`, `PROD_OP_WORKFLOW_FINALIZE`.
- Update production controllers to stop implicitly allowing `ROL_PLANEADOR` on write/workflow endpoints by removing `ROL_PLANEADOR` from `@PreAuthorize` on endpoints that require execution/write permissions (affecting `OrdenProduccionController`, `ChecklistEtapaController`, `EtapaProduccionController`, `BatchRecordController`).
- Update test RBAC seed `src/test/resources/db/migration/test/V2__rbac_seed_planeador.sql` to explicitly include only the intended read/create/export permissions for planeador and to align test DB migrations with the trimmed policy.
- Adjust and extend MockMvc security tests to assert the new behavior: planeador can list/see/create/export where allowed, and receives `403 Forbidden` on endpoints for starting/finishing stages, checklist/batch write endpoints, cancel/finalize/edit OPs; also add CSRF in checklist write tests and stronger assertions in `AuthControllerTest` about visible/absent permissions.

### Testing
- Ran the full test suite with `mvn test`, which passed after the changes (previous failures were iteratively fixed during the rollout) and ended with a successful build: all automated tests green on the final run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978cba95c2c8333a166b58f882b70eb)