### PR TITLE
Authorize inventory adjustments and conteos reads by granular permissions

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -28,7 +28,7 @@ public class ConteoCiclicoController {
     private final ConteoCiclicoService conteoCiclicoService;
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_CONTEOS_READ','ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
     public ResponseEntity<Page<ConteoCiclicoResumenResponseDTO>> listar(
             @RequestParam(required = false) Integer almacenId,
             @RequestParam(required = false) String estado,
@@ -42,14 +42,14 @@ public class ConteoCiclicoController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_CONTEOS_READ','ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
     public ResponseEntity<ConteoCiclicoResponseDTO> obtenerPorId(@PathVariable Long id) {
         ConteoCiclicoResponseDTO respuesta = conteoCiclicoService.obtenerPorId(id);
         return ResponseEntity.ok(respuesta);
     }
 
     @GetMapping("/{id}/lotes")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_CONTEOS_READ','ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
     public ResponseEntity<List<ConteoCiclicoLoteResponseDTO>> listarLotes(
             @PathVariable Long id,
             @RequestParam Long productoId,

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -349,7 +349,8 @@ public class SecurityConfig {
 
                     auth.requestMatchers("/api/inventario/ajustes/**").hasAnyAuthority(
                             RolUsuario.ROL_CONTADOR.name(),
-                            RolUsuario.ROL_SUPER_ADMIN.name()
+                            RolUsuario.ROL_SUPER_ADMIN.name(),
+                            "INV_AJUSTES_WRITE"
                     );
 
                     auth.requestMatchers("/api/reportes/**").hasAnyAuthority(

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/AjusteInventarioControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/AjusteInventarioControllerSecurityTest.java
@@ -1,0 +1,134 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.willyes.clemenintegra.inventario.dto.AjusteInventarioRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.AjusteInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.service.AjusteInventarioService;
+import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
+import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.SuperAdminSoloLecturaWriteBlockFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AjusteInventarioController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, AjusteInventarioControllerSecurityTest.MethodSecurityConfig.class})
+@ImportAutoConfiguration({SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
+class AjusteInventarioControllerSecurityTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    @org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity(prePostEnabled = true)
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AjusteInventarioService ajusteInventarioService;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private RequestTimingFilter requestTimingFilter;
+    @MockBean
+    private RequestIdFilter requestIdFilter;
+    @MockBean
+    private SuperAdminSoloLecturaWriteBlockFilter superAdminSoloLecturaWriteBlockFilter;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void configureFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestTimingFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestIdFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(superAdminSoloLecturaWriteBlockFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    void permiteCrearAjusteConPermisoInventario() throws Exception {
+        AjusteInventarioRequestDTO request = AjusteInventarioRequestDTO.builder()
+                .cantidad(new BigDecimal("3.00"))
+                .motivo("Corrección")
+                .productoId(10L)
+                .almacenId(2L)
+                .usuarioId(5L)
+                .build();
+
+        when(ajusteInventarioService.crear(any(AjusteInventarioRequestDTO.class)))
+                .thenReturn(AjusteInventarioResponseDTO.builder()
+                        .id(1L)
+                        .fecha(LocalDateTime.now())
+                        .cantidad(new BigDecimal("3.00"))
+                        .motivo("Corrección")
+                        .build());
+
+        mockMvc.perform(post("/api/inventario/ajustes")
+                        .with(SecurityMockMvcRequestPostProcessors.user("contador-permiso")
+                                .authorities(() -> "INV_AJUSTES_WRITE"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerSecurityTest.java
@@ -1,0 +1,120 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResumenResponseDTO;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico;
+import com.willyes.clemenintegra.inventario.service.ConteoCiclicoService;
+import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
+import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.SuperAdminSoloLecturaWriteBlockFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ConteoCiclicoController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, ConteoCiclicoControllerSecurityTest.MethodSecurityConfig.class})
+@ImportAutoConfiguration({SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
+class ConteoCiclicoControllerSecurityTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    @org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity(prePostEnabled = true)
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ConteoCiclicoService conteoCiclicoService;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private RequestTimingFilter requestTimingFilter;
+    @MockBean
+    private RequestIdFilter requestIdFilter;
+    @MockBean
+    private SuperAdminSoloLecturaWriteBlockFilter superAdminSoloLecturaWriteBlockFilter;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void configureFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestTimingFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestIdFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(superAdminSoloLecturaWriteBlockFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    void permiteListarConteosConPermisoLectura() throws Exception {
+        ConteoCiclicoResumenResponseDTO response = ConteoCiclicoResumenResponseDTO.builder()
+                .id(1L)
+                .estado(EstadoConteoCiclico.BORRADOR)
+                .build();
+        when(conteoCiclicoService.listar(any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(response)));
+
+        mockMvc.perform(get("/api/inventario/conteos")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(SecurityMockMvcRequestPostProcessors.user("contador-permiso")
+                                .authorities(() -> "INV_CONTEOS_READ")))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow the frontend-granular permissions to enable access to inventory Ajustes and Conteos without removing legacy role checks.
- Keep changes minimal and backward compatible so existing role-based behavior remains intact for all write operations.
- Facilitate QA by adding focused security tests that run with the real security filter chain enabled.

### Description
- Allow `/api/inventario/ajustes/**` to be accessed when the user has the `INV_AJUSTES_WRITE` authority in addition to the existing roles by updating `SecurityConfig` (added authority at the Ajustes matcher). (`src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java`)
- Permit read access to conteos endpoints by the `INV_CONTEOS_READ` authority while preserving legacy role checks by updating `@PreAuthorize` on the GET endpoints in `ConteoCiclicoController`. (`src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java`)
- Add two MockMvc security tests that exercise the real filter chain with mocked dependencies: `AjusteInventarioControllerSecurityTest` verifies POST `/api/inventario/ajustes` with `INV_AJUSTES_WRITE`, and `ConteoCiclicoControllerSecurityTest` verifies GET `/api/inventario/conteos` with `INV_CONTEOS_READ`. (`src/test/java/com/willyes/clemenintegra/inventario/controller/AjusteInventarioControllerSecurityTest.java`, `src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerSecurityTest.java`)
- Note: Conteo write endpoints remain role-based only because there is no `INV_CONTEOS_WRITE` authority present in the repository; adding that permission and a DB migration/seed is a follow-up task.

### Testing
- Ran the new controller security tests via Maven with the command `mvn -Dtest=AjusteInventarioControllerSecurityTest,ConteoCiclicoControllerSecurityTest test` and observed the tests execute under the Spring test context with the security filters enabled; the tests completed successfully with no failures.
- Tests exercise the real filter chain by using `@AutoConfigureMockMvc(addFilters = true)` and mocking authentication-related filters and providers to let authorization rules be evaluated.
- CI/local command to run the full suite of the new checks is the same Maven command shown above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a20c29900833393ea0cdb9db6c3b3)