### PR TITLE
Fix OP solicitud origin fallback and detail state

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -858,6 +858,17 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
     }
 
     private SolicitudMovimientoItemDTO toItemDTO(SolicitudMovimiento s, SolicitudMovimientoDetalle det) {
+        Almacen almacenOrigen = Optional.ofNullable(det.getAlmacenOrigen())
+                .orElseGet(() -> Optional.ofNullable(s.getAlmacenOrigen())
+                        .orElseGet(() -> Optional.ofNullable(det.getLote())
+                                .map(LoteProducto::getAlmacen)
+                                .orElse(null)));
+        Almacen almacenDestino = Optional.ofNullable(det.getAlmacenDestino())
+                .orElse(s.getAlmacenDestino());
+        String estadoDetalle = det.getEstado() != null
+                ? det.getEstado().name()
+                : (s.getEstado() != null ? s.getEstado().name() : null);
+
         return SolicitudMovimientoItemDTO.builder()
                 .solicitudId(s.getId())
                 .productoId(s.getProducto() != null ? s.getProducto().getId().longValue() : null)
@@ -867,15 +878,15 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                 .cantidadSolicitada(det.getCantidad())
                 .cantidadAtendida(det.getCantidadAtendida())
                 .unidadMedida(s.getProducto() != null && s.getProducto().getUnidadMedida() != null ? s.getProducto().getUnidadMedida().getNombre() : null)
-                .almacenOrigenId(det.getAlmacenOrigen() != null ? det.getAlmacenOrigen().getId().longValue() : null)
-                .nombreAlmacenOrigen(det.getAlmacenOrigen() != null ? det.getAlmacenOrigen().getNombre() : null)
-                .ubicacionAlmacenOrigen(det.getAlmacenOrigen() != null ? det.getAlmacenOrigen().getUbicacion() : "-")
-                .almacenDestinoId(det.getAlmacenDestino() != null ? det.getAlmacenDestino().getId().longValue() : null)
-                .nombreAlmacenDestino(det.getAlmacenDestino() != null ? det.getAlmacenDestino().getNombre() : null)
-                .ubicacionAlmacenDestino(det.getAlmacenDestino() != null ? det.getAlmacenDestino().getUbicacion() : "-")
+                .almacenOrigenId(almacenOrigen != null ? almacenOrigen.getId().longValue() : null)
+                .nombreAlmacenOrigen(almacenOrigen != null ? almacenOrigen.getNombre() : null)
+                .ubicacionAlmacenOrigen(almacenOrigen != null ? almacenOrigen.getUbicacion() : "-")
+                .almacenDestinoId(almacenDestino != null ? almacenDestino.getId().longValue() : null)
+                .nombreAlmacenDestino(almacenDestino != null ? almacenDestino.getNombre() : null)
+                .ubicacionAlmacenDestino(almacenDestino != null ? almacenDestino.getUbicacion() : "-")
                 .motivoMovimientoId(s.getMotivoMovimiento() != null ? s.getMotivoMovimiento().getId() : null)
                 .tipoMovimientoDetalleId(s.getTipoMovimientoDetalle() != null ? s.getTipoMovimientoDetalle().getId() : null)
-                .estado(s.getEstado() != null ? s.getEstado().name() : null)
+                .estado(estadoDetalle)
                 .fechaSolicitud(s.getFechaSolicitud())
                 .usuarioSolicitante(s.getUsuarioSolicitante() != null ? s.getUsuarioSolicitante().getNombreCompleto() : null)
                 .observaciones(s.getObservaciones())

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
@@ -1,0 +1,137 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoItemDTO;
+import com.willyes.clemenintegra.inventario.dto.SolicitudesPorOrdenDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MotivoMovimientoRepository;
+import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoDetalleRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
+import com.willyes.clemenintegra.inventario.repository.TipoMovimientoDetalleRepository;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
+import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SolicitudMovimientoServiceImplPorOrdenTest {
+
+    @Mock
+    private SolicitudMovimientoRepository repository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private LoteProductoRepository loteRepository;
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private OrdenProduccionRepository ordenProduccionRepository;
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+    @Mock
+    private MovimientoInventarioRepository movimientoInventarioRepository;
+    @Mock
+    private ReservaLoteService reservaLoteService;
+    @Mock
+    private LoteCalidadValidator loteCalidadValidator;
+
+    @InjectMocks
+    private SolicitudMovimientoServiceImpl service;
+
+    @Test
+    void obtenerPorOrdenMantieneOrigenDesdeLoteYEstadoPendienteEnDetalle() {
+        Almacen origen = Almacen.builder()
+                .id(1)
+                .nombre("Alm Origen")
+                .ubicacion("OR-01")
+                .build();
+        Almacen destino = Almacen.builder()
+                .id(6)
+                .nombre("Pre-Bodega Producción")
+                .ubicacion("PB-01")
+                .build();
+        LoteProducto lote = LoteProducto.builder()
+                .id(10L)
+                .codigoLote("L-001")
+                .almacen(origen)
+                .build();
+        SolicitudMovimientoDetalle pendienteDetalle = SolicitudMovimientoDetalle.builder()
+                .id(228L)
+                .lote(lote)
+                .cantidad(BigDecimal.TEN)
+                .cantidadAtendida(BigDecimal.ZERO)
+                .estado(EstadoSolicitudMovimientoDetalle.PENDIENTE)
+                .almacenOrigen(null)
+                .almacenDestino(destino)
+                .build();
+        SolicitudMovimientoDetalle atendidoDetalle = SolicitudMovimientoDetalle.builder()
+                .id(229L)
+                .lote(lote)
+                .cantidad(BigDecimal.ONE)
+                .cantidadAtendida(BigDecimal.ONE)
+                .estado(EstadoSolicitudMovimientoDetalle.ATENDIDO)
+                .almacenOrigen(origen)
+                .almacenDestino(destino)
+                .build();
+        OrdenProduccion op = OrdenProduccion.builder()
+                .id(100L)
+                .codigoOrden("OP-TEST-001")
+                .fechaInicio(LocalDateTime.now())
+                .build();
+        SolicitudMovimiento pendiente = SolicitudMovimiento.builder()
+                .id(222L)
+                .estado(EstadoSolicitudMovimiento.ATENDIDA)
+                .ordenProduccion(op)
+                .detalles(List.of(pendienteDetalle))
+                .build();
+        SolicitudMovimiento atendida = SolicitudMovimiento.builder()
+                .id(223L)
+                .estado(EstadoSolicitudMovimiento.CERRADA)
+                .ordenProduccion(op)
+                .detalles(List.of(atendidoDetalle))
+                .build();
+
+        when(repository.findWithDetalles(eq(op.getId()), isNull(), isNull(), isNull(), eq(false), anyList()))
+                .thenReturn(List.of(pendiente, atendida));
+
+        SolicitudesPorOrdenDTO dto = service.obtenerPorOrden(op.getId());
+
+        assertThat(dto.getItems()).hasSize(2);
+        SolicitudMovimientoItemDTO itemPendiente = dto.getItems().stream()
+                .filter(item -> item.getSolicitudId().equals(222L))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(itemPendiente.getEstado()).isEqualTo("PENDIENTE");
+        assertThat(itemPendiente.getAlmacenOrigenId()).isEqualTo(1L);
+        assertThat(itemPendiente.getAlmacenDestinoId()).isEqualTo(6L);
+    }
+}


### PR DESCRIPTION
### Motivation
- The frontend was receiving incorrect origin/destination IDs and wrong "attended completely" status for OP requests because the item DTO used inconsistent fallbacks and derived state from the request header instead of the detail. 

### Description
- Update `toItemDTO` in `SolicitudMovimientoServiceImpl` to resolve `almacenOrigen` with the fallback `detalle -> cabecera -> lote` and `almacenDestino` from `detalle` or fallback to cabecera. 
- Make the item `estado` prefer the detail state with a fallback to the solicitud state when detail state is missing. 
- Replace direct uses of `det.getAlmacenOrigen()`/`det.getAlmacenDestino()` in the DTO builder with the resolved `almacenOrigen`/`almacenDestino` objects, and expose their IDs/names/ubicaciones accordingly. 
- Add a unit test `SolicitudMovimientoServiceImplPorOrdenTest` that simulates an OP with one closed/attended solicitud and one pending solicitud and asserts the pending item keeps `estado = PENDIENTE` and correct `almacenOrigenId`/`almacenDestinoId`.

### Testing
- Ran the focused unit test with `mvn -Dtest=SolicitudMovimientoServiceImplPorOrdenTest test` which executed the new test class. 
- Test outcome: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0` and `BUILD SUCCESS`. 
- The change is covered by the new unit test that validates the DTO mapping and state logic for mixed (closed + pending) solicitudes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e94b9c4e483338cdda1e99e572aad)