### PR TITLE
Usar ubicaciones_fisicas en picklist (consulta bulk + tests)

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteUbicacionPicklistProjection.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/LoteUbicacionPicklistProjection.java
@@ -1,0 +1,9 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+public interface LoteUbicacionPicklistProjection {
+    Integer getProductoId();
+    Integer getAlmacenId();
+    String getCodigoLote();
+    String getUbicacionCodigo();
+    String getUbicacionDescripcion();
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -1,6 +1,7 @@
 package com.willyes.clemenintegra.inventario.repository;
 
 import com.willyes.clemenintegra.inventario.dto.LoteAlertaActivaProjection;
+import com.willyes.clemenintegra.inventario.dto.LoteUbicacionPicklistProjection;
 import com.willyes.clemenintegra.inventario.dto.StockAlertaProjection;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.Producto;
@@ -319,4 +320,21 @@ WHERE lp.codigoLote = :codigoLote
         WHERE lp.fecha_vencimiento IS NOT NULL
         """, nativeQuery = true)
     List<LoteAlertaActivaProjection> listarLotesConVencimiento();
+
+    @Query(value = """
+        SELECT lp.productos_id AS productoId,
+               lp.almacenes_id AS almacenId,
+               lp.codigo_lote AS codigoLote,
+               uf.codigo AS ubicacionCodigo,
+               uf.descripcion AS ubicacionDescripcion
+        FROM lotes_productos lp
+        LEFT JOIN ubicaciones_fisicas uf ON uf.id = lp.ubicaciones_fisicas_id
+        WHERE lp.productos_id IN (:productoIds)
+          AND lp.almacenes_id IN (:almacenIds)
+          AND lp.codigo_lote IN (:codigosLote)
+        """, nativeQuery = true)
+    List<LoteUbicacionPicklistProjection> findUbicacionesFisicasPicklist(
+            @Param("productoIds") Collection<Integer> productoIds,
+            @Param("almacenIds") Collection<Integer> almacenIds,
+            @Param("codigosLote") Collection<String> codigosLote);
 }

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -37,6 +37,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
@@ -690,6 +691,7 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
 
     List<PicklistItem> buildPicklistItems(List<SolicitudMovimiento> solicitudes) {
         List<PicklistItem> items = new ArrayList<>();
+        Map<PicklistKey, String> ubicaciones = cargarUbicacionesFisicas(solicitudes);
 
         for (SolicitudMovimiento solicitud : solicitudes) {
             List<SolicitudMovimientoDetalle> detalles = Optional.ofNullable(solicitud.getDetalles())
@@ -707,9 +709,10 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                             ? solicitud.getProducto().getUnidadMedida().getNombre()
                             : "-";
                     String almOrigen = origen != null ? origen.getNombre() : "-";
-                    String ubicOrigen = origen != null && origen.getUbicacion() != null ? origen.getUbicacion() : "-";
+                    String ubicOrigen = resolverUbicacionFisica(ubicaciones, solicitud, origen,
+                            detalle != null ? detalle.getLote() : null);
                     String almDestino = destino != null ? destino.getNombre() : "-";
-                    String ubicDestino = destino != null && destino.getUbicacion() != null ? destino.getUbicacion() : "-";
+                    String ubicDestino = "-";
                     String obs = solicitud.getObservaciones() != null ? solicitud.getObservaciones() : "-";
 
                     items.add(new PicklistItem(
@@ -734,9 +737,9 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                     ? solicitud.getProducto().getUnidadMedida().getNombre()
                     : "-";
             String almOrigen = solicitud.getAlmacenOrigen() != null ? solicitud.getAlmacenOrigen().getNombre() : "-";
-            String ubicOrigen = solicitud.getAlmacenOrigen() != null ? solicitud.getAlmacenOrigen().getUbicacion() : "-";
+            String ubicOrigen = resolverUbicacionFisica(ubicaciones, solicitud, solicitud.getAlmacenOrigen(), solicitud.getLote());
             String almDestino = solicitud.getAlmacenDestino() != null ? solicitud.getAlmacenDestino().getNombre() : "-";
-            String ubicDestino = solicitud.getAlmacenDestino() != null ? solicitud.getAlmacenDestino().getUbicacion() : "-";
+            String ubicDestino = "-";
             String obs = solicitud.getObservaciones() != null ? solicitud.getObservaciones() : "-";
 
             items.add(new PicklistItem(
@@ -771,6 +774,87 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
             String ubicacionDestino,
             String observaciones
     ) {
+    }
+
+    private Map<PicklistKey, String> cargarUbicacionesFisicas(List<SolicitudMovimiento> solicitudes) {
+        Set<Integer> productoIds = new HashSet<>();
+        Set<Integer> almacenIds = new HashSet<>();
+        Set<String> codigosLote = new HashSet<>();
+
+        for (SolicitudMovimiento solicitud : solicitudes) {
+            List<SolicitudMovimientoDetalle> detalles = Optional.ofNullable(solicitud.getDetalles())
+                    .orElseGet(Collections::emptyList);
+            if (!detalles.isEmpty()) {
+                for (SolicitudMovimientoDetalle detalle : detalles) {
+                    Almacen origen = detalle.getAlmacenOrigen() != null ? detalle.getAlmacenOrigen() : solicitud.getAlmacenOrigen();
+                    registrarLlaveUbicacion(productoIds, almacenIds, codigosLote, solicitud, origen,
+                            detalle != null ? detalle.getLote() : null);
+                }
+                continue;
+            }
+            registrarLlaveUbicacion(productoIds, almacenIds, codigosLote, solicitud, solicitud.getAlmacenOrigen(),
+                    solicitud.getLote());
+        }
+
+        if (productoIds.isEmpty() || almacenIds.isEmpty() || codigosLote.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<LoteUbicacionPicklistProjection> ubicaciones = loteRepository.findUbicacionesFisicasPicklist(
+                productoIds,
+                almacenIds,
+                codigosLote
+        );
+        Map<PicklistKey, String> resultado = new HashMap<>();
+        for (LoteUbicacionPicklistProjection ubicacion : ubicaciones) {
+            PicklistKey key = new PicklistKey(
+                    ubicacion.getProductoId(),
+                    ubicacion.getAlmacenId(),
+                    ubicacion.getCodigoLote()
+            );
+            resultado.putIfAbsent(key, formatearUbicacion(ubicacion.getUbicacionCodigo(),
+                    ubicacion.getUbicacionDescripcion()));
+        }
+        return resultado;
+    }
+
+    private void registrarLlaveUbicacion(Set<Integer> productoIds,
+                                         Set<Integer> almacenIds,
+                                         Set<String> codigosLote,
+                                         SolicitudMovimiento solicitud,
+                                         Almacen origen,
+                                         LoteProducto lote) {
+        Integer productoId = solicitud.getProducto() != null ? solicitud.getProducto().getId() : null;
+        Integer almacenId = origen != null ? origen.getId() : null;
+        String codigoLote = lote != null ? lote.getCodigoLote() : null;
+        if (productoId != null && almacenId != null && StringUtils.hasText(codigoLote)) {
+            productoIds.add(productoId);
+            almacenIds.add(almacenId);
+            codigosLote.add(codigoLote);
+        }
+    }
+
+    private String resolverUbicacionFisica(Map<PicklistKey, String> ubicaciones,
+                                           SolicitudMovimiento solicitud,
+                                           Almacen origen,
+                                           LoteProducto lote) {
+        Integer productoId = solicitud.getProducto() != null ? solicitud.getProducto().getId() : null;
+        Integer almacenId = origen != null ? origen.getId() : null;
+        String codigoLote = lote != null ? lote.getCodigoLote() : null;
+        if (productoId == null || almacenId == null || !StringUtils.hasText(codigoLote)) {
+            return "-";
+        }
+        return ubicaciones.getOrDefault(new PicklistKey(productoId, almacenId, codigoLote), "-");
+    }
+
+    private String formatearUbicacion(String codigo, String descripcion) {
+        if (!StringUtils.hasText(codigo) || !StringUtils.hasText(descripcion)) {
+            return "-";
+        }
+        return codigo + " - " + descripcion;
+    }
+
+    private record PicklistKey(Integer productoId, Integer almacenId, String codigoLote) {
     }
 
     private SolicitudMovimientoItemDTO toItemDTO(SolicitudMovimiento s, SolicitudMovimientoDetalle det) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServicePicklistTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServicePicklistTest.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.dto.LoteUbicacionPicklistProjection;
 import com.willyes.clemenintegra.inventario.dto.PicklistDTO;
 import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
@@ -68,6 +69,14 @@ class SolicitudMovimientoServicePicklistTest {
                 BigDecimal.valueOf(5)
         );
 
+        when(loteRepository.findUbicacionesFisicasPicklist(anySet(), anySet(), anySet()))
+                .thenReturn(List.of(crearUbicacionProjection(
+                        solicitud.getProducto().getId(),
+                        solicitud.getDetalles().getFirst().getAlmacenOrigen().getId(),
+                        "L-001",
+                        "BOD-05-A01",
+                        "PT.POSICION A01"
+                )));
         when(repository.findWithDetalles(eq(1L), isNull(), isNull(), isNull(), eq(false), anyList()))
                 .thenReturn(List.of(solicitud));
 
@@ -78,9 +87,9 @@ class SolicitudMovimientoServicePicklistTest {
         assertThat(item.producto()).isEqualTo("EQUINACEA POLVO");
         assertThat(item.lote()).isEqualTo("L-001");
         assertThat(item.almacenOrigen()).isEqualTo("Bodega MP");
-        assertThat(item.ubicacionOrigen()).isEqualTo("Pasillo 1");
+        assertThat(item.ubicacionOrigen()).isEqualTo("BOD-05-A01 - PT.POSICION A01");
         assertThat(item.almacenDestino()).isEqualTo("Pre-Bodega");
-        assertThat(item.ubicacionDestino()).isEqualTo("Zona F");
+        assertThat(item.ubicacionDestino()).isEqualTo("-");
 
         PicklistDTO picklist = service.generarPicklist(1L, true);
         assertThat(picklist.getArchivo()).isNotEmpty();
@@ -89,6 +98,8 @@ class SolicitudMovimientoServicePicklistTest {
     @Test
     @DisplayName("generarPicklist crea una fila por cada detalle con su lote")
     void generarPicklist_multiDetalleGeneraMultiplesFilas() throws Exception {
+        when(loteRepository.findUbicacionesFisicasPicklist(anySet(), anySet(), anySet()))
+                .thenReturn(List.of());
         SolicitudMovimientoDetalle detalle1 = crearDetalle("L-001", "Bodega 1", "Rack A", BigDecimal.valueOf(2));
         SolicitudMovimientoDetalle detalle2 = crearDetalle("L-002", "Bodega 2", "Rack B", BigDecimal.valueOf(3));
 
@@ -111,13 +122,16 @@ class SolicitudMovimientoServicePicklistTest {
     @Test
     @DisplayName("generarPicklist usa cabecera como respaldo cuando no hay detalles")
     void generarPicklist_sinDetallesUsaCabecera() throws Exception {
+        when(loteRepository.findUbicacionesFisicasPicklist(anySet(), anySet(), anySet()))
+                .thenReturn(List.of());
         Producto producto = new Producto();
         producto.setNombre("Producto sin detalle");
         UnidadMedida um = new UnidadMedida();
         um.setNombre("KG");
         producto.setUnidadMedida(um);
+        producto.setId(99);
 
-        Almacen origen = Almacen.builder().nombre("Almacen Cabecera").ubicacion("Zona C").build();
+        Almacen origen = Almacen.builder().id(7).nombre("Almacen Cabecera").ubicacion("Zona C").build();
         LoteProducto loteCabecera = new LoteProducto();
         loteCabecera.setCodigoLote("CAB-001");
 
@@ -141,9 +155,57 @@ class SolicitudMovimientoServicePicklistTest {
                 .satisfies(item -> {
                     assertThat(item.lote()).isEqualTo("CAB-001");
                     assertThat(item.almacenOrigen()).isEqualTo("Almacen Cabecera");
-                    assertThat(item.ubicacionOrigen()).isEqualTo("Zona C");
+                    assertThat(item.ubicacionOrigen()).isEqualTo("-");
                     assertThat(item.producto()).isEqualTo("Producto sin detalle");
                 });
+    }
+
+    @Test
+    @DisplayName("generarPicklist usa ubicacion fisica cuando existe y '-' cuando no existe")
+    void generarPicklist_ubicacionFisicaOptional() {
+        SolicitudMovimiento solicitud = crearSolicitudConDetalle(
+                "Producto ubicacion",
+                "L-100",
+                "Almacen A",
+                "Pasillo Z",
+                "Almacen B",
+                "Zona X",
+                BigDecimal.valueOf(2)
+        );
+        when(loteRepository.findUbicacionesFisicasPicklist(anySet(), anySet(), anySet()))
+                .thenReturn(List.of(crearUbicacionProjection(
+                        solicitud.getProducto().getId(),
+                        solicitud.getDetalles().getFirst().getAlmacenOrigen().getId(),
+                        "L-100",
+                        "BOD-05-A01",
+                        "PT.POSICION A01"
+                )));
+
+        List<SolicitudMovimientoServiceImpl.PicklistItem> items = service.buildPicklistItems(List.of(solicitud));
+
+        assertThat(items)
+                .hasSize(1)
+                .first()
+                .satisfies(item -> {
+                    assertThat(item.ubicacionOrigen()).isEqualTo("BOD-05-A01 - PT.POSICION A01");
+                    assertThat(item.ubicacionDestino()).isEqualTo("-");
+                });
+
+        when(loteRepository.findUbicacionesFisicasPicklist(anySet(), anySet(), anySet()))
+                .thenReturn(List.of(crearUbicacionProjection(
+                        solicitud.getProducto().getId(),
+                        solicitud.getDetalles().getFirst().getAlmacenOrigen().getId(),
+                        "L-100",
+                        null,
+                        null
+                )));
+
+        List<SolicitudMovimientoServiceImpl.PicklistItem> itemsSinUbicacion = service.buildPicklistItems(List.of(solicitud));
+
+        assertThat(itemsSinUbicacion)
+                .hasSize(1)
+                .first()
+                .satisfies(item -> assertThat(item.ubicacionOrigen()).isEqualTo("-"));
     }
 
     private SolicitudMovimiento crearSolicitudConDetalle(String nombreProducto,
@@ -155,8 +217,8 @@ class SolicitudMovimientoServicePicklistTest {
                                                          BigDecimal cantidad) {
         SolicitudMovimiento solicitud = crearSolicitudBase(nombreProducto, "GRM");
 
-        Almacen origen = Almacen.builder().nombre(nombreAlmacenOrigen).ubicacion(ubicacionAlmacenOrigen).build();
-        Almacen destino = Almacen.builder().nombre(nombreAlmacenDestino).ubicacion(ubicacionDestino).build();
+        Almacen origen = Almacen.builder().id(10).nombre(nombreAlmacenOrigen).ubicacion(ubicacionAlmacenOrigen).build();
+        Almacen destino = Almacen.builder().id(11).nombre(nombreAlmacenDestino).ubicacion(ubicacionDestino).build();
         LoteProducto lote = new LoteProducto();
         lote.setCodigoLote(codigoLote);
 
@@ -175,7 +237,7 @@ class SolicitudMovimientoServicePicklistTest {
     private SolicitudMovimientoDetalle crearDetalle(String codigoLote, String nombreAlmacen, String ubicacion, BigDecimal cantidad) {
         LoteProducto lote = new LoteProducto();
         lote.setCodigoLote(codigoLote);
-        Almacen origen = Almacen.builder().nombre(nombreAlmacen).ubicacion(ubicacion).build();
+        Almacen origen = Almacen.builder().id(20).nombre(nombreAlmacen).ubicacion(ubicacion).build();
 
         return SolicitudMovimientoDetalle.builder()
                 .lote(lote)
@@ -191,6 +253,7 @@ class SolicitudMovimientoServicePicklistTest {
         Producto producto = new Producto();
         producto.setNombre(nombreProducto);
         producto.setUnidadMedida(um);
+        producto.setId(1);
 
         OrdenProduccion ordenProduccion = OrdenProduccion.builder()
                 .id(1L)
@@ -208,6 +271,39 @@ class SolicitudMovimientoServicePicklistTest {
                 .fechaSolicitud(LocalDateTime.now())
                 .observaciones("Observacion prueba")
                 .build();
+    }
+
+    private LoteUbicacionPicklistProjection crearUbicacionProjection(Integer productoId,
+                                                                     Integer almacenId,
+                                                                     String codigoLote,
+                                                                     String codigo,
+                                                                     String descripcion) {
+        return new LoteUbicacionPicklistProjection() {
+            @Override
+            public Integer getProductoId() {
+                return productoId;
+            }
+
+            @Override
+            public Integer getAlmacenId() {
+                return almacenId;
+            }
+
+            @Override
+            public String getCodigoLote() {
+                return codigoLote;
+            }
+
+            @Override
+            public String getUbicacionCodigo() {
+                return codigo;
+            }
+
+            @Override
+            public String getUbicacionDescripcion() {
+                return descripcion;
+            }
+        };
     }
 
 }


### PR DESCRIPTION
### Motivation
- El picklist estaba mostrando `Almacen.ubicacion` en vez de la ubicación física real ubicada en `ubicaciones_fisicas`; se requiere que `Ubic. Origen` muestre `ubicaciones_fisicas.codigo + " - " + ubicaciones_fisicas.descripcion` sin introducir N+1 queries.

### Description
- Agregado `LoteUbicacionPicklistProjection` para proyectar resultados de la consulta nativa que trae `productoId`, `almacenId`, `codigoLote`, `ubicacionCodigo` y `ubicacionDescripcion` (archivo `src/main/java/com/willyes/clemenintegra/inventario/dto/LoteUbicacionPicklistProjection.java`, ~L1-L9). 
- Añadido método nativo en `LoteProductoRepository` llamado `findUbicacionesFisicasPicklist(...)` que realiza una única consulta para obtener ubicaciones físicas por lotes y almacenes (archivo `src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java`, ~L324-L339). La query exacta es:
  `SELECT lp.productos_id AS productoId, lp.almacenes_id AS almacenId, lp.codigo_lote AS codigoLote, uf.codigo AS ubicacionCodigo, uf.descripcion AS ubicacionDescripcion FROM lotes_productos lp LEFT JOIN ubicaciones_fisicas uf ON uf.id = lp.ubicaciones_fisicas_id WHERE lp.productos_id IN (:productoIds) AND lp.almacenes_id IN (:almacenIds) AND lp.codigo_lote IN (:codigosLote)`
- En `SolicitudMovimientoServiceImpl` se añadió la recolección de llaves `(productoId, almacenId, codigoLote)`, la llamada bulk al repository y el mapeo a `Map<PicklistKey,String>` con el formato `"COD - DESC"` o `"-"` si falta; además `Ubic. Destino` se deja por defecto `"-"` (archivo `src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java`, cambios principales alrededor de `buildPicklistItems` y utilidades nuevas, ~L692-L858 y ~L779-L859). 
- Ajustadas pruebas unitarias en `SolicitudMovimientoServicePicklistTest` para mockear `findUbicacionesFisicasPicklist` y validar ambos casos: existencia de ubicación física formateada `"BOD-05-A01 - PT.POSICION A01"` y ausencia que produce `"-"` (archivo `src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServicePicklistTest.java`, ~L59-L307).

### Testing
- Ejecutado test unitario específico con `mvn -Dtest=SolicitudMovimientoServicePicklistTest test` y las pruebas relacionadas al picklist pasaron exitosamente. 
- Se añadieron mocks en la suite para validar: A) cuando existe `ubicaciones_fisicas` devuelve `"BOD-05-A01 - PT.POSICION A01"`, B) cuando es `null` devuelve `"-"` (tests añadidos/ajustados en `SolicitudMovimientoServicePicklistTest`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb37ed44083338de1353ca05396e8)