### PR TITLE
Restringe aplicación de conteos cíclicos a Contador/Super Admin

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -105,7 +105,7 @@ public class ConteoCiclicoController {
     }
 
     @PostMapping("/{id}/aplicar")
-    @PreAuthorize("hasAnyAuthority('INV_CONTEOS_WRITE','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_CONTADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<ConteoCiclicoResponseDTO> aplicar(@PathVariable Long id,
                                                             @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey) {
         ConteoCiclicoResponseDTO respuesta = conteoCiclicoService.aplicar(id, idempotencyKey);

--- a/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/security/SecurityConfig.java
@@ -192,6 +192,11 @@ public class SecurityConfig {
                             "INV_CONTEOS_READ"
                     );
 
+                    auth.requestMatchers(HttpMethod.POST, "/api/inventario/conteos/*/aplicar").hasAnyAuthority(
+                            RolUsuario.ROL_CONTADOR.name(),
+                            RolUsuario.ROL_SUPER_ADMIN.name()
+                    );
+
                     auth.requestMatchers("/api/inventario/conteos/**").hasAnyAuthority(
                             RolUsuario.ROL_JEFE_ALMACENES.name(),
                             RolUsuario.ROL_SUPER_ADMIN.name(),

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerSecurityTest.java
@@ -35,6 +35,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -157,4 +159,36 @@ class ConteoCiclicoControllerSecurityTest {
                                 .authorities(() -> "INV_CONTEOS_READ")))
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    void permiteAplicarConteoConRolContador() throws Exception {
+        ConteoCiclicoResponseDTO response = ConteoCiclicoResponseDTO.builder()
+                .id(77L)
+                .estado(EstadoConteoCiclico.APLICADO)
+                .build();
+        when(conteoCiclicoService.aplicar(anyLong(), eq("k1"))).thenReturn(response);
+
+        mockMvc.perform(post("/api/inventario/conteos/77/aplicar")
+                        .header("Idempotency-Key", "k1")
+                        .with(SecurityMockMvcRequestPostProcessors.user("contador")
+                                .authorities(() -> "ROL_CONTADOR")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void rechazaAplicarConteoConRolJefeAlmacenes() throws Exception {
+        mockMvc.perform(post("/api/inventario/conteos/77/aplicar")
+                        .with(SecurityMockMvcRequestPostProcessors.user("jefe")
+                                .authorities(() -> "ROL_JEFE_ALMACENES")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void rechazaAplicarConteoConPermisoWriteSinRolContador() throws Exception {
+        mockMvc.perform(post("/api/inventario/conteos/77/aplicar")
+                        .with(SecurityMockMvcRequestPostProcessors.user("perm-write")
+                                .authorities(() -> "INV_CONTEOS_WRITE")))
+                .andExpect(status().isForbidden());
+    }
+
 }

--- a/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
@@ -27,6 +27,7 @@ import com.willyes.clemenintegra.planeacion.service.PlanProduccionService;
 import com.willyes.clemenintegra.planeacion.model.PlanProduccionSemanal;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.ConteoCiclicoResponseDTO;
 import com.willyes.clemenintegra.inventario.mapper.LoteProductoMapper;
 import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
 import com.willyes.clemenintegra.inventario.repository.MovimientoInventarioRepository;
@@ -305,9 +306,14 @@ class ContadorRoleSecurityTest {
 
     @Test
     @WithMockUser(authorities = "ROL_CONTADOR")
-    void contadorNoPuedeAplicarNiCerrarConteo() throws Exception {
+    void contadorPuedeAplicarPeroNoCerrarConteo() throws Exception {
+        when(conteoCiclicoService.aplicar(any(), any())).thenReturn(ConteoCiclicoResponseDTO.builder()
+                .id(1L)
+                .estado(com.willyes.clemenintegra.inventario.model.enums.EstadoConteoCiclico.APLICADO)
+                .build());
+
         mockMvc.perform(post("/api/inventario/conteos/1/aplicar"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isOk());
 
         mockMvc.perform(post("/api/inventario/conteos/1/cerrar"))
                 .andExpect(status().isForbidden());


### PR DESCRIPTION
### Motivation
- Evitar que roles operativos (ej. `ROL_JEFE_ALMACENES`) o permisos genéricos (`INV_CONTEOS_WRITE`) ejecuten la acción de `aplicar` sobre conteos cíclicos, que modifica `lotes_productos` y `movimientos_inventario`.
- Mantener el resto de operaciones de conteo (crear/iniciar/cerrar/guardar detalles/put) con las reglas actuales para roles operativos y permisos existentes.

### Description
- Agregada una regla específica en `SecurityConfig` para `POST /api/inventario/conteos/*/aplicar` permitiendo únicamente `ROL_CONTADOR` y `ROL_SUPER_ADMIN`, y colocada antes del matcher general de `/api/inventario/conteos/**` para asegurar precedencia; se usó el patrón `"/api/inventario/conteos/*/aplicar"` con `HttpMethod.POST`.
- Alineado el método controlador `@PostMapping("/{id}/aplicar")` en `ConteoCiclicoController` cambiando `@PreAuthorize` a `hasAnyAuthority('ROL_CONTADOR','ROL_SUPER_ADMIN')` para que la protección coincida con la configuración HTTP.
- Añadidas pruebas MockMvc en `ConteoCiclicoControllerSecurityTest` para validar que `ROL_CONTADOR` puede `POST /api/inventario/conteos/{id}/aplicar` y que `ROL_JEFE_ALMACENES` o un principal con solo `INV_CONTEOS_WRITE` reciben `403`.
- Ajustada la prueba `ContadorRoleSecurityTest` para reflejar el nuevo comportamiento (contador puede aplicar pero no cerrar); no se introdujo nuevo permiso RBAC (`INV_CONTEOS_APPLY`) en esta iteración.
- No se tocaron las reglas de negocio de `aplicar` ni los flujos de ajustes o movimientos y no se editaron migraciones existentes.

### Testing
- Ejecutado `mvn -q -Dtest=ConteoCiclicoControllerSecurityTest,ContadorRoleSecurityTest,ConteoCiclicoControllerTest test` y las pruebas relevantes pasaron exitosamente.
- Ejecutado `mvn -q test` (suite completa) y la compilación/ejecución de tests terminó sin fallos.
- Casos verificados en tests: `ROL_CONTADOR` -> `POST /api/inventario/conteos/{id}/aplicar` devuelve `200`; `ROL_JEFE_ALMACENES` -> `POST .../aplicar` devuelve `403`; principal con `INV_CONTEOS_WRITE` pero sin `ROL_CONTADOR` -> `403`; `GET /api/inventario/conteos` por `ROL_CONTADOR` -> `200`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a3ab19b34833393b369a5e8f0d6c8)