### PR TITLE
Allow multiple PS in production formulas and remove single-PS-lot restriction

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -324,38 +324,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
         BigDecimal cantidadProgramada = orden.getCantidadProgramada();
 
-        // --- PS: detectar insumo semielaborado, pero lotePsId es OPCIONAL ---
         List<DetalleFormula> detallesFormula = obtenerDetallesFormulaSeguro(formula);
-        List<DetalleFormula> insumosPs = obtenerInsumosPs(detallesFormula);
-
-        if (insumosPs.size() > 1) {
-            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
-                    "Solo se admite un insumo de tipo PRODUCTO_SEMI_ELABORADO por fórmula");
-        }
-
-        // ID del insumo PS (si existe)
-        Long insumoPsId = insumosPs.isEmpty()
-                ? null
-                : insumosPs.get(0).getInsumo().getId().longValue();
-
-        // Lote PS seleccionado manualmente (opcional)
-        LoteProducto lotePsSeleccionado = null;
-        if (insumoPsId != null && orden.getLotePsId() != null) {
-            Long lotePsId = orden.getLotePsId();
-            lotePsSeleccionado = loteProductoRepository.findById(lotePsId)
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "LOTE_NO_ENCONTRADO"));
-
-            if (lotePsSeleccionado.getProducto() == null
-                    || lotePsSeleccionado.getProducto().getCategoriaProducto() == null
-                    || lotePsSeleccionado.getProducto().getCategoriaProducto().getTipo() != TipoCategoria.PRODUCTO_SEMI_ELABORADO) {
-                throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
-                        "El lote seleccionado no corresponde a un producto semielaborado");
-            }
-            if (lotePsSeleccionado.getEstado() != EstadoLote.LIBERADO) {
-                throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
-                        "El lote de producto semielaborado debe estar LIBERADO");
-            }
-        }
 
         // Cargar todos los productos de los insumos en una sola consulta para evitar N+1
         List<Long> insumoIds = detallesFormula.stream()
@@ -391,27 +360,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             }
 
             // ---- FEFO: preview por insumo ----
-            DistribucionFefoResult distribucionPreview;
-            if (insumoPsId != null && insumoPsId.equals(insumoId)) {
-                // PS: FEFO pero forzando a un solo lote. Si no hay selección manual, FEFO elige.
-                Long loteForzadoId = (lotePsSeleccionado != null ? lotePsSeleccionado.getId() : null);
-                distribucionPreview = disponibilidadInsumoService.calcularDisponibilidad(
-                        insumoId,
-                        cantidadRequerida,
-                        almacenesValidos,
-                        true,              // modoPreview: solo validación
-                        loteForzadoId,     // null → FEFO elige lote PS
-                        true               // bloquearMultiplesLotes: un único lote PS
-                );
-            } else {
-                // MP / ME / SU: lógica normal
-                distribucionPreview = disponibilidadInsumoService.calcularDisponibilidad(
-                        insumoId,
-                        cantidadRequerida,
-                        almacenesValidos,
-                        true               // modoPreview
-                );
-            }
+            DistribucionFefoResult distribucionPreview = disponibilidadInsumoService.calcularDisponibilidad(
+                    insumoId,
+                    cantidadRequerida,
+                    almacenesValidos,
+                    true               // modoPreview
+            );
 
             BigDecimal stockLibreFefo = Optional.ofNullable(distribucionPreview.getStockLibreTotal())
                     .orElse(BigDecimal.ZERO);
@@ -1421,10 +1375,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         if (lotesPs.isEmpty()) {
             return null;
         }
-        if (lotesPs.size() > 1) {
-            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
-                    "Solo se permite consumir un lote de producto semielaborado por orden");
-        }
         Long loteId = lotesPs.get(0);
         return loteProductoRepository.findById(loteId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "LOTE_NO_ENCONTRADO"));
@@ -1450,11 +1400,14 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
         List<DetalleFormula> detallesFormula = obtenerDetallesFormulaSeguro(formula);
         List<DetalleFormula> insumosPs = obtenerInsumosPs(detallesFormula);
-        if (insumosPs.size() > 1) {
-            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
-                    "Solo se admite un insumo de tipo PRODUCTO_SEMI_ELABORADO por fórmula");
-        }
-        Long insumoPsId = insumosPs.isEmpty() ? null : insumosPs.get(0).getInsumo().getId().longValue();
+        boolean tieneInsumoPsEnFormula = !insumosPs.isEmpty();
+        java.util.Set<Long> insumosPsIds = insumosPs.stream()
+                .map(DetalleFormula::getInsumo)
+                .filter(Objects::nonNull)
+                .map(Producto::getId)
+                .filter(Objects::nonNull)
+                .map(Integer::longValue)
+                .collect(Collectors.toSet());
 
         // Idempotencia: si ya existen solicitudes SALIDA pendientes para esta OP, no recrear
         List<EstadoSolicitudMovimiento> estadosPendientes = parseEstados(estadosSolicitudPendientesConf);
@@ -1489,8 +1442,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
         TipoCategoria tipoProducto = obtenerTipoCategoriaProducto(orden.getProducto());
         boolean esProductoSemiElaborado = tipoProducto == TipoCategoria.PRODUCTO_SEMI_ELABORADO;
-        boolean tieneInsumoPsEnFormula = insumoPsId != null;
-
         for (DetalleFormula insumo : detallesFormula) {
             if (insumo == null || insumo.getInsumo() == null) {
                 continue;
@@ -1517,7 +1468,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     .orElse(null);
 
             if (!esProductoSemiElaborado && tieneInsumoPsEnFormula
-                    && !Objects.equals(insumoId, insumoPsId)
                     && tipoInsumo == TipoCategoria.MATERIA_PRIMA) {
                 log.debug("OP-reserva: MP {} omitida en OP con PS para evitar doble consumo", insumoId);
                 continue;
@@ -1526,23 +1476,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             BigDecimal requeridaSolicitud = requerida.setScale(6, RoundingMode.HALF_UP);
             List<Long> almacenesValidos = disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo.getInsumo());
 
-            boolean esInsumoPs = insumoPsId != null && insumoPsId.equals(insumoId);
-            DistribucionFefoResult distribucion;
-            if (esInsumoPs) {
-                distribucion = disponibilidadInsumoService.calcularDisponibilidad(
-                        insumoId,
-                        requerida,
-                        almacenesValidos,
-                        false,
-                        lotePsId,
-                        true);
-            } else {
-                distribucion = disponibilidadInsumoService.calcularDisponibilidad(
-                        insumoId,
-                        requerida,
-                        almacenesValidos,
-                        false);
-            }
+            boolean esInsumoPs = insumosPsIds.contains(insumoId);
+            DistribucionFefoResult distribucion = disponibilidadInsumoService.calcularDisponibilidad(
+                    insumoId,
+                    requerida,
+                    almacenesValidos,
+                    false);
 
             BigDecimal faltanteDistribucion = Optional.ofNullable(distribucion.getFaltante())
                     .orElse(BigDecimal.ZERO)
@@ -1562,12 +1501,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             Long primerLoteId = primerDetalle.getLoteProductoId();
             if (primerLoteId == null) {
                 manejarStockInsuficiente(insumo.getInsumo(), distribucion);
-            }
-
-            if (esInsumoPs && lotePsId != null
-                    && !lotePsId.equals(primerLoteId)) {
-                throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
-                        "El lote reservado para el producto semielaborado no coincide con el solicitado");
             }
 
             SolicitudMovimientoRequestDTO solicitudReq = SolicitudMovimientoRequestDTO.builder()

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServicePsFefoTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServicePsFefoTest.java
@@ -7,7 +7,6 @@ import com.willyes.clemenintegra.bom.model.enums.EstadoFormula;
 import com.willyes.clemenintegra.bom.repository.FormulaProductoRepository;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoResponseDTO;
-import com.willyes.clemenintegra.inventario.model.LoteProducto;
 import com.willyes.clemenintegra.inventario.model.MotivoMovimiento;
 import com.willyes.clemenintegra.inventario.model.Producto;
 import com.willyes.clemenintegra.inventario.model.SolicitudMovimiento;
@@ -37,7 +36,6 @@ import com.willyes.clemenintegra.produccion.repository.EtapaProduccionRepository
 import com.willyes.clemenintegra.produccion.repository.OrdenProduccionRepository;
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoDetalle;
 import com.willyes.clemenintegra.produccion.service.model.DistribucionFefoResult;
-import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
 import org.junit.jupiter.api.BeforeEach;
@@ -186,14 +184,14 @@ class OrdenProduccionServicePsFefoTest {
     }
 
     @Test
-    @DisplayName("Crea OP con PS sin lote explícito eligiendo FEFO en un solo lote")
+    @DisplayName("Crea OP con PS sin lote explícito usando FEFO estándar")
     void crearOp_psAutoSeleccion() {
         DistribucionFefoResult preview = fefoResult(true, 501L);
         DistribucionFefoResult reserva = fefoResult(false, 501L);
 
-        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(true), isNull(), eq(true)))
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(true)))
                 .thenReturn(preview);
-        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(false), isNull(), eq(true)))
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(false)))
                 .thenReturn(reserva);
 
         ResultadoValidacionOrdenDTO resultado = service.guardarConValidacionStock(orden);
@@ -201,9 +199,9 @@ class OrdenProduccionServicePsFefoTest {
         assertThat(resultado.isEsValida()).isTrue();
         assertThat(resultado.getOrden()).isNotNull();
         verify(disponibilidadInsumoService, times(1))
-                .calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(true), isNull(), eq(true));
+                .calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(true));
         verify(disponibilidadInsumoService, times(1))
-                .calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(false), isNull(), eq(true));
+                .calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(false));
     }
 
     @Test
@@ -220,7 +218,7 @@ class OrdenProduccionServicePsFefoTest {
                 .detalles(List.of())
                 .build();
 
-        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(true), isNull(), eq(true)))
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(true)))
                 .thenReturn(preview);
 
         ResultadoValidacionOrdenDTO resultado = service.guardarConValidacionStock(orden);
@@ -231,38 +229,44 @@ class OrdenProduccionServicePsFefoTest {
     }
 
     @Test
-    @DisplayName("Valida que el lote forzado sea PS")
-    void crearOp_loteNoPs() {
-        LoteProducto lote = new LoteProducto();
-        lote.setId(900L);
-        Producto otroProducto = new Producto();
-        CategoriaProducto catMp = new CategoriaProducto();
-        catMp.setTipo(TipoCategoria.MATERIA_PRIMA);
-        otroProducto.setCategoriaProducto(catMp);
-        lote.setProducto(otroProducto);
-        orden.setLotePsId(900L);
+    @DisplayName("Permite múltiples insumos PS en la fórmula sin restricción de lote")
+    void crearOp_conMultiplesPs() {
+        Producto productoPs2 = new Producto();
+        productoPs2.setId(201);
+        CategoriaProducto categoriaPs2 = new CategoriaProducto();
+        categoriaPs2.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        productoPs2.setCategoriaProducto(categoriaPs2);
+        UnidadMedida umPs2 = new UnidadMedida();
+        umPs2.setSimbolo("KG");
+        productoPs2.setUnidadMedida(umPs2);
+        productoPs2.setModoControlInventario(ModoControlInventario.CONTROL_STOCK);
 
-        when(loteProductoRepository.findById(900L)).thenReturn(Optional.of(lote));
+        DetalleFormula insumoPs2 = new DetalleFormula();
+        insumoPs2.setInsumo(productoPs2);
+        insumoPs2.setCantidadNecesaria(BigDecimal.ONE);
 
-        assertThatThrownBy(() -> service.guardarConValidacionStock(orden))
-                .isInstanceOf(CustomBusinessException.class)
-                .hasMessageContaining("no corresponde a un producto semielaborado");
-    }
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(insumoPs, insumoPs2));
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(100L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+        when(productoRepository.findAllById(anyList())).thenReturn(List.of(productoPs, productoPs2));
 
-    @Test
-    @DisplayName("Valida que el lote PS esté LIBERADO")
-    void crearOp_lotePsNoLiberado() {
-        LoteProducto lote = new LoteProducto();
-        lote.setId(901L);
-        lote.setEstado(EstadoLote.DISPONIBLE);
-        lote.setProducto(productoPs);
-        orden.setLotePsId(901L);
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(true)))
+                .thenReturn(fefoResult(true, 501L));
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(201L), any(BigDecimal.class), anyList(), eq(true)))
+                .thenReturn(fefoResult(true, 502L));
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(false)))
+                .thenReturn(fefoResult(false, 501L));
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(201L), any(BigDecimal.class), anyList(), eq(false)))
+                .thenReturn(fefoResult(false, 502L));
 
-        when(loteProductoRepository.findById(901L)).thenReturn(Optional.of(lote));
+        ResultadoValidacionOrdenDTO resultado = service.guardarConValidacionStock(orden);
 
-        assertThatThrownBy(() -> service.guardarConValidacionStock(orden))
-                .isInstanceOf(CustomBusinessException.class)
-                .hasMessageContaining("debe estar LIBERADO");
+        assertThat(resultado.isEsValida()).isTrue();
+        verify(disponibilidadInsumoService, times(1))
+                .calcularDisponibilidad(eq(200L), any(BigDecimal.class), anyList(), eq(true));
+        verify(disponibilidadInsumoService, times(1))
+                .calcularDisponibilidad(eq(201L), any(BigDecimal.class), anyList(), eq(true));
     }
 
     private DistribucionFefoResult fefoResult(boolean preview, Long loteId) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -291,8 +291,8 @@ class OrdenProduccionServiceReservaTest {
     }
 
     @Test
-    @DisplayName("reservarInsumosParaOP usa el lote PS forzado cuando la fórmula lo requiere")
-    void reservarInsumosParaOp_conPsUsaLoteForzado() {
+    @DisplayName("reservarInsumosParaOP trata PS como insumo estándar aunque se envíe lotePsId")
+    void reservarInsumosParaOp_psSinForzarLote() {
         Producto insumoPs = new Producto();
         insumoPs.setId(200);
         insumoPs.setNombre("Base PS");
@@ -330,7 +330,7 @@ class OrdenProduccionServiceReservaTest {
                         .build()))
                 .build();
 
-        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), eq(List.of(5L)), eq(false), eq(500L), eq(true)))
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), eq(List.of(5L)), eq(false)))
                 .thenReturn(distribucion);
 
         SolicitudMovimiento solicitudBase = new SolicitudMovimiento();
@@ -341,13 +341,132 @@ class OrdenProduccionServiceReservaTest {
 
         service.reservarInsumosParaOP(1L, 500L);
 
-        verify(disponibilidadInsumoService).calcularDisponibilidad(eq(200L), any(BigDecimal.class), eq(List.of(5L)), eq(false), eq(500L), eq(true));
+        verify(disponibilidadInsumoService).calcularDisponibilidad(eq(200L), any(BigDecimal.class), eq(List.of(5L)), eq(false));
 
         ArgumentCaptor<SolicitudMovimiento> solicitudCaptor = ArgumentCaptor.forClass(SolicitudMovimiento.class);
         verify(solicitudMovimientoRepository).saveAndFlush(solicitudCaptor.capture());
         List<SolicitudMovimientoDetalle> detallesGuardados = solicitudCaptor.getValue().getDetalles();
         assertThat(detallesGuardados).hasSize(1);
         assertThat(detallesGuardados.get(0).getLote().getId()).isEqualTo(500L);
+    }
+
+    @Test
+    @DisplayName("reservarInsumosParaOP permite múltiples PS en la fórmula")
+    void reservarInsumosParaOp_multiplesPs() {
+        Producto insumoPs1 = new Producto();
+        insumoPs1.setId(200);
+        insumoPs1.setNombre("PS Base 1");
+        insumoPs1.setUnidadMedida(new UnidadMedida());
+        com.willyes.clemenintegra.inventario.model.CategoriaProducto categoriaPs1 = new com.willyes.clemenintegra.inventario.model.CategoriaProducto();
+        categoriaPs1.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        insumoPs1.setCategoriaProducto(categoriaPs1);
+
+        Producto insumoPs2 = new Producto();
+        insumoPs2.setId(201);
+        insumoPs2.setNombre("PS Base 2");
+        insumoPs2.setUnidadMedida(new UnidadMedida());
+        com.willyes.clemenintegra.inventario.model.CategoriaProducto categoriaPs2 = new com.willyes.clemenintegra.inventario.model.CategoriaProducto();
+        categoriaPs2.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        insumoPs2.setCategoriaProducto(categoriaPs2);
+
+        DetalleFormula detallePs1 = new DetalleFormula();
+        detallePs1.setInsumo(insumoPs1);
+        detallePs1.setCantidadNecesaria(BigDecimal.ONE);
+
+        DetalleFormula detallePs2 = new DetalleFormula();
+        detallePs2.setInsumo(insumoPs2);
+        detallePs2.setCantidadNecesaria(BigDecimal.ONE);
+
+        FormulaProducto formulaPs = new FormulaProducto();
+        formulaPs.setDetalles(List.of(detallePs1, detallePs2));
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formulaPs));
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(insumoPs1)).thenReturn(List.of(5L));
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(insumoPs2)).thenReturn(List.of(5L));
+        when(solicitudMovimientoService.registrarSolicitud(any(SolicitudMovimientoRequestDTO.class)))
+                .thenReturn(SolicitudMovimientoResponseDTO.builder().id(100L).build(),
+                        SolicitudMovimientoResponseDTO.builder().id(101L).build());
+
+        DistribucionFefoResult distribucionPs1 = DistribucionFefoResult.builder()
+                .productoInsumoId(insumoPs1.getId().longValue())
+                .requerido(new BigDecimal("5.50000000"))
+                .stockLibreTotal(new BigDecimal("6.000000"))
+                .faltante(BigDecimal.ZERO)
+                .suficiente(true)
+                .detalles(List.of(DistribucionFefoDetalle.builder()
+                        .loteProductoId(500L)
+                        .almacenId(5L)
+                        .cantidadCalculo(new BigDecimal("5.50000000"))
+                        .cantidadReserva(new BigDecimal("5.500000"))
+                        .disponible(new BigDecimal("6.000000"))
+                        .estado(EstadoLote.LIBERADO.name())
+                        .build()))
+                .build();
+
+        DistribucionFefoResult distribucionPs2 = DistribucionFefoResult.builder()
+                .productoInsumoId(insumoPs2.getId().longValue())
+                .requerido(new BigDecimal("5.50000000"))
+                .stockLibreTotal(new BigDecimal("6.000000"))
+                .faltante(BigDecimal.ZERO)
+                .suficiente(true)
+                .detalles(List.of(DistribucionFefoDetalle.builder()
+                        .loteProductoId(501L)
+                        .almacenId(5L)
+                        .cantidadCalculo(new BigDecimal("5.50000000"))
+                        .cantidadReserva(new BigDecimal("5.500000"))
+                        .disponible(new BigDecimal("6.000000"))
+                        .estado(EstadoLote.LIBERADO.name())
+                        .build()))
+                .build();
+
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), eq(List.of(5L)), eq(false)))
+                .thenReturn(distribucionPs1);
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(201L), any(BigDecimal.class), eq(List.of(5L)), eq(false)))
+                .thenReturn(distribucionPs2);
+
+        when(solicitudMovimientoRepository.findById(anyLong()))
+                .thenAnswer(invocation -> Optional.of(crearSolicitudBase()));
+
+        service.reservarInsumosParaOP(1L, null);
+
+        verify(disponibilidadInsumoService).calcularDisponibilidad(eq(200L), any(BigDecimal.class), eq(List.of(5L)), eq(false));
+        verify(disponibilidadInsumoService).calcularDisponibilidad(eq(201L), any(BigDecimal.class), eq(List.of(5L)), eq(false));
+    }
+
+    @Test
+    @DisplayName("obtenerLotePsReservado no falla si hay múltiples lotes PS")
+    void obtenerLotePsReservado_conMultiplesLotesPs() {
+        LoteProducto lote1 = new LoteProducto();
+        lote1.setId(701L);
+        Producto ps1 = new Producto();
+        com.willyes.clemenintegra.inventario.model.CategoriaProducto categoriaPs = new com.willyes.clemenintegra.inventario.model.CategoriaProducto();
+        categoriaPs.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        ps1.setCategoriaProducto(categoriaPs);
+        lote1.setProducto(ps1);
+
+        LoteProducto lote2 = new LoteProducto();
+        lote2.setId(702L);
+        Producto ps2 = new Producto();
+        ps2.setCategoriaProducto(categoriaPs);
+        lote2.setProducto(ps2);
+
+        SolicitudMovimientoDetalle detalle1 = new SolicitudMovimientoDetalle();
+        detalle1.setLote(lote1);
+        SolicitudMovimientoDetalle detalle2 = new SolicitudMovimientoDetalle();
+        detalle2.setLote(lote2);
+
+        SolicitudMovimiento solicitud = new SolicitudMovimiento();
+        solicitud.setDetalles(List.of(detalle1, detalle2));
+
+        when(solicitudMovimientoRepository.findWithDetalles(eq(1L), eq(null), eq(null), eq(null), eq(false), anyList()))
+                .thenReturn(List.of(solicitud));
+        when(loteProductoRepository.findById(701L)).thenReturn(Optional.of(lote1));
+
+        LoteProducto resultado = ReflectionTestUtils.invokeMethod(service, "obtenerLotePsReservado", 1L);
+
+        assertThat(resultado).isNotNull();
+        assertThat(resultado.getId()).isEqualTo(701L);
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Remove backend rules that blocked having more than one PRODUCTO_SEMI_ELABORADO (PS) in a formula and that forced a single PS lot per production order so PS can be handled like any other insumo in FEFO flows.
- Ensure the API remains backwards-compatible with an optional `lotePsId` but do not treat it as a required or limiting parameter.

### Description
- Removed validation that threw when a formula contained more than one PS and stopped forcing a single PS insumo in `guardarConValidacionStock` and `reservarInsumosParaOP` by deleting those `SOLICITUD_INVALIDA` checks and related special-case branches.
- Stopped forcing a unique `lotePs` for consumption by removing the single-lot check in `obtenerLotePsReservado`, returning the first reserved lot when multiple exist instead of failing.
- Decoupled the `lotePsId` special-flow: FEFO preview/reserva now calls `disponibilidadInsumoService.calcularDisponibilidad` with the common signature for all insumos (PS treated equal to MP/ME), while still accepting `lotePsId` in the API without enforcing it.
- Updated unit tests to reflect the new behavior and added tests for multi-PS scenarios: modified `OrdenProduccionServicePsFefoTest` and `OrdenProduccionServiceReservaTest` to assert that multiple PS are allowed, that FEFO selection works per-insumo, and that `obtenerLotePsReservado` does not fail when multiple PS lots exist.

### Testing
- Ran the targeted unit suites with `mvn -Dtest=OrdenProduccionServicePsFefoTest,OrdenProduccionServiceReservaTest test`, which compiled and executed the updated tests successfully after small test adjustments to match the new FEFO signatures.
- Tests exercised creation (`guardarConValidacionStock`) and reservation (`reservarInsumosParaOP`) flows including: (1) OP creation with two distinct PS in the formula, (2) `reservarInsumosParaOP` with multiple PS, and (3) `obtenerLotePsReservado` when multiple PS lots exist; the updated tests passed.
- Adjusted mocks in tests to remove expectations of the old PS-specific `calcularDisponibilidad` overload and to assert calls to the standardized FEFO method.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f8bfba84833381bc02ad2ef3bcd5)