### PR TITLE
Fix reserva lote resolution to origin and add repair endpoint

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ReservaLoteAdminController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ReservaLoteAdminController.java
@@ -1,0 +1,27 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.ReservaLoteRepairRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.ReservaLoteRepairResultDTO;
+import com.willyes.clemenintegra.inventario.service.ReservaLoteRepairService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/repair")
+@RequiredArgsConstructor
+public class ReservaLoteAdminController {
+
+    private final ReservaLoteRepairService reservaLoteRepairService;
+
+    @PostMapping("/reservas-lote")
+    @PreAuthorize("hasAuthority('ROL_SUPER_ADMIN')")
+    public ResponseEntity<ReservaLoteRepairResultDTO> repararReservasLote(
+            @RequestBody(required = false) ReservaLoteRepairRequestDTO request) {
+        return ResponseEntity.ok(reservaLoteRepairService.repararReservasLote(request));
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ReservaLoteRepairRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ReservaLoteRepairRequestDTO.java
@@ -1,0 +1,8 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import java.util.List;
+
+public record ReservaLoteRepairRequestDTO(List<Long> detalleIds,
+                                          Long ordenProduccionId,
+                                          Integer batchSize) {
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ReservaLoteRepairResultDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ReservaLoteRepairResultDTO.java
@@ -1,0 +1,10 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+import java.util.List;
+
+public record ReservaLoteRepairResultDTO(int totalEvaluadas,
+                                         int actualizadas,
+                                         int sinCambios,
+                                         int pendientes,
+                                         List<Long> reservasActualizadas) {
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ReservaLoteRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ReservaLoteRepository.java
@@ -45,6 +45,15 @@ public interface ReservaLoteRepository extends JpaRepository<ReservaLote, Long> 
     BigDecimal sumPendienteActivaByLoteId(@Param("loteId") Long loteId,
                                           @Param("estadoActiva") EstadoReservaLote estadoActiva);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<ReservaLote> findByEstadoAndSolicitudMovimientoDetalleIdIn(EstadoReservaLote estado,
+                                                                    Collection<Long> detalleIds);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<ReservaLote> findByEstadoAndSolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionId(
+            EstadoReservaLote estado,
+            Long ordenProduccionId);
+
     List<ReservaLote> findBySolicitudMovimientoDetalleId(Long detalleId);
 
     List<ReservaLote> findBySolicitudMovimientoDetalle_SolicitudMovimientoId(Long solicitudId);
@@ -63,4 +72,3 @@ public interface ReservaLoteRepository extends JpaRepository<ReservaLote, Long> 
                                               @Param("productoId") Long productoId,
                                               @Param("estado") EstadoReservaLote estado);
 }
-

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteRepairService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteRepairService.java
@@ -1,0 +1,210 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.ReservaLoteRepairRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.ReservaLoteRepairResultDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.ReservaLote;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoDetalleRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ReservaLoteRepairService {
+
+    private static final Logger log = LoggerFactory.getLogger(ReservaLoteRepairService.class);
+
+    private static final int DEFAULT_BATCH_SIZE = 100;
+
+    private final ReservaLoteRepository reservaLoteRepository;
+    private final LoteProductoRepository loteProductoRepository;
+    private final SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    public ReservaLoteRepairResultDTO repararReservasLote(ReservaLoteRepairRequestDTO request) {
+        if (request == null || (isEmpty(request.detalleIds()) && request.ordenProduccionId() == null)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Debe indicar detalleIds o ordenProduccionId para reparar reservas");
+        }
+
+        int batchSize = request.batchSize() != null && request.batchSize() > 0
+                ? request.batchSize()
+                : DEFAULT_BATCH_SIZE;
+
+        List<ReservaLote> reservas = cargarReservas(request);
+        if (reservas.isEmpty()) {
+            return new ReservaLoteRepairResultDTO(0, 0, 0, 0, List.of());
+        }
+
+        List<Long> actualizadas = new ArrayList<>();
+        int pendientes = 0;
+        int sinCambios = 0;
+
+        for (int i = 0; i < reservas.size(); i += batchSize) {
+            List<ReservaLote> batch = reservas.subList(i, Math.min(i + batchSize, reservas.size()));
+            RepairBatchResult result = transactionTemplate.execute(status -> repararBatch(batch));
+            if (result != null) {
+                actualizadas.addAll(result.reservasActualizadas());
+                pendientes += result.pendientes();
+                sinCambios += result.sinCambios();
+            }
+        }
+
+        return new ReservaLoteRepairResultDTO(reservas.size(),
+                actualizadas.size(),
+                sinCambios,
+                pendientes,
+                actualizadas);
+    }
+
+    private RepairBatchResult repararBatch(List<ReservaLote> batch) {
+        List<Long> actualizadas = new ArrayList<>();
+        int pendientes = 0;
+        int sinCambios = 0;
+
+        for (ReservaLote reserva : batch) {
+            if (reserva == null || reserva.getId() == null) {
+                continue;
+            }
+
+            Long reservaId = reserva.getId();
+            SolicitudMovimientoDetalle detalle = cargarDetalle(reserva);
+            if (detalle == null || detalle.getId() == null) {
+                pendientes++;
+                log.warn("REPAIR_RESERVA_LOTE pendiente: reservaId={} sin detalle asociado", reservaId);
+                continue;
+            }
+
+            LoteProducto loteActual = cargarLoteActual(reserva);
+            if (loteActual == null) {
+                pendientes++;
+                log.warn("REPAIR_RESERVA_LOTE pendiente: reservaId={} sin lote actual", reservaId);
+                continue;
+            }
+
+            Integer productoId = loteActual.getProducto() != null ? loteActual.getProducto().getId() : null;
+            String codigoLote = loteActual.getCodigoLote();
+            Integer almacenOrigenId = resolverAlmacenOrigenId(detalle, loteActual);
+
+            if (productoId == null || almacenOrigenId == null || !StringUtils.hasText(codigoLote)) {
+                pendientes++;
+                log.warn("REPAIR_RESERVA_LOTE pendiente: reservaId={} detalleId={} productoId={} almacenOrigenId={} codigoLote={}",
+                        reservaId, detalle.getId(), productoId, almacenOrigenId, codigoLote);
+                continue;
+            }
+
+            Optional<LoteProducto> loteCorrectoOpt = loteProductoRepository
+                    .findByProductoIdAndCodigoLoteAndAlmacenIdForUpdate(productoId, codigoLote, almacenOrigenId);
+
+            if (loteCorrectoOpt.isEmpty()) {
+                pendientes++;
+                log.warn("REPAIR_RESERVA_LOTE pendiente: reservaId={} detalleId={} no existe loteOrigen productoId={} almacenOrigenId={} codigoLote={}",
+                        reservaId, detalle.getId(), productoId, almacenOrigenId, codigoLote);
+                continue;
+            }
+
+            LoteProducto loteCorrecto = loteCorrectoOpt.get();
+            if (Objects.equals(loteCorrecto.getId(), loteActual.getId())) {
+                sinCambios++;
+                continue;
+            }
+
+            Long loteAnteriorId = loteActual.getId();
+            Integer almacenAnteriorId = loteActual.getAlmacen() != null ? loteActual.getAlmacen().getId() : null;
+
+            reserva.setLote(loteCorrecto);
+            reservaLoteRepository.save(reserva);
+
+            recalcularStockReservado(loteActual);
+            recalcularStockReservado(loteCorrecto);
+
+            actualizadas.add(reservaId);
+            log.info("REPAIR_RESERVA_LOTE reasignada reservaId={} detalleId={} loteAnteriorId={} loteNuevoId={} almacenAnteriorId={} almacenNuevoId={}",
+                    reservaId,
+                    detalle.getId(),
+                    loteAnteriorId,
+                    loteCorrecto.getId(),
+                    almacenAnteriorId,
+                    loteCorrecto.getAlmacen() != null ? loteCorrecto.getAlmacen().getId() : null);
+        }
+
+        return new RepairBatchResult(actualizadas, pendientes, sinCambios);
+    }
+
+    private List<ReservaLote> cargarReservas(ReservaLoteRepairRequestDTO request) {
+        if (!isEmpty(request.detalleIds())) {
+            return reservaLoteRepository.findByEstadoAndSolicitudMovimientoDetalleIdIn(
+                    EstadoReservaLote.ACTIVA, request.detalleIds());
+        }
+        return reservaLoteRepository.findByEstadoAndSolicitudMovimientoDetalle_SolicitudMovimiento_OrdenProduccionId(
+                EstadoReservaLote.ACTIVA, request.ordenProduccionId());
+    }
+
+    private SolicitudMovimientoDetalle cargarDetalle(ReservaLote reserva) {
+        Long detalleId = reserva.getSolicitudMovimientoDetalle() != null
+                ? reserva.getSolicitudMovimientoDetalle().getId()
+                : null;
+        if (detalleId == null) {
+            return null;
+        }
+        return solicitudMovimientoDetalleRepository.findById(detalleId).orElse(null);
+    }
+
+    private LoteProducto cargarLoteActual(ReservaLote reserva) {
+        Long loteId = reserva.getLote() != null ? reserva.getLote().getId() : null;
+        if (loteId == null) {
+            return null;
+        }
+        return loteProductoRepository.findByIdForUpdate(loteId).orElse(null);
+    }
+
+    private Integer resolverAlmacenOrigenId(SolicitudMovimientoDetalle detalle, LoteProducto loteActual) {
+        return Optional.ofNullable(detalle.getAlmacenOrigen())
+                .map(Almacen::getId)
+                .orElseGet(() -> Optional.ofNullable(detalle.getSolicitudMovimiento())
+                        .map(SolicitudMovimiento::getAlmacenOrigen)
+                        .map(Almacen::getId)
+                        .orElseGet(() -> loteActual.getAlmacen() != null ? loteActual.getAlmacen().getId() : null));
+    }
+
+    private void recalcularStockReservado(LoteProducto lote) {
+        if (lote == null || lote.getId() == null) {
+            return;
+        }
+        BigDecimal pendiente = Optional.ofNullable(reservaLoteRepository
+                        .sumPendienteActivaByLoteId(lote.getId(), EstadoReservaLote.ACTIVA))
+                .orElse(BigDecimal.ZERO)
+                .setScale(6, RoundingMode.HALF_UP);
+        lote.setStockReservado(pendiente);
+    }
+
+    private boolean isEmpty(List<?> list) {
+        return list == null || list.isEmpty();
+    }
+
+    private record RepairBatchResult(List<Long> reservasActualizadas, int pendientes, int sinCambios) {
+        private RepairBatchResult {
+            reservasActualizadas = reservasActualizadas != null ? reservasActualizadas : Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ReservaLoteService.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.service;
 
+import com.willyes.clemenintegra.inventario.model.Almacen;
 import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.ReservaLote;
 import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
@@ -7,6 +8,7 @@ import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoDetalleRepository;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -15,12 +17,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -32,6 +36,7 @@ public class ReservaLoteService {
 
     private final ReservaLoteRepository reservaLoteRepository;
     private final LoteProductoRepository loteProductoRepository;
+    private final SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
     private final SolicitudMovimientoRepository solicitudMovimientoRepository;
 
     @Transactional(readOnly = true)
@@ -120,9 +125,8 @@ public class ReservaLoteService {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "DETALLE_RESERVA_INVALIDO");
         }
 
-        Long loteId = detalle.getLote().getId();
-        LoteProducto lote = loteProductoRepository.findByIdForUpdate(loteId)
-                .orElseThrow(() -> new NoSuchElementException("Lote no encontrado"));
+        LoteProducto lote = resolverLoteOrigen(detalle);
+        Long loteId = lote.getId();
 
         BigDecimal cantidad = Optional.ofNullable(detalle.getCantidad())
                 .orElse(BigDecimal.ZERO)
@@ -138,7 +142,7 @@ public class ReservaLoteService {
                 .findByDetalleIdAndLoteIdForUpdate(detalle.getId(), loteId);
 
         BigDecimal totalPendiente = Optional.ofNullable(reservaLoteRepository
-                        .sumPendienteByLoteId(loteId, EstadoReservaLote.CANCELADA))
+                        .sumPendienteActivaByLoteId(loteId, EstadoReservaLote.ACTIVA))
                 .orElse(BigDecimal.ZERO)
                 .setScale(6, RoundingMode.HALF_UP);
 
@@ -288,7 +292,7 @@ public class ReservaLoteService {
 
     private void recalcularStockReservado(LoteProducto lote) {
         BigDecimal totalPendiente = Optional.ofNullable(reservaLoteRepository
-                        .sumPendienteByLoteId(lote.getId(), EstadoReservaLote.CANCELADA))
+                        .sumPendienteActivaByLoteId(lote.getId(), EstadoReservaLote.ACTIVA))
                 .orElse(BigDecimal.ZERO)
                 .setScale(6, RoundingMode.HALF_UP);
         lote.setStockReservado(totalPendiente);
@@ -300,5 +304,45 @@ public class ReservaLoteService {
                     lote.getId(), totalPendiente, stock);
         }
     }
-}
 
+    private LoteProducto resolverLoteOrigen(SolicitudMovimientoDetalle detalle) {
+        Long loteId = detalle.getLote() != null ? detalle.getLote().getId() : null;
+        if (loteId == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVA_LOTE_INVALIDA");
+        }
+
+        LoteProducto loteDetalle = loteProductoRepository.findById(loteId)
+                .orElseThrow(() -> new NoSuchElementException("Lote no encontrado"));
+
+        Integer productoId = loteDetalle.getProducto() != null ? loteDetalle.getProducto().getId() : null;
+        String codigoLote = loteDetalle.getCodigoLote();
+
+        Integer almacenOrigenId = Optional.ofNullable(detalle.getAlmacenOrigen())
+                .map(almacen -> almacen.getId())
+                .orElseGet(() -> Optional.ofNullable(detalle.getSolicitudMovimiento())
+                        .map(SolicitudMovimiento::getAlmacenOrigen)
+                        .map(Almacen::getId)
+                        .orElseGet(() -> loteDetalle.getAlmacen() != null ? loteDetalle.getAlmacen().getId() : null));
+
+        if (productoId == null || almacenOrigenId == null || !StringUtils.hasText(codigoLote)) {
+            log.warn("RESERVA_LOTE_ORIGEN_INCOMPLETO detalleId={} loteId={} productoId={} almacenOrigenId={} codigoLote={}",
+                    detalle.getId(), loteId, productoId, almacenOrigenId, codigoLote);
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVA_LOTE_ORIGEN_INCOMPLETO");
+        }
+
+        LoteProducto loteOrigen = loteProductoRepository
+                .findByProductoIdAndCodigoLoteAndAlmacenIdForUpdate(productoId, codigoLote, almacenOrigenId)
+                .orElseThrow(() -> {
+                    log.warn("RESERVA_LOTE_ORIGEN_NO_ENCONTRADO detalleId={} productoId={} almacenOrigenId={} codigoLote={}",
+                            detalle.getId(), productoId, almacenOrigenId, codigoLote);
+                    return new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVA_LOTE_ORIGEN_NO_ENCONTRADO");
+                });
+
+        if (!Objects.equals(loteOrigen.getId(), loteId)) {
+            detalle.setLote(loteOrigen);
+            solicitudMovimientoDetalleRepository.save(detalle);
+        }
+
+        return loteOrigen;
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteRepairServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteRepairServiceTest.java
@@ -1,0 +1,107 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.ReservaLoteRepairRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.ReservaLoteRepairResultDTO;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.ReservaLote;
+import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoDetalleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReservaLoteRepairServiceTest {
+
+    @Mock
+    private ReservaLoteRepository reservaLoteRepository;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    @InjectMocks
+    private ReservaLoteRepairService service;
+
+    @Test
+    @DisplayName("repararReservasLote reasigna reservas activas al lote del almacén origen")
+    void repararReservasLote_reasignaReserva() {
+        Producto producto = new Producto();
+        producto.setId(99);
+
+        LoteProducto loteDestino = LoteProducto.builder()
+                .id(2255L)
+                .codigoLote("00049")
+                .producto(producto)
+                .stockLote(BigDecimal.ZERO)
+                .almacen(Almacen.builder().id(6).build())
+                .build();
+
+        LoteProducto loteOrigen = LoteProducto.builder()
+                .id(2148L)
+                .codigoLote("00049")
+                .producto(producto)
+                .stockLote(new BigDecimal("10"))
+                .almacen(Almacen.builder().id(1).build())
+                .build();
+
+        SolicitudMovimientoDetalle detalle = SolicitudMovimientoDetalle.builder()
+                .id(77L)
+                .lote(loteDestino)
+                .almacenOrigen(Almacen.builder().id(1).build())
+                .build();
+
+        ReservaLote reserva = ReservaLote.builder()
+                .id(500L)
+                .lote(loteDestino)
+                .cantidadReservada(new BigDecimal("2"))
+                .cantidadConsumida(BigDecimal.ZERO)
+                .estado(EstadoReservaLote.ACTIVA)
+                .solicitudMovimientoDetalle(detalle)
+                .build();
+
+        when(reservaLoteRepository.findByEstadoAndSolicitudMovimientoDetalleIdIn(
+                EstadoReservaLote.ACTIVA, List.of(77L)))
+                .thenReturn(List.of(reserva));
+        when(solicitudMovimientoDetalleRepository.findById(77L)).thenReturn(Optional.of(detalle));
+        when(loteProductoRepository.findByIdForUpdate(2255L)).thenReturn(Optional.of(loteDestino));
+        when(loteProductoRepository.findByProductoIdAndCodigoLoteAndAlmacenIdForUpdate(99, "00049", 1))
+                .thenReturn(Optional.of(loteOrigen));
+        when(reservaLoteRepository.save(any(ReservaLote.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(reservaLoteRepository.sumPendienteActivaByLoteId(eq(2255L), any())).thenReturn(BigDecimal.ZERO);
+        when(reservaLoteRepository.sumPendienteActivaByLoteId(eq(2148L), any())).thenReturn(BigDecimal.ZERO);
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+
+        ReservaLoteRepairResultDTO result = service.repararReservasLote(
+                new ReservaLoteRepairRequestDTO(List.of(77L), null, 50));
+
+        assertThat(result.actualizadas()).isEqualTo(1);
+        assertThat(result.reservasActualizadas()).containsExactly(500L);
+        assertThat(reserva.getLote().getId()).isEqualTo(2148L);
+        assertThat(reserva.getCantidadReservada()).isEqualByComparingTo(new BigDecimal("2.000000"));
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ReservaLoteServiceTest.java
@@ -8,6 +8,7 @@ import com.willyes.clemenintegra.inventario.model.SolicitudMovimientoDetalle;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.ReservaLoteRepository;
+import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoDetalleRepository;
 import com.willyes.clemenintegra.inventario.repository.SolicitudMovimientoRepository;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.UnidadMedida;
@@ -30,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class ReservaLoteServiceTest {
@@ -40,6 +42,8 @@ class ReservaLoteServiceTest {
     private LoteProductoRepository loteProductoRepository;
     @Mock
     private SolicitudMovimientoRepository solicitudMovimientoRepository;
+    @Mock
+    private SolicitudMovimientoDetalleRepository solicitudMovimientoDetalleRepository;
 
     @InjectMocks
     private ReservaLoteService service;
@@ -51,18 +55,27 @@ class ReservaLoteServiceTest {
                 .id(10L)
                 .cantidad(new BigDecimal("3.45678901"))
                 .lote(LoteProducto.builder().id(5L).build())
+                .almacenOrigen(Almacen.builder().id(1).build())
                 .build();
 
+        Producto producto = new Producto();
+        producto.setId(1);
         LoteProducto lote = LoteProducto.builder()
                 .id(5L)
+                .codigoLote("L-5")
+                .producto(producto)
                 .stockLote(new BigDecimal("10"))
-                .almacen(new Almacen())
+                .almacen(Almacen.builder().id(1).build())
                 .build();
 
-        when(loteProductoRepository.findByIdForUpdate(5L)).thenReturn(Optional.of(lote));
+        when(loteProductoRepository.findById(5L)).thenReturn(Optional.of(lote));
+        when(loteProductoRepository.findByProductoIdAndCodigoLoteAndAlmacenIdForUpdate(1, "L-5", 1))
+                .thenReturn(Optional.of(lote));
         when(reservaLoteRepository.findByDetalleIdAndLoteIdForUpdate(10L, 5L)).thenReturn(Optional.empty());
-        when(reservaLoteRepository.sumPendienteByLoteId(eq(5L), any())).thenReturn(BigDecimal.ZERO);
+        when(reservaLoteRepository.sumPendienteActivaByLoteId(eq(5L), any())).thenReturn(BigDecimal.ZERO);
         when(reservaLoteRepository.save(any(ReservaLote.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(solicitudMovimientoDetalleRepository.save(any(SolicitudMovimientoDetalle.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
 
         ReservaLote reserva = service.crearOActualizarDesdeDetalle(detalle);
 
@@ -97,7 +110,7 @@ class ReservaLoteServiceTest {
         when(reservaLoteRepository.save(any(ReservaLote.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
         when(loteProductoRepository.findByIdForUpdate(8L)).thenReturn(Optional.of(lote));
-        when(reservaLoteRepository.sumPendienteByLoteId(eq(8L), any())).thenReturn(BigDecimal.ZERO);
+        when(reservaLoteRepository.sumPendienteActivaByLoteId(eq(8L), any())).thenReturn(BigDecimal.ZERO);
 
         service.liberarReservasPorOrden(1L);
 
@@ -116,9 +129,11 @@ class ReservaLoteServiceTest {
                 .id(30L)
                 .cantidad(new BigDecimal("6"))
                 .lote(LoteProducto.builder().id(15L).build())
+                .almacenOrigen(Almacen.builder().id(1).build())
                 .build();
 
         Producto producto = new Producto();
+        producto.setId(1);
         producto.setCodigoSku("MP-COLRO");
         producto.setNombre("Colorante Rojo");
         UnidadMedida unidadMedida = new UnidadMedida();
@@ -131,12 +146,16 @@ class ReservaLoteServiceTest {
                 .producto(producto)
                 .stockLote(new BigDecimal("5"))
                 .stockReservado(new BigDecimal("2"))
-                .almacen(new Almacen())
+                .almacen(Almacen.builder().id(1).build())
                 .build();
 
-        when(loteProductoRepository.findByIdForUpdate(15L)).thenReturn(Optional.of(lote));
+        when(loteProductoRepository.findById(15L)).thenReturn(Optional.of(lote));
+        when(loteProductoRepository.findByProductoIdAndCodigoLoteAndAlmacenIdForUpdate(1, "L-15", 1))
+                .thenReturn(Optional.of(lote));
         when(reservaLoteRepository.findByDetalleIdAndLoteIdForUpdate(30L, 15L)).thenReturn(Optional.empty());
-        when(reservaLoteRepository.sumPendienteByLoteId(eq(15L), any())).thenReturn(new BigDecimal("2"));
+        when(reservaLoteRepository.sumPendienteActivaByLoteId(eq(15L), any())).thenReturn(new BigDecimal("2"));
+        lenient().when(solicitudMovimientoDetalleRepository.save(any(SolicitudMovimientoDetalle.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
 
         assertThatThrownBy(() -> service.crearOActualizarDesdeDetalle(detalle))
                 .isInstanceOf(ResponseStatusException.class)
@@ -144,5 +163,48 @@ class ReservaLoteServiceTest {
                 .hasMessageContaining("Colorante Rojo")
                 .hasMessageContaining("MILILITRO")
                 .hasMessageContaining("3.000000");
+    }
+
+    @Test
+    @DisplayName("crearOActualizarDesdeDetalle usa lote del almacén origen cuando el código existe en otro almacén")
+    void crearOActualizarDesdeDetalle_usaLoteOrigen() {
+        Producto producto = new Producto();
+        producto.setId(99);
+
+        LoteProducto loteDestino = LoteProducto.builder()
+                .id(2255L)
+                .codigoLote("00049")
+                .producto(producto)
+                .stockLote(BigDecimal.ZERO)
+                .almacen(Almacen.builder().id(6).build())
+                .build();
+
+        LoteProducto loteOrigen = LoteProducto.builder()
+                .id(2148L)
+                .codigoLote("00049")
+                .producto(producto)
+                .stockLote(new BigDecimal("10"))
+                .almacen(Almacen.builder().id(1).build())
+                .build();
+
+        SolicitudMovimientoDetalle detalle = SolicitudMovimientoDetalle.builder()
+                .id(77L)
+                .cantidad(new BigDecimal("2"))
+                .lote(LoteProducto.builder().id(2255L).build())
+                .almacenOrigen(Almacen.builder().id(1).build())
+                .build();
+
+        when(loteProductoRepository.findById(2255L)).thenReturn(Optional.of(loteDestino));
+        when(loteProductoRepository.findByProductoIdAndCodigoLoteAndAlmacenIdForUpdate(99, "00049", 1))
+                .thenReturn(Optional.of(loteOrigen));
+        when(reservaLoteRepository.findByDetalleIdAndLoteIdForUpdate(77L, 2148L)).thenReturn(Optional.empty());
+        when(reservaLoteRepository.sumPendienteActivaByLoteId(eq(2148L), any())).thenReturn(BigDecimal.ZERO);
+        when(reservaLoteRepository.save(any(ReservaLote.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(solicitudMovimientoDetalleRepository.save(any(SolicitudMovimientoDetalle.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ReservaLote reserva = service.crearOActualizarDesdeDetalle(detalle);
+
+        assertThat(reserva.getLote().getId()).isEqualTo(2148L);
     }
 }


### PR DESCRIPTION
### Motivation
- Correct inconsistent reservations that were still pointing to lotes in the wrong almacén (e.g. pre-bodega id 6) after manual stock moves, causing `RESERVA_STOCK_INSUFICIENTE` on approval. 
- Provide a safe, auditable repair mechanism to reassign existing `ACTIVA` reservas to the correct origin lote (product + almacén + codigo_lote) without cancelling reservations.

### Description
- Change reservation resolution so creation/validation always resolves the origin lote by `(productoId, codigoLote, almacenOrigenId)` in `ReservaLoteService` via a new `resolverLoteOrigen` method and persist the corrected `SolicitudMovimientoDetalle` when needed. 
- Stop relying on global `codigo_lote` lookup: use `LoteProductoRepository.findByProductoIdAndCodigoLoteAndAlmacenIdForUpdate(...)` and avoid searching only by code; updated calls to `loteProductoRepository.findById(...)` where appropriate. 
- Use active-reservas aggregation instead of the old canceled-sum to compute reserved amounts by switching to `sumPendienteActivaByLoteId(...)` and update `recalcularStockReservado`/reservation checks accordingly. 
- Add a repair service `ReservaLoteRepairService` (batch processing, transactional per batch) plus DTOs `ReservaLoteRepairRequestDTO` / `ReservaLoteRepairResultDTO` and an admin controller `POST /api/admin/repair/reservas-lote` protected by `ROL_SUPER_ADMIN` that reassigns `ACTIVA` reservas to the correct origin lote, logs structured bitacora entries and recalculates `stock_reservado`. 
- Add repository query helpers to fetch reservations by estado + detalle ids or by ordenProduccion id for repair batching. 
- Add and update unit tests: extend `ReservaLoteServiceTest` with origin-lote selection cases and update stubs; add `ReservaLoteRepairServiceTest` to assert the reasignment behavior and invariants.

### Testing
- Ran unit tests matching reservation scope with `mvn -Dtest=*Reserva* test` and they all passed: total tests run 13 with 0 failures. 
- Verified `ReservaLoteService` tests for normalization, insuficiente message and origin-lote selection passed. 
- Verified `ReservaLoteRepairService` test reassigns an `ACTIVA` reserva to the correct origin lote and preserves `cantidad_reservada` and logs the reassignment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fd04f0bac83339359248fa00228fb)