### PR TITLE
test: asegurar filtro productoId en movimientos

### DIFF
--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerFechaWebMvcTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerFechaWebMvcTest.java
@@ -126,4 +126,29 @@ class MovimientoInventarioControllerFechaWebMvcTest {
         assertThat(inicioCaptor.getValue()).isEqualTo(LocalDateTime.of(2025, 12, 8, 0, 0));
         assertThat(finCaptor.getValue()).isEqualTo(LocalDateTime.of(2025, 12, 16, 23, 59, 59));
     }
+
+    @Test
+    @WithMockUser(authorities = "ROL_SUPER_ADMIN")
+    @DisplayName("/filtrar propaga productoId al servicio")
+    void filtrarDebePropagarProductoId() throws Exception {
+        given(movimientoInventarioService.filtrar(any(), any(), any(), any(), any(), any(), any(Pageable.class)))
+                .willReturn(Page.empty());
+
+        mockMvc.perform(get("/api/movimientos/filtrar")
+                        .param("fechaInicio", "2025-12-08")
+                        .param("fechaFin", "2025-12-16")
+                        .param("productoId", "99")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(movimientoInventarioService).filtrar(
+                any(LocalDateTime.class),
+                any(LocalDateTime.class),
+                eq(99L),
+                isNull(),
+                isNull(),
+                isNull(),
+                any(Pageable.class)
+        );
+    }
 }

--- a/src/test/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepositoryFechaTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepositoryFechaTest.java
@@ -151,6 +151,83 @@ class MovimientoInventarioRepositoryFechaTest {
         assertThat(resultados.get(0).getFechaIngreso()).isAfterOrEqualTo(resultados.get(1).getFechaIngreso());
     }
 
+    @Test
+    @DisplayName("filtrar por productoId devuelve solo movimientos del producto solicitado")
+    void filtrarPorProductoId() {
+        Producto otroProducto = entityManager.persist(Producto.builder()
+                .codigoSku("SKU-2")
+                .nombre("Producto alterno")
+                .stockMinimo(BigDecimal.ONE)
+                .stockMinimoProveedor(BigDecimal.ZERO)
+                .leadTimeCompraDias(1)
+                .leadTimeProduccionDias(1)
+                .stockSeguridad(BigDecimal.ZERO)
+                .stockMaximoPlaneacion(BigDecimal.ZERO)
+                .rendimientoUnidad(BigDecimal.ONE)
+                .activo(true)
+                .fechaCreacion(LocalDateTime.now())
+                .tipoAnalisis(TipoAnalisisCalidad.NINGUNO)
+                .requiereAnalisisFisico(false)
+                .requiereAnalisisQuimico(false)
+                .requiereAnalisisMicrobiologico(false)
+                .unidadMedida(producto.getUnidadMedida())
+                .categoriaProducto(producto.getCategoriaProducto())
+                .creadoPor(usuario)
+                .modoControlInventario(ModoControlInventario.CONTROL_STOCK)
+                .build());
+
+        LoteProducto otroLote = entityManager.persist(LoteProducto.builder()
+                .codigoLote("L-002")
+                .fechaFabricacion(LocalDateTime.of(2025, 12, 2, 10, 0))
+                .fechaVencimiento(LocalDateTime.of(2026, 1, 2, 10, 0))
+                .stockLote(BigDecimal.TEN)
+                .agotado(false)
+                .stockReservado(BigDecimal.ZERO)
+                .estado(EstadoLote.DISPONIBLE)
+                .producto(otroProducto)
+                .almacen(almacen)
+                .build());
+
+        MovimientoInventario movimientoProductoObjetivo = crearMovimiento(
+                LocalDateTime.of(2025, 12, 12, 11, 0),
+                BigDecimal.valueOf(3)
+        );
+
+        MovimientoInventario movimientoOtroProducto = MovimientoInventario.builder()
+                .cantidad(BigDecimal.valueOf(9))
+                .tipoMovimiento(TipoMovimiento.RECEPCION)
+                .clasificacion(ClasificacionMovimientoInventario.RECEPCION_COMPRA)
+                .fechaIngreso(LocalDateTime.of(2025, 12, 12, 12, 0))
+                .docReferencia("OC-999")
+                .registradoPor(usuario)
+                .producto(otroProducto)
+                .lote(otroLote)
+                .almacenOrigen(almacen)
+                .almacenDestino(null)
+                .motivoMovimiento(motivoMovimiento)
+                .tipoMovimientoDetalle(tipoMovimientoDetalle)
+                .build();
+        movimientoInventarioRepository.save(movimientoOtroProducto);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<MovimientoInventario> page = movimientoInventarioRepository.filtrar(
+                LocalDateTime.of(2025, 12, 12, 0, 0),
+                LocalDateTime.of(2025, 12, 12, 23, 59, 59),
+                producto.getId().longValue(),
+                null,
+                null,
+                null,
+                PageRequest.of(0, 10, Sort.by("fechaIngreso").descending())
+        );
+
+        assertThat(page.getContent())
+                .hasSize(1)
+                .extracting(MovimientoInventario::getId)
+                .containsExactly(movimientoProductoObjetivo.getId());
+    }
+
     private MovimientoInventario crearMovimiento(LocalDateTime fechaIngreso, BigDecimal cantidad) {
         MovimientoInventario movimiento = MovimientoInventario.builder()
                 .cantidad(cantidad)

--- a/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
@@ -355,6 +355,15 @@ class ContadorRoleSecurityTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    void compradorNoPuedeConsultarMovimientosFiltrados() throws Exception {
+        mockMvc.perform(get("/api/movimientos/filtrar")
+                        .param("fechaInicio", "2026-01-01")
+                        .param("fechaFin", "2026-01-31"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     @WithMockUser(authorities = "ROL_CONTADOR")
     void contadorPuedeLeerModulosInventarioPermitidos() throws Exception {
         when(productoService.listarTodos(any(), any(), any(), any(), any())).thenReturn(new PageImpl<>(List.of()));


### PR DESCRIPTION
### Motivation
- Garantizar que el endpoint de listado/filtrado de movimientos (`GET /api/movimientos/filtrar`) soporte y propague correctamente `productoId` y que no se rompa en futuras refactorizaciones. 
- Añadir pruebas que validen comportamiento funcional (propagación), consulta en BD (filtro por producto) y reglas de seguridad (403 para roles no permitidos).

### Description
- Agregué un test WebMvc que verifica que `productoId` se propaga desde `MovimientoInventarioController.filtrar` al servicio (`src/test/java/com/willyes/clemenintegra/inventario/controller/MovimientoInventarioControllerFechaWebMvcTest.java`, aprox. L130-L153). 
- Agregué un test DataJpa que comprueba que `MovimientoInventarioRepository.filtrar` devuelve únicamente movimientos del `productoId` solicitado (`src/test/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepositoryFechaTest.java`, aprox. L154-L229). 
- Agregué un test de seguridad que valida que un rol no autorizado (`ROL_COMPRADOR`) recibe `403` al llamar `/api/movimientos/filtrar` (`src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java`, aprox. L357-L364). 
- No fue necesario modificar Controller/Service/Repository productivo porque la firma del controlador y la query del repositorio ya aceptaban y aplicaban `productoId` y usan `@EntityGraph` para evitar N+1 (referencias: `MovimientoInventarioController` y `MovimientoInventarioRepository`).

### Testing
- Ejecuté los tests incluidos con: `mvn -q -Dtest=MovimientoInventarioControllerFechaWebMvcTest,MovimientoInventarioRepositoryFechaTest,ContadorRoleSecurityTest test`.
- Resultado: las pruebas unitarias/integradas añadidas se ejecutaron como parte del conjunto y pasaron correctamente (no se detectaron fallos en la ejecución seleccionada).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb60cdf6083339fcd10cb32c24da7)