### PR TITLE
Fix FEFO availability when stock_reservado is null and add PS FEFO tests

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -199,9 +199,9 @@ WHERE lp.codigoLote = :codigoLote
     @Query(value = """
         SELECT lp.id AS loteProductoId,
                lp.codigo_lote AS codigoLote,
-               (lp.stock_lote - lp.stock_reservado) AS stockLote,
+               (lp.stock_lote - COALESCE(lp.stock_reservado, 0)) AS stockLote,
                lp.stock_lote AS stockFisico,
-               lp.stock_reservado AS stockReservado,
+               COALESCE(lp.stock_reservado, 0) AS stockReservado,
                lp.fecha_vencimiento AS fechaVencimiento,
                lp.almacenes_id AS almacenId,
                a.nombre AS nombreAlmacen,
@@ -211,7 +211,7 @@ WHERE lp.codigoLote = :codigoLote
         WHERE lp.productos_id = :productoId
           AND lp.estado IN ('DISPONIBLE','LIBERADO')
           AND lp.agotado = false
-          AND (lp.stock_lote - lp.stock_reservado) > 0
+          AND (lp.stock_lote - COALESCE(lp.stock_reservado, 0)) > 0
         ORDER BY lp.fecha_vencimiento ASC
         LIMIT :limit
         """, nativeQuery = true)

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java
@@ -159,6 +159,54 @@ class DisponibilidadInsumoServiceTest {
     }
 
     @Test
+    @DisplayName("calcularDisponibilidad PS LIBERADO cubre requerido y no bloquea")
+    void calcularDisponibilidad_psLiberadoCubreRequerido() {
+        when(loteProductoRepository.findFefoDisponibles(80L, Integer.MAX_VALUE))
+                .thenReturn(List.of(
+                        lote(401L, "PS-001", new BigDecimal("2860.000000"), new BigDecimal("2860.000000"),
+                                BigDecimal.ZERO, EstadoLote.LIBERADO, 9L)
+                ));
+
+        DistribucionFefoResult resultado = service.calcularDisponibilidad(80L, new BigDecimal("90"), List.of(), true);
+
+        assertThat(resultado.isSuficiente()).isTrue();
+        assertThat(resultado.getStockLibreTotal()).isEqualByComparingTo(new BigDecimal("2860.000000"));
+        assertThat(resultado.getFaltante()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+    }
+
+    @Test
+    @DisplayName("calcularDisponibilidad PS en cuarentena o retenido no aporta stock libre")
+    void calcularDisponibilidad_psNoElegiblePorEstado() {
+        when(loteProductoRepository.findFefoDisponibles(81L, Integer.MAX_VALUE))
+                .thenReturn(List.of(
+                        lote(402L, "PS-002", new BigDecimal("2860.000000"), new BigDecimal("2860.000000"),
+                                BigDecimal.ZERO, EstadoLote.EN_CUARENTENA, 9L)
+                ));
+
+        DistribucionFefoResult resultado = service.calcularDisponibilidad(81L, new BigDecimal("90"), List.of(), true);
+
+        assertThat(resultado.isSuficiente()).isFalse();
+        assertThat(resultado.getStockLibreTotal()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+        assertThat(resultado.getFaltante()).isEqualByComparingTo(new BigDecimal("90.000000"));
+    }
+
+    @Test
+    @DisplayName("calcularDisponibilidad descuenta reservas parciales sin quedar en cero")
+    void calcularDisponibilidad_descuentaReservasParciales() {
+        when(loteProductoRepository.findFefoDisponibles(82L, Integer.MAX_VALUE))
+                .thenReturn(List.of(
+                        lote(403L, "PS-003", new BigDecimal("70.000000"), new BigDecimal("100.000000"),
+                                new BigDecimal("30.000000"), EstadoLote.LIBERADO, 9L)
+                ));
+
+        DistribucionFefoResult resultado = service.calcularDisponibilidad(82L, new BigDecimal("60"), List.of(), true);
+
+        assertThat(resultado.isSuficiente()).isTrue();
+        assertThat(resultado.getStockLibreTotal()).isEqualByComparingTo(new BigDecimal("70.000000"));
+        assertThat(resultado.getFaltante()).isEqualByComparingTo(BigDecimal.ZERO.setScale(6));
+    }
+
+    @Test
     @DisplayName("calcularDisponibilidad excluye lotes de Pre-Bodega Producción")
     void calcularDisponibilidad_excluyePreBodega() {
         when(loteProductoRepository.findFefoDisponibles(55L, Integer.MAX_VALUE))


### PR DESCRIPTION
### Motivation
- FEFO availability query was excluding lots when `stock_reservado` was `NULL`, causing `stockLibreFefo = 0` while UI "Disponible/Total" showed >0.
- Align FEFO lot selection with the existing `stockDisponible` logic that uses `COALESCE` so PS (prefixed) lots in `LIBERADO` are counted correctly without changing QA/state rules.

### Description
- Changed native FEFO query in `LoteProductoRepository.findFefoDisponibles` to use `COALESCE(lp.stock_reservado, 0)` when computing `stockLote`, `stockReservado`, and in the `> 0` filter so `NULL` reservations are treated as zero (file: `src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java`, approx lines 199–215).
- Added unit tests in `DisponibilidadInsumoServiceTest` covering: PS with `LIBERADO` lot supplying required quantity, PS lot in `EN_CUARENTENA` being excluded, and partial reservations being subtracted correctly (file: `src/test/java/com/willyes/clemenintegra/produccion/service/DisponibilidadInsumoServiceTest.java`, tests added around lines ~160–210).
- This fix preserves existing state filters (`DISPONIBLE`/`LIBERADO` and per-product quality-only `LIBERADO`) and keeps reservation subtraction semantics intact; it only fixes null-handling.

### Testing
- Ran the focused unit tests with `mvn -q -Dtest=DisponibilidadInsumoServiceTest test` and they completed successfully (tests for FEFO preview and the three new PS cases passed).
- Existing `DisponibilidadInsumoServiceTest` cases were executed as part of the run and did not fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980ff67e9cc8333ab7321bd21135f39)