### PR TITLE
feat: reporte de compras por línea de OC con exportación a Excel

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteComprasController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteComprasController.java
@@ -1,0 +1,50 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.reportes.ReporteComprasRowDTO;
+import com.willyes.clemenintegra.inventario.service.ReporteComprasService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/reportes/compras")
+@RequiredArgsConstructor
+public class ReporteComprasController {
+
+    private static final MediaType EXCEL_MEDIA_TYPE =
+            MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+
+    private final ReporteComprasService reporteComprasService;
+
+    @GetMapping
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    public List<ReporteComprasRowDTO> obtenerReporte(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta) {
+        return reporteComprasService.generar(desde, hasta);
+    }
+
+    @GetMapping("/excel")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')")
+    public ResponseEntity<byte[]> exportarExcel(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta) {
+        byte[] excel = reporteComprasService.exportarExcel(desde, hasta);
+        String fileName = String.format("reporte_compras_%s_%s.xlsx", desde, hasta);
+
+        return ResponseEntity.ok()
+                .contentType(EXCEL_MEDIA_TYPE)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"")
+                .body(excel);
+    }
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/reportes/ReporteComprasRowDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/reportes/ReporteComprasRowDTO.java
@@ -1,0 +1,30 @@
+package com.willyes.clemenintegra.inventario.dto.reportes;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReporteComprasRowDTO {
+
+    private String ocCodigo;
+    private String productoCodigo;
+    private String productoNombre;
+    private String udm;
+    private BigDecimal cantidad;
+    private LocalDateTime fechaOc;
+    private LocalDate fechaPactada;
+    private LocalDate fechaRecepcion;
+    private String proveedorNombre;
+    private String condicionesPago;
+    private BigDecimal precioUnitario;
+    private BigDecimal iva;
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ReporteComprasRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ReporteComprasRepository.java
@@ -1,0 +1,52 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import com.willyes.clemenintegra.inventario.model.OrdenCompraDetalle;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ReporteComprasRepository extends Repository<OrdenCompraDetalle, Long> {
+
+    @Query(value = """
+            SELECT
+                oc.codigo_orden                              AS ocCodigo,
+                p.codigo_sku                                 AS productoCodigo,
+                p.nombre                                     AS productoNombre,
+                COALESCE(um.simbolo_impresion, um.simbolo)  AS udm,
+                d.cantidad                                   AS cantidad,
+                oc.fecha_orden                               AS fechaOc,
+                oc.fecha_compromiso_entrega                  AS fechaPactada,
+                MAX(ro.fecha_recepcion)                      AS fechaRecepcion,
+                pr.proveedor                                 AS proveedorNombre,
+                oc.condiciones_pago                          AS condicionesPago,
+                d.valor_unitario                             AS precioUnitario,
+                d.iva                                        AS iva
+            FROM orden_compra_detalle d
+            JOIN ordenes_compra oc ON oc.id = d.ordenes_compra_id
+            JOIN productos p ON p.id = d.productos_id
+            JOIN unidades_medida um ON um.id = p.unidades_medida_id
+            JOIN proveedores pr ON pr.id = oc.proveedor_id
+            LEFT JOIN recepciones_oc_detalles rod ON rod.orden_compra_detalle_id = d.id
+            LEFT JOIN recepciones_oc ro ON ro.id = rod.recepcion_oc_id
+            WHERE oc.fecha_orden BETWEEN :desde AND :hasta
+            GROUP BY
+                d.id,
+                oc.codigo_orden,
+                p.codigo_sku,
+                p.nombre,
+                COALESCE(um.simbolo_impresion, um.simbolo),
+                d.cantidad,
+                oc.fecha_orden,
+                oc.fecha_compromiso_entrega,
+                pr.proveedor,
+                oc.condiciones_pago,
+                d.valor_unitario,
+                d.iva
+            ORDER BY oc.fecha_orden DESC, oc.codigo_orden DESC
+            """, nativeQuery = true)
+    List<ReporteComprasRowProjection> obtenerReporte(@Param("desde") LocalDateTime desde,
+                                                     @Param("hasta") LocalDateTime hasta);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/ReporteComprasRowProjection.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/ReporteComprasRowProjection.java
@@ -1,0 +1,32 @@
+package com.willyes.clemenintegra.inventario.repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public interface ReporteComprasRowProjection {
+
+    String getOcCodigo();
+
+    String getProductoCodigo();
+
+    String getProductoNombre();
+
+    String getUdm();
+
+    BigDecimal getCantidad();
+
+    LocalDateTime getFechaOc();
+
+    LocalDate getFechaPactada();
+
+    LocalDate getFechaRecepcion();
+
+    String getProveedorNombre();
+
+    String getCondicionesPago();
+
+    BigDecimal getPrecioUnitario();
+
+    BigDecimal getIva();
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ReporteComprasService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ReporteComprasService.java
@@ -1,0 +1,13 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.reportes.ReporteComprasRowDTO;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ReporteComprasService {
+
+    List<ReporteComprasRowDTO> generar(LocalDate desde, LocalDate hasta);
+
+    byte[] exportarExcel(LocalDate desde, LocalDate hasta);
+}

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ReporteComprasServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ReporteComprasServiceImpl.java
@@ -1,0 +1,119 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.reportes.ReporteComprasRowDTO;
+import com.willyes.clemenintegra.inventario.repository.ReporteComprasRepository;
+import com.willyes.clemenintegra.inventario.repository.ReporteComprasRowProjection;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReporteComprasServiceImpl implements ReporteComprasService {
+
+    private static final DateTimeFormatter FECHA_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter FECHA_HORA_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    private final ReporteComprasRepository reporteComprasRepository;
+
+    @Override
+    public List<ReporteComprasRowDTO> generar(LocalDate desde, LocalDate hasta) {
+        validarRango(desde, hasta);
+        LocalDateTime fechaDesde = desde.atStartOfDay();
+        LocalDateTime fechaHasta = hasta.atTime(LocalTime.MAX);
+
+        return reporteComprasRepository.obtenerReporte(fechaDesde, fechaHasta)
+                .stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    @Override
+    public byte[] exportarExcel(LocalDate desde, LocalDate hasta) {
+        List<ReporteComprasRowDTO> filas = generar(desde, hasta);
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("ReporteCompras");
+            String[] headers = {
+                    "OC", "Código", "Nombre", "UDM", "Cantidad", "Fecha OC", "Fecha pactada", "Fecha recepción",
+                    "Proveedor", "Condiciones de pago", "Precio unitario", "IVA"
+            };
+
+            Row header = sheet.createRow(0);
+            for (int i = 0; i < headers.length; i++) {
+                header.createCell(i).setCellValue(headers[i]);
+            }
+
+            int rowIndex = 1;
+            for (ReporteComprasRowDTO fila : filas) {
+                Row row = sheet.createRow(rowIndex++);
+                row.createCell(0).setCellValue(valorTexto(fila.getOcCodigo()));
+                row.createCell(1).setCellValue(valorTexto(fila.getProductoCodigo()));
+                row.createCell(2).setCellValue(valorTexto(fila.getProductoNombre()));
+                row.createCell(3).setCellValue(valorTexto(fila.getUdm()));
+                row.createCell(4).setCellValue(valorDecimal(fila.getCantidad()));
+                row.createCell(5).setCellValue(fila.getFechaOc() != null ? fila.getFechaOc().format(FECHA_HORA_FORMAT) : "");
+                row.createCell(6).setCellValue(fila.getFechaPactada() != null ? fila.getFechaPactada().format(FECHA_FORMAT) : "");
+                row.createCell(7).setCellValue(fila.getFechaRecepcion() != null ? fila.getFechaRecepcion().format(FECHA_FORMAT) : "");
+                row.createCell(8).setCellValue(valorTexto(fila.getProveedorNombre()));
+                row.createCell(9).setCellValue(valorTexto(fila.getCondicionesPago()));
+                row.createCell(10).setCellValue(valorDecimal(fila.getPrecioUnitario()));
+                row.createCell(11).setCellValue(valorDecimal(fila.getIva()));
+            }
+
+            for (int i = 0; i < headers.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException("No fue posible generar el archivo Excel del reporte de compras", e);
+        }
+    }
+
+    private ReporteComprasRowDTO toDto(ReporteComprasRowProjection projection) {
+        return ReporteComprasRowDTO.builder()
+                .ocCodigo(projection.getOcCodigo())
+                .productoCodigo(projection.getProductoCodigo())
+                .productoNombre(projection.getProductoNombre())
+                .udm(projection.getUdm())
+                .cantidad(projection.getCantidad())
+                .fechaOc(projection.getFechaOc())
+                .fechaPactada(projection.getFechaPactada())
+                .fechaRecepcion(projection.getFechaRecepcion())
+                .proveedorNombre(projection.getProveedorNombre())
+                .condicionesPago(projection.getCondicionesPago())
+                .precioUnitario(projection.getPrecioUnitario())
+                .iva(projection.getIva())
+                .build();
+    }
+
+    private void validarRango(LocalDate desde, LocalDate hasta) {
+        if (desde == null || hasta == null) {
+            throw new IllegalArgumentException("Los parámetros desde y hasta son obligatorios");
+        }
+        if (hasta.isBefore(desde)) {
+            throw new IllegalArgumentException("La fecha hasta no puede ser anterior a la fecha desde");
+        }
+    }
+
+    private String valorTexto(String valor) {
+        return valor != null ? valor : "";
+    }
+
+    private String valorDecimal(BigDecimal valor) {
+        return valor != null ? valor.toPlainString() : "";
+    }
+}

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ReporteComprasControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ReporteComprasControllerTest.java
@@ -1,0 +1,110 @@
+package com.willyes.clemenintegra.inventario.controller;
+
+import com.willyes.clemenintegra.inventario.dto.reportes.ReporteComprasRowDTO;
+import com.willyes.clemenintegra.inventario.service.ReporteComprasService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ReporteComprasController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(ReporteComprasControllerTest.MethodSecurityTestConfig.class)
+class ReporteComprasControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReporteComprasService reporteComprasService;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter usuarioInactivoFilter;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void obtenerReporteRetorna200ConCamposEsperados() throws Exception {
+        ReporteComprasRowDTO fila = ReporteComprasRowDTO.builder()
+                .ocCodigo("OC-001")
+                .productoCodigo("SKU-001")
+                .productoNombre("Materia Prima")
+                .udm("KG")
+                .cantidad(new BigDecimal("10.50"))
+                .fechaOc(LocalDateTime.of(2026, 2, 2, 10, 30))
+                .fechaPactada(LocalDate.of(2026, 2, 10))
+                .fechaRecepcion(LocalDate.of(2026, 2, 12))
+                .proveedorNombre("Proveedor Demo")
+                .condicionesPago("CONTADO")
+                .precioUnitario(new BigDecimal("25000"))
+                .iva(new BigDecimal("19"))
+                .build();
+
+        when(reporteComprasService.generar(any(), any())).thenReturn(List.of(fila));
+
+        mockMvc.perform(get("/api/reportes/compras")
+                        .param("desde", "2026-02-01")
+                        .param("hasta", "2026-02-28"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].ocCodigo").value("OC-001"))
+                .andExpect(jsonPath("$[0].productoCodigo").value("SKU-001"))
+                .andExpect(jsonPath("$[0].productoNombre").value("Materia Prima"))
+                .andExpect(jsonPath("$[0].udm").value("KG"))
+                .andExpect(jsonPath("$[0].cantidad").isNotEmpty())
+                .andExpect(jsonPath("$[0].fechaOc").isNotEmpty())
+                .andExpect(jsonPath("$[0].fechaPactada").isNotEmpty())
+                .andExpect(jsonPath("$[0].fechaRecepcion").isNotEmpty())
+                .andExpect(jsonPath("$[0].proveedorNombre").value("Proveedor Demo"))
+                .andExpect(jsonPath("$[0].condicionesPago").value("CONTADO"))
+                .andExpect(jsonPath("$[0].precioUnitario").isNotEmpty())
+                .andExpect(jsonPath("$[0].iva").isNotEmpty());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    void exportarExcelRetorna200YBytesNoVacios() throws Exception {
+        when(reporteComprasService.exportarExcel(any(), any())).thenReturn(new byte[]{1, 2, 3});
+
+        mockMvc.perform(get("/api/reportes/compras/excel")
+                        .param("desde", "2026-02-01")
+                        .param("hasta", "2026-02-28"))
+                .andExpect(status().isOk())
+                .andExpect(content().bytes(new byte[]{1, 2, 3}))
+                .andExpect(content().contentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"reporte_compras_2026-02-01_2026-02-28.xlsx\""));
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class MethodSecurityTestConfig {
+    }
+}


### PR DESCRIPTION
### Motivation
- Proveer un reporte por línea de Orden de Compra que permita consultar detalle y descargar un XLSX con filtros por rango de fechas usando las tablas reales de OC y recepciones.

### Description
- Añadidos DTO / repositorio / servicio / controller para el reporte: `ReporteComprasRowDTO`, `ReporteComprasRepository` (query nativa), `ReporteComprasRowProjection`, `ReporteComprasService` y `ReporteComprasServiceImpl`, y `ReporteComprasController`; archivos en `src/main/java/com/willyes/clemenintegra/inventario/...`.
- La query nativa consulta `ordenes_compra`, `orden_compra_detalle`, `productos`, `unidades_medida`, `proveedores`, `recepciones_oc` y `recepciones_oc_detalles`, aplica `COALESCE(um.simbolo_impresion, um.simbolo)` para UDM y `MAX(ro.fecha_recepcion)` para obtener la última fecha de recepción por ítem, y filtra por `oc.fecha_orden BETWEEN :desde AND :hasta`.
- `ReporteComprasServiceImpl` normaliza el rango de fechas (`desde.atStartOfDay()` / `hasta.atTime(LocalTime.MAX)`), mapea la proyección al `ReporteComprasRowDTO` y genera XLSX con Apache POI (hoja `ReporteCompras`, encabezados en el orden requerido y formato de fechas/BigDecimal sin notación científica).
- Nuevos endpoints en `ReporteComprasController`: `GET /api/reportes/compras` (JSON) y `GET /api/reportes/compras/excel` (XLSX), ambos protegidos con `hasAnyAuthority('ROL_COMPRADOR','ROL_SUPER_ADMIN')`.

### Testing
- Se agregó `ReporteComprasControllerTest` (WebMvcTest) que valida que `GET /api/reportes/compras` retorna `200` con columnas esperadas y que `GET /api/reportes/compras/excel` retorna `200` con bytes no vacíos y `Content-Disposition` correcto.
- Se ejecutaron los tests y compilación: `mvn -q -Dtest=ReporteComprasControllerTest test` (ok) y `mvn -q -DskipTests compile` (ok).

Files created (principales)
- `src/main/java/com/willyes/clemenintegra/inventario/dto/reportes/ReporteComprasRowDTO.java`
- `src/main/java/com/willyes/clemenintegra/inventario/repository/ReporteComprasRepository.java`
- `src/main/java/com/willyes/clemenintegra/inventario/repository/ReporteComprasRowProjection.java`
- `src/main/java/com/willyes/clemenintegra/inventario/service/ReporteComprasService.java`
- `src/main/java/com/willyes/clemenintegra/inventario/service/ReporteComprasServiceImpl.java`
- `src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteComprasController.java`
- `src/test/java/com/willyes/clemenintegra/inventario/controller/ReporteComprasControllerTest.java`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985e2f4832c8333bedb07c2c91aaa74)