### PR TITLE
Prevent duplicate production stage cloning

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaProduccionRepository.java
@@ -10,6 +10,10 @@ import java.util.Optional;
 public interface EtapaProduccionRepository extends JpaRepository<EtapaProduccion, Long> {
     List<EtapaProduccion> findByOrdenProduccionIdOrderBySecuenciaAsc(Long ordenProduccionId);
 
+    boolean existsByOrdenProduccionId(Long ordenProduccionId);
+
+    long countByOrdenProduccionId(Long ordenProduccionId);
+
     long countByOrdenProduccionIdAndFechaInicioIsNotNullAndFechaFinIsNull(Long ordenProduccionId);
 
     Optional<EtapaProduccion> findTopByOrdenProduccionIdAndFechaInicioIsNotNullAndFechaFinIsNullOrderByFechaInicioDescIdDesc(Long ordenProduccionId);

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -86,6 +86,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.lang.Nullable;
 import org.springframework.web.ErrorResponseException;
 import org.springframework.http.ProblemDetail;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -1334,6 +1335,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
     public void clonarEtapasParaOrden(OrdenProduccion op, List<EtapaPlantilla> plantilla) {
         if (plantilla == null || plantilla.isEmpty()) return;
+        if (op == null || op.getId() == null) {
+            return;
+        }
+        if (etapaProduccionRepository.existsByOrdenProduccionId(op.getId())) {
+            return;
+        }
         List<EtapaProduccion> etapas = plantilla.stream()
                 .map(p -> EtapaProduccion.builder()
                         .nombre(p.getNombre())
@@ -1346,7 +1353,11 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                         .usuarioNombre(null)
                         .build())
                 .toList();
-        etapaProduccionRepository.saveAll(etapas);
+        try {
+            etapaProduccionRepository.saveAll(etapas);
+        } catch (DataIntegrityViolationException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "ETAPAS_DUPLICADAS_OP", ex);
+        }
     }
 
     public void clonarEtapas(Long ordenId) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -53,6 +53,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.ErrorResponseException;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.junit.jupiter.api.BeforeEach;
@@ -1576,6 +1577,58 @@ class OrdenProduccionServiceImplTest {
         assertThat(dto.getCantidadConsumida()).isEqualByComparingTo(new BigDecimal("3"));
         assertThat(dto.getFaltante()).isEqualByComparingTo(new BigDecimal("7"));
         assertThat(dto.getCantidadAlistada()).isEqualByComparingTo(new BigDecimal("2.5"));
+    }
+
+    @Test
+    @DisplayName("clonarEtapasParaOrden crea etapas cuando la OP no tiene etapas previas")
+    void clonarEtapasParaOrden_creaEtapas() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(10L);
+        EtapaPlantilla etapa1 = EtapaPlantilla.builder().id(1L).nombre("Dispensado").secuencia(1).build();
+        EtapaPlantilla etapa2 = EtapaPlantilla.builder().id(2L).nombre("Mezcla").secuencia(2).build();
+
+        when(etapaProduccionRepository.existsByOrdenProduccionId(10L)).thenReturn(false);
+
+        ArgumentCaptor<List<EtapaProduccion>> captor = ArgumentCaptor.forClass(List.class);
+        service.clonarEtapasParaOrden(orden, List.of(etapa1, etapa2));
+
+        verify(etapaProduccionRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("clonarEtapasParaOrden es idempotente cuando ya existen etapas")
+    void clonarEtapasParaOrden_idempotente() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(11L);
+        EtapaPlantilla etapa = EtapaPlantilla.builder().id(1L).nombre("Envasado").secuencia(1).build();
+
+        when(etapaProduccionRepository.existsByOrdenProduccionId(11L)).thenReturn(false, true);
+
+        service.clonarEtapasParaOrden(orden, List.of(etapa));
+        service.clonarEtapasParaOrden(orden, List.of(etapa));
+
+        verify(etapaProduccionRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("clonarEtapasParaOrden traduce conflicto de integridad a 409")
+    void clonarEtapasParaOrden_traduceConflict() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(12L);
+        EtapaPlantilla etapa = EtapaPlantilla.builder().id(1L).nombre("Control").secuencia(1).build();
+
+        when(etapaProduccionRepository.existsByOrdenProduccionId(12L)).thenReturn(false);
+        doThrow(new DataIntegrityViolationException("dup"))
+                .when(etapaProduccionRepository).saveAll(anyList());
+
+        assertThatThrownBy(() -> service.clonarEtapasParaOrden(orden, List.of(etapa)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException rse = (ResponseStatusException) ex;
+                    assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+                    assertThat(rse.getReason()).isEqualTo("ETAPAS_DUPLICADAS_OP");
+                });
     }
 
     private OrdenProduccion crearOrdenBase(Long id, BigDecimal programada, BigDecimal producida, EstadoProduccion estado) {


### PR DESCRIPTION
### Motivation

- Prevent creation of duplicate `etapa_produccion` rows for the same Orden de Producción (OP) because the DB already enforces `UNIQUE(orden_produccion_id, secuencia)` and concurrent/double submits currently can produce 500s. 
- Make the backend idempotent on stage cloning and translate integrity conflicts into a 409 (Conflict) with a clear error code so callers can handle races or retries.

### Description

- Added repository helpers `existsByOrdenProduccionId(Long)` and `countByOrdenProduccionId(Long)` in `src/main/java/com/willyes/clemenintegra/produccion/repository/EtapaProduccionRepository.java` to detect existing stages.  
- Made `clonarEtapasParaOrden` (in `src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java`) early-return when `op` is null/has no id or when `existsByOrdenProduccionId(op.getId())` is true, and kept the save in a try/catch.  
- Catch `DataIntegrityViolationException` from `saveAll` and translate it to `ResponseStatusException` with `HttpStatus.CONFLICT` and reason `ETAPAS_DUPLICADAS_OP` to surface a 409 to clients.  
- Added unit tests in `src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java` covering successful cloning, idempotency (double-call no duplicate save), and translation of integrity violation to 409 (`clonarEtapasParaOrden_creaEtapas`, `clonarEtapasParaOrden_idempotente`, `clonarEtapasParaOrden_traduceConflict`).

### Testing

- Ran the unit test class with `mvn -q -Dtest=OrdenProduccionServiceImplTest test` and the test suite that includes the three new tests executed and completed successfully.  
- The added tests assert (1) N stages are prepared and saved for a new OP, (2) a second call does not trigger a second `saveAll`, and (3) a `DataIntegrityViolationException` during `saveAll` is mapped to a `ResponseStatusException` with status `409` and reason `ETAPAS_DUPLICADAS_OP`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cc342bcc88333b258fd37fe0b6c93)