### PR TITLE
Fix checklist CSV line breaks and add export test

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImpl.java
@@ -178,7 +178,9 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
     public byte[] exportCsvPorOrden(Long ordenId) {
         List<EtapaProduccion> etapas = etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(ordenId);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        String header = "ordenId,etapaId,etapaNombre,paso,obligatorio,estado,noAplica,permitirNoAplica,observacion,completedAt,completedBy\n";
+        String lineSeparator = System.lineSeparator();
+        String header = "ordenId,etapaId,etapaNombre,paso,obligatorio,estado,noAplica,permitirNoAplica,observacion,completedAt,completedBy"
+                + lineSeparator;
         try {
             out.write(header.getBytes(StandardCharsets.UTF_8));
             for (EtapaProduccion etapa : etapas) {
@@ -197,7 +199,7 @@ public class ChecklistEtapaServiceImpl implements ChecklistEtapaService {
                             safe(item.getCompletedAt()),
                             csv(item.getCompletedBy() != null ? item.getCompletedBy().getNombreCompleto() : null)
                     );
-                    out.write((line + "\\n").getBytes(StandardCharsets.UTF_8));
+                    out.write((line + lineSeparator).getBytes(StandardCharsets.UTF_8));
                 }
             }
             return out.toByteArray();

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/ChecklistEtapaServiceImplTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -297,5 +298,43 @@ class ChecklistEtapaServiceImplTest {
         when(checklistRepository.findByEtapaProduccionIdOrderByIdAsc(15L)).thenReturn(List.of(placeholder));
 
         assertThrows(CustomBusinessException.class, () -> service.validarChecklistCompleto(15L));
+    }
+
+    @Test
+    @DisplayName("Exportar CSV por orden genera multiples lineas reales")
+    void exportCsvPorOrden_generaLineas() {
+        EtapaProduccion etapa = EtapaProduccion.builder()
+                .id(1L)
+                .nombre("Empaque")
+                .build();
+        when(etapaProduccionRepository.findByOrdenProduccionIdOrderBySecuenciaAsc(99L))
+                .thenReturn(List.of(etapa));
+        when(checklistRepository.findByEtapaProduccionIdOrderByIdAsc(1L))
+                .thenReturn(List.of(
+                        ChecklistEtapaItem.builder()
+                                .id(10L)
+                                .nombrePaso("Paso 1")
+                                .obligatorio(true)
+                                .estado(EstadoChecklistItem.COMPLETADO)
+                                .noAplica(false)
+                                .permitirNoAplica(true)
+                                .build(),
+                        ChecklistEtapaItem.builder()
+                                .id(11L)
+                                .nombrePaso("Paso 2")
+                                .obligatorio(false)
+                                .estado(EstadoChecklistItem.PENDIENTE)
+                                .noAplica(false)
+                                .permitirNoAplica(false)
+                                .build()
+                ));
+
+        byte[] bytes = service.exportCsvPorOrden(99L);
+        String csv = new String(bytes, StandardCharsets.UTF_8);
+
+        assertThat(csv).doesNotContain("\\n");
+        String[] lines = csv.split("\n");
+        assertThat(lines.length).isGreaterThan(2);
+        assertThat(lines[0]).contains("ordenId,etapaId,etapaNombre");
     }
 }


### PR DESCRIPTION
### Motivation
- The exported checklist CSV was written with literal "\\n" characters, producing a single-line file instead of real row breaks.

### Description
- Replace literal "\\n" with `System.lineSeparator()` for both header and row writes in `exportCsvPorOrden(Long)` and keep UTF-8 output via `StandardCharsets.UTF_8`.
- Preserve existing CSV escaping by continuing to use the `csv(...)` method and keep the comma delimiter unchanged.
- Add a unit test `exportCsvPorOrden_generaLineas` in `ChecklistEtapaServiceImplTest` that asserts the result is UTF-8 bytes, contains the header, has more than two real lines when split by `\n`, and does not contain the literal `"\\n"` sequence.

### Testing
- Attempted to run `mvn -q -Dtest=ChecklistEtapaServiceImplTest test`, but execution failed due to a dependency resolution error (HTTP 502 from Maven Central), so the test suite could not be completed in this environment.
- The new unit test was added and is expected to pass once dependencies are available and Maven can resolve artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979108e6688833384403f71a370247a)