### PR TITLE
Omitir insumos SIN_CONTROL_STOCK del consumo automático y del cálculo de faltantes

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -17,6 +17,7 @@ import com.willyes.clemenintegra.inventario.model.enums.EstadoOrdenCompra;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoReservaLote;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimiento;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoCategoria;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.produccion.model.EtapaProduccion;
@@ -3780,6 +3781,13 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
             final Producto producto = sol.getProducto();
             if (producto == null || producto.getId() == null) {
                 log.warn("CONSUMO_OP: solicitud sin producto. solId={}", sol.getId());
+                continue;
+            }
+            ModoControlInventario modoControl = Optional.ofNullable(producto.getModoControlInventario())
+                    .orElse(ModoControlInventario.CONTROL_STOCK);
+            if (modoControl == ModoControlInventario.SIN_CONTROL_STOCK) {
+                log.debug("CONSUMO_OP: producto sin control de stock, se omite consumo automático. solId={}, productoId={}",
+                        sol.getId(), producto.getId());
                 continue;
             }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1946,6 +1946,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             if (det == null || det.getInsumo() == null) {
                 continue;
             }
+            ModoControlInventario modoControl = Optional.ofNullable(det.getInsumo().getModoControlInventario())
+                    .orElse(ModoControlInventario.CONTROL_STOCK);
+            if (modoControl == ModoControlInventario.SIN_CONTROL_STOCK) {
+                log.debug("OP-insumos: insumo {} sin control de stock, se omite en faltantes", det.getInsumo().getId());
+                continue;
+            }
             BigDecimal requerida = det.getCantidadNecesaria().multiply(orden.getCantidadProgramada());
             Long insumoId = det.getInsumo().getId().longValue();
             // Consumido real: salidas de producción registradas para la OP (independiente de etapa).

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceConsumoEtapaTest.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.inventario.model.*;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.EstadoSolicitudMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.ModoControlInventario;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.repository.*;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
@@ -227,6 +228,31 @@ class MovimientoInventarioServiceConsumoEtapaTest {
         assertThatThrownBy(() -> service.consumirInsumosPorOrden(10L, 20L, 5L))
                 .isInstanceOf(CustomBusinessException.class)
                 .hasFieldOrPropertyWithValue("code", ApiErrorCode.CONSUMO_PREBODEGA_INSUFICIENTE);
+    }
+
+    @Test
+    void consumirInsumosPorOrden_sinControlStockOmiteConsumo() {
+        SolicitudMovimiento solicitud = solicitudConDetalle();
+        solicitud.getProducto().setModoControlInventario(ModoControlInventario.SIN_CONTROL_STOCK);
+
+        TypedQuery<SolicitudMovimiento> query = mock(TypedQuery.class);
+        when(entityManager.createQuery(anyString(), eq(SolicitudMovimiento.class))).thenReturn(query);
+        when(query.setParameter(eq("opId"), any())).thenReturn(query);
+        when(query.getResultList()).thenReturn(List.of(solicitud));
+
+        when(catalogResolver.getAlmacenPreBodegaProduccionId()).thenReturn(30L);
+        EtapaProduccion etapaActiva = EtapaProduccion.builder()
+                .id(20L)
+                .estado(EstadoEtapa.EN_PROCESO)
+                .fechaInicio(LocalDateTime.now())
+                .ordenProduccion(OrdenProduccion.builder().id(10L).build())
+                .build();
+        when(etapaProduccionRepository.findById(anyLong())).thenReturn(Optional.of(etapaActiva));
+
+        service.consumirInsumosPorOrden(10L, 20L, 5L);
+
+        verify(service, never()).registrarMovimiento(any(MovimientoInventarioDTO.class));
+        verify(loteProductoRepository, never()).findByCodigoLoteAndProductoIdAndAlmacenId(anyString(), anyInt(), anyInt());
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -1527,6 +1527,37 @@ class OrdenProduccionServiceImplTest {
     }
 
     @Test
+    @DisplayName("listarInsumos omite insumos sin control de stock")
+    void listarInsumos_omiteSinControlStock() {
+        OrdenProduccion orden = new OrdenProduccion();
+        orden.setId(202L);
+        orden.setCantidadProgramada(new BigDecimal("5"));
+        Producto producto = new Producto();
+        producto.setId(10);
+        orden.setProducto(producto);
+
+        Producto insumo = new Producto();
+        insumo.setId(302);
+        insumo.setNombre("Insumo SM");
+        insumo.setModoControlInventario(ModoControlInventario.SIN_CONTROL_STOCK);
+
+        DetalleFormula detalle = new DetalleFormula();
+        detalle.setInsumo(insumo);
+        detalle.setCantidadNecesaria(new BigDecimal("2"));
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(detalle));
+
+        when(ordenProduccionRepository.findById(202L)).thenReturn(Optional.of(orden));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+
+        List<com.willyes.clemenintegra.produccion.dto.InsumoOPDTO> lista = service.listarInsumos(202L);
+
+        assertThat(lista).isEmpty();
+    }
+
+    @Test
     @DisplayName("listarInsumos descuenta reservas consumidas")
     void listarInsumos_conReservasConsumidas() {
         OrdenProduccion orden = new OrdenProduccion();


### PR DESCRIPTION
### Motivation
- Evitar que insumos con `modo_control_inventario = SIN_CONTROL_STOCK` disparen el error `CONSUMO_PREBODEGA_INSUFICIENTE` al iniciar una etapa. 
- Los insumos sin control de stock no deben participar en consumo automático ni contar como faltantes bloqueantes en la UI.

### Description
- En `MovimientoInventarioServiceImpl.consumirInsumosPorOrden` se añade un filtro para saltarse productos cuyo `modoControlInventario == SIN_CONTROL_STOCK` antes de buscar lotes en Pre-Bodega y emitir salidas. (archivo: `src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java`)
- En `OrdenProduccionServiceImpl.listarInsumos` se excluyen los insumos `SIN_CONTROL_STOCK` del cálculo/listado de faltantes para que no aparezcan como faltantes bloqueantes en la vista de OP. (archivo: `src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java`)
- Se agregaron dos tests unitarios: `consumirInsumosPorOrden_sinControlStockOmiteConsumo` en `MovimientoInventarioServiceConsumoEtapaTest` y `listarInsumos_omiteSinControlStock` en `OrdenProduccionServiceImplTest` para cubrir los casos nuevos. (archivos: `src/test/java/.../MovimientoInventarioServiceConsumoEtapaTest.java`, `src/test/java/.../OrdenProduccionServiceImplTest.java`)

### Testing
- Ejecuté los tests específicos con `mvn -q -Dtest=MovimientoInventarioServiceConsumoEtapaTest,OrdenProduccionServiceImplTest test` and the suite completed successfully without failures. 
- Nuevos tests added: `consumirInsumosPorOrden_sinControlStockOmiteConsumo` and `listarInsumos_omiteSinControlStock`, both asserting the skip behavior and passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980c8892e948333843d80819aff3548)