### PR TITLE
Permitir lectura de productos con permiso granular INV_PRODUCT_READ

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -40,7 +40,7 @@ public class ProductoController {
     private final UsuarioRepository usuarioRepository;
 
     @GetMapping("/buscar")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
             "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoOptionDTO>> buscarProductos(
             @RequestParam(name = "q", required = false) String q,
@@ -54,7 +54,7 @@ public class ProductoController {
     }
 
     @GetMapping("/buscar-insumos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoResumenDTO>> buscarInsumos(
             @RequestParam(name = "term") String term,
             @PageableDefault(size = 20, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {
@@ -64,7 +64,7 @@ public class ProductoController {
     }
 
     @GetMapping("/buscar-pt")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoResumenDTO>> buscarProductosTerminados(
             @RequestParam(name = "term") String term,
             @PageableDefault(size = 20, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {
@@ -74,7 +74,7 @@ public class ProductoController {
     }
 
     @GetMapping("/buscar-fabricables")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoAutocompleteDTO>> buscarProductosFabricablesAutocomplete(
             @RequestParam("term") String term,
             Pageable pageable
@@ -84,7 +84,7 @@ public class ProductoController {
     }
 
     @GetMapping("/categoria/{nombre}")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
             "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<List<ProductoResponseDTO>> buscarPorCategoria(
             @PathVariable String nombre) {
@@ -96,20 +96,20 @@ public class ProductoController {
     }
 
     @GetMapping("/fabricables")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_JEFE_PRODUCCION','ROL_JEFE_ALMACENES','ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<List<ProductoResponseDTO>> getProductosFabricables() {
         List<ProductoResponseDTO> productos = productoService.findProductosFabricables();
         return ResponseEntity.ok(productos);
     }
 
     @GetMapping("/producto-terminado")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public List<ProductoResponseDTO> getProductosTerminados() {
         return productoService.findByCategoriaTipo("PRODUCTO_TERMINADO");
     }
 
     @GetMapping("/insumos")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public List<ProductoResponseDTO> getProductosInsumo() {
         return productoService.findByCategoriaTipoIn(List.of(
                 "MATERIA_PRIMA",
@@ -120,7 +120,7 @@ public class ProductoController {
     }
 
     @GetMapping("/insumos/autocomplete")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
     public ResponseEntity<Page<InsumoAutocompleteDTO>> buscarInsumosAutocomplete(
             @RequestParam("term") String term,
             Pageable pageable
@@ -130,7 +130,7 @@ public class ProductoController {
     }
 
     @GetMapping("/terminados")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_JEFE_CALIDAD','ROL_JEFE_PRODUCCION','ROL_SUPER_ADMIN')")
     public List<ProductoResponseDTO> getProductosTerminadosPublico() {
         return productoService.findByCategoriaTipo("PRODUCTO_TERMINADO");
     }
@@ -156,7 +156,7 @@ public class ProductoController {
     }
 
     @GetMapping("/{id:[0-9]+}")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
             "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<ProductoResponseDTO> obtenerPorId(@PathVariable Long id) {
         ProductoResponseDTO producto = productoService.obtenerPorId(id);
@@ -230,7 +230,7 @@ public class ProductoController {
     }
 
     @GetMapping("/con-lotes")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
             "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<List<ProductoConEstadoLoteDTO>> productosConLotesPorEstado(
             @RequestParam String estado) {
@@ -243,7 +243,7 @@ public class ProductoController {
     }
 
     @GetMapping("/agrupado-por-lotes")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_JEFE_PRODUCCION','ROL_COMPRADOR'," +
             "'ROL_JEFE_CALIDAD','ROL_MICROBIOLOGO','ROL_ANALISTA_CALIDAD','ROL_PLANEADOR')")
     public ResponseEntity<List<ProductoConLotesDTO>> productosAgrupadosPorLotesEnEstado(
             @RequestParam String estado) {
@@ -256,7 +256,7 @@ public class ProductoController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD'," +
+    @PreAuthorize("hasAnyAuthority('INV_PRODUCT_READ','ROL_JEFE_ALMACENES', 'ROL_ALMACENISTA', 'ROL_SUPER_ADMIN', 'ROL_JEFE_CALIDAD'," +
             " 'ROL_JEFE_PRODUCCION','ROL_PLANEADOR')")
     public ResponseEntity<Page<ProductoResponseDTO>> obtenerTodos(
             @RequestParam(required = false) String nombre,

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -117,6 +117,7 @@ public class SecurityConfig {
                     );
 
                     auth.requestMatchers(HttpMethod.GET, "/api/inventario/productos/**").hasAnyAuthority(
+                            "INV_PRODUCT_READ",
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
@@ -137,6 +138,20 @@ public class SecurityConfig {
                             RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_LIDER_ALIMENTOS.name(),
                             RolUsuario.ROL_LIDER_HOMEOPATICOS.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers(HttpMethod.GET, "/api/productos/**").hasAnyAuthority(
+                            "INV_PRODUCT_READ",
+                            RolUsuario.ROL_ALMACENISTA.name(),
+                            RolUsuario.ROL_JEFE_ALMACENES.name(),
+                            RolUsuario.ROL_CONTADOR.name(),
+                            RolUsuario.ROL_COMPRADOR.name(),
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_ANALISTA_CALIDAD.name(),
+                            RolUsuario.ROL_MICROBIOLOGO.name(),
+                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ProductoControllerSecurityTest.java
@@ -1,0 +1,128 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.UnidadMedidaRepository;
+import com.willyes.clemenintegra.inventario.service.ProductoService;
+import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
+import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.SuperAdminSoloLecturaWriteBlockFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProductoController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, ProductoControllerSecurityTest.MethodSecurityConfig.class})
+@ImportAutoConfiguration({SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
+class ProductoControllerSecurityTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    @org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity(prePostEnabled = true)
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProductoService productoService;
+    @MockBean
+    private ProductoRepository productoRepository;
+    @MockBean
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @MockBean
+    private UnidadMedidaRepository unidadMedidaRepository;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private RequestTimingFilter requestTimingFilter;
+    @MockBean
+    private RequestIdFilter requestIdFilter;
+    @MockBean
+    private SuperAdminSoloLecturaWriteBlockFilter superAdminSoloLecturaWriteBlockFilter;
+
+    @BeforeEach
+    void configureFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestTimingFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestIdFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(superAdminSoloLecturaWriteBlockFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    void permiteListarProductosConPermisoLectura() throws Exception {
+        when(productoService.listarTodos(any(), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/productos")
+                        .with(SecurityMockMvcRequestPostProcessors.user("contador-permiso")
+                                .authorities(() -> "INV_PRODUCT_READ")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void rechazaListarProductosSinPermiso() throws Exception {
+        mockMvc.perform(get("/api/productos")
+                        .with(SecurityMockMvcRequestPostProcessors.user("sin-permiso")))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
### Motivation
- El frontend para ROL_CONTADOR fallaba con 403 porque las llamadas al catálogo de productos solo aceptaban roles legacy; hace falta aceptar permiso granular de lectura.
- Objetivo: desbloquear pantallas de Ajustes y Conteos permitiendo lectura de productos con el permiso `INV_PRODUCT_READ` sin abrir escrituras.

### Description
- Seguridad central: en `SecurityConfig` se añadió `INV_PRODUCT_READ` a las reglas `GET /api/inventario/productos/**` y `GET /api/productos/**` para permitir acceso por permiso granular además de los roles legacy.
- Controller: se actualizaron las anotaciones `@PreAuthorize` en `ProductoController` para incluir `INV_PRODUCT_READ` en todos los endpoints `GET` relacionados con productos, manteniendo sin cambios las reglas de escritura (`POST/PUT/DELETE/PATCH`).
- Tests: se agregó `ProductoControllerSecurityTest` (MockMVC) que verifica que un usuario con la autoridad `INV_PRODUCT_READ` obtiene `200` en `GET /api/productos` y que un usuario sin permisos obtiene `403`.

### Testing
- Ejecuté el test focalizado con `mvn -q -Dtest=ProductoControllerSecurityTest test` y la suite de MockMVC del controlador de productos pasó correctamente.
- Las pruebas activaron los filtros de seguridad simulados (`JwtAuthenticationFilter`, `UsuarioInactivoFilter`, `SuperAdminSoloLecturaWriteBlockFilter`, etc.) para validar el comportamiento real de autorización en entorno de test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a273c555c8333ac7841e56ea1b3f7)