### PR TITLE
Fix por-orden DTO mapping to prioritize detalle-level almacenes and expose estadoDetalle

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -858,32 +858,19 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
     }
 
     private SolicitudMovimientoItemDTO toItemDTO(SolicitudMovimiento s, SolicitudMovimientoDetalle det) {
-        Long almacenOrigenId = Optional.ofNullable(det.getAlmacenOrigen())
-                .map(Almacen::getId)
-                .map(Integer::longValue)
+        Almacen almacenOrigen = Optional.ofNullable(det.getAlmacenOrigen())
                 .orElseGet(() -> Optional.ofNullable(s.getAlmacenOrigen())
-                        .map(Almacen::getId)
-                        .map(Integer::longValue)
                         .orElseGet(() -> Optional.ofNullable(det.getLote())
                                 .map(LoteProducto::getAlmacen)
-                                .map(Almacen::getId)
-                                .map(Integer::longValue)
                                 .orElse(null)));
-        Long almacenDestinoId = Optional.ofNullable(det.getAlmacenDestino())
-                .map(Almacen::getId)
-                .map(Integer::longValue)
+        Almacen almacenDestino = Optional.ofNullable(det.getAlmacenDestino())
                 .orElseGet(() -> Optional.ofNullable(s.getAlmacenDestino())
-                        .map(Almacen::getId)
-                        .map(Integer::longValue)
                         .orElse(null));
-        Almacen almacenOrigen = almacenOrigenId != null
-                ? almacenRepository.findById(almacenOrigenId).orElse(null)
-                : null;
-        Almacen almacenDestino = almacenDestinoId != null
-                ? almacenRepository.findById(almacenDestinoId).orElse(null)
-                : null;
-        String estadoDetalle = det.getEstado() != null
-                ? det.getEstado().name()
+        Long almacenOrigenId = almacenOrigen != null ? almacenOrigen.getId().longValue() : null;
+        Long almacenDestinoId = almacenDestino != null ? almacenDestino.getId().longValue() : null;
+        String estadoDetalle = det.getEstado() != null ? det.getEstado().name() : null;
+        String estado = estadoDetalle != null
+                ? estadoDetalle
                 : (s.getEstado() != null ? s.getEstado().name() : null);
 
         return SolicitudMovimientoItemDTO.builder()
@@ -903,7 +890,7 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
                 .ubicacionAlmacenDestino(almacenDestino != null ? almacenDestino.getUbicacion() : "-")
                 .motivoMovimientoId(s.getMotivoMovimiento() != null ? s.getMotivoMovimiento().getId() : null)
                 .tipoMovimientoDetalleId(s.getTipoMovimientoDetalle() != null ? s.getTipoMovimientoDetalle().getId() : null)
-                .estado(estadoDetalle)
+                .estado(estado)
                 .estadoDetalle(estadoDetalle)
                 .fechaSolicitud(s.getFechaSolicitud())
                 .usuarioSolicitante(s.getUsuarioSolicitante() != null ? s.getUsuarioSolicitante().getNombreCompleto() : null)
@@ -915,15 +902,22 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
         if (items == null || items.isEmpty()) {
             return "PENDIENTE";
         }
-        boolean todosPendientes = items.stream().allMatch(i -> "PENDIENTE".equals(i.getEstado()));
-        boolean todosAutorizados = items.stream().allMatch(i -> "AUTORIZADA".equals(i.getEstado()));
+        boolean todosPendientes = items.stream().allMatch(i -> "PENDIENTE".equals(resolverEstadoItem(i)));
+        boolean todosAtendidos = items.stream().allMatch(i -> "ATENDIDO".equals(resolverEstadoItem(i)));
         if (todosPendientes) {
             return "PENDIENTE";
         }
-        if (todosAutorizados) {
-            return "AUTORIZADA";
+        if (todosAtendidos) {
+            return "ATENDIDO";
         }
         return "MIXTO";
+    }
+
+    private String resolverEstadoItem(SolicitudMovimientoItemDTO item) {
+        if (item == null) {
+            return null;
+        }
+        return item.getEstadoDetalle() != null ? item.getEstadoDetalle() : item.getEstado();
     }
 
     /**

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/SolicitudPorOrdenControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/SolicitudPorOrdenControllerTest.java
@@ -1,0 +1,143 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoItemDTO;
+import com.willyes.clemenintegra.inventario.dto.SolicitudesPorOrdenDTO;
+import com.willyes.clemenintegra.inventario.service.SolicitudMovimientoService;
+import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
+import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
+import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter;
+import com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider;
+import com.willyes.clemenintegra.shared.security.SecurityConfig;
+import com.willyes.clemenintegra.shared.security.SuperAdminSoloLecturaWriteBlockFilter;
+import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SolicitudPorOrdenController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, SolicitudPorOrdenControllerTest.MethodSecurityConfig.class})
+@ImportAutoConfiguration({SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
+class SolicitudPorOrdenControllerTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    @org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity(prePostEnabled = true)
+    static class MethodSecurityConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SolicitudMovimientoService solicitudMovimientoService;
+    @MockBean
+    private UsuarioService usuarioService;
+    @MockBean
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockBean
+    private UsuarioInactivoFilter usuarioInactivoFilter;
+    @MockBean
+    private RequestTimingFilter requestTimingFilter;
+    @MockBean
+    private RequestIdFilter requestIdFilter;
+    @MockBean
+    private SuperAdminSoloLecturaWriteBlockFilter superAdminSoloLecturaWriteBlockFilter;
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void configureFilters() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(usuarioInactivoFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestTimingFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(requestIdFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(superAdminSoloLecturaWriteBlockFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    void listarPorOrdenIncluyeEstadoDetalleYAlmacenes() throws Exception {
+        SolicitudMovimientoItemDTO item = SolicitudMovimientoItemDTO.builder()
+                .solicitudId(222L)
+                .almacenOrigenId(1L)
+                .almacenDestinoId(6L)
+                .nombreAlmacenOrigen("Alm Origen")
+                .nombreAlmacenDestino("Pre-Bodega Producción")
+                .estado("PENDIENTE")
+                .estadoDetalle("PENDIENTE")
+                .build();
+        SolicitudesPorOrdenDTO dto = SolicitudesPorOrdenDTO.builder()
+                .ordenProduccionId(100L)
+                .codigoOrden("OP-TEST-001")
+                .estadoAgregado("MIXTO")
+                .items(List.of(item))
+                .itemsCount(1)
+                .build();
+
+        when(solicitudMovimientoService.listGroupByOrden(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(dto)));
+
+        mockMvc.perform(get("/api/inventarios/solicitudes/por-orden")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(SecurityMockMvcRequestPostProcessors.user("planeador")
+                                .authorities(() -> "ROL_PLANEADOR")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].items[0].estadoDetalle").value("PENDIENTE"))
+                .andExpect(jsonPath("$.content[0].items[0].almacenOrigenId").value(1))
+                .andExpect(jsonPath("$.content[0].items[0].almacenDestinoId").value(6))
+                .andExpect(jsonPath("$.content[0].items[0].nombreAlmacenOrigen").value("Alm Origen"))
+                .andExpect(jsonPath("$.content[0].items[0].nombreAlmacenDestino").value("Pre-Bodega Producción"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
@@ -121,9 +121,6 @@ class SolicitudMovimientoServiceImplPorOrdenTest {
 
         when(repository.findWithDetalles(eq(op.getId()), isNull(), isNull(), isNull(), eq(false), anyList()))
                 .thenReturn(List.of(pendiente, atendida));
-        when(almacenRepository.findById(1L)).thenReturn(java.util.Optional.of(origen));
-        when(almacenRepository.findById(6L)).thenReturn(java.util.Optional.of(destino));
-
         SolicitudesPorOrdenDTO dto = service.obtenerPorOrden(op.getId());
 
         assertThat(dto.getItems()).hasSize(2);


### PR DESCRIPTION
### Motivation
- The previous por-orden mapping could hide detalle-level information by favoring cabecera fields, causing the frontend to infer wrong origen/destino and order state.
- Each item must represent a single `SolicitudMovimientoDetalle` and expose the detail's real state and almacen identifiers so the UI can compute aggregated states reliably.
- Provide a stable, explicit `estadoDetalle` while keeping backward-compatible `estado` behavior as a fallback.

### Description
- Updated `toItemDTO` in `SolicitudMovimientoServiceImpl` to resolve `almacenOrigen` as: `detalle.almacenOrigen` -> `solicitud.almacenOrigen` -> `detalle.lote.almacen`, and to resolve `almacenDestino` as: `detalle.almacenDestino` -> `solicitud.almacenDestino`, never swapping or copying origin/destination fields.
- Set `estadoDetalle` from `det.getEstado()` and set `estado` to `estadoDetalle` when present, otherwise fallback to `solicitud.getEstado()`; ensure `estadoDetalle` is not overwritten.
- Removed unnecessary repository lookups for almacenes in the mapping path and populated `almacenOrigenId`, `almacenDestinoId`, `nombreAlmacenOrigen`, and `nombreAlmacenDestino` directly from resolved `Almacen` objects.
- Adjusted `calcularEstadoAgregado` to evaluate aggregate state using a new `resolverEstadoItem` that prefers `estadoDetalle` for accurate MIXTO/PENDIENTE/ATENDIDO calculations.
- Added `SolicitudPorOrdenControllerTest` (MockMvc) to assert JSON serialization of `estadoDetalle` and almacen ids/names, and updated `SolicitudMovimientoServiceImplPorOrdenTest` to reflect the new mapping.

### Testing
- Ran unit test `SolicitudMovimientoServiceImplPorOrdenTest` with `mvn -Dtest=SolicitudMovimientoServiceImplPorOrdenTest test` and it completed successfully (tests: 1, failures: 0, errors: 0, build: SUCCESS).
- Added controller-level test `SolicitudPorOrdenControllerTest` to cover serialization of `estadoDetalle` and almacen fields (included in repo; can be executed with standard test goal).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ebbad8af483339b0f3f4e8677d4d0)