### PR TITLE
feat(inventario): endpoint dedicado de lotes para conteos por producto y almacén

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoController.java
@@ -60,6 +60,16 @@ public class ConteoCiclicoController {
         return ResponseEntity.ok(respuesta);
     }
 
+
+    @GetMapping("/lotes")
+    @PreAuthorize("hasAnyAuthority('INV_CONTEOS_READ','ROL_ALMACENISTA','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_CONTADOR')")
+    public ResponseEntity<List<ConteoCiclicoLoteResponseDTO>> listarLotesPorProductoYAlmacen(
+            @RequestParam Long productoId,
+            @RequestParam Integer almacenId) {
+        List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService.listarLotesParaConteo(productoId, almacenId);
+        return ResponseEntity.ok(respuesta);
+    }
+
     @PostMapping
     @PreAuthorize("hasAnyAuthority('INV_CONTEOS_WRITE','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
     public ResponseEntity<ConteoCiclicoResponseDTO> crear(@Valid @RequestBody ConteoCiclicoRequestDTO request) {

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoLoteResponseDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/ConteoCiclicoLoteResponseDTO.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 public class ConteoCiclicoLoteResponseDTO {
     Long id;
     String codigoLote;
+    String estado;
     BigDecimal stockLote;
     LocalDateTime fechaVencimiento;
     Long ubicacionFisicaId;

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/LoteProductoRepository.java
@@ -282,6 +282,17 @@ WHERE lp.codigoLote = :codigoLote
                                         @Param("q") String q,
                                         @Param("estados") Collection<EstadoLote> estados);
 
+    @Query("""
+        select lp
+        from LoteProducto lp
+        left join fetch lp.ubicacionFisica uf
+        where lp.producto.id = :productoId
+          and lp.almacen.id = :almacenId
+        order by lp.fechaVencimiento asc nulls last, lp.id asc
+    """)
+    List<LoteProducto> buscarParaConteoPorProductoYAlmacen(@Param("productoId") Long productoId,
+                                                            @Param("almacenId") Integer almacenId);
+
     @Query(value = """
         SELECT lp.productos_id        AS productoId,
                p.nombre               AS nombreProducto,

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoService.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 public class ConteoCiclicoService {
 
     private static final EnumSet<EstadoLote> LOTES_OPERABLES = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
-    private static final EnumSet<EstadoLote> LOTES_CONTABLES = EnumSet.of(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
 
     private final ConteoCiclicoRepository conteoRepository;
     private final ConteoCiclicoDetalleRepository detalleRepository;
@@ -102,16 +101,23 @@ public class ConteoCiclicoService {
         }
 
         String filtroTexto = (q == null || q.isBlank()) ? null : q.trim();
+        final UbicacionFisica ubicacionSeleccionada = ubicacion;
+        final String filtroTextoNormalizado = filtroTexto != null ? filtroTexto.toLowerCase() : null;
 
         log.debug("[ConteoCiclico] listarLotes conteoId={}, almacenId={}, productoId={}, ubicacionFisicaId={}, search={}",
-                conteoId, almacenId, producto.getId(), ubicacion != null ? ubicacion.getId() : null, filtroTexto);
+                conteoId, almacenId, producto.getId(),
+                ubicacionSeleccionada != null ? ubicacionSeleccionada.getId() : null, filtroTexto);
 
-        List<LoteProducto> lotes = loteProductoRepository.buscarParaConteo(
+        List<LoteProducto> lotes = loteProductoRepository.buscarParaConteoPorProductoYAlmacen(
                 producto.getId().longValue(),
-                almacenId,
-                ubicacion != null ? ubicacion.getId() : null,
-                filtroTexto,
-                LOTES_CONTABLES);
+                almacenId).stream()
+                .filter(lp -> ubicacionSeleccionada == null || (lp.getUbicacionFisica() != null
+                        && Objects.equals(lp.getUbicacionFisica().getId(), ubicacionSeleccionada.getId())))
+                .filter(lp -> !StringUtils.hasText(filtroTextoNormalizado)
+                        || (lp.getCodigoLote() != null
+                        && lp.getCodigoLote().toLowerCase().contains(filtroTextoNormalizado)))
+                .filter(lp -> lp.getStockLote() != null && lp.getStockLote().compareTo(BigDecimal.ZERO) > 0)
+                .toList();
 
         log.debug("[ConteoCiclico] lotes encontrados antes de mapear: {}", lotes.size());
         lotes.stream()
@@ -128,6 +134,32 @@ public class ConteoCiclicoService {
                 .map(lp -> ConteoCiclicoLoteResponseDTO.builder()
                         .id(lp.getId())
                         .codigoLote(lp.getCodigoLote())
+                        .estado(lp.getEstado() != null ? lp.getEstado().name() : null)
+                        .stockLote(Optional.ofNullable(lp.getStockLote()).orElse(BigDecimal.ZERO))
+                        .fechaVencimiento(lp.getFechaVencimiento())
+                        .ubicacionFisicaId(lp.getUbicacionFisica() != null ? lp.getUbicacionFisica().getId() : null)
+                        .ubicacionCodigo(lp.getUbicacionFisica() != null ? lp.getUbicacionFisica().getCodigo() : null)
+                        .build())
+                .toList();
+    }
+
+
+    @Transactional(readOnly = true)
+    public List<ConteoCiclicoLoteResponseDTO> listarLotesParaConteo(Long productoId, Integer almacenId) {
+        if (productoId == null || almacenId == null) {
+            throw new CustomBusinessException(ApiErrorCode.SOLICITUD_INVALIDA,
+                    "Debe especificar productoId y almacenId");
+        }
+
+        List<LoteProducto> lotes = loteProductoRepository.buscarParaConteoPorProductoYAlmacen(productoId, almacenId).stream()
+                .filter(lp -> lp.getStockLote() != null && lp.getStockLote().compareTo(BigDecimal.ZERO) > 0)
+                .toList();
+
+        return lotes.stream()
+                .map(lp -> ConteoCiclicoLoteResponseDTO.builder()
+                        .id(lp.getId())
+                        .codigoLote(lp.getCodigoLote())
+                        .estado(lp.getEstado() != null ? lp.getEstado().name() : null)
                         .stockLote(Optional.ofNullable(lp.getStockLote()).orElse(BigDecimal.ZERO))
                         .fechaVencimiento(lp.getFechaVencimiento())
                         .ubicacionFisicaId(lp.getUbicacionFisica() != null ? lp.getUbicacionFisica().getId() : null)

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/ConteoCiclicoControllerTest.java
@@ -94,6 +94,28 @@ class ConteoCiclicoControllerTest {
                 .andExpect(jsonPath("$.estado").value("EN_CONTEO"));
     }
 
+
+    @Test
+    @WithMockUser(authorities = "ROL_ALMACENISTA")
+    void listarLotesPorProductoYAlmacenDevuelveLotesEnCuarentena() throws Exception {
+        ConteoCiclicoLoteResponseDTO lote = ConteoCiclicoLoteResponseDTO.builder()
+                .id(501L)
+                .codigoLote("L-728-01")
+                .estado("EN_CUARENTENA")
+                .stockLote(new BigDecimal("2.00"))
+                .build();
+
+        when(conteoCiclicoService.listarLotesParaConteo(728L, 7)).thenReturn(List.of(lote));
+
+        mockMvc.perform(get("/api/inventario/conteos/lotes")
+                        .param("productoId", "728")
+                        .param("almacenId", "7"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(501))
+                .andExpect(jsonPath("$[0].codigoLote").value("L-728-01"))
+                .andExpect(jsonPath("$[0].estado").value("EN_CUARENTENA"));
+    }
+
     @Test
     @WithMockUser(authorities = "ROL_ALMACENISTA")
     void listarLotesParaConteoSinQDevuelveListado() throws Exception {

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/ConteoCiclicoServiceTest.java
@@ -24,7 +24,6 @@ import org.springframework.data.domain.PageRequest;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,7 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -399,7 +397,7 @@ class ConteoCiclicoServiceTest {
     }
 
     @Test
-    void listarLotesParaConteoUsaEstadosContables() {
+    void listarLotesParaConteoIncluyeEnCuarentenaYFiltraStockCero() {
         ConteoCiclico conteo = ConteoCiclico.builder()
                 .id(2L)
                 .almacen(new Almacen(7))
@@ -407,31 +405,37 @@ class ConteoCiclicoServiceTest {
         Producto producto = new Producto();
         producto.setId(3);
 
-        LoteProducto loteDisponible = LoteProducto.builder()
+        LoteProducto loteCuarentena = LoteProducto.builder()
                 .id(15L)
                 .producto(producto)
                 .almacen(conteo.getAlmacen())
-                .codigoLote("DIS-001")
+                .codigoLote("CUA-001")
+                .estado(EstadoLote.EN_CUARENTENA)
+                .stockLote(new BigDecimal("4.00"))
+                .build();
+
+        LoteProducto loteSinStock = LoteProducto.builder()
+                .id(16L)
+                .producto(producto)
+                .almacen(conteo.getAlmacen())
+                .codigoLote("SIN-001")
                 .estado(EstadoLote.DISPONIBLE)
                 .stockLote(BigDecimal.ZERO)
                 .build();
 
         when(conteoCiclicoRepository.findById(2L)).thenReturn(Optional.of(conteo));
         when(productoRepository.findById(3L)).thenReturn(Optional.of(producto));
-        when(loteProductoRepository.buscarParaConteo(eq(3L), eq(7), isNull(), isNull(), anyCollection()))
-                .thenReturn(List.of(loteDisponible));
+        when(loteProductoRepository.buscarParaConteoPorProductoYAlmacen(3L, 7))
+                .thenReturn(List.of(loteCuarentena, loteSinStock));
 
-        ArgumentCaptor<Collection<EstadoLote>> estadosCaptor = ArgumentCaptor.forClass(Collection.class);
-
-        List<com.willyes.clemenintegra.inventario.dto.ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
+        List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
                 .listarLotesParaConteo(2L, 3L, null, null);
 
         assertThat(respuesta).hasSize(1);
         assertThat(respuesta.getFirst().getId()).isEqualTo(15L);
+        assertThat(respuesta.getFirst().getEstado()).isEqualTo("EN_CUARENTENA");
 
-        verify(loteProductoRepository).buscarParaConteo(eq(3L), eq(7), isNull(), isNull(), estadosCaptor.capture());
-        assertThat(estadosCaptor.getValue())
-                .containsExactlyInAnyOrder(EstadoLote.DISPONIBLE, EstadoLote.LIBERADO);
+        verify(loteProductoRepository).buscarParaConteoPorProductoYAlmacen(3L, 7);
     }
 
     @Test
@@ -454,7 +458,7 @@ class ConteoCiclicoServiceTest {
 
         when(conteoCiclicoRepository.findById(12L)).thenReturn(Optional.of(conteo));
         when(productoRepository.findById(8L)).thenReturn(Optional.of(producto));
-        when(loteProductoRepository.buscarParaConteo(eq(8L), eq(5), isNull(), isNull(), anyCollection()))
+        when(loteProductoRepository.buscarParaConteoPorProductoYAlmacen(8L, 5))
                 .thenReturn(List.of(lote));
 
         List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
@@ -492,7 +496,7 @@ class ConteoCiclicoServiceTest {
 
         when(conteoCiclicoRepository.findById(14L)).thenReturn(Optional.of(conteo));
         when(productoRepository.findById(11L)).thenReturn(Optional.of(producto));
-        when(loteProductoRepository.buscarParaConteo(eq(11L), eq(4), isNull(), isNull(), anyCollection()))
+        when(loteProductoRepository.buscarParaConteoPorProductoYAlmacen(11L, 4))
                 .thenReturn(List.of(lote));
 
         List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
@@ -523,10 +527,8 @@ class ConteoCiclicoServiceTest {
 
         when(conteoCiclicoRepository.findById(13L)).thenReturn(Optional.of(conteo));
         when(productoRepository.findById(9L)).thenReturn(Optional.of(producto));
-        when(loteProductoRepository.buscarParaConteo(eq(9L), eq(6), isNull(), anyString(), anyCollection()))
+        when(loteProductoRepository.buscarParaConteoPorProductoYAlmacen(9L, 6))
                 .thenReturn(List.of(lote));
-
-        ArgumentCaptor<String> qCaptor = ArgumentCaptor.forClass(String.class);
 
         List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService
                 .listarLotesParaConteo(13L, 9L, null, " 20251003 ");
@@ -534,8 +536,32 @@ class ConteoCiclicoServiceTest {
         assertThat(respuesta).hasSize(1);
         assertThat(respuesta.getFirst().getCodigoLote()).isEqualTo("L20251003-01");
 
-        verify(loteProductoRepository).buscarParaConteo(eq(9L), eq(6), isNull(), qCaptor.capture(), anyCollection());
-        assertThat(qCaptor.getValue()).isEqualTo("20251003");
+        verify(loteProductoRepository).buscarParaConteoPorProductoYAlmacen(9L, 6);
+    }
+
+    @Test
+    void listarLotesParaConteoPorProductoYAlmacenIncluyeEstadoEnCuarentena() {
+        Producto producto = new Producto();
+        producto.setId(728);
+        Almacen almacen = new Almacen(7);
+
+        LoteProducto lote = LoteProducto.builder()
+                .id(501L)
+                .producto(producto)
+                .almacen(almacen)
+                .codigoLote("L-728-01")
+                .estado(EstadoLote.EN_CUARENTENA)
+                .stockLote(new BigDecimal("2.00"))
+                .build();
+
+        when(loteProductoRepository.buscarParaConteoPorProductoYAlmacen(728L, 7))
+                .thenReturn(List.of(lote));
+
+        List<ConteoCiclicoLoteResponseDTO> respuesta = conteoCiclicoService.listarLotesParaConteo(728L, 7);
+
+        assertThat(respuesta).hasSize(1);
+        assertThat(respuesta.getFirst().getEstado()).isEqualTo("EN_CUARENTENA");
+        assertThat(respuesta.getFirst().getCodigoLote()).isEqualTo("L-728-01");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Conteos deben listar los lotes de un producto en el almacén del conteo incluyendo lotes con estado `EN_CUARENTENA` sin afectar la lógica/endpoint de Movimientos/Consumos. 
- Se necesitaba un endpoint dedicado que devuelva lotes por `productoId` + `almacenId` y permita orden FEFO y filtrado mínimo para la UI de select.

### Description
- Añadido nuevo método de repositorio `LoteProductoRepository#buscarParaConteoPorProductoYAlmacen(Long productoId, Integer almacenId)` con `ORDER BY fechaVencimiento ASC, id ASC` para obtener lotes de un producto en un almacén sin filtrar por estado. 
- Modificada la lógica en `ConteoCiclicoService#listarLotesParaConteo(conteoId, productoId, ubicacionFisicaId, q)` para usar la nueva consulta y aplicar en memoria los filtros de ubicación, búsqueda por texto y `stockLote > 0`. 
- Agregado método de servicio dedicado `ConteoCiclicoService#listarLotesParaConteo(Long productoId, Integer almacenId)` que valida parámetros y retorna lotes del almacén (usa `stockLote > 0`). 
- Nuevo endpoint controlador `GET /api/inventario/conteos/lotes?productoId={id}&almacenId={id}` en `ConteoCiclicoController` que expone el método de servicio sin tocar el endpoint existente `GET /api/inventario/conteos/{id}/lotes`. 
- Extendido `ConteoCiclicoLoteResponseDTO` con el campo `estado` para que la UI pueda mostrar el estado del lote. 
- Tests: se añadió un test MockMvc para el nuevo endpoint y se actualizaron/extendieron tests unitarios en `ConteoCiclicoServiceTest` para cubrir inclusión de `EN_CUARENTENA`, filtrado de `stockLote > 0` y reusos del nuevo repositorio.

### Testing
- Ejecutado `mvn -Dtest=ConteoCiclicoControllerTest,ConteoCiclicoServiceTest test` y todos los tests dirigidos pasaron exitosamente. 
- Se validó localmente que el nuevo endpoint devuelve lotes con `estado = EN_CUARENTENA` para los datos de prueba agregados en los tests. 
- No se modificaron ni rompieron los endpoints usados por Movimientos/Consumos; las pruebas existentes de movimientos no se tocaron y la suite objetivo pasó.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc98da2888333978d361493be39a1)