### PR TITLE
RBAC: permitir exportes para CONTADOR, revocar acceso a planeación/MRP/OC y agregar migración y tests

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ReporteInventarioController.java
@@ -41,7 +41,7 @@ public class ReporteInventarioController {
             MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
 
     @GetMapping("/alta-rotacion")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR','ROL_PLANEADOR','ROL_CONTADOR','INV_REPORTES_EXPORT')")
     public ResponseEntity<byte[]> altaRotacion(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin
@@ -57,7 +57,7 @@ public class ReporteInventarioController {
     }
 
     @GetMapping("/baja-rotacion")
-    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR','ROL_PLANEADOR','ROL_CONTADOR','INV_REPORTES_EXPORT')")
     public ResponseEntity<byte[]> bajaRotacion(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin
@@ -153,7 +153,7 @@ public class ReporteInventarioController {
     }
 
     @GetMapping(value = "/stock-disponible", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_SUPER_ADMIN','ROL_PLANEADOR','ROL_CONTADOR','INV_REPORTES_EXPORT')")
     public ResponseEntity<byte[]> exportarStockDisponible() {
         log.info("Generando reporte de stock disponible");
         try (Workbook workbook = productoService.generarReporteStockDisponibleExcel();
@@ -174,7 +174,7 @@ public class ReporteInventarioController {
 
     @GetMapping(value = "/productos-por-vencer", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD'," +
-            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR','ROL_CONTADOR','INV_REPORTES_EXPORT')")
     public ResponseEntity<byte[]> exportarLotesPorVencer(
             @RequestParam(name = "fechaInicio", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam(name = "fechaFin", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin
@@ -202,7 +202,7 @@ public class ReporteInventarioController {
     @GetMapping(value = "/productos-vencidos",
             produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD'," +
-            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR','ROL_CONTADOR','INV_REPORTES_EXPORT')")
     public ResponseEntity<byte[]> exportProductosVencidos(
             @RequestParam(name = "producto", required = false) Long productoId,
             @RequestParam(name = "almacen", required = false) Long almacenId) {
@@ -224,7 +224,7 @@ public class ReporteInventarioController {
 
     @GetMapping("/alertas-inventario")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_ANALISTA_CALIDAD'," +
-            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR','ROL_CONTADOR','INV_REPORTES_EXPORT')")
     public ResponseEntity<byte[]> exportarAlertasInventario() {
         ByteArrayOutputStream stream = loteProductoService.generarReporteAlertasActivasExcel();
         return ResponseEntity.ok()
@@ -235,7 +235,7 @@ public class ReporteInventarioController {
 
     @GetMapping(value = "/movimientos", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION'," +
-            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR')")
+            "'ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_PLANEADOR','ROL_CONTADOR','INV_REPORTES_EXPORT')")
     public ResponseEntity<byte[]> exportarReporteMovimientos(
             @RequestParam(name = "fechaInicio", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam(name = "fechaFin", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin

--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/MrpController.java
@@ -46,7 +46,7 @@ public class MrpController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_PLANEADOR','ROL_CONTADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<?> obtener(@PathVariable Long id) {
         try {
             CorridaMrp corrida = mrpService.obtenerCorrida(id);
@@ -57,7 +57,7 @@ public class MrpController {
     }
 
     @GetMapping("/{id}/excel")
-    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_PLANEADOR','ROL_CONTADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_COMPRADOR','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<?> exportarExcel(@PathVariable Long id) {
         try {
             byte[] excel = mrpReporteService.generarExcelCorrida(id);

--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
@@ -70,7 +70,7 @@ public class PlanProduccionController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_PLANEADOR','ROL_CONTADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<PlanProduccionSemanalDTO> obtener(@PathVariable Long id) {
         return planProduccionService.buscarPorId(id)
                 .map(plan -> ResponseEntity.ok(toDto(plan)))

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -274,12 +274,19 @@ public class SecurityConfig {
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
-                    // 1) Lectura de planes semanales (Producción + Compras + Super Admin)
-                    auth.requestMatchers(HttpMethod.GET, "/api/planeacion/planes-semanales/**").hasAnyAuthority(
+                    // 1) Lectura de listado de planes semanales (auditoría para Contador)
+                    auth.requestMatchers(HttpMethod.GET, "/api/planeacion/planes-semanales").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
                             RolUsuario.ROL_COMPRADOR.name(),
                             RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_CONTADOR.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+                    // 1.1) Detalle de planes semanales: sin acceso para Contador
+                    auth.requestMatchers(HttpMethod.GET, "/api/planeacion/planes-semanales/**").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_PRODUCCION.name(),
+                            RolUsuario.ROL_COMPRADOR.name(),
+                            RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
                     // 2) Resto de operaciones de planeación (crear/editar/eliminar):
@@ -292,7 +299,6 @@ public class SecurityConfig {
                     auth.requestMatchers(HttpMethod.GET, "/api/mrp/**").hasAnyAuthority(
                             RolUsuario.ROL_COMPRADOR.name(),
                             RolUsuario.ROL_PLANEADOR.name(),
-                            RolUsuario.ROL_CONTADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 

--- a/src/main/resources/db/migration/inventario/V20260209__rbac_contador_exports_and_remove_planning.sql
+++ b/src/main/resources/db/migration/inventario/V20260209__rbac_contador_exports_and_remove_planning.sql
@@ -1,0 +1,30 @@
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'INV_REPORTES_EXPORT', 'INV', 'EXPORT', 'Exportacion de reportes de inventario', b'1'
+where not exists (select 1 from permisos where codigo = 'INV_REPORTES_EXPORT');
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'INV_REPORTES_EXPORT'
+)
+where r.codigo = 'ROL_CONTADOR'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );
+
+delete rp
+from roles_permisos rp
+join roles r on r.id = rp.rol_id
+join permisos p on p.id = rp.permiso_id
+where r.codigo = 'ROL_CONTADOR'
+  and p.codigo in (
+    'PO_PLAN_SEMANAL_READ',
+    'PO_PLAN_SEMANAL_WRITE',
+    'PO_MRP_READ',
+    'PO_MRP_WRITE',
+    'PO_OC_CREATE',
+    'PO_OC_EDIT',
+    'PO_OC_WRITE'
+  );

--- a/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
@@ -8,6 +8,22 @@ import com.willyes.clemenintegra.inventario.controller.LoteProductoController;
 import com.willyes.clemenintegra.inventario.controller.MovimientoInventarioController;
 import com.willyes.clemenintegra.inventario.controller.ProductoController;
 import com.willyes.clemenintegra.inventario.controller.SolicitudMovimientoController;
+import com.willyes.clemenintegra.inventario.controller.ReporteInventarioController;
+import com.willyes.clemenintegra.inventario.controller.OrdenCompraController;
+import com.willyes.clemenintegra.inventario.service.OrdenCompraService;
+import com.willyes.clemenintegra.inventario.service.RecepcionOCService;
+import com.willyes.clemenintegra.inventario.service.HistorialEstadoOrdenService;
+import com.willyes.clemenintegra.inventario.service.OrdenCompraPdfService;
+import com.willyes.clemenintegra.inventario.service.ReporteInventarioService;
+import com.willyes.clemenintegra.inventario.mapper.OrdenCompraMapper;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraRepository;
+import com.willyes.clemenintegra.inventario.repository.OrdenCompraDetalleRepository;
+import com.willyes.clemenintegra.inventario.repository.ProveedorRepository;
+import com.willyes.clemenintegra.planeacion.controller.MrpController;
+import com.willyes.clemenintegra.planeacion.controller.PlanProduccionController;
+import com.willyes.clemenintegra.planeacion.service.MrpService;
+import com.willyes.clemenintegra.planeacion.service.MrpReporteService;
+import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
@@ -71,7 +87,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         CategoriaProductoController.class,
         MovimientoInventarioController.class,
         LoteProductoController.class,
-        AlertaInventarioController.class
+        AlertaInventarioController.class,
+        ReporteInventarioController.class,
+        PlanProduccionController.class,
+        MrpController.class,
+        OrdenCompraController.class
 })
 @AutoConfigureMockMvc(addFilters = true)
 @Import({SecurityConfig.class, ContadorRoleSecurityTest.MethodSecurityConfig.class})
@@ -102,6 +122,30 @@ class ContadorRoleSecurityTest {
     private LoteProductoService loteProductoService;
     @MockBean
     private AlertaInventarioService alertaInventarioService;
+    @MockBean
+    private ReporteInventarioService reporteInventarioService;
+    @MockBean
+    private PlanProduccionService planProduccionService;
+    @MockBean
+    private MrpService mrpService;
+    @MockBean
+    private MrpReporteService mrpReporteService;
+    @MockBean
+    private OrdenCompraService ordenCompraService;
+    @MockBean
+    private RecepcionOCService recepcionOCService;
+    @MockBean
+    private HistorialEstadoOrdenService historialEstadoOrdenService;
+    @MockBean
+    private OrdenCompraPdfService ordenCompraPdfService;
+    @MockBean
+    private OrdenCompraMapper ordenCompraMapper;
+    @MockBean
+    private OrdenCompraRepository ordenCompraRepository;
+    @MockBean
+    private OrdenCompraDetalleRepository ordenCompraDetalleRepository;
+    @MockBean
+    private ProveedorRepository proveedorRepository;
     @MockBean
     private ProductoRepository productoRepository;
     @MockBean
@@ -268,6 +312,53 @@ class ContadorRoleSecurityTest {
 
         mockMvc.perform(get("/api/inventario/alertas").param("diasVencimiento", "30"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_CONTADOR")
+    void contadorPuedeExportarReportesInventarioYRotacion() throws Exception {
+        when(reporteInventarioService.generarReporteAltaRotacion(any(), any())).thenReturn(new org.apache.poi.xssf.usermodel.XSSFWorkbook());
+        when(reporteInventarioService.generarReporteBajaRotacion(any(), any())).thenReturn(new org.apache.poi.xssf.usermodel.XSSFWorkbook());
+        when(productoService.generarReporteStockDisponibleExcel()).thenReturn(new org.apache.poi.xssf.usermodel.XSSFWorkbook());
+        when(movimientoInventarioService.generarReporteMovimientosExcel(any(), any())).thenReturn(new org.apache.poi.xssf.usermodel.XSSFWorkbook());
+
+        mockMvc.perform(get("/api/reportes/alta-rotacion")
+                        .param("fechaInicio", "2026-01-01")
+                        .param("fechaFin", "2026-01-31"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/reportes/baja-rotacion")
+                        .param("fechaInicio", "2026-01-01")
+                        .param("fechaFin", "2026-01-31"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/reportes/stock-disponible"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/reportes/movimientos")
+                        .param("fechaInicio", "2026-01-01")
+                        .param("fechaFin", "2026-01-31"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_CONTADOR")
+    void contadorSinAccesoPlaneacionYCreacionOc() throws Exception {
+        when(planProduccionService.listar(any(), any(), any(), any())).thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/planeacion/planes-semanales"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/planeacion/planes-semanales/1"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/mrp/corridas/1"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/ordenes-compra")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Resolver 403 en descargas de reportes (rotación e inventario) permitiendo a `ROL_CONTADOR` acceder a endpoints de export (attachment/content-disposition).
- Aplicar nuevo alcance del rol CONTADOR retirando acceso a detalle de planes semanales, a endpoints de MRP y a operaciones de creación/edición de OC.
- Persistir cambios en RBAC con una migración que agrega permisos de export y revoca permisos previos que otorgaban acceso de planeación/compras.

### Description
- Ajusta reglas globales en `SecurityConfig` para permitir que `GET /api/planeacion/planes-semanales` sea accesible por `ROL_CONTADOR` pero que `GET /api/planeacion/planes-semanales/**` (detalle) NO lo sea. También se removió `ROL_CONTADOR` de los `GET /api/mrp/**`.
- Modifica controladores: `PlanProduccionController` quitó `ROL_CONTADOR` del `@PreAuthorize` del endpoint de detalle (`GET /{id}`) y `MrpController` quitó `ROL_CONTADOR` de los `@PreAuthorize` que daban acceso a lectura/export de corridas MRP.
- Habilita exportes para CONTADOR en `ReporteInventarioController` añadiendo `ROL_CONTADOR` y el permiso RBAC `INV_REPORTES_EXPORT` a los endpoints de export/descarga (`/api/reportes/*`, incluidos `alta-rotacion`, `baja-rotacion`, `stock-disponible`, `movimientos`, etc.).
- Añade una migración `V20260209__rbac_contador_exports_and_remove_planning.sql` que crea/asegura el permiso `INV_REPORTES_EXPORT`, lo asigna a `ROL_CONTADOR` y elimina roles_permisos que otorgaran a `ROL_CONTADOR` acceso a `PO_PLAN_SEMANAL_*`, `PO_MRP_*`, `PO_OC_*` si existían.
- Actualiza `ContadorRoleSecurityTest` para validar con MockMvc los escenarios requeridos: exportes permitidos (200), detalle plan/consulta MRP/crear OC denegados (403) y mantener pruebas previas de módulos de inventario.

### Testing
- Se ejecutó la suite MockMvc específica con `mvn -q -Dtest=ContadorRoleSecurityTest test` y las pruebas relacionadas a CONTADOR pasaron (exportes devolvieron `200`, detalle plan/consulta MRP/crear OC devolvieron `403`).
- No se ejecutaron otras suites completas en esta PR; los cambios están cubiertos por los tests unitarios/integración agregados/actualizados en `ContadorRoleSecurityTest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a17095ce48333b42b0d5ac2901665)