### PR TITLE
Fix production service test wiring for lote consecutivo

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
@@ -12,6 +12,7 @@ import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.never;
@@ -43,6 +45,11 @@ class DisponibilidadInsumoServiceTest {
 
     @InjectMocks
     private DisponibilidadInsumoService service;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(null);
+    }
 
     @Test
     @DisplayName("calcularDisponibilidad mantiene faltante y stock en preview y real")

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -71,6 +71,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -132,6 +133,7 @@ class OrdenProduccionServiceImplTest {
     @Mock private ReservaLoteRepository reservaLoteRepository;
     @Mock private DisponibilidadInsumoService disponibilidadInsumoService;
     @Mock private ChecklistEtapaService checklistEtapaService;
+    @Mock private LoteConsecutivoDiaService loteConsecutivoDiaService;
 
     @Spy
     @InjectMocks
@@ -168,6 +170,7 @@ class OrdenProduccionServiceImplTest {
         lenient().when(catalogResolver.getTipoDetalleSalidaId()).thenReturn(11L);
         lenient().when(catalogResolver.getMotivoSalidaProduccionId()).thenReturn(11L);
         lenient().when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(6L);
+        lenient().when(loteConsecutivoDiaService.obtenerSiguienteConsecutivo(any(LocalDate.class))).thenReturn(1);
         TipoMovimientoDetalle tipoSalida = new TipoMovimientoDetalle();
         tipoSalida.setId(11L);
         lenient().when(tipoMovimientoDetalleRepository.findById(11L)).thenReturn(Optional.of(tipoSalida));

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -69,6 +69,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -116,6 +117,7 @@ class OrdenProduccionServiceReservaTest {
     @Mock private VidaUtilProductoService vidaUtilProductoService;
     @Mock private ReservaLoteService reservaLoteService;
     @Mock private DisponibilidadInsumoService disponibilidadInsumoService;
+    @Mock private LoteConsecutivoDiaService loteConsecutivoDiaService;
 
     @InjectMocks
     private OrdenProduccionServiceImpl service;
@@ -185,6 +187,7 @@ class OrdenProduccionServiceReservaTest {
         ReflectionTestUtils.setField(service, "estadosSolicitudPendientesConf", "PENDIENTE");
         ReflectionTestUtils.setField(service, "estadosSolicitudConcluyentesConf", "EJECUTADA");
         ReflectionTestUtils.setField(service, "clasificacionEntradaPtConf", "ENTRADA_PRODUCTO_TERMINADO");
+        lenient().when(loteConsecutivoDiaService.obtenerSiguienteConsecutivo(any(LocalDate.class))).thenReturn(1);
     }
 
     @Test
@@ -258,19 +261,19 @@ class OrdenProduccionServiceReservaTest {
 
         DistribucionFefoResult resultado = DistribucionFefoResult.builder()
                 .productoInsumoId(50L)
-                .requerido(new BigDecimal("6.000000"))
-                .stockFisicoTotal(new BigDecimal("6.000000"))
+                .requerido(new BigDecimal("6.790123"))
+                .stockFisicoTotal(new BigDecimal("6.790123"))
                 .stockReservadoTotal(BigDecimal.ZERO)
-                .stockLibreTotal(new BigDecimal("6.000000"))
+                .stockLibreTotal(new BigDecimal("6.790123"))
                 .faltante(BigDecimal.ZERO)
                 .suficiente(true)
                 .detalles(List.of(
                         DistribucionFefoDetalle.builder()
                                 .loteProductoId(300L)
                                 .almacenId(99L)
-                                .cantidadCalculo(new BigDecimal("6.00000000"))
-                                .cantidadReserva(new BigDecimal("6.000000"))
-                                .disponible(new BigDecimal("6.000000"))
+                                .cantidadCalculo(new BigDecimal("6.79012300"))
+                                .cantidadReserva(new BigDecimal("6.790123"))
+                                .disponible(new BigDecimal("6.790123"))
                                 .estado("DISPONIBLE")
                                 .build()
                 ))


### PR DESCRIPTION
### Motivation
- Resolve NPEs in production-service unit tests caused by missing `LoteConsecutivoDiaService` injection when code paths generate lote codes.
- Keep production code unchanged and fix only test wiring and deterministic stubs so business-validations run and assertions are stable.

### Description
- Added a `@Mock private LoteConsecutivoDiaService loteConsecutivoDiaService` and a deterministic lenient stub `when(...obtenerSiguienteConsecutivo(any(LocalDate.class))).thenReturn(1)` to `OrdenProduccionServiceImplTest` so `generarCodigoLote(...)` no longer throws NPEs.
- Added the same `@Mock` + lenient stub in `OrdenProduccionServiceReservaTest` and imported `LocalDate` where needed so reserva-related tests also have the service available.
- Aligned FEFO/distribution numbers in `OrdenProduccionServiceReservaTest` to stable values (`6.790123` and matching detail amounts) so origin/destination validation and quantity math exercise the intended branches deterministically.
- In `DisponibilidadInsumoServiceTest` added a `@BeforeEach` lenient stub `lenient().when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(null)` (and imported `BeforeEach`) to avoid pre-bodega-origin checks interfering with unrelated tests; made the stub lenient to avoid unnecessary-stubbing errors.
- Only test files were changed (mocks, imports and setup); no production/business logic was altered.

### Testing
- Ran targeted tests: `mvn -Dtest=OrdenProduccionServiceImplTest,OrdenProduccionServiceReservaTest test` and they passed (both tests suites succeeded).
- Ran full test suite: `mvn test` and the build completed successfully with all tests passing (previous failures due to NPE/unnecessary stubbing resolved).
- Commit includes only the three modified test files and a commit message `Fix test wiring for lote consecutivo`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d2e99cdfc8333ab5b64c195e2e0dc)