### PR TITLE
Enforce detalle-driven OP mapping and detalle completeness (SOLICITUD_DETALLE_INCOMPLETO)

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -3295,6 +3295,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
 
         // Solo procesamos partidas PENDIENTE o PARCIAL
         for (SolicitudMovimientoDetalle det : solicitud.getDetalles()) {
+            validarDetalleCompleto(solicitud, det);
             if (det.getEstado() != EstadoSolicitudMovimientoDetalle.PENDIENTE
                     && det.getEstado() != EstadoSolicitudMovimientoDetalle.PARCIAL) {
                 continue;
@@ -3310,7 +3311,15 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             // 1) Lote origen con lock
             Long loteId = det.getLote() != null ? det.getLote().getId() : null;
             if (loteId == null) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "DETALLE_SIN_LOTE");
+                throw new CustomBusinessException(
+                        ApiErrorCode.SOLICITUD_DETALLE_INCOMPLETO,
+                        "SOLICITUD_DETALLE_INCOMPLETO",
+                        Map.of(
+                                "solicitudId", solicitud.getId(),
+                                "detalleId", det.getId(),
+                                "missingFields", List.of("lote_id")
+                        )
+                );
             }
 
             LoteProducto loteOrigen = loteProductoRepository.findByIdForUpdate(loteId)
@@ -3337,9 +3346,16 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             else if (det.getLote() != null && det.getLote().getCodigoLote() != null) {
                 codigoLote = det.getLote().getCodigoLote();
             }
-            // 3) Como último recurso, tomamos el que traiga la solicitud principal
-            else if (solicitud != null && solicitud.getCodigoLote() != null) {
-                codigoLote = solicitud.getCodigoLote();
+            if (!StringUtils.hasText(codigoLote)) {
+                throw new CustomBusinessException(
+                        ApiErrorCode.SOLICITUD_DETALLE_INCOMPLETO,
+                        "SOLICITUD_DETALLE_INCOMPLETO",
+                        Map.of(
+                                "solicitudId", solicitud.getId(),
+                                "detalleId", det.getId(),
+                                "missingFields", List.of("codigo_lote")
+                        )
+                );
             }
             LoteProducto loteDestino = ensureDestinoLote(
                     producto,
@@ -3694,6 +3710,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                     "CONFIG_FALTANTE: inventory.tipoDetalle.salidaId");
 
             for (SolicitudMovimientoDetalle det : Optional.ofNullable(sol.getDetalles()).orElse(List.of())) {
+                validarDetalleCompleto(sol.getId(), det);
 
                 // Cantidad “a consumir” = atendida (si la hubo) o solicitada
                 final BigDecimal qtySolicitada = Optional.ofNullable(det.getCantidad()).orElse(BigDecimal.ZERO);
@@ -3711,11 +3728,18 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
                 final String codigoLote =
                         (det.getLote() != null && det.getLote().getCodigoLote() != null)
                                 ? det.getLote().getCodigoLote()
-                                : sol.getCodigoLote();
+                                : null;
 
-                if (codigoLote == null) {
-                    log.warn("CONSUMO_OP: detalle sin codigoLote, solId={}, detId={}", sol.getId(), det.getId());
-                    continue;
+                if (!StringUtils.hasText(codigoLote)) {
+                    throw new CustomBusinessException(
+                            ApiErrorCode.SOLICITUD_DETALLE_INCOMPLETO,
+                            "SOLICITUD_DETALLE_INCOMPLETO",
+                            Map.of(
+                                    "solicitudId", sol.getId(),
+                                    "detalleId", det.getId(),
+                                    "missingFields", List.of("codigo_lote")
+                            )
+                    );
                 }
 
                 final Optional<LoteProducto> lotePreBodegaOpt = loteProductoRepository

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java
@@ -398,6 +398,37 @@ class MovimientoInventarioServiceSolicitudOpTest {
     }
 
     @Test
+    void procesarMovimientoPorPartidas_rechazaDetalleSinAlmacenOrigen() {
+        SolicitudMovimientoDetalle detalle = new SolicitudMovimientoDetalle();
+        detalle.setId(400L);
+        detalle.setCantidad(new BigDecimal("10"));
+        detalle.setCantidadAtendida(BigDecimal.ZERO);
+        detalle.setEstado(EstadoSolicitudMovimientoDetalle.PENDIENTE);
+        detalle.setLote(LoteProducto.builder().id(500L).codigoLote("L-500").build());
+        detalle.setAlmacenOrigen(null);
+        detalle.setAlmacenDestino(new Almacen(6));
+
+        SolicitudMovimiento solicitud = new SolicitudMovimiento();
+        solicitud.setId(450L);
+        solicitud.setDetalles(List.of(detalle));
+        detalle.setSolicitudMovimiento(solicitud);
+
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                service,
+                "procesarMovimientoPorPartidas",
+                solicitud,
+                new Producto(),
+                new Almacen(6),
+                TipoMovimiento.TRANSFERENCIA,
+                false))
+                .isInstanceOf(CustomBusinessException.class)
+                .satisfies(ex -> {
+                    CustomBusinessException cbe = (CustomBusinessException) ex;
+                    assertThat(cbe.getCode()).isEqualTo(ApiErrorCode.SOLICITUD_DETALLE_INCOMPLETO);
+                });
+    }
+
+    @Test
     void registrarMovimiento_solicitudOp_sinSolicitudIdUsaDetalleFallback() {
         Producto producto = new Producto();
         producto.setId(2);

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -113,12 +114,18 @@ class SolicitudMovimientoServiceImplPorOrdenTest {
                 .id(222L)
                 .estado(EstadoSolicitudMovimiento.ATENDIDA)
                 .ordenProduccion(op)
+                .almacenOrigen(null)
+                .almacenDestino(null)
+                .lote(null)
                 .detalles(List.of(pendienteDetalle))
                 .build();
         SolicitudMovimiento atendida = SolicitudMovimiento.builder()
                 .id(223L)
                 .estado(EstadoSolicitudMovimiento.CERRADA)
                 .ordenProduccion(op)
+                .almacenOrigen(null)
+                .almacenDestino(null)
+                .lote(null)
                 .detalles(List.of(atendidoDetalle))
                 .build();
 
@@ -139,6 +146,111 @@ class SolicitudMovimientoServiceImplPorOrdenTest {
         assertThat(itemPendiente.getAlmacenDestinoId()).isEqualTo(6L);
         assertThat(itemPendiente.getNombreAlmacenOrigen()).isEqualTo("Alm Origen");
         assertThat(itemPendiente.getNombreAlmacenDestino()).isEqualTo("Pre-Bodega Producción");
+    }
+
+    @Test
+    void listGroupByOrdenSerializaDetalleYEstadoSinContaminacion() {
+        Almacen origen = Almacen.builder()
+                .id(1)
+                .nombre("Alm Origen")
+                .ubicacion("OR-01")
+                .build();
+        Almacen destino = Almacen.builder()
+                .id(6)
+                .nombre("Pre-Bodega Producción")
+                .ubicacion("PB-01")
+                .build();
+        LoteProducto lote = LoteProducto.builder()
+                .id(2148L)
+                .codigoLote("L-2148")
+                .almacen(origen)
+                .build();
+        SolicitudMovimientoDetalle pendienteDetalle = SolicitudMovimientoDetalle.builder()
+                .id(228L)
+                .lote(lote)
+                .cantidad(BigDecimal.TEN)
+                .cantidadAtendida(BigDecimal.ZERO)
+                .estado(EstadoSolicitudMovimientoDetalle.PENDIENTE)
+                .almacenOrigen(origen)
+                .almacenDestino(destino)
+                .build();
+        SolicitudMovimientoDetalle atendidoDetalle = SolicitudMovimientoDetalle.builder()
+                .id(229L)
+                .lote(lote)
+                .cantidad(BigDecimal.ONE)
+                .cantidadAtendida(BigDecimal.ONE)
+                .estado(EstadoSolicitudMovimientoDetalle.ATENDIDO)
+                .almacenOrigen(origen)
+                .almacenDestino(destino)
+                .build();
+        OrdenProduccion op = OrdenProduccion.builder()
+                .id(38L)
+                .codigoOrden("OP-038")
+                .fechaInicio(LocalDateTime.now())
+                .build();
+        SolicitudMovimiento solicitud = SolicitudMovimiento.builder()
+                .id(222L)
+                .estado(EstadoSolicitudMovimiento.PENDIENTE)
+                .ordenProduccion(op)
+                .almacenOrigen(null)
+                .almacenDestino(null)
+                .lote(null)
+                .detalles(List.of(pendienteDetalle, atendidoDetalle))
+                .build();
+
+        when(repository.findWithDetalles(isNull(), anyList(), isNull(), isNull(), eq(false), anyList()))
+                .thenReturn(List.of(solicitud));
+
+        SolicitudesPorOrdenDTO dto = service.listGroupByOrden(
+                List.of(EstadoSolicitudMovimiento.PENDIENTE), null, null, Pageable.ofSize(10))
+                .getContent().get(0);
+
+        assertThat(dto.getEstadoAgregado()).isEqualTo("MIXTO");
+        SolicitudMovimientoItemDTO itemPendiente = dto.getItems().stream()
+                .filter(item -> item.getDetalleId().equals(228L))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(itemPendiente.getLoteId()).isEqualTo(2148L);
+        assertThat(itemPendiente.getAlmacenOrigenId()).isEqualTo(1L);
+        assertThat(itemPendiente.getAlmacenDestinoId()).isEqualTo(6L);
+        assertThat(itemPendiente.getEstadoDetalle()).isEqualTo("PENDIENTE");
+        assertThat(itemPendiente.getEstado()).isEqualTo("PENDIENTE");
+    }
+
+    @Test
+    void listGroupByOrdenRechazaDetalleIncompleto() {
+        SolicitudMovimientoDetalle pendienteDetalle = SolicitudMovimientoDetalle.builder()
+                .id(228L)
+                .cantidad(BigDecimal.TEN)
+                .cantidadAtendida(BigDecimal.ZERO)
+                .estado(null)
+                .almacenOrigen(null)
+                .almacenDestino(null)
+                .lote(null)
+                .build();
+        OrdenProduccion op = OrdenProduccion.builder()
+                .id(100L)
+                .codigoOrden("OP-TEST-001")
+                .fechaInicio(LocalDateTime.now())
+                .build();
+        SolicitudMovimiento pendiente = SolicitudMovimiento.builder()
+                .id(222L)
+                .estado(EstadoSolicitudMovimiento.PENDIENTE)
+                .ordenProduccion(op)
+                .detalles(List.of(pendienteDetalle))
+                .build();
+
+        when(repository.findWithDetalles(isNull(), anyList(), isNull(), isNull(), eq(false), anyList()))
+                .thenReturn(List.of(pendiente));
+
+        assertThatThrownBy(() -> service.listGroupByOrden(
+                List.of(EstadoSolicitudMovimiento.PENDIENTE), null, null, Pageable.ofSize(10)))
+                .isInstanceOf(CustomBusinessException.class)
+                .satisfies(ex -> {
+                    CustomBusinessException cbe = (CustomBusinessException) ex;
+                    assertThat(cbe.getCode()).isEqualTo(ApiErrorCode.SOLICITUD_DETALLE_INCOMPLETO);
+                });
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Fix incorrect fallback behavior that allowed lote/almacén/estado to be taken from cabecera or other sources when detalle existed or was incomplete, which produced wrong /por-orden responses and incorrect movimientos. 
- Force the system to be detalle-driven for solicitudes por OP and fail fast with a 422 business error when a detalle is incomplete so bad data is not silently masked.

### Description

- MovimientoInventarioServiceImpl: require detalle completeness when processing partidas and OP-consumption by calling `validarDetalleCompleto(...)` and stop using cabecera fallbacks for lote/codigo; missing `lote_id` or `codigo_lote` now throws `CustomBusinessException(ApiErrorCode.SOLICITUD_DETALLE_INCOMPLETO)` instead of silently falling back (changes around `procesarMovimientoPorPartidas` and `consumirInsumosPorOrden`). (file: `src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java`, approx lines 3286-3794)
- Error contract: use `SOLICITUD_DETALLE_INCOMPLETO` with details map `{"solicitudId", "detalleId", "missingFields"}` when a required detalle field is absent (lote_id, almacen_origen_id, almacen_destino_id or codigo_lote).
- Tests: add and adjust unit tests to assert detalle-driven behavior and the new error paths: add `listGroupByOrdenSerializaDetalleYEstadoSinContaminacion` and `listGroupByOrdenRechazaDetalleIncompleto` to `SolicitudMovimientoServiceImplPorOrdenTest`, and add `procesarMovimientoPorPartidas_rechazaDetalleSinAlmacenOrigen` to `MovimientoInventarioServiceSolicitudOpTest`; also updated a couple of pageable usages in tests. (files: `src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java` ~L80-L254, `src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceSolicitudOpTest.java` ~L360-L430)

### Testing

- Ran the focused unit tests with: `mvn -Dtest=SolicitudMovimientoServiceImplPorOrdenTest,MovimientoInventarioServiceSolicitudOpTest test` and received `BUILD SUCCESS` with the two target test classes passing.
- The new tests validate that `/por-orden` items are serialized from detalle (include `detalleId`, `loteId`, `almacenOrigenId`, `almacenDestinoId`, `estadoDetalle`) and that incomplete detalles produce `ApiErrorCode.SOLICITUD_DETALLE_INCOMPLETO` (422) as required.
- The movement test ensures `procesarMovimientoPorPartidas` rejects detalles missing origen (prevents dangerous fallback during movement generation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7d29a70c8333ac13a89f51126ac0)