### PR TITLE
Enforce cierre PARCIAL/TOTAL limits and use pessimistic lock in registrarCierre

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -862,7 +862,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     public OrdenProduccion registrarCierre(Long id, CierreProduccionRequestDTO dto) {
         String traceId = UUID.randomUUID().toString();
         try (MDC.MDCCloseable ignored = MDC.putCloseable("opTraceId", traceId)) {
-            OrdenProduccion orden = repository.findById(id)
+            OrdenProduccion orden = repository.findByIdForUpdate(id)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ORDEN_NO_ENCONTRADA"));
 
             if (orden.getEstado() == EstadoProduccion.FINALIZADA ||
@@ -933,6 +933,32 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             BigDecimal cantidadProgramada = Optional.ofNullable(orden.getCantidadProgramada()).orElse(BigDecimal.ZERO);
             BigDecimal producidaAntes = Optional.ofNullable(orden.getCantidadProducidaAcumulada()).orElse(BigDecimal.ZERO);
             BigDecimal producidaDespues = producidaAntes.add(cantidad);
+
+            if (dto.getTipo() == TipoCierre.PARCIAL) {
+                if (producidaDespues.compareTo(cantidadProgramada) >= 0) {
+                    ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.UNPROCESSABLE_ENTITY);
+                    problem.setTitle("Regla de cierre de Orden de Producción");
+                    problem.setDetail("El cierre parcial no puede completar o exceder la cantidad programada.");
+                    problem.setProperty("code", "CIERRE_PARCIAL_SUPERA_PROGRAMADA");
+                    problem.setProperty("cantidadProgramada", cantidadProgramada);
+                    problem.setProperty("acumuladoActual", producidaAntes);
+                    problem.setProperty("cantidadSolicitada", cantidad);
+                    problem.setProperty("acumuladoPropuesto", producidaDespues);
+                    throw new ErrorResponseException(HttpStatus.UNPROCESSABLE_ENTITY, problem, null);
+                }
+            } else if (dto.getTipo() == TipoCierre.TOTAL) {
+                if (producidaDespues.compareTo(cantidadProgramada) != 0) {
+                    ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.UNPROCESSABLE_ENTITY);
+                    problem.setTitle("Regla de cierre de Orden de Producción");
+                    problem.setDetail("El cierre total debe completar exactamente la cantidad programada.");
+                    problem.setProperty("code", "CIERRE_TOTAL_NO_COINCIDE_PROGRAMADA");
+                    problem.setProperty("cantidadProgramada", cantidadProgramada);
+                    problem.setProperty("acumuladoActual", producidaAntes);
+                    problem.setProperty("cantidadSolicitada", cantidad);
+                    problem.setProperty("acumuladoPropuesto", producidaDespues);
+                    throw new ErrorResponseException(HttpStatus.UNPROCESSABLE_ENTITY, problem, null);
+                }
+            }
             boolean cierreDefinitivo = esCierreDefinitivo(dto);
             EstadoProduccion estadoObjetivo = calcularEstadoObjetivo(orden, producidaDespues, cierreDefinitivo);
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -1106,7 +1106,7 @@ class OrdenProduccionServiceImplTest {
     @DisplayName("registrarCierre no re-ejecuta consumo cuando la orden ya está cerrada")
     void registrarCierre_idempotenciaOrdenFinalizada() {
         OrdenProduccion orden = crearOrdenBase(255L, new BigDecimal("50"), BigDecimal.ZERO, EstadoProduccion.FINALIZADA);
-        when(ordenProduccionRepository.findById(255L)).thenReturn(Optional.of(orden));
+        when(ordenProduccionRepository.findByIdForUpdate(255L)).thenReturn(Optional.of(orden));
 
         CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
                 .cantidad(new BigDecimal("5"))
@@ -1119,6 +1119,102 @@ class OrdenProduccionServiceImplTest {
                 .isEqualTo("ORDEN_NO_CERRABLE");
 
         verify(movimientoInventarioService, never()).consumirInsumosPorOrden(anyLong(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("registrarCierre parcial no puede completar la cantidad programada")
+    void registrarCierre_parcialNoCompletaProgramada() {
+        OrdenProduccion orden = crearOrdenBase(310L, new BigDecimal("30000"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("30000"))
+                .tipo(TipoCierre.PARCIAL)
+                .build();
+
+        assertThatThrownBy(() -> service.registrarCierre(310L, dto))
+                .isInstanceOf(ErrorResponseException.class)
+                .satisfies(ex -> {
+                    ErrorResponseException error = (ErrorResponseException) ex;
+                    ProblemDetail body = error.getBody();
+                    assertThat(body.getProperties().get("code")).isEqualTo("CIERRE_PARCIAL_SUPERA_PROGRAMADA");
+                });
+    }
+
+    @Test
+    @DisplayName("registrarCierre parcial no puede completar programada con el restante exacto")
+    void registrarCierre_parcialNoCompletaConRestante() {
+        OrdenProduccion orden = crearOrdenBase(311L, new BigDecimal("30000"), new BigDecimal("29999"), EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("1"))
+                .tipo(TipoCierre.PARCIAL)
+                .build();
+
+        assertThatThrownBy(() -> service.registrarCierre(311L, dto))
+                .isInstanceOf(ErrorResponseException.class)
+                .satisfies(ex -> {
+                    ErrorResponseException error = (ErrorResponseException) ex;
+                    ProblemDetail body = error.getBody();
+                    assertThat(body.getProperties().get("code")).isEqualTo("CIERRE_PARCIAL_SUPERA_PROGRAMADA");
+                });
+    }
+
+    @Test
+    @DisplayName("registrarCierre parcial permite quedarse debajo de la programada")
+    void registrarCierre_parcialPermiteAcumularMenor() {
+        OrdenProduccion orden = crearOrdenBase(312L, new BigDecimal("30000"), new BigDecimal("10000"), EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("19999"))
+                .tipo(TipoCierre.PARCIAL)
+                .build();
+
+        OrdenProduccion resultado = service.registrarCierre(312L, dto);
+
+        assertThat(resultado.getCantidadProducidaAcumulada()).isEqualByComparingTo(new BigDecimal("29999.00"));
+        assertThat(resultado.getEstado()).isEqualTo(EstadoProduccion.EN_PROCESO);
+    }
+
+    @Test
+    @DisplayName("registrarCierre total debe cerrar restante exacto")
+    void registrarCierre_totalDebeCerrarExacto() {
+        OrdenProduccion orden = crearOrdenBase(313L, new BigDecimal("30000"), new BigDecimal("29999"), EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("1"))
+                .tipo(TipoCierre.TOTAL)
+                .build();
+
+        OrdenProduccion resultado = service.registrarCierre(313L, dto);
+
+        assertThat(resultado.getCantidadProducidaAcumulada()).isEqualByComparingTo(new BigDecimal("30000.00"));
+        assertThat(resultado.getEstado()).isEqualTo(EstadoProduccion.FINALIZADA);
+    }
+
+    @Test
+    @DisplayName("registrarCierre total rechaza cantidad que no completa la programada")
+    void registrarCierre_totalNoCoincideProgramada() {
+        OrdenProduccion orden = crearOrdenBase(314L, new BigDecimal("30000"), new BigDecimal("20000"), EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("5000"))
+                .tipo(TipoCierre.TOTAL)
+                .build();
+
+        assertThatThrownBy(() -> service.registrarCierre(314L, dto))
+                .isInstanceOf(ErrorResponseException.class)
+                .satisfies(ex -> {
+                    ErrorResponseException error = (ErrorResponseException) ex;
+                    ProblemDetail body = error.getBody();
+                    assertThat(body.getProperties().get("code")).isEqualTo("CIERRE_TOTAL_NO_COINCIDE_PROGRAMADA");
+                });
     }
 
     @Test
@@ -1142,7 +1238,7 @@ class OrdenProduccionServiceImplTest {
     }
 
     @Test
-    @DisplayName("registrarCierre total incompleto exige confirmación antes de cerrar")
+    @DisplayName("registrarCierre total incompleto es rechazado")
     void registrarCierre_totalIncompletoRequiereConfirmacion() {
         OrdenProduccion orden = crearOrdenBase(301L, new BigDecimal("100"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
         stubInfraCierre(orden, 1L);
@@ -1159,16 +1255,15 @@ class OrdenProduccionServiceImplTest {
                 .satisfies(ex -> {
                     ErrorResponseException error = (ErrorResponseException) ex;
                     ProblemDetail body = error.getBody();
-                    assertThat(body.getProperties().get("code")).isEqualTo("OP_CIERRE_PARCIAL_REQUIERE_CONFIRMACION");
+                    assertThat(body.getProperties().get("code")).isEqualTo("CIERRE_TOTAL_NO_COINCIDE_PROGRAMADA");
                 });
     }
 
     @Test
-    @DisplayName("registrarCierre total incompleto con confirmación marca CERRADA_INCOMPLETA")
+    @DisplayName("registrarCierre total incompleto con confirmación también es rechazado")
     void registrarCierre_totalIncompletoConfirmado() {
         OrdenProduccion orden = crearOrdenBase(302L, new BigDecimal("100"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
         stubInfraCierre(orden, 1L);
-        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
                 .cantidad(new BigDecimal("80"))
@@ -1177,10 +1272,13 @@ class OrdenProduccionServiceImplTest {
                 .confirmarCierreParcial(true)
                 .build();
 
-        OrdenProduccion resultado = service.registrarCierre(302L, dto);
-
-        assertThat(resultado.getEstado()).isEqualTo(EstadoProduccion.CERRADA_INCOMPLETA);
-        assertThat(resultado.getTipoCierre()).isEqualTo(TipoCierre.PARCIAL);
+        assertThatThrownBy(() -> service.registrarCierre(302L, dto))
+                .isInstanceOf(ErrorResponseException.class)
+                .satisfies(ex -> {
+                    ErrorResponseException error = (ErrorResponseException) ex;
+                    ProblemDetail body = error.getBody();
+                    assertThat(body.getProperties().get("code")).isEqualTo("CIERRE_TOTAL_NO_COINCIDE_PROGRAMADA");
+                });
     }
 
     @Test
@@ -1354,7 +1452,7 @@ class OrdenProduccionServiceImplTest {
     @Test
     @DisplayName("registrarCierre total usa la última etapa finalizada cuando no hay activa")
     void registrarCierre_totalSinEtapaActiva() {
-        OrdenProduccion orden = crearOrdenBase(350L, new BigDecimal("80"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        OrdenProduccion orden = crearOrdenBase(350L, new BigDecimal("40"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
         stubInfraCierre(orden, 1L);
         LocalDateTime fin = LocalDateTime.now().minusHours(1);
         EtapaProduccion etapaFinalizada = EtapaProduccion.builder()
@@ -1381,7 +1479,7 @@ class OrdenProduccionServiceImplTest {
     @Test
     @DisplayName("registrarCierre registra consumo real antes de consultar insumos")
     void registrarCierre_actualizaConsumido() {
-        OrdenProduccion orden = crearOrdenBase(360L, new BigDecimal("3"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        OrdenProduccion orden = crearOrdenBase(360L, new BigDecimal("4"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
         stubInfraCierre(orden, 1L);
         Producto insumo = new Producto();
         insumo.setId(600);
@@ -1425,7 +1523,7 @@ class OrdenProduccionServiceImplTest {
     @Test
     @DisplayName("registrarCierre es idempotente al registrar consumos de insumos")
     void registrarCierre_idempotenciaConsumos() {
-        OrdenProduccion orden = crearOrdenBase(370L, new BigDecimal("10"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        OrdenProduccion orden = crearOrdenBase(370L, new BigDecimal("12"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
         stubInfraCierre(orden, 1L);
         when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -1703,6 +1801,7 @@ class OrdenProduccionServiceImplTest {
     }
 
     private void stubInfraCierre(OrdenProduccion orden, long cierresRegistrados) {
+        when(ordenProduccionRepository.findByIdForUpdate(orden.getId())).thenReturn(Optional.of(orden));
         when(ordenProduccionRepository.findById(orden.getId())).thenReturn(Optional.of(orden));
         when(loteProductoRepository.findByOrdenProduccionIdAndProductoId(
                 orden.getId(), orden.getProducto().getId().longValue())).thenReturn(Optional.empty());

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceReservaTest.java
@@ -156,6 +156,7 @@ class OrdenProduccionServiceReservaTest {
         unidadInsumo.setNombre("MILILITRO");
         productoInsumo.setUnidadMedida(unidadInsumo);
 
+        when(ordenProduccionRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(orden));
         when(ordenProduccionRepository.findById(1L)).thenReturn(Optional.of(orden));
         when(formulaProductoRepository.findByProductoIdAndEstadoAndActivoTrue(10L, EstadoFormula.APROBADA))
                 .thenAnswer(invocation -> Optional.of(crearFormula()));
@@ -766,7 +767,7 @@ class OrdenProduccionServiceReservaTest {
     @DisplayName("registrarCierre total sin pendientes libera reservas")
     void registrarCierre_totalSinPendientesLiberaReservas() {
         CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
-                .cantidad(new BigDecimal("1.25"))
+                .cantidad(new BigDecimal("5.5"))
                 .tipo(TipoCierre.TOTAL)
                 .confirmarCierreParcial(true)
                 .build();


### PR DESCRIPTION
### Motivation
- Evitar que un cierre PARCIAL complete o exceda la cantidad programada y que un cierre TOTAL no cierre exactamente lo restante, evitando inconsistencias y carreras en la OP.
- Usar lock pesimista al recuperar la OP durante el flujo de cierre para evitar condiciones de carrera sobre el acumulado y respetar la versión/estado de la OP.

### Description
- En `OrdenProduccionServiceImpl.registrarCierre` se cambió la carga de la OP a `repository.findByIdForUpdate(id)` y se agregó validación temprana del acumulado: para `TipoCierre.PARCIAL` se rechaza si `producidaAntes + cantidad >= cantidadProgramada` con `ProblemDetail` código `CIERRE_PARCIAL_SUPERA_PROGRAMADA`, y para `TipoCierre.TOTAL` se exige igualdad exacta con código `CIERRE_TOTAL_NO_COINCIDE_PROGRAMADA` y propiedades `cantidadProgramada`, `acumuladoActual`, `cantidadSolicitada` y `acumuladoPropuesto`.
- Las validaciones se ejecutan inmediatamente después de calcular `producidaAntes`/`producidaDespues` y antes de registrar consumos, crear/actualizar lote PT o registrar movimiento de entrada, manteniendo el resto del flujo intacto.
- Se añadieron/ajustaron tests en `OrdenProduccionServiceImplTest` que cubren los casos límite solicitados (parciales que intentan completar/exceder, parciales válidos por debajo, total que cierra exacto y total inválido), y se ajustaron fixtures/stubs para usar `findByIdForUpdate` en los tests; también se actualizó `OrdenProduccionServiceReservaTest` para usar ambas variantes (`findByIdForUpdate` y `findById`) y para un cierre total coherente con `cantidadProgramada`.
- Archivos modificados: `src/main/java/.../OrdenProduccionServiceImpl.java`, `src/test/java/.../OrdenProduccionServiceImplTest.java`, `src/test/java/.../OrdenProduccionServiceReservaTest.java` (cambios focalizados en `registrarCierre` y tests relacionados).
- Inserciones aproximadas: validación y lock en `OrdenProduccionServiceImpl.registrarCierre` alrededor de las líneas ~861 y ~933–961; nuevos tests en `OrdenProduccionServiceImplTest` alrededor de ~1124–1218; ajustes de stubs en ~1680+. 

### Testing
- Ejecuté `mvn -Dtest=OrdenProduccionServiceImplTest,OrdenProduccionServiceReservaTest test` y ambas clases de prueba pasaron sin errores (BUILD SUCCESS); los tests nuevos/cuadrados también pasaron.
- Las pruebas automáticas cubren los escenarios solicitados: parcial que intenta completar/exceder falla con `CIERRE_PARCIAL_SUPERA_PROGRAMADA`, parcial válido por debajo OK, total exacto finaliza OK y total inválido falla con `CIERRE_TOTAL_NO_COINCIDE_PROGRAMADA`.
- No se tocaron otros módulos fuera del parche acotado y los tests se ajustaron solo donde fue necesario para el nuevo comportamiento de bloqueo y validación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698235b25d30833385ea7ad197c595e2)