### PR TITLE
Prevent doc_referencia overflow: remove observaciones fallback and enforce OP code

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioController.java
@@ -396,8 +396,11 @@ public class MovimientoInventarioController {
             }
         }
         String docReferencia = dto.docReferencia();
-        if ((docReferencia == null || docReferencia.isBlank()) && destinoTexto != null) {
-            docReferencia = "DESTINO: " + destinoTexto;
+        if (docReferencia != null) {
+            docReferencia = docReferencia.trim();
+            if (docReferencia.isBlank()) {
+                docReferencia = null;
+            }
         }
         return new MovimientoInventarioDTO(
                 dto.id(),

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceImpl.java
@@ -116,6 +116,7 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
     );
     private static final int MAX_BITACORA_VALOR_NUEVO = 255;
     private static final int MAX_BITACORA_OBSERVACION = 500;
+    private static final int MAX_DOC_REFERENCIA_LENGTH = 45;
 
     static final record MovimientoLoteDetalle(LoteProducto lote, BigDecimal cantidad) { }
 
@@ -902,6 +903,23 @@ public class MovimientoInventarioServiceImpl implements MovimientoInventarioServ
         if (clasificacion == ClasificacionMovimientoInventario.SALIDA_CLIENTE) {
             log.debug("SALIDA_CLIENTE motivoMovimientoId={}",
                     movimiento.getMotivoMovimiento() != null ? movimiento.getMotivoMovimiento().getId() : null);
+        }
+
+        if (ordenProduccion != null && StringUtils.hasText(ordenProduccion.getCodigoOrden())) {
+            movimiento.setDocReferencia(ordenProduccion.getCodigoOrden().trim());
+        }
+
+        String docReferenciaFinal = movimiento.getDocReferencia();
+        if (docReferenciaFinal != null) {
+            docReferenciaFinal = docReferenciaFinal.trim();
+            if (docReferenciaFinal.isBlank()) {
+                movimiento.setDocReferencia(null);
+            } else {
+                if (docReferenciaFinal.length() > MAX_DOC_REFERENCIA_LENGTH) {
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "DOC_REFERENCIA_LARGA");
+                }
+                movimiento.setDocReferencia(docReferenciaFinal);
+            }
         }
 
         MovimientoInventario guardado = repository.save(movimiento);

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerErrorHandlingTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerErrorHandlingTest.java
@@ -180,6 +180,7 @@ class MovimientoInventarioControllerErrorHandlingTest {
         verify(movimientoInventarioService).registrarMovimiento(captor.capture(), anyString());
         com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO dto = captor.getValue();
         org.assertj.core.api.Assertions.assertThat(dto.destinoTexto()).isEqualTo("texto legacy");
+        org.assertj.core.api.Assertions.assertThat(dto.docReferencia()).isNull();
         org.assertj.core.api.Assertions.assertThat(dto.loteLegacy()).isTrue();
     }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/MovimientoInventarioServiceTransferenciaTest.java
@@ -16,6 +16,7 @@ import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoI
 import com.willyes.clemenintegra.inventario.model.enums.EstadoLote;
 import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
 import com.willyes.clemenintegra.inventario.repository.*;
+import com.willyes.clemenintegra.produccion.model.OrdenProduccion;
 import com.willyes.clemenintegra.shared.exception.ApiErrorCode;
 import com.willyes.clemenintegra.shared.exception.CustomBusinessException;
 import com.willyes.clemenintegra.shared.model.Usuario;
@@ -49,6 +50,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -264,6 +266,130 @@ class MovimientoInventarioServiceTransferenciaTest {
 
         assertThat(respuesta.getId()).isEqualTo(201L);
         assertThat(loteDestino.getUbicacionFisica()).isEqualTo(ubicacion);
+    }
+
+    @Test
+    void movimientoOp_fuerzaDocReferenciaConCodigoOrden() {
+        Producto producto = crearProducto(8, 2);
+        LoteProducto lote = crearLote(30L, producto, 1, EstadoLote.LIBERADO,
+                new BigDecimal("4000"), BigDecimal.ZERO, false);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("1000"),
+                TipoMovimiento.TRANSFERENCIA,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_INTERNA_PRODUCCION,
+                null,
+                "Se realiza movimiento bajo la orden OP-CLEMEN-20260204-57",
+                null,
+                null,
+                null,
+                producto.getId(),
+                lote.getId(),
+                1,
+                6,
+                null,
+                null,
+                null,
+                5L,
+                null,
+                null,
+                100L,
+                null,
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                null,
+                null,
+                null
+        );
+
+        configurarMocksBasicos(producto, lote);
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(dto.tipoMovimiento());
+        movimientoEntidad.setClasificacion(dto.clasificacionMovimientoInventario());
+        movimientoEntidad.setCantidad(dto.cantidad());
+        movimientoEntidad.setDocReferencia(dto.docReferencia());
+
+        OrdenProduccion op = new OrdenProduccion();
+        op.setId(100L);
+        op.setCodigoOrden("OP-CLEMEN-20260204-57");
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+        given(entityManager.getReference(eq(OrdenProduccion.class), eq(100L))).willReturn(op);
+        given(movimientoInventarioRepository.save(any(MovimientoInventario.class))).willAnswer(invocation -> {
+            MovimientoInventario mov = invocation.getArgument(0);
+            mov.setId(200L);
+            return mov;
+        });
+        given(mapper.safeToResponseDTO(any(MovimientoInventario.class)))
+                .willReturn(MovimientoInventarioResponseDTO.builder().id(200L).build());
+
+        service.registrarMovimiento(dto);
+
+        ArgumentCaptor<MovimientoInventario> movimientoCaptor = ArgumentCaptor.forClass(MovimientoInventario.class);
+        verify(movimientoInventarioRepository, times(1)).save(movimientoCaptor.capture());
+        assertThat(movimientoCaptor.getValue().getDocReferencia()).isEqualTo("OP-CLEMEN-20260204-57");
+    }
+
+    @Test
+    void movimientoNoOp_conDocReferenciaMayorA45_retorna422() {
+        Producto producto = crearProducto(8, 2);
+        LoteProducto lote = crearLote(30L, producto, 1, EstadoLote.LIBERADO,
+                new BigDecimal("4000"), BigDecimal.ZERO, false);
+
+        MovimientoInventarioDTO dto = new MovimientoInventarioDTO(
+                null,
+                new BigDecimal("1000"),
+                TipoMovimiento.TRANSFERENCIA,
+                ClasificacionMovimientoInventario.TRANSFERENCIA_GENERAL,
+                "DOC-REFERENCIA-DEMASIADO-LARGA-PARA-VALIDAR-LIMITE-45-CHARS",
+                null,
+                null,
+                null,
+                null,
+                producto.getId(),
+                lote.getId(),
+                1,
+                6,
+                null,
+                null,
+                null,
+                5L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                null,
+                null,
+                null
+        );
+
+        configurarMocksBasicos(producto, lote);
+
+        MovimientoInventario movimientoEntidad = new MovimientoInventario();
+        movimientoEntidad.setFechaIngreso(LocalDateTime.now());
+        movimientoEntidad.setTipoMovimiento(dto.tipoMovimiento());
+        movimientoEntidad.setClasificacion(dto.clasificacionMovimientoInventario());
+        movimientoEntidad.setCantidad(dto.cantidad());
+        movimientoEntidad.setDocReferencia(dto.docReferencia());
+
+        given(mapper.toEntity(dto)).willReturn(movimientoEntidad);
+
+        assertThatThrownBy(() -> service.registrarMovimiento(dto))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("422 UNPROCESSABLE_ENTITY \"DOC_REFERENCIA_LARGA\"");
+
+        verify(movimientoInventarioRepository, never()).save(any(MovimientoInventario.class));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Proteger la columna `movimientos_inventario.doc_referencia (VARCHAR(45))` contra errores MySQLDataTruncation causados por rellenar `docReferencia` con texto libre largo a partir de `observaciones`/`destinoTexto`.
- Evitar que el backend construya automáticamente `"DESTINO: ..."` cuando el front no envía `docReferencia`, porque produce cadenas >45 caracteres en producción.
- Garantizar que los movimientos ligados a una Orden de Producción usen el código corto de la OP como `docReferencia` para cumplir la restricción de longitud.

### Description
- Eliminada la regla que rellenaba `docReferencia` con `"DESTINO: " + destinoTexto` en `normalizarMovimientoDto(...)` y dejada solo la normalización (trim/null) de `docReferencia` en el controller (`MovimientoInventarioController`).
- Añadido `MAX_DOC_REFERENCIA_LENGTH = 45` y lógica en `MovimientoInventarioServiceImpl.registrarMovimiento(...)` para forzar `movimiento.docReferencia = ordenProduccion.getCodigoOrden()` cuando aplica, normalizar el valor final y lanzar `ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "DOC_REFERENCIA_LARGA")` si supera 45 caracteres.
- Las reglas aplican inmediatamente antes de `repository.save(...)` para asegurar consistencia y no afectar otros flujos (recepciones, remisiones, devoluciones, movimientos manuales sin OP).
- Actualizados/añadidos tests unitarios: el test del controller verifica que `observaciones` se mapea a `destinoTexto` pero no a `docReferencia`, y se añadieron tests que comprueban que la ruta OP pone el código de OP como `docReferencia` y que un `docReferencia` demasiado largo produce `422 DOC_REFERENCIA_LARGA`.

### Testing
- Ejecutado `mvn -Dtest=MovimientoInventarioControllerErrorHandlingTest,MovimientoInventarioServiceTransferenciaTest test` y se obtuvo `BUILD SUCCESS` con las pruebas específicas verdes.
- Tests ejecutados: `MovimientoInventarioControllerErrorHandlingTest` y `MovimientoInventarioServiceTransferenciaTest`, total de tests en ejecución objetivo pasaron (sin fallos).
- Verificación local que la nueva validación lanza `422 DOC_REFERENCIA_LARGA` para referencias >45 y que los movimientos OP guardan el `orden.getCodigoOrden()` como `docReferencia`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c153c7408333ade0f04fb566d380)