### PR TITLE
RBAC: allow CONTADOR to read PlanSemanal detail, restrict Calidad, add documental write permission

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/NoConformidadController.java
@@ -27,7 +27,7 @@ public class NoConformidadController {
     private final UsuarioRepository usuarioRepository;
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_CONTADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<Page<NoConformidadDTO>> listar(
             @RequestParam(required = false) SeveridadNoConformidad severidad,
             @RequestParam(required = false) OrigenNoConformidad origen,
@@ -37,7 +37,7 @@ public class NoConformidadController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_CONTADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<NoConformidadDetalleDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerPorId(id));
     }

--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/RetencionLoteController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/RetencionLoteController.java
@@ -24,7 +24,7 @@ public class RetencionLoteController {
     private final RetencionLoteMapper mapper;
 
     @GetMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_CONTADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<Page<RetencionLoteDTO>> listar(
             @RequestParam(required = false) EstadoRetencion estado,
             @PageableDefault(size = 10) Pageable pageable) {
@@ -32,7 +32,7 @@ public class RetencionLoteController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO','ROL_CONTADOR')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO')")
     public ResponseEntity<RetencionLoteDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerPorId(id));
     }

--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/VidaUtilProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/VidaUtilProductoController.java
@@ -23,7 +23,7 @@ public class VidaUtilProductoController {
 
     @GetMapping("/producto-terminado/{productoId}")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO'," +
-            "'ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_CONTADOR','ROL_SUPER_ADMIN')")
+            "'ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<VidaUtilProductoDTO> obtenerPorProducto(@PathVariable Integer productoId) {
         return vidaUtilProductoService.buscarPorProductoId(productoId)
                 .map(vida -> ResponseEntity.ok(mapToDto(vida)))
@@ -32,7 +32,7 @@ public class VidaUtilProductoController {
 
     @GetMapping("/productos-terminados")
     @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_ANALISTA_CALIDAD','ROL_MICROBIOLOGO'," +
-            "'ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_CONTADOR','ROL_SUPER_ADMIN')")
+            "'ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<Page<VidaUtilProductoDTO>> listar(
             @RequestParam(required = false) String filtro,
             @RequestParam(name = "search", required = false) String search,

--- a/src/main/java/com/willyes/clemenintegra/documental/controller/ControlDocumentalController.java
+++ b/src/main/java/com/willyes/clemenintegra/documental/controller/ControlDocumentalController.java
@@ -52,7 +52,7 @@ public class ControlDocumentalController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','CONTROL_DOCUMENTAL_WRITE')")
     public ResponseEntity<DocumentoDTO> crear(
             @Valid @RequestBody DocumentoCreateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -61,7 +61,7 @@ public class ControlDocumentalController {
     }
 
     @PostMapping(path = "/{id}/versiones", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN','CONTROL_DOCUMENTAL_WRITE')")
     public ResponseEntity<DocumentoVersionDTO> agregarVersion(
             @PathVariable Long id,
             @RequestPart("archivo") MultipartFile archivo,

--- a/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/planeacion/controller/PlanProduccionController.java
@@ -70,7 +70,7 @@ public class PlanProduccionController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_PRODUCCION','ROL_COMPRADOR','ROL_PLANEADOR','ROL_CONTADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<PlanProduccionSemanalDTO> obtener(@PathVariable Long id) {
         return planProduccionService.buscarPorId(id)
                 .map(plan -> ResponseEntity.ok(toDto(plan)))

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -282,11 +282,12 @@ public class SecurityConfig {
                             RolUsuario.ROL_CONTADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
-                    // 1.1) Detalle de planes semanales: sin acceso para Contador
+                    // 1.1) Detalle de planes semanales: lectura permitida para Contador
                     auth.requestMatchers(HttpMethod.GET, "/api/planeacion/planes-semanales/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
                             RolUsuario.ROL_COMPRADOR.name(),
                             RolUsuario.ROL_PLANEADOR.name(),
+                            RolUsuario.ROL_CONTADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
                     // 2) Resto de operaciones de planeación (crear/editar/eliminar):
@@ -321,10 +322,26 @@ public class SecurityConfig {
                     );
 
 
+                    auth.requestMatchers(HttpMethod.POST,
+                            "/api/documental/documentos",
+                            "/api/documental/documentos/*/versiones").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name(),
+                            "CONTROL_DOCUMENTAL_WRITE"
+                    );
+
+                    auth.requestMatchers(HttpMethod.DELETE,
+                            "/api/documental/documentos/**").hasAnyAuthority(
+                            RolUsuario.ROL_JEFE_CALIDAD.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
+                    auth.requestMatchers("/api/documental/documentos/**").authenticated();
+
                     auth.requestMatchers(HttpMethod.GET, "/api/calidad/capas", "/api/calidad/capas/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
-                            RolUsuario.ROL_CONTADOR.name(),
-                            RolUsuario.ROL_SUPER_ADMIN.name()
+                            RolUsuario.ROL_SUPER_ADMIN.name(),
+                            "CONTROL_DOCUMENTAL_WRITE"
                     );
                     auth.requestMatchers("/api/calidad/capas", "/api/calidad/capas/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
@@ -350,7 +367,6 @@ public class SecurityConfig {
                             RolUsuario.ROL_MICROBIOLOGO.name(),
                             RolUsuario.ROL_JEFE_PRODUCCION.name(),
                             RolUsuario.ROL_PLANEADOR.name(),
-                            RolUsuario.ROL_CONTADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 
@@ -371,7 +387,6 @@ public class SecurityConfig {
                             RolUsuario.ROL_JEFE_CALIDAD.name(),
                             RolUsuario.ROL_ANALISTA_CALIDAD.name(),
                             RolUsuario.ROL_MICROBIOLOGO.name(),
-                            RolUsuario.ROL_CONTADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 

--- a/src/main/resources/db/migration/inventario/V20260210__rbac_contador_quality_trim_and_documental_write.sql
+++ b/src/main/resources/db/migration/inventario/V20260210__rbac_contador_quality_trim_and_documental_write.sql
@@ -1,0 +1,29 @@
+insert into permisos (codigo, modulo, accion, descripcion, activo)
+select 'CONTROL_DOCUMENTAL_WRITE', 'DOC', 'WRITE', 'Creacion y carga de versiones en control documental', b'1'
+where not exists (select 1 from permisos where codigo = 'CONTROL_DOCUMENTAL_WRITE');
+
+insert into roles_permisos (rol_id, permiso_id)
+select r.id, p.id
+from roles r
+join permisos p on p.codigo in (
+    'PO_PLAN_SEMANAL_READ',
+    'CONTROL_DOCUMENTAL_WRITE'
+)
+where r.codigo = 'ROL_CONTADOR'
+  and not exists (
+    select 1 from roles_permisos rp
+    where rp.rol_id = r.id and rp.permiso_id = p.id
+  );
+
+delete rp
+from roles_permisos rp
+join roles r on r.id = rp.rol_id
+join permisos p on p.id = rp.permiso_id
+where r.codigo = 'ROL_CONTADOR'
+  and (
+      p.codigo in ('QC_RETENCIONES_READ', 'QC_RETENCIONES_WRITE', 'QC_NO_CONFORMIDADES_READ', 'QC_NO_CONFORMIDADES_WRITE',
+                   'QC_VIDA_UTIL_READ', 'QC_VIDA_UTIL_WRITE')
+      or p.codigo like 'QC_RETENCION%'
+      or p.codigo like 'QC_NO_CONFORMIDAD%'
+      or p.codigo like 'QC_VIDA_UTIL%'
+  );

--- a/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
@@ -24,6 +24,7 @@ import com.willyes.clemenintegra.planeacion.controller.PlanProduccionController;
 import com.willyes.clemenintegra.planeacion.service.MrpService;
 import com.willyes.clemenintegra.planeacion.service.MrpReporteService;
 import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
+import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
@@ -43,6 +44,17 @@ import com.willyes.clemenintegra.inventario.service.ProductoService;
 import com.willyes.clemenintegra.inventario.service.SolicitudMovimientoService;
 import com.willyes.clemenintegra.inventario.service.StockQueryService;
 import com.willyes.clemenintegra.calidad.service.EvaluacionCalidadService;
+import com.willyes.clemenintegra.calidad.controller.NoConformidadController;
+import com.willyes.clemenintegra.calidad.controller.RetencionLoteController;
+import com.willyes.clemenintegra.calidad.controller.VidaUtilProductoController;
+import com.willyes.clemenintegra.calidad.mapper.RetencionLoteMapper;
+import com.willyes.clemenintegra.calidad.service.NoConformidadService;
+import com.willyes.clemenintegra.calidad.service.RetencionLoteService;
+import com.willyes.clemenintegra.calidad.service.VidaUtilProductoService;
+import com.willyes.clemenintegra.documental.controller.ControlDocumentalController;
+import com.willyes.clemenintegra.documental.dto.DocumentoDTO;
+import com.willyes.clemenintegra.documental.dto.DocumentoVersionDTO;
+import com.willyes.clemenintegra.documental.service.ControlDocumentalService;
 import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
 import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
@@ -55,6 +67,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,6 +80,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -74,7 +88,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -91,7 +108,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         ReporteInventarioController.class,
         PlanProduccionController.class,
         MrpController.class,
-        OrdenCompraController.class
+        OrdenCompraController.class,
+        RetencionLoteController.class,
+        NoConformidadController.class,
+        VidaUtilProductoController.class,
+        ControlDocumentalController.class
 })
 @AutoConfigureMockMvc(addFilters = true)
 @Import({SecurityConfig.class, ContadorRoleSecurityTest.MethodSecurityConfig.class})
@@ -164,6 +185,16 @@ class ContadorRoleSecurityTest {
     private LoteProductoMapper loteProductoMapper;
     @MockBean
     private EvaluacionCalidadService evaluacionCalidadService;
+    @MockBean
+    private RetencionLoteService retencionLoteService;
+    @MockBean
+    private RetencionLoteMapper retencionLoteMapper;
+    @MockBean
+    private NoConformidadService noConformidadService;
+    @MockBean
+    private VidaUtilProductoService vidaUtilProductoService;
+    @MockBean
+    private ControlDocumentalService controlDocumentalService;
     @MockBean
     private UsuarioService usuarioService;
     @MockBean
@@ -343,13 +374,32 @@ class ContadorRoleSecurityTest {
 
     @Test
     @WithMockUser(authorities = "ROL_CONTADOR")
-    void contadorSinAccesoPlaneacionYCreacionOc() throws Exception {
+    void contadorPuedeConsultarPlanSemanalPeroNoMutarlo() throws Exception {
         when(planProduccionService.listar(any(), any(), any(), any())).thenReturn(new PageImpl<>(List.of()));
+        when(planProduccionService.buscarPorId(1L)).thenReturn(Optional.of(new PlanProduccionSemanal()));
 
         mockMvc.perform(get("/api/planeacion/planes-semanales"))
                 .andExpect(status().isOk());
 
         mockMvc.perform(get("/api/planeacion/planes-semanales/1"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/planeacion/planes-semanales")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(put("/api/planeacion/planes-semanales/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(patch("/api/planeacion/planes-semanales/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(delete("/api/planeacion/planes-semanales/1"))
                 .andExpect(status().isForbidden());
 
         mockMvc.perform(get("/api/mrp/corridas/1"))
@@ -358,6 +408,40 @@ class ContadorRoleSecurityTest {
         mockMvc.perform(post("/api/ordenes-compra")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+
+    @Test
+    @WithMockUser(authorities = {"ROL_CONTADOR", "CONTROL_DOCUMENTAL_WRITE"})
+    void contadorPuedeCrearYSubirControlDocumentalPeroNoEliminar() throws Exception {
+        when(controlDocumentalService.crearDocumento(any(), any())).thenReturn(DocumentoDTO.builder().build());
+        when(controlDocumentalService.agregarVersion(any(), any(), any(), any())).thenReturn(DocumentoVersionDTO.builder().build());
+
+        mockMvc.perform(post("/api/documental/documentos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"codigo\":\"DOC-1\",\"nombre\":\"Manual\",\"tipo\":\"PROCEDIMIENTO\",\"area\":\"CALIDAD\"}"))
+                .andExpect(status().isOk());
+
+        MockMultipartFile archivo = new MockMultipartFile("archivo", "doc.txt", "text/plain", "ok".getBytes());
+        mockMvc.perform(multipart("/api/documental/documentos/1/versiones")
+                        .file(archivo))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/documental/documentos/1"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_CONTADOR")
+    void contadorNoPuedeConsultarRetencionesNiNoConformidadesNiVidaUtil() throws Exception {
+        mockMvc.perform(get("/api/calidad/retenciones"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/calidad/no-conformidades"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/calidad/vida-util/productos-terminados"))
                 .andExpect(status().isForbidden());
     }
 


### PR DESCRIPTION
### Motivation
- Align ROL_CONTADOR with the new real-permissions policy: allow read-only access to plan weekly details while keeping all plan mutations blocked. 
- Remove contador access to sensitive Calidad areas (retenciones, no conformidades, vida útil). 
- Provide controlled document management for contador (create/upload allowed, delete always denied) via a dedicated permission.

### Description
- Planeación: enabled `GET /api/planeacion/planes-semanales/{id}` for `ROL_CONTADOR` by updating `PlanProduccionController` and the HTTP matchers in `SecurityConfig` to include the role for detail GETs while leaving `/api/planeacion/**` mutating routes unchanged.
- Calidad: removed `ROL_CONTADOR` from `@PreAuthorize` on `RetencionLoteController`, `NoConformidadController` and `VidaUtilProductoController` so contador no longer has read access to retenciones, no-conformidades or vida útil endpoints.
- Control documental: introduced permission-aware rules so POST (create) and POST version uploads are allowed to authorities with `CONTROL_DOCUMENTAL_WRITE` (and existing quality/admin roles), DELETE routes remain restricted to quality/admin; `ControlDocumentalController` annotation updated and `SecurityConfig` updated to include matchers for `CONTROL_DOCUMENTAL_WRITE` and to require authentication for documental GETs.
- RBAC migration: added incremental Flyway migration `V20260210__rbac_contador_quality_trim_and_documental_write.sql` that creates `CONTROL_DOCUMENTAL_WRITE`, grants `PO_PLAN_SEMANAL_READ` and `CONTROL_DOCUMENTAL_WRITE` to `ROL_CONTADOR`, and removes Calidad-related retenciones/no-conformidades/vida-util permissions from `ROL_CONTADOR`.
- Tests: extended `ContadorRoleSecurityTest` to assert the new policy: plan weekly list/detail accessible, all plan mutating methods return 403 for contador, documental create/upload allowed when `CONTROL_DOCUMENTAL_WRITE` is present and delete returns 403, and Calidad lists/GETs for retenciones/no-conformidades/vida útil return 403.

### Testing
- Ran the controller security MockMvc suite for the touched scenarios with `mvn -q -Dtest=ContadorRoleSecurityTest test` and the adjusted test class passed locally. 
- The changes compile and the modified MockMvc security tests for plan, calidad and documental behaved as expected (green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1fb897488333ae3fa789a4adc5b7)