### PR TITLE
Ajusta seguridad para rol CONTADOR en CAPAs y alertas de producción

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/calidad/controller/CapaController.java
+++ b/src/main/java/com/willyes/clemenintegra/calidad/controller/CapaController.java
@@ -31,7 +31,7 @@ public class CapaController {
     private final CapaService service;
 
     @GetMapping
-    @org.springframework.security.access.prepost.PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_CONTADOR','ROL_SUPER_ADMIN')")
+    @org.springframework.security.access.prepost.PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<Page<CapaDTO>> listar(
             @RequestParam(required = false) EstadoCapa estado,
             @RequestParam(required = false) SeveridadNoConformidad severidad,
@@ -40,7 +40,7 @@ public class CapaController {
     }
 
     @GetMapping("/{id}")
-    @org.springframework.security.access.prepost.PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_CONTADOR','ROL_SUPER_ADMIN')")
+    @org.springframework.security.access.prepost.PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<CapaDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerPorId(id));
     }
@@ -75,13 +75,13 @@ public class CapaController {
     }
 
     @GetMapping("/{id}/archivos")
-    @org.springframework.security.access.prepost.PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_CONTADOR','ROL_SUPER_ADMIN')")
+    @org.springframework.security.access.prepost.PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<List<CapaArchivoDTO>> listarArchivos(@PathVariable Long id) {
         return ResponseEntity.ok(service.listarArchivos(id));
     }
 
     @GetMapping({"/{capaId}/archivos/{archivoId}/descargar", "/{capaId}/archivos/{archivoId}"})
-    @org.springframework.security.access.prepost.PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_CONTADOR','ROL_SUPER_ADMIN')")
+    @org.springframework.security.access.prepost.PreAuthorize("hasAnyAuthority('ROL_JEFE_CALIDAD','ROL_SUPER_ADMIN')")
     public ResponseEntity<ByteArrayResource> descargarArchivo(@PathVariable Long capaId, @PathVariable Long archivoId) {
         CapaArchivoDescargaDTO archivo = service.descargarArchivo(capaId, archivoId);
         MediaType mediaType = archivo.getContentType() != null

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -140,6 +140,7 @@ public class SecurityConfig {
                             RolUsuario.ROL_PLANEADOR.name(),
                             RolUsuario.ROL_LIDER_ALIMENTOS.name(),
                             RolUsuario.ROL_LIDER_HOMEOPATICOS.name(),
+                            RolUsuario.ROL_CONTADOR.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name()
                     );
 

--- a/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
@@ -55,6 +55,10 @@ import com.willyes.clemenintegra.documental.controller.ControlDocumentalControll
 import com.willyes.clemenintegra.documental.dto.DocumentoDTO;
 import com.willyes.clemenintegra.documental.dto.DocumentoVersionDTO;
 import com.willyes.clemenintegra.documental.service.ControlDocumentalService;
+import com.willyes.clemenintegra.produccion.controller.IndicadoresProduccionController;
+import com.willyes.clemenintegra.produccion.dto.IndicadoresProduccionResponseDTO;
+import com.willyes.clemenintegra.produccion.service.ProduccionIndicadoresService;
+import com.willyes.clemenintegra.produccion.service.ReporteIndicadoresProduccionService;
 import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
 import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
 import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
@@ -112,7 +116,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         RetencionLoteController.class,
         NoConformidadController.class,
         VidaUtilProductoController.class,
-        ControlDocumentalController.class
+        ControlDocumentalController.class,
+        IndicadoresProduccionController.class
 })
 @AutoConfigureMockMvc(addFilters = true)
 @Import({SecurityConfig.class, ContadorRoleSecurityTest.MethodSecurityConfig.class})
@@ -196,6 +201,10 @@ class ContadorRoleSecurityTest {
     @MockBean
     private ControlDocumentalService controlDocumentalService;
     @MockBean
+    private ProduccionIndicadoresService produccionIndicadoresService;
+    @MockBean
+    private ReporteIndicadoresProduccionService reporteIndicadoresProduccionService;
+    @MockBean
     private UsuarioService usuarioService;
     @MockBean
     private UsuarioRepository usuarioRepository;
@@ -244,6 +253,27 @@ class ContadorRoleSecurityTest {
             chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
             return null;
         }).when(superAdminSoloLecturaWriteBlockFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ROL_CONTADOR")
+    void contadorPuedeConsultarIndicadoresYAlertasPeroNoCapas() throws Exception {
+        when(produccionIndicadoresService.calcularIndicadores(any(), any(), org.mockito.ArgumentMatchers.anyInt()))
+                .thenReturn(IndicadoresProduccionResponseDTO.builder().build());
+        when(produccionIndicadoresService.obtenerOrdenesConAlertas(any(), org.mockito.ArgumentMatchers.anyInt()))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/produccion/indicadores")
+                        .param("fechaInicio", "2026-01-01")
+                        .param("fechaFin", "2026-01-31"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/produccion/ordenes/alertas")
+                        .param("fechaReferencia", "2026-01-12"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/calidad/capas"))
+                .andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Revocar el acceso de `ROL_CONTADOR` a endpoints de CAPAs y permitir específicamente que `ROL_CONTADOR` consulte las alertas de producción sin abrir otros endpoints mutantes de producción.

### Description
- Se removió `ROL_CONTADOR` de las anotaciones `@PreAuthorize` en `CapaController` para los endpoints de listado, detalle y archivos, dejando solo `ROL_JEFE_CALIDAD` y `ROL_SUPER_ADMIN`.
- Se agregó `RolUsuario.ROL_CONTADOR.name()` al matcher HTTP GET que protege `/api/produccion/ordenes/alertas` en `SecurityConfig` para permitir acceso de solo lectura a CONTADOR a esa ruta.
- Se actualizó `ContadorRoleSecurityTest` para incluir `IndicadoresProduccionController`, agregar mocks de `ProduccionIndicadoresService` y `ReporteIndicadoresProduccionService`, y añadir la prueba `contadorPuedeConsultarIndicadoresYAlertasPeroNoCapas` que valida `GET /api/produccion/indicadores` -> 200, `GET /api/produccion/ordenes/alertas` -> 200 y `GET /api/calidad/capas` -> 403.
- Se ajustaron los stubs de Mockito en el test para usar `anyInt()` donde corresponde y evitar errores con matchers en parámetros primitivos.

### Testing
- Ejecutado: `mvn -Dtest=ContadorRoleSecurityTest,AlertasProduccionControllerSecurityTest,CapaControllerSecurityTest test`, y los tests objetivo pasaron correctamente.
- Nota: el wrapper `./mvnw` no está presente en el repo, por lo que se ejecutó `mvn` directamente para las pruebas automáticas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a28d31d708333859cfb53c1501c1e)