### PR TITLE
Bind legacy `observaciones` to MovimientoInventarioDTO.destinoTexto and add test

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -66,6 +66,7 @@ public class MovimientoInventarioController {
     @PostMapping
     public ResponseEntity<?> registrar(@RequestBody @Valid MovimientoInventarioDTO dto,
                                        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey) {
+        log.debug("[INVENTARIO] payload recibido observaciones={} dto={}", dto.destinoTexto(), dto);
         dto = normalizarMovimientoDto(dto);
         try {
             int atenciones = dto.atenciones() != null ? dto.atenciones().size() : 0;

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.willyes.clemenintegra.inventario.model.enums.CausaDevolucionPT;
@@ -23,6 +24,7 @@ public record MovimientoInventarioDTO(
         TipoMovimiento tipoMovimiento,
         ClasificacionMovimientoInventario clasificacionMovimientoInventario,
         String docReferencia,
+        @JsonAlias("observaciones")
         String destinoTexto,
         String clienteNombre,
         CausaDevolucionPT causaDevolucionPt,

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerErrorHandlingTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerErrorHandlingTest.java
@@ -7,6 +7,7 @@ import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -22,6 +23,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -145,5 +147,39 @@ class MovimientoInventarioControllerErrorHandlingTest {
                         .content(payload))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(42));
+    }
+
+    @Test
+    @WithMockUser(username = "analista", authorities = "ROL_ALMACENISTA")
+    void whenLegacyObservacionesProvidedMapsToDestinoTexto() throws Exception {
+        when(movimientoInventarioService.registrarMovimiento(any(), anyString()))
+                .thenReturn(com.willyes.clemenintegra.inventario.dto.MovimientoInventarioResponseDTO.builder()
+                        .id(55L)
+                        .build());
+
+        String payload = """
+                {
+                  \"tipoMovimiento\": \"RECEPCION\",
+                  \"clasificacionMovimientoInventario\": \"RECEPCION_COMPRA\",
+                  \"productoId\": 8,
+                  \"cantidad\": 1,
+                  \"loteLegacy\": true,
+                  \"observaciones\": \"texto legacy\"
+                }
+                """;
+
+        mockMvc.perform(post("/api/movimientos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Idempotency-Key", "test-" + UUID.randomUUID())
+                        .content(payload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(55));
+
+        ArgumentCaptor<com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO> captor =
+                ArgumentCaptor.forClass(com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO.class);
+        verify(movimientoInventarioService).registrarMovimiento(captor.capture(), anyString());
+        com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO dto = captor.getValue();
+        org.assertj.core.api.Assertions.assertThat(dto.destinoTexto()).isEqualTo("texto legacy");
+        org.assertj.core.api.Assertions.assertThat(dto.loteLegacy()).isTrue();
     }
 }


### PR DESCRIPTION
### Motivation
- Frontend legacy payloads send `observaciones`, but the backend expected `destinoTexto`, causing `dto.destinoTexto()` to be null and triggering `DEVOLUCION_PT_LEGACY_REQUIERE_OBSERVACIONES` when `loteLegacy=true`.

### Description
- Add `@JsonAlias("observaciones")` to `destinoTexto` in `MovimientoInventarioDTO` so incoming JSON `observaciones` binds to `destinoTexto` (`src/main/java/com/willyes/clemenintegra/inventario/dto/MovimientoInventarioDTO.java`).
- Add a debug log at the start of `MovimientoInventarioController.registrar` to print the received `destinoTexto` and the DTO for troubleshooting (`src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java`).
- Add a WebMvc test `whenLegacyObservacionesProvidedMapsToDestinoTexto` that POSTs `loteLegacy=true` with `observaciones` and asserts the service receives `destinoTexto` populated and returns 201 (`src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerErrorHandlingTest.java`).

### Testing
- Ran `mvn -q -Dtest=MovimientoInventarioControllerErrorHandlingTest test`, and the test class ran successfully including the new test which asserts `dto.destinoTexto()` equals the provided `observaciones` and the request returns HTTP 201.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c677aaac833383f346146ef23f27)