### PR TITLE
Allow confirmed homeopatico OP creation, persist override fields and improve integrity diagnostics

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionController.java
@@ -111,7 +111,7 @@ public class OrdenProduccionController {
 
     @PostMapping
     @PreAuthorize("hasAnyAuthority('PROD_OP_CREATE','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
-    public ResponseEntity<ResultadoValidacionOrdenDTO> crear(@RequestBody OrdenProduccionRequestDTO request) {
+    public ResponseEntity<ResultadoValidacionOrdenDTO> crear(@Valid @RequestBody OrdenProduccionRequestDTO request) {
         ResultadoValidacionOrdenDTO resultado = service.crearOrden(request);
         HttpStatus status = resultado.isEsValida() ? HttpStatus.CREATED : HttpStatus.BAD_REQUEST;
         if (!resultado.isEsValida()) {

--- a/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/dto/OrdenProduccionRequestDTO.java
@@ -48,5 +48,14 @@ public class OrdenProduccionRequestDTO {
 
     private Boolean confirmacionHomeopatico;
 
+    @Size(max = 500, message = "motivoOverrideHomeopatico no debe superar 500 caracteres")
     private String motivoOverrideHomeopatico;
+
+    @AssertTrue(message = "motivoOverrideHomeopatico es obligatorio cuando confirmacionHomeopatico=true y debe tener al menos 20 caracteres")
+    public boolean isMotivoOverrideValidoCuandoConfirmado() {
+        if (!Boolean.TRUE.equals(confirmacionHomeopatico)) {
+            return true;
+        }
+        return motivoOverrideHomeopatico != null && motivoOverrideHomeopatico.trim().length() >= 20;
+    }
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java
@@ -20,6 +20,8 @@ public class ProduccionMapper {
                 .unidadMedida(producto.getUnidadMedida())
                 .responsable(responsable)
                 .lotePsId(dto.getLotePsId())
+                .confirmacionHomeopatico(Boolean.TRUE.equals(dto.getConfirmacionHomeopatico()))
+                .motivoOverrideHomeopatico(dto.getMotivoOverrideHomeopatico() != null ? dto.getMotivoOverrideHomeopatico().trim() : null)
                 .build();
     }
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/model/OrdenProduccion.java
@@ -90,6 +90,14 @@ public class OrdenProduccion {
     @Column(name = "batch_record_observaciones_calidad", columnDefinition = "TEXT")
     private String batchRecordObservacionesCalidad;
 
+
+    @Column(name = "confirmacion_homeopatico", nullable = false)
+    @Builder.Default
+    private Boolean confirmacionHomeopatico = Boolean.FALSE;
+
+    @Column(name = "motivo_override_homeopatico", length = 500)
+    private String motivoOverrideHomeopatico;
+
     @Transient
     private Long lotePsId;
 

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -153,6 +153,7 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     private static final int SEMANAS_HOMEOPATICO = 78;
     private static final BigDecimal CANTIDAD_MAXIMA_HOMEOPATICO = new BigDecimal("30");
     private static final int MOTIVO_OVERRIDE_MIN_LENGTH = 20;
+    private static final int MOTIVO_OVERRIDE_MAX_LENGTH = 500;
 
     @Value("${inventory.solicitud.estados.pendientes}")
     private String estadosSolicitudPendientesConf;
@@ -536,7 +537,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             );
         }
         String motivo = dto.getMotivoOverrideHomeopatico();
-        if (motivo == null || motivo.trim().length() < MOTIVO_OVERRIDE_MIN_LENGTH) {
+        String motivoNormalizado = motivo != null ? motivo.trim() : null;
+        if (motivoNormalizado == null || motivoNormalizado.length() < MOTIVO_OVERRIDE_MIN_LENGTH) {
             throw new CustomBusinessException(
                     ApiErrorCode.OP_HOMEOPATICO_MOTIVO_OBLIGATORIO,
                     "Debe ingresar una justificación de al menos 20 caracteres para continuar con la OP homeopática.",
@@ -547,6 +549,13 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                             "maxRecomendado", CANTIDAD_MAXIMA_HOMEOPATICO,
                             "minCaracteresMotivo", MOTIVO_OVERRIDE_MIN_LENGTH
                     )
+            );
+        }
+        if (motivoNormalizado.length() > MOTIVO_OVERRIDE_MAX_LENGTH) {
+            throw new CustomBusinessException(
+                    ApiErrorCode.SOLICITUD_INVALIDA,
+                    "motivoOverrideHomeopatico no debe superar 500 caracteres",
+                    Map.of("maxCaracteresMotivo", MOTIVO_OVERRIDE_MAX_LENGTH)
             );
         }
     }

--- a/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/willyes/clemenintegra/shared/exception/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -172,6 +173,38 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ErrorResponseDTO> handleDataIntegrityViolation(DataIntegrityViolationException ex,
                                                                          HttpServletRequest request) {
+        Throwable root = getRootCause(ex);
+        String requestId = MDC.get("requestId");
+        String method = request != null ? request.getMethod() : null;
+        String uri = request != null ? request.getRequestURI() : null;
+
+        String sqlState = null;
+        Integer errorCode = null;
+        String constraint = null;
+
+        if (root instanceof SQLException sqlException) {
+            sqlState = sqlException.getSQLState();
+            errorCode = sqlException.getErrorCode();
+        }
+        if (root instanceof org.hibernate.exception.ConstraintViolationException hibernateConstraintViolationException) {
+            constraint = hibernateConstraintViolationException.getConstraintName();
+            if (hibernateConstraintViolationException.getSQLException() != null) {
+                sqlState = hibernateConstraintViolationException.getSQLException().getSQLState();
+                errorCode = hibernateConstraintViolationException.getSQLException().getErrorCode();
+            }
+        }
+
+        log.error("DataIntegrityViolation requestId={} method={} uri={} rootType={} sqlState={} errorCode={} constraint={} rootMessage={}",
+                requestId,
+                method,
+                uri,
+                root != null ? root.getClass().getName() : null,
+                sqlState,
+                errorCode,
+                constraint,
+                root != null ? root.getMessage() : null,
+                ex);
+
         return buildResponse(HttpStatus.CONFLICT,
                 "CONFLICTO_INTEGRIDAD",
                 "Conflicto de integridad en la operación solicitada.",

--- a/src/main/resources/db/migration/inventario/V20260211__orden_produccion_homeopatico_columns.sql
+++ b/src/main/resources/db/migration/inventario/V20260211__orden_produccion_homeopatico_columns.sql
@@ -1,0 +1,26 @@
+-- Persistencia de confirmación y motivo de override homeopático en orden_produccion
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+           WHERE table_schema = DATABASE() AND table_name='orden_produccion' AND column_name='confirmacion_homeopatico');
+SET @sql := IF(@c=0,
+ 'ALTER TABLE orden_produccion ADD COLUMN confirmacion_homeopatico TINYINT(1) NOT NULL DEFAULT 0 AFTER unidad_medida_id',
+ 'SELECT 1');
+PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+           WHERE table_schema = DATABASE() AND table_name='orden_produccion' AND column_name='motivo_override_homeopatico');
+SET @sql := IF(@c=0,
+ 'ALTER TABLE orden_produccion ADD COLUMN motivo_override_homeopatico VARCHAR(500) NULL AFTER confirmacion_homeopatico',
+ 'SELECT 1');
+PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- Ajusta longitud por compatibilidad con validación de API
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+           WHERE table_schema = DATABASE()
+             AND table_name='orden_produccion'
+             AND column_name='motivo_override_homeopatico'
+             AND CHARACTER_MAXIMUM_LENGTH IS NOT NULL
+             AND CHARACTER_MAXIMUM_LENGTH < 500);
+SET @sql := IF(@c>0,
+ 'ALTER TABLE orden_produccion MODIFY COLUMN motivo_override_homeopatico VARCHAR(500) NULL',
+ 'SELECT 1');
+PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;

--- a/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/controller/OrdenProduccionControllerTest.java
@@ -257,6 +257,22 @@ class OrdenProduccionControllerTest {
                 .andExpect(jsonPath("$.details.semanasVigencia").value(78));
     }
 
+
+    @Test
+    @WithMockUser(authorities = "ROL_JEFE_PRODUCCION")
+    @DisplayName("POST /api/produccion/ordenes retorna 400 cuando confirmacionHomeopatico=true y motivo inválido")
+    void crearOrden_homeopaticoConfirmadoConMotivoInvalido_responde400() throws Exception {
+        OrdenProduccionRequestDTO request = buildRequest();
+        request.setConfirmacionHomeopatico(true);
+        request.setMotivoOverrideHomeopatico("muy corto");
+
+        mockMvc.perform(post("/api/produccion/ordenes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SOLICITUD_INVALIDA"));
+    }
+
     @Test
     @WithMockUser(authorities = "ROL_JEFE_CALIDAD")
     @DisplayName("GET /api/produccion/ordenes/{id} permite consulta a jefe de calidad")


### PR DESCRIPTION
### Motivation
- Permitir crear una Orden de Producción (OP) cuando `confirmacionHomeopatico=true` y `motivoOverrideHomeopatico` es válido, evitando el rechazo genérico 409 por validaciones cliente/BD. 
- Registrar el root cause técnico real (constraint / SQLState / mensaje) cuando ocurre `DataIntegrityViolationException` para facilitar diagnóstico de truncamientos o FKs. 
- Asegurar que los campos de override homeopático se persistan en la tabla `orden_produccion` y que la API valide longitudes para evitar errores de integridad en BD.

### Description
- Se agregó validación en `OrdenProduccionRequestDTO` para `motivoOverrideHomeopatico` con `@Size(max=500)` y una regla condicional `@AssertTrue` que exige ≥20 caracteres cuando `confirmacionHomeopatico=true`, y se habilitó `@Valid` en el `POST /api/produccion/ordenes` para que payloads inválidos devuelvan `400`.
- Se mapearon y persistieron los nuevos campos en la entidad `OrdenProduccion` (`confirmacion_homeopatico` boolean default `false`, `motivo_override_homeopatico VARCHAR(500)`) y en el `ProduccionMapper` se copia la confirmación y el motivo desde el DTO a la entidad.
- Se añadió verificación en `OrdenProduccionServiceImpl.validarHandshakeHomeopatico(...)` que normaliza el motivo, comprueba longitud mínima (20) y máxima (500) y lanza `CustomBusinessException` con códigos claros antes de persistir.
- Se creó migración Flyway idempotente `V20260211__orden_produccion_homeopatico_columns.sql` para agregar/ajustar `confirmacion_homeopatico` y `motivo_override_homeopatico` en `orden_produccion` (incluye ajuste de longitud si era menor a 500).
- El handler global en `GlobalExceptionHandler` para `DataIntegrityViolationException` ahora extrae y loguea el `root cause` completo incluyendo `requestId`, `method`, `uri`, `sqlState`, `errorCode`, `constraint` y el mensaje raíz, manteniendo la respuesta cliente `409 CONFLICTO_INTEGRIDAD` pero sin ocultar detalles en logs.
- Punto exacto donde se persiste la OP: `OrdenProduccionServiceImpl.guardarConValidacionStock(...)` realiza `repository.save(orden)` después de la validación homeopática y antes de clonar etapas/reservar insumos.

### Testing
- Se ejecutaron los tests unitarios/web relevantes con `mvn -Dtest=OrdenProduccionServiceImplTest,OrdenProduccionControllerTest test` y el `BUILD SUCCESS` confirmó que todos los tests corrieron OK. 
- Se añadió test de controlador que verifica que `POST /api/produccion/ordenes` con `confirmacionHomeopatico=true` y `motivoOverrideHomeopatico` inválido retorna `400 SOLICITUD_INVALIDA`, y los tests de servicio existentes cubren los casos: sin confirmación → `OP_HOMEOPATICO_REQUIERE_CONFIRMACION` y confirmación válida → creación y auditoría registrada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c8d9f6e388333af6238dabaf9fdf6)