### PR TITLE
Exclude Pre-Bodega as OP origin; add CORRECCION_SALIDA_CLIENTE enum and tests

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/model/enums/ClasificacionMovimientoInventario.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/model/enums/ClasificacionMovimientoInventario.java
@@ -22,6 +22,7 @@ public enum ClasificacionMovimientoInventario {
     SALIDA_MUESTRA_CALIDAD, //
     SALIDA_PRODUCCION,
     SALIDA_CLIENTE,//
+    CORRECCION_SALIDA_CLIENTE,
 
     // TRANSFERENCIAS
     TRANSFERENCIA_INTERNA_PRODUCCION,
@@ -29,7 +30,6 @@ public enum ClasificacionMovimientoInventario {
     LIBERACION_CALIDAD,
     RECHAZO_CALIDAD
 }
-
 
 
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java
@@ -107,7 +107,11 @@ public class DisponibilidadInsumoService {
         List<LoteFefoDisponibleProjection> lotesDisponibles = loteProductoRepository
                 .findFefoDisponibles(productoInsumoId, Integer.MAX_VALUE);
         Long preBodegaId = catalogResolver.getAlmacenPreBodegaProduccionId();
+        List<LoteFefoDisponibleProjection> lotesPreBodega = List.of();
         if (preBodegaId != null) {
+            lotesPreBodega = lotesDisponibles.stream()
+                    .filter(lote -> Objects.equals(lote.getAlmacenId(), preBodegaId))
+                    .toList();
             lotesDisponibles = lotesDisponibles.stream()
                     .filter(lote -> lote.getAlmacenId() == null || !Objects.equals(lote.getAlmacenId(), preBodegaId))
                     .toList();
@@ -123,16 +127,26 @@ public class DisponibilidadInsumoService {
                 .map(this::calcularStockLibre)
                 .filter(Objects::nonNull)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-        if (preBodegaId != null && stockLibreElegible.compareTo(requerida) < 0) {
+        BigDecimal stockLibrePreBodega = lotesPreBodega.stream()
+                .map(this::calcularStockLibre)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        Long almacenOrigenId = resolveAlmacenOrigenId(preferidos, producto);
+        BigDecimal faltanteOrigen = requerida.subtract(stockLibreElegible).max(BigDecimal.ZERO);
+        if (preBodegaId != null
+                && stockLibreElegible.compareTo(BigDecimal.ZERO) == 0
+                && stockLibrePreBodega.compareTo(BigDecimal.ZERO) > 0) {
+            Map<String, Object> detalles = new java.util.LinkedHashMap<>();
+            detalles.put("productoInsumoId", productoInsumoId);
+            detalles.put("preBodegaId", preBodegaId);
+            detalles.put("almacenOrigenId", almacenOrigenId);
+            detalles.put("requerido", requerida);
+            detalles.put("disponibleElegible", stockLibreElegible);
+            detalles.put("faltante", faltanteOrigen);
             throw new CustomBusinessException(
                     ApiErrorCode.PREBODEGA_ORIGEN_INVALIDO,
                     "STOCK_INSUFICIENTE_ORIGEN: la Pre-Bodega Producción no se considera origen de insumos",
-                    Map.of(
-                            "productoInsumoId", productoInsumoId,
-                            "preBodegaId", preBodegaId,
-                            "requerido", requerida,
-                            "stockLibreElegible", stockLibreElegible
-                    ));
+                    detalles);
         }
 
         List<LoteFefoDisponibleProjection> lotesSeleccionados = new ArrayList<>(lotesElegibles);
@@ -158,7 +172,6 @@ public class DisponibilidadInsumoService {
             if (lotesSeleccionados.isEmpty() || cubierto.compareTo(requerida) < 0) {
                 usoFallback = true;
                 motivoFallback = lotesSeleccionados.isEmpty() ? "SIN_ALMACEN_CONFIGURADO" : "STOCK_NO_DISPONIBLE_EN_ORIGEN";
-                lotesSeleccionados = lotesElegibles;
             }
         } else if (!lotesElegibles.isEmpty()) {
             usoFallback = true;
@@ -185,9 +198,10 @@ public class DisponibilidadInsumoService {
                 .findFirst()
                 .ifPresent(estado -> log.warn("Disponibilidad FEFO detectó lote en estado no permitido: {}", estado));
 
-        BigDecimal stockFisicoTotal = sumar(lotesElegibles, LoteFefoDisponibleProjection::getStockFisico);
-        BigDecimal stockReservadoTotal = sumar(lotesElegibles, LoteFefoDisponibleProjection::getStockReservado);
-        BigDecimal stockLibreTotal = lotesElegibles.stream()
+        List<LoteFefoDisponibleProjection> lotesTotales = preferidos.isEmpty() ? lotesElegibles : lotesSeleccionados;
+        BigDecimal stockFisicoTotal = sumar(lotesTotales, LoteFefoDisponibleProjection::getStockFisico);
+        BigDecimal stockReservadoTotal = sumar(lotesTotales, LoteFefoDisponibleProjection::getStockReservado);
+        BigDecimal stockLibreTotal = lotesTotales.stream()
                 .map(this::calcularStockLibre)
                 .reduce(BigDecimal.ZERO, BigDecimal::add)
                 .setScale(6, RoundingMode.HALF_UP);
@@ -288,6 +302,18 @@ public class DisponibilidadInsumoService {
     private boolean esLotePermitido(LoteFefoDisponibleProjection lote, EnumSet<EstadoLote> estadosPermitidos) {
         EstadoLote estado = parseEstadoLoteSafe(lote.getEstado());
         return estado != null && estadosPermitidos.contains(estado);
+    }
+
+    private Long resolveAlmacenOrigenId(List<Long> preferidos, Producto producto) {
+        if (preferidos != null && !preferidos.isEmpty()) {
+            return preferidos.get(0);
+        }
+        return Optional.ofNullable(producto)
+                .map(Producto::getCategoriaProducto)
+                .map(CategoriaProducto::getTipo)
+                .map(ALMACENES_ORIGEN_POR_CATEGORIA::get)
+                .map(func -> func.apply(catalogResolver))
+                .orElse(null);
     }
 
     private BigDecimal calcularStockLibre(LoteFefoDisponibleProjection lote) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MotivoMovimientoServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MotivoMovimientoServiceImplTest.java
@@ -1,0 +1,52 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.MotivoMovimientoResponseDTO;
+import com.willyes.clemenintegra.inventario.mapper.MotivoMovimientoMapper;
+import com.willyes.clemenintegra.inventario.model.MotivoMovimiento;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.repository.MotivoMovimientoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MotivoMovimientoServiceImplTest {
+
+    @Mock
+    private MotivoMovimientoRepository repository;
+
+    @Mock
+    private MotivoMovimientoMapper mapper;
+
+    @InjectMocks
+    private MotivoMovimientoServiceImpl service;
+
+    @Test
+    @DisplayName("listar no falla cuando existe motivo CORRECCION_SALIDA_CLIENTE")
+    void listar_conCorreccionSalidaCliente() {
+        MotivoMovimiento motivo = MotivoMovimiento.builder()
+                .id(50L)
+                .descripcion("Corrección salida cliente")
+                .motivo(ClasificacionMovimientoInventario.CORRECCION_SALIDA_CLIENTE)
+                .build();
+        MotivoMovimientoResponseDTO dto = new MotivoMovimientoResponseDTO(50L, "CORRECCION_SALIDA_CLIENTE");
+
+        when(repository.findAll(PageRequest.of(0, 10))).thenReturn(new PageImpl<>(List.of(motivo)));
+        when(mapper.toDTO(motivo)).thenReturn(dto);
+
+        Page<MotivoMovimientoResponseDTO> result = service.listar(PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).containsExactly(dto);
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
@@ -77,7 +77,7 @@ class DisponibilidadInsumoServiceTest {
     void calcularDisponibilidad_insuficienteCalculaFaltante() {
         when(loteProductoRepository.findFefoDisponibles(20L, Integer.MAX_VALUE))
                 .thenReturn(List.of(
-                        lote(5L, "C", new BigDecimal("2.500000"), new BigDecimal("3.000000"), new BigDecimal("0.500000"), EstadoLote.DISPONIBLE, 5L)
+                        lote(5L, "C", new BigDecimal("2.500000"), new BigDecimal("3.000000"), new BigDecimal("0.500000"), EstadoLote.DISPONIBLE, 7L)
                 ));
         when(catalogResolver.getAlmacenOrigenMateriaPrimaId()).thenReturn(7L);
 
@@ -175,6 +175,22 @@ class DisponibilidadInsumoServiceTest {
     }
 
     @Test
+    @DisplayName("calcularDisponibilidad no falla cuando hay stock suficiente en almacén origen válido")
+    void calcularDisponibilidad_stockSuficienteOrigenValido() {
+        when(loteProductoRepository.findFefoDisponibles(65L, Integer.MAX_VALUE))
+                .thenReturn(List.of(
+                        lote(210L, "PB-003", new BigDecimal("2.000000"), new BigDecimal("2.000000"), BigDecimal.ZERO, EstadoLote.DISPONIBLE, 6L),
+                        lote(211L, "MP-002", new BigDecimal("5.000000"), new BigDecimal("5.000000"), BigDecimal.ZERO, EstadoLote.DISPONIBLE, 5L)
+                ));
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(6L);
+
+        DistribucionFefoResult resultado = service.calcularDisponibilidad(65L, new BigDecimal("3"), List.of(5L), false);
+
+        assertThat(resultado.isSuficiente()).isTrue();
+        assertThat(resultado.getFaltante()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+    }
+
+    @Test
     @DisplayName("calcularDisponibilidad falla si solo hay stock en Pre-Bodega Producción")
     void calcularDisponibilidad_preBodegaUnicoOrigen() {
         when(loteProductoRepository.findFefoDisponibles(66L, Integer.MAX_VALUE))
@@ -188,6 +204,14 @@ class DisponibilidadInsumoServiceTest {
                 .satisfies(ex -> {
                     CustomBusinessException error = (CustomBusinessException) ex;
                     assertThat(error.getCode()).isEqualTo(ApiErrorCode.PREBODEGA_ORIGEN_INVALIDO);
+                    assertThat(error.getDetails())
+                            .isInstanceOfSatisfying(java.util.Map.class, details -> assertThat(details).containsKeys(
+                                    "productoInsumoId",
+                                    "preBodegaId",
+                                    "almacenOrigenId",
+                                    "requerido",
+                                    "disponibleElegible",
+                                    "faltante"));
                 });
     }
 


### PR DESCRIPTION
### Motivation
- Fix OP/FEFO availability so the Pre-Bodega Producción is never considered an origin when validating insumo availability. 
- Prevent the 500 crash in `/api/motivos` caused by a DB value not present in the Java enum by aligning the enum with the DB. 
- Provide clearer error details and unit coverage for both flows to avoid regressions.

### Description
- Adjusted `DisponibilidadInsumoService.calcularDisponibilidad(...)` to separate lots that belong to the configured Pre-Bodega and exclude them from eligible/origin lots, compute eligible totals from origin warehouses only, and compute origin id with a new helper `resolveAlmacenOrigenId(...)` (file: `src/main/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoService.java`, changes roughly lines 107–317 and helper at ~307–317).
- When only pre-bodega has stock the service now throws `CustomBusinessException` with enriched details (`productoInsumoId`, `preBodegaId`, `almacenOrigenId`, `requerido`, `disponibleElegible`, `faltante`) instead of the previous minimal payload (same file, error creation near lines ~136–149).
- Compute totals (`stockFisicoTotal`, `stockReservadoTotal`, `stockLibreTotal`) based on selected origin lots (change around lines ~201–207) and avoid incorrectly switching selected lots back to all elegibles in the preferidos-fallback branch.
- Added enum value `CORRECCION_SALIDA_CLIENTE` to `ClasificacionMovimientoInventario` to match DB values (file: `src/main/java/com/willyes/clemenintegra/inventario/model/enums/ClasificacionMovimientoInventario.java`, ~line 25).
- Added/updated tests: extended `DisponibilidadInsumoServiceTest` with a case where origin (non-prebodega) has sufficient stock and strengthened the Pre-Bodega-only failure assertions (file: `src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java`, changes around ~160–210), and added `MotivoMovimientoServiceImplTest` to assert listing works when a `CORRECCION_SALIDA_CLIENTE` motivo exists (new file: `src/test/java/com/willyes/clemenintegra/inventario/service/MotivoMovimientoServiceImplTest.java`).

### Testing
- Ran unit tests with `mvn -Dtest=DisponibilidadInsumoServiceTest,MotivoMovimientoServiceImplTest test` and the run completed successfully with all tests passing (9 tests, 0 failures / BUILD SUCCESS). 
- Existing related FEFO tests in `DisponibilidadInsumoServiceTest` were preserved and updated assertions pass locally.
- No changes were made to external APIs or other movement classifications to avoid side effects.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698080d700108333af26034adc009efb)