### PR TITLE
Reservas FEFO multi-lote y no omitir MP cuando existe PS en fórmula

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1399,16 +1399,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "FORMULA_NO_ENCONTRADA"));
 
         List<DetalleFormula> detallesFormula = obtenerDetallesFormulaSeguro(formula);
-        List<DetalleFormula> insumosPs = obtenerInsumosPs(detallesFormula);
-        boolean tieneInsumoPsEnFormula = !insumosPs.isEmpty();
-        java.util.Set<Long> insumosPsIds = insumosPs.stream()
-                .map(DetalleFormula::getInsumo)
-                .filter(Objects::nonNull)
-                .map(Producto::getId)
-                .filter(Objects::nonNull)
-                .map(Integer::longValue)
-                .collect(Collectors.toSet());
-
         // Idempotencia: si ya existen solicitudes SALIDA pendientes para esta OP, no recrear
         List<EstadoSolicitudMovimiento> estadosPendientes = parseEstados(estadosSolicitudPendientesConf);
         List<SolicitudMovimiento> yaPendientes = Optional.ofNullable(
@@ -1440,8 +1430,6 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 .findById(catalogResolver.getTipoDetalleSalidaId())
                 .orElseThrow(() -> new IllegalStateException("Tipo detalle SALIDA_PRODUCCION no configurado"));
 
-        TipoCategoria tipoProducto = obtenerTipoCategoriaProducto(orden.getProducto());
-        boolean esProductoSemiElaborado = tipoProducto == TipoCategoria.PRODUCTO_SEMI_ELABORADO;
         for (DetalleFormula insumo : detallesFormula) {
             if (insumo == null || insumo.getInsumo() == null) {
                 continue;
@@ -1463,20 +1451,9 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 continue;
             }
 
-            TipoCategoria tipoInsumo = Optional.ofNullable(insumo.getInsumo().getCategoriaProducto())
-                    .map(CategoriaProducto::getTipo)
-                    .orElse(null);
-
-            if (!esProductoSemiElaborado && tieneInsumoPsEnFormula
-                    && tipoInsumo == TipoCategoria.MATERIA_PRIMA) {
-                log.debug("OP-reserva: MP {} omitida en OP con PS para evitar doble consumo", insumoId);
-                continue;
-            }
-
             BigDecimal requeridaSolicitud = requerida.setScale(6, RoundingMode.HALF_UP);
             List<Long> almacenesValidos = disponibilidadInsumoService.resolverAlmacenesPreferidos(insumo.getInsumo());
 
-            boolean esInsumoPs = insumosPsIds.contains(insumoId);
             DistribucionFefoResult distribucion = disponibilidadInsumoService.calcularDisponibilidad(
                     insumoId,
                     requerida,
@@ -1494,57 +1471,69 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 manejarStockInsuficiente(insumo.getInsumo(), distribucion);
             }
 
-            if (distribucion.getDetalles().isEmpty()) {
-                manejarStockInsuficiente(insumo.getInsumo(), distribucion);
-            }
-            DistribucionFefoDetalle primerDetalle = distribucion.getDetalles().get(0);
-            Long primerLoteId = primerDetalle.getLoteProductoId();
-            if (primerLoteId == null) {
+            List<DistribucionFefoDetalle> detallesDistribucion = distribucion.getDetalles();
+            if (detallesDistribucion.isEmpty()) {
                 manejarStockInsuficiente(insumo.getInsumo(), distribucion);
             }
 
-            SolicitudMovimientoRequestDTO solicitudReq = SolicitudMovimientoRequestDTO.builder()
-                    .tipoMovimiento(TipoMovimiento.SALIDA)
-                    .productoId(insumoId)
-                    .loteId(primerLoteId)
-                    .cantidad(requeridaSolicitud)
-                    .ordenProduccionId(orden.getId())
-                    .usuarioSolicitanteId(usuario.getId())
-                    .motivoMovimientoId(motivo.getId())
-                    .tipoMovimientoDetalleId(detalle.getId())
-                    .almacenDestinoId(catalogResolver.getAlmacenPreBodegaProduccionId())
-                    .build();
+            BigDecimal totalReservado = detallesDistribucion.stream()
+                    .map(DistribucionFefoDetalle::getCantidadReserva)
+                    .filter(Objects::nonNull)
+                    .filter(cantidad -> cantidad.compareTo(BigDecimal.ZERO) > 0)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add)
+                    .setScale(6, RoundingMode.HALF_UP);
 
-            SolicitudMovimientoResponseDTO solicitudCreada = solicitudMovimientoService.registrarSolicitud(solicitudReq);
-            Long solicitudId = solicitudCreada.getId();
-            if (solicitudId == null) {
-                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "SOLICITUD_NO_ENCONTRADA");
+            if (totalReservado.compareTo(requeridaSolicitud) != 0) {
+                manejarStockInsuficiente(insumo.getInsumo(), distribucion);
             }
 
-            SolicitudMovimiento solicitud = solicitudMovimientoRepository.findById(solicitudId)
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "SOLICITUD_NO_ENCONTRADA"));
-
-            solicitud.setLote(null);
-            solicitud.setAlmacenOrigen(null);
-
-            List<SolicitudMovimientoDetalle> detallesSolicitud = solicitud.getDetalles();
-            if (detallesSolicitud == null) {
-                detallesSolicitud = new ArrayList<>();
-                solicitud.setDetalles(detallesSolicitud);
-            } else {
-                log.debug("OP-RESERVA antes limpiar: detallesPrevios={} ordenId={} insumoId={}",
-                        detallesSolicitud.size(),
-                        ordenId,
-                        insumoId);
-                detallesSolicitud.clear();
-            }
-
-            for (DistribucionFefoDetalle detalleDistribucion : distribucion.getDetalles()) {
+            for (DistribucionFefoDetalle detalleDistribucion : detallesDistribucion) {
                 BigDecimal usarDetalle = Optional.ofNullable(detalleDistribucion.getCantidadReserva())
                         .orElse(BigDecimal.ZERO);
                 if (usarDetalle.compareTo(BigDecimal.ZERO) <= 0) {
                     continue;
                 }
+                Long loteId = detalleDistribucion.getLoteProductoId();
+                if (loteId == null) {
+                    manejarStockInsuficiente(insumo.getInsumo(), distribucion);
+                }
+
+                SolicitudMovimientoRequestDTO solicitudReq = SolicitudMovimientoRequestDTO.builder()
+                        .tipoMovimiento(TipoMovimiento.SALIDA)
+                        .productoId(insumoId)
+                        .loteId(loteId)
+                        .cantidad(usarDetalle)
+                        .ordenProduccionId(orden.getId())
+                        .usuarioSolicitanteId(usuario.getId())
+                        .motivoMovimientoId(motivo.getId())
+                        .tipoMovimientoDetalleId(detalle.getId())
+                        .almacenDestinoId(catalogResolver.getAlmacenPreBodegaProduccionId())
+                        .build();
+
+                SolicitudMovimientoResponseDTO solicitudCreada = solicitudMovimientoService.registrarSolicitud(solicitudReq);
+                Long solicitudId = solicitudCreada.getId();
+                if (solicitudId == null) {
+                    throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "SOLICITUD_NO_ENCONTRADA");
+                }
+
+                SolicitudMovimiento solicitud = solicitudMovimientoRepository.findById(solicitudId)
+                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "SOLICITUD_NO_ENCONTRADA"));
+
+                solicitud.setLote(null);
+                solicitud.setAlmacenOrigen(null);
+
+                List<SolicitudMovimientoDetalle> detallesSolicitud = solicitud.getDetalles();
+                if (detallesSolicitud == null) {
+                    detallesSolicitud = new ArrayList<>();
+                    solicitud.setDetalles(detallesSolicitud);
+                } else {
+                    log.debug("OP-RESERVA antes limpiar: detallesPrevios={} ordenId={} insumoId={}",
+                            detallesSolicitud.size(),
+                            ordenId,
+                            insumoId);
+                    detallesSolicitud.clear();
+                }
+
                 Long almacenOrigenId = detalleDistribucion.getAlmacenId();
                 Long almacenDestinoId = solicitud.getAlmacenDestino() != null
                         ? Long.valueOf(solicitud.getAlmacenDestino().getId())
@@ -1563,9 +1552,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
 
                 SolicitudMovimientoDetalle detSolicitud = SolicitudMovimientoDetalle.builder()
                         .solicitudMovimiento(solicitud)
-                        .lote(detalleDistribucion.getLoteProductoId() != null
-                                ? new LoteProducto(detalleDistribucion.getLoteProductoId())
-                                : null)
+                        .lote(new LoteProducto(loteId))
                         .cantidad(usarDetalle)
                         .almacenOrigen(almacenOrigenId != null
                                 ? new Almacen(Math.toIntExact(almacenOrigenId))
@@ -1573,10 +1560,10 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                         .almacenDestino(solicitud.getAlmacenDestino())
                         .build();
                 detallesSolicitud.add(detSolicitud);
-            }
 
-            solicitudMovimientoRepository.saveAndFlush(solicitud);
-            reservaLoteService.sincronizarReservasSolicitud(solicitud);
+                solicitudMovimientoRepository.saveAndFlush(solicitud);
+                reservaLoteService.sincronizarReservasSolicitud(solicitud);
+            }
         }
     }
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -1857,8 +1857,8 @@ class OrdenProduccionServiceImplTest {
     }
 
     @Test
-    @DisplayName("reservarInsumosParaOP en PT con PS omite MP y conserva PS + ME")
-    void reservarInsumosParaOP_ptConPsIncluyePsYMe() {
+    @DisplayName("reservarInsumosParaOP en PT con PS incluye MP, PS y ME")
+    void reservarInsumosParaOP_ptConPsIncluyeTodos() {
         doCallRealMethod().when(service).reservarInsumosParaOP(anyLong(), any());
         ReflectionTestUtils.setField(service, "estadosSolicitudPendientesConf", "PENDIENTE,AUTORIZADA");
 
@@ -1885,14 +1885,14 @@ class OrdenProduccionServiceImplTest {
         service.reservarInsumosParaOP(600L, null);
 
         ArgumentCaptor<SolicitudMovimientoRequestDTO> captor = ArgumentCaptor.forClass(SolicitudMovimientoRequestDTO.class);
-        verify(solicitudMovimientoService, times(2)).registrarSolicitud(captor.capture());
+        verify(solicitudMovimientoService, times(3)).registrarSolicitud(captor.capture());
 
         List<Long> productosSolicitados = captor.getAllValues().stream()
                 .map(SolicitudMovimientoRequestDTO::getProductoId)
                 .toList();
 
         assertThat(productosSolicitados)
-                .containsExactlyInAnyOrder(301L, 302L);
+                .containsExactlyInAnyOrder(301L, 302L, 303L);
     }
 
     @Test

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -194,7 +194,10 @@ class OrdenProduccionServiceReservaTest {
     @DisplayName("reservarInsumosParaOP genera detalles multi-lote con escala ajustada")
     void reservarInsumosParaOp_creaDetallesMultiLote() {
         when(solicitudMovimientoService.registrarSolicitud(any(SolicitudMovimientoRequestDTO.class)))
-                .thenReturn(SolicitudMovimientoResponseDTO.builder().id(100L).build());
+                .thenReturn(SolicitudMovimientoResponseDTO.builder().id(100L).build(),
+                        SolicitudMovimientoResponseDTO.builder().id(101L).build());
+        when(solicitudMovimientoRepository.findById(anyLong()))
+                .thenAnswer(invocation -> Optional.of(crearSolicitudBase()));
         DistribucionFefoResult resultado = DistribucionFefoResult.builder()
                 .productoInsumoId(50L)
                 .requerido(new BigDecimal("6.790123"))
@@ -229,12 +232,18 @@ class OrdenProduccionServiceReservaTest {
         service.reservarInsumosParaOP(1L, null);
 
         ArgumentCaptor<SolicitudMovimientoRequestDTO> dtoCaptor = ArgumentCaptor.forClass(SolicitudMovimientoRequestDTO.class);
-        verify(solicitudMovimientoService).registrarSolicitud(dtoCaptor.capture());
-        assertThat(dtoCaptor.getValue().getCantidad()).isEqualByComparingTo(new BigDecimal("6.790123"));
+        verify(solicitudMovimientoService, org.mockito.Mockito.times(2)).registrarSolicitud(dtoCaptor.capture());
+        List<BigDecimal> cantidadesSolicitadas = dtoCaptor.getAllValues().stream()
+                .map(SolicitudMovimientoRequestDTO::getCantidad)
+                .toList();
+        assertThat(cantidadesSolicitadas)
+                .containsExactlyInAnyOrder(new BigDecimal("3.123456"), new BigDecimal("3.666667"));
 
         ArgumentCaptor<SolicitudMovimiento> solicitudCaptor = ArgumentCaptor.forClass(SolicitudMovimiento.class);
-        verify(solicitudMovimientoRepository).saveAndFlush(solicitudCaptor.capture());
-        List<SolicitudMovimientoDetalle> detalles = solicitudCaptor.getValue().getDetalles();
+        verify(solicitudMovimientoRepository, org.mockito.Mockito.times(2)).saveAndFlush(solicitudCaptor.capture());
+        List<SolicitudMovimientoDetalle> detalles = solicitudCaptor.getAllValues().stream()
+                .flatMap(solicitud -> solicitud.getDetalles().stream())
+                .toList();
         assertThat(detalles).hasSize(2);
         BigDecimal total = detalles.stream()
                 .map(SolicitudMovimientoDetalle::getCantidad)
@@ -242,7 +251,141 @@ class OrdenProduccionServiceReservaTest {
         assertThat(detalles.get(0).getCantidad().scale()).isEqualTo(6);
         assertThat(detalles.get(1).getCantidad().scale()).isEqualTo(6);
         assertThat(total).isEqualByComparingTo(new BigDecimal("6.790123"));
-        verify(reservaLoteService).sincronizarReservasSolicitud(solicitudCaptor.getValue());
+        verify(reservaLoteService, org.mockito.Mockito.times(2)).sincronizarReservasSolicitud(any());
+    }
+
+    @Test
+    @DisplayName("reservarInsumosParaOP no omite MP cuando hay PS en la fórmula")
+    void reservarInsumosParaOp_noOmiteMpConPs() {
+        Producto insumoPs = new Producto();
+        insumoPs.setId(200);
+        insumoPs.setNombre("Base PS");
+        insumoPs.setUnidadMedida(new UnidadMedida());
+        com.willyes.clemenintegra.inventario.model.CategoriaProducto categoriaPs =
+                new com.willyes.clemenintegra.inventario.model.CategoriaProducto();
+        categoriaPs.setTipo(TipoCategoria.PRODUCTO_SEMI_ELABORADO);
+        insumoPs.setCategoriaProducto(categoriaPs);
+        insumoPs.setModoControlInventario(ModoControlInventario.CONTROL_STOCK);
+
+        Producto insumoMp = new Producto();
+        insumoMp.setId(201);
+        insumoMp.setNombre("MP Extra");
+        insumoMp.setUnidadMedida(new UnidadMedida());
+        com.willyes.clemenintegra.inventario.model.CategoriaProducto categoriaMp =
+                new com.willyes.clemenintegra.inventario.model.CategoriaProducto();
+        categoriaMp.setTipo(TipoCategoria.MATERIA_PRIMA);
+        insumoMp.setCategoriaProducto(categoriaMp);
+        insumoMp.setModoControlInventario(ModoControlInventario.CONTROL_STOCK);
+
+        DetalleFormula detallePs = new DetalleFormula();
+        detallePs.setInsumo(insumoPs);
+        detallePs.setCantidadNecesaria(BigDecimal.ONE);
+        DetalleFormula detalleMp = new DetalleFormula();
+        detalleMp.setInsumo(insumoMp);
+        detalleMp.setCantidadNecesaria(BigDecimal.ONE);
+
+        FormulaProducto formula = new FormulaProducto();
+        formula.setDetalles(List.of(detallePs, detalleMp));
+
+        when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
+                .thenReturn(Optional.of(formula));
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(insumoPs)).thenReturn(List.of(5L));
+        when(disponibilidadInsumoService.resolverAlmacenesPreferidos(insumoMp)).thenReturn(List.of(5L));
+
+        DistribucionFefoResult distribucionPs = DistribucionFefoResult.builder()
+                .productoInsumoId(insumoPs.getId().longValue())
+                .requerido(new BigDecimal("5.500000"))
+                .stockLibreTotal(new BigDecimal("5.500000"))
+                .faltante(BigDecimal.ZERO)
+                .suficiente(true)
+                .detalles(List.of(DistribucionFefoDetalle.builder()
+                        .loteProductoId(300L)
+                        .almacenId(5L)
+                        .cantidadCalculo(new BigDecimal("5.50000000"))
+                        .cantidadReserva(new BigDecimal("5.500000"))
+                        .disponible(new BigDecimal("5.500000"))
+                        .estado(EstadoLote.LIBERADO.name())
+                        .build()))
+                .build();
+
+        DistribucionFefoResult distribucionMp = DistribucionFefoResult.builder()
+                .productoInsumoId(insumoMp.getId().longValue())
+                .requerido(new BigDecimal("5.500000"))
+                .stockLibreTotal(new BigDecimal("5.500000"))
+                .faltante(BigDecimal.ZERO)
+                .suficiente(true)
+                .detalles(List.of(DistribucionFefoDetalle.builder()
+                        .loteProductoId(301L)
+                        .almacenId(5L)
+                        .cantidadCalculo(new BigDecimal("5.50000000"))
+                        .cantidadReserva(new BigDecimal("5.500000"))
+                        .disponible(new BigDecimal("5.500000"))
+                        .estado(EstadoLote.LIBERADO.name())
+                        .build()))
+                .build();
+
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(200L), any(BigDecimal.class), eq(List.of(5L)), eq(false)))
+                .thenReturn(distribucionPs);
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(201L), any(BigDecimal.class), eq(List.of(5L)), eq(false)))
+                .thenReturn(distribucionMp);
+
+        when(solicitudMovimientoService.registrarSolicitud(any(SolicitudMovimientoRequestDTO.class)))
+                .thenReturn(SolicitudMovimientoResponseDTO.builder().id(100L).build(),
+                        SolicitudMovimientoResponseDTO.builder().id(101L).build());
+        when(solicitudMovimientoRepository.findById(anyLong())).thenReturn(Optional.of(crearSolicitudBase()));
+
+        service.reservarInsumosParaOP(1L, null);
+
+        ArgumentCaptor<SolicitudMovimientoRequestDTO> captor = ArgumentCaptor.forClass(SolicitudMovimientoRequestDTO.class);
+        verify(solicitudMovimientoService, org.mockito.Mockito.times(2)).registrarSolicitud(captor.capture());
+        List<Long> productosSolicitados = captor.getAllValues().stream()
+                .map(SolicitudMovimientoRequestDTO::getProductoId)
+                .toList();
+        assertThat(productosSolicitados).containsExactlyInAnyOrder(200L, 201L);
+    }
+
+    @Test
+    @DisplayName("reservarInsumosParaOP mantiene comportamiento con un solo lote FEFO")
+    void reservarInsumosParaOp_unSoloLoteFefo() {
+        when(solicitudMovimientoService.registrarSolicitud(any(SolicitudMovimientoRequestDTO.class)))
+                .thenReturn(SolicitudMovimientoResponseDTO.builder().id(100L).build());
+        when(solicitudMovimientoRepository.findById(anyLong())).thenReturn(Optional.of(crearSolicitudBase()));
+
+        DistribucionFefoResult resultado = DistribucionFefoResult.builder()
+                .productoInsumoId(50L)
+                .requerido(new BigDecimal("6.790123"))
+                .stockFisicoTotal(new BigDecimal("6.790123"))
+                .stockReservadoTotal(BigDecimal.ZERO)
+                .stockLibreTotal(new BigDecimal("6.790123"))
+                .faltante(BigDecimal.ZERO)
+                .suficiente(true)
+                .detalles(List.of(
+                        DistribucionFefoDetalle.builder()
+                                .loteProductoId(200L)
+                                .almacenId(5L)
+                                .cantidadCalculo(new BigDecimal("6.79012300"))
+                                .cantidadReserva(new BigDecimal("6.790123"))
+                                .disponible(new BigDecimal("6.790123"))
+                                .estado("DISPONIBLE")
+                                .build()
+                ))
+                .build();
+
+        when(disponibilidadInsumoService.calcularDisponibilidad(eq(50L), any(BigDecimal.class), anyList(), eq(false)))
+                .thenReturn(resultado);
+
+        service.reservarInsumosParaOP(1L, null);
+
+        ArgumentCaptor<SolicitudMovimientoRequestDTO> dtoCaptor = ArgumentCaptor.forClass(SolicitudMovimientoRequestDTO.class);
+        verify(solicitudMovimientoService).registrarSolicitud(dtoCaptor.capture());
+        assertThat(dtoCaptor.getValue().getCantidad()).isEqualByComparingTo(new BigDecimal("6.790123"));
+
+        ArgumentCaptor<SolicitudMovimiento> solicitudCaptor = ArgumentCaptor.forClass(SolicitudMovimiento.class);
+        verify(solicitudMovimientoRepository).saveAndFlush(solicitudCaptor.capture());
+        List<SolicitudMovimientoDetalle> detalles = solicitudCaptor.getValue().getDetalles();
+        assertThat(detalles).hasSize(1);
+        assertThat(detalles.get(0).getCantidad()).isEqualByComparingTo(new BigDecimal("6.790123"));
+        assertThat(detalles.get(0).getLote().getId()).isEqualTo(200L);
     }
 
     @Test
@@ -569,6 +712,8 @@ class OrdenProduccionServiceReservaTest {
         when(disponibilidadInsumoService.resolverAlmacenesPreferidos(jarabe)).thenReturn(List.of(5L));
         when(solicitudMovimientoService.registrarSolicitud(any(SolicitudMovimientoRequestDTO.class)))
                 .thenReturn(SolicitudMovimientoResponseDTO.builder().id(100L).build());
+        when(solicitudMovimientoRepository.findById(anyLong()))
+                .thenAnswer(invocation -> Optional.of(crearSolicitudBase()));
         when(disponibilidadInsumoService.calcularDisponibilidad(eq(60L), any(BigDecimal.class), eq(List.of(5L)), eq(false)))
                 .thenReturn(crearDistribucionJarabeResult(60L));
 
@@ -577,14 +722,16 @@ class OrdenProduccionServiceReservaTest {
         assertThatCode(() -> service.reservarInsumosParaOP(1L, null)).doesNotThrowAnyException();
 
         ArgumentCaptor<SolicitudMovimiento> solicitudCaptor = ArgumentCaptor.forClass(SolicitudMovimiento.class);
-        verify(solicitudMovimientoRepository).saveAndFlush(solicitudCaptor.capture());
-        List<SolicitudMovimientoDetalle> detalles = solicitudCaptor.getValue().getDetalles();
+        verify(solicitudMovimientoRepository, org.mockito.Mockito.times(7)).saveAndFlush(solicitudCaptor.capture());
+        List<SolicitudMovimientoDetalle> detalles = solicitudCaptor.getAllValues().stream()
+                .flatMap(solicitud -> solicitud.getDetalles().stream())
+                .toList();
         assertThat(detalles).hasSize(7);
         BigDecimal total = detalles.stream()
                 .map(SolicitudMovimientoDetalle::getCantidad)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
         assertThat(total).isEqualByComparingTo(new BigDecimal("139650.000000"));
-        verify(reservaLoteService).sincronizarReservasSolicitud(solicitudCaptor.getValue());
+        verify(reservaLoteService, org.mockito.Mockito.times(7)).sincronizarReservasSolicitud(any());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Evitar que el sistema omita automáticamente materias primas (MP) o materiales de empaque (ME) cuando hay productos semielaborados (PS) en la fórmula, ya que MP/ME adicionales deben reservarse y consumirse.
- Corregir la lógica de reserva FEFO que antes asignaba toda la cantidad al primer lote en lugar de respetar la distribución real por lotes.

### Description
- Eliminé la rama que omitía MP/ME por la presencia de PS en `reservarInsumosParaOP`, dejando sólo la exclusión por `SIN_CONTROL_STOCK` para mantener la excepción vigente.
- Reemplacé la lógica que tomaba el `primerDetalle` por una iteración sobre `distribucion.getDetalles()` y ahora se crean solicitudes/solicitudes por lote con la cantidad parcial (`cantidadReserva`) devuelta por FEFO.
- Añadí validaciones: si la lista de detalles FEFO está vacía o la suma de `cantidadReserva` difiere de la cantidad requerida (con escala esperada), o si algún `loteId` es `null`, se invoca `manejarStockInsuficiente(...)`.
- Actualicé pruebas: ajusté el test de PT con PS para esperar MP+PS+ME; y añadí/actualicé tests en `OrdenProduccionServiceReservaTest` para cubrir multi-lote FEFO, caso de un solo lote, y que MP no se omite cuando hay PS.

### Testing
- Ejecuté `mvn -q -Dtest=OrdenProduccionServicePsFefoTest,OrdenProduccionServiceReservaTest test` para validar los cambios.
- Las pruebas automatizadas relevantes (`OrdenProduccionServicePsFefoTest` y `OrdenProduccionServiceReservaTest`) se ejecutaron tras los ajustes y pasaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982091b600c833383340923dfdd67c5)