### PR TITLE
Reset execution fields when cloning production stages

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1342,6 +1342,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                         .estado(EstadoEtapa.PENDIENTE)
                         .fechaInicio(null)
                         .fechaFin(null)
+                        .usuarioId(null)
+                        .usuarioNombre(null)
                         .build())
                 .toList();
         etapaProduccionRepository.saveAll(etapas);

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -518,6 +518,8 @@ class OrdenProduccionServiceImplTest {
             assertThat(etapa.getEstado()).isEqualTo(EstadoEtapa.PENDIENTE);
             assertThat(etapa.getFechaInicio()).isNull();
             assertThat(etapa.getFechaFin()).isNull();
+            assertThat(etapa.getUsuarioId()).isNull();
+            assertThat(etapa.getUsuarioNombre()).isNull();
         });
     }
 


### PR DESCRIPTION
### Motivation
- Prevent cloned production stages from inheriting execution metadata (user/dates/state) that can leave new OPs with `FINALIZADA` stages and block inventory movements.

### Description
- Set `usuarioId = null` and `usuarioNombre = null` when building `EtapaProduccion` in `OrdenProduccionServiceImpl.clonarEtapasParaOrden` so cloned stages start clean (file `src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java`, ~L1335), and update the unit test `clonarEtapasParaOrden_inicializaFechasNulas` to assert these fields are `null` (file `src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java`, ~L500).

### Testing
- Executed `mvn -Dtest=OrdenProduccionServiceImplTest test` and the targeted tests passed: `Tests run: 45, Failures: 0, Errors: 0, Skipped: 0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a55c73b2c8333a86f0e838c3fd1de)