### PR TITLE
Fix solicitud movimiento item mapping and expose estadoDetalle

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/SolicitudMovimientoItemDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/SolicitudMovimientoItemDTO.java
@@ -30,6 +30,7 @@ public class SolicitudMovimientoItemDTO {
     private Long motivoMovimientoId;
     private Long tipoMovimientoDetalleId;
     private String estado;
+    private String estadoDetalle;
     private LocalDateTime fechaSolicitud;
     private String usuarioSolicitante;
     private String observaciones;

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -858,13 +858,30 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
     }
 
     private SolicitudMovimientoItemDTO toItemDTO(SolicitudMovimiento s, SolicitudMovimientoDetalle det) {
-        Almacen almacenOrigen = Optional.ofNullable(det.getAlmacenOrigen())
+        Long almacenOrigenId = Optional.ofNullable(det.getAlmacenOrigen())
+                .map(Almacen::getId)
+                .map(Integer::longValue)
                 .orElseGet(() -> Optional.ofNullable(s.getAlmacenOrigen())
+                        .map(Almacen::getId)
+                        .map(Integer::longValue)
                         .orElseGet(() -> Optional.ofNullable(det.getLote())
                                 .map(LoteProducto::getAlmacen)
+                                .map(Almacen::getId)
+                                .map(Integer::longValue)
                                 .orElse(null)));
-        Almacen almacenDestino = Optional.ofNullable(det.getAlmacenDestino())
-                .orElse(s.getAlmacenDestino());
+        Long almacenDestinoId = Optional.ofNullable(det.getAlmacenDestino())
+                .map(Almacen::getId)
+                .map(Integer::longValue)
+                .orElseGet(() -> Optional.ofNullable(s.getAlmacenDestino())
+                        .map(Almacen::getId)
+                        .map(Integer::longValue)
+                        .orElse(null));
+        Almacen almacenOrigen = almacenOrigenId != null
+                ? almacenRepository.findById(almacenOrigenId).orElse(null)
+                : null;
+        Almacen almacenDestino = almacenDestinoId != null
+                ? almacenRepository.findById(almacenDestinoId).orElse(null)
+                : null;
         String estadoDetalle = det.getEstado() != null
                 ? det.getEstado().name()
                 : (s.getEstado() != null ? s.getEstado().name() : null);
@@ -878,15 +895,16 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                 .cantidadSolicitada(det.getCantidad())
                 .cantidadAtendida(det.getCantidadAtendida())
                 .unidadMedida(s.getProducto() != null && s.getProducto().getUnidadMedida() != null ? s.getProducto().getUnidadMedida().getNombre() : null)
-                .almacenOrigenId(almacenOrigen != null ? almacenOrigen.getId().longValue() : null)
+                .almacenOrigenId(almacenOrigenId)
                 .nombreAlmacenOrigen(almacenOrigen != null ? almacenOrigen.getNombre() : null)
                 .ubicacionAlmacenOrigen(almacenOrigen != null ? almacenOrigen.getUbicacion() : "-")
-                .almacenDestinoId(almacenDestino != null ? almacenDestino.getId().longValue() : null)
+                .almacenDestinoId(almacenDestinoId)
                 .nombreAlmacenDestino(almacenDestino != null ? almacenDestino.getNombre() : null)
                 .ubicacionAlmacenDestino(almacenDestino != null ? almacenDestino.getUbicacion() : "-")
                 .motivoMovimientoId(s.getMotivoMovimiento() != null ? s.getMotivoMovimiento().getId() : null)
                 .tipoMovimientoDetalleId(s.getTipoMovimientoDetalle() != null ? s.getTipoMovimientoDetalle().getId() : null)
                 .estado(estadoDetalle)
+                .estadoDetalle(estadoDetalle)
                 .fechaSolicitud(s.getFechaSolicitud())
                 .usuarioSolicitante(s.getUsuarioSolicitante() != null ? s.getUsuarioSolicitante().getNombreCompleto() : null)
                 .observaciones(s.getObservaciones())

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
@@ -121,6 +121,8 @@ class SolicitudMovimientoServiceImplPorOrdenTest {
 
         when(repository.findWithDetalles(eq(op.getId()), isNull(), isNull(), isNull(), eq(false), anyList()))
                 .thenReturn(List.of(pendiente, atendida));
+        when(almacenRepository.findById(1L)).thenReturn(java.util.Optional.of(origen));
+        when(almacenRepository.findById(6L)).thenReturn(java.util.Optional.of(destino));
 
         SolicitudesPorOrdenDTO dto = service.obtenerPorOrden(op.getId());
 
@@ -131,7 +133,10 @@ class SolicitudMovimientoServiceImplPorOrdenTest {
                 .orElseThrow();
 
         assertThat(itemPendiente.getEstado()).isEqualTo("PENDIENTE");
+        assertThat(itemPendiente.getEstadoDetalle()).isEqualTo("PENDIENTE");
         assertThat(itemPendiente.getAlmacenOrigenId()).isEqualTo(1L);
         assertThat(itemPendiente.getAlmacenDestinoId()).isEqualTo(6L);
+        assertThat(itemPendiente.getNombreAlmacenOrigen()).isEqualTo("Alm Origen");
+        assertThat(itemPendiente.getNombreAlmacenDestino()).isEqualTo("Pre-Bodega Producción");
     }
 }


### PR DESCRIPTION
### Motivation
- Corregir inconsistencias en el DTO que consume el front para que el estado y los almacenes reflejen siempre la información del detalle cuando exista, evitando que el estado de cabecera "tape" un detalle pendiente.
- Garantizar un contrato estable del JSON de salida con campos claros para que el frontend no tenga que adivinar nombres/ids ni interpretar estados.

### Description
- Actualiza el mapeo en `SolicitudMovimientoServiceImpl#toItemDTO` para preferir los IDs de almacén del detalle (`det_alm_origen_id` / `det_alm_destino_id`) y usar la cabecera como fallback, resolviendo los nombres mediante `AlmacenRepository` por cada id por separado.
- Mantiene el estado del detalle como fuente de verdad (`det.getEstado()`), y expone el campo adicional `estadoDetalle` en `SolicitudMovimientoItemDTO` junto a `estado` para un contrato explícito y legible (valores como `PENDIENTE` / `ATENDIDO`).
- Normaliza los campos de salida del DTO a `estadoDetalle`, `almacenOrigenId`, `almacenDestinoId`, `nombreAlmacenOrigen` y `nombreAlmacenDestino` para cumplir el contrato requerido por el frontend.
- Cambios aplicados en `src/main/java/.../SolicitudMovimientoServiceImpl.java`, `src/main/java/.../dto/SolicitudMovimientoItemDTO.java` y test actualizado en `src/test/java/.../SolicitudMovimientoServiceImplPorOrdenTest.java`.

### Testing
- Se agregó/actualizó el test `SolicitudMovimientoServiceImplPorOrdenTest` que construye una OP con una solicitud cerrada y otra con un detalle pendiente y valida que el item pendiente devuelva `estadoDetalle = PENDIENTE`, `almacenOrigenId = 1`, `almacenDestinoId = 6` y nombres de almacén correspondientes, y el test pasó.
- Ejecutado: `mvn -Dtest=SolicitudMovimientoServiceImplPorOrdenTest test` y el resultado fue `BUILD SUCCESS` con el test pasando (Tests run: 1, Failures: 0, Errors: 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb8f6407883339131a22ba1c4fd0a)