### PR TITLE
Evitar entidad detached en override homeopático: usar OrdenProduccion managed

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -499,9 +499,8 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         orden.setCantidadProducidaAcumulada(BigDecimal.ZERO);
 
         ResultadoValidacionOrdenDTO resultado = guardarConValidacionStock(orden);
-        if (requiereOverrideHomeopatico && resultado.isEsValida() && resultado.getOrden() != null
-                && resultado.getOrden().id != null) {
-            registrarOverrideHomeopatico(resultado.getOrden().id, producto, semanasVigencia,
+        if (requiereOverrideHomeopatico && resultado.isEsValida() && orden.getId() != null) {
+            registrarOverrideHomeopatico(orden, producto, semanasVigencia,
                     cantidadConvertida, dto.getMotivoOverrideHomeopatico());
         }
         resultado.setUnidadesProducidas(unidadesProducidas);
@@ -560,11 +559,16 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
         }
     }
 
-    private void registrarOverrideHomeopatico(Long ordenProduccionId,
+    private void registrarOverrideHomeopatico(OrdenProduccion orden,
                                               Producto producto,
                                               Integer semanasVigencia,
                                               BigDecimal cantidadSolicitada,
                                               String motivo) {
+        String motivoNormalizado = motivo != null ? motivo.trim() : null;
+
+        orden.setConfirmacionHomeopatico(Boolean.TRUE);
+        orden.setMotivoOverrideHomeopatico(motivoNormalizado);
+
         Usuario usuarioActual = null;
         try {
             usuarioActual = usuarioService.obtenerUsuarioAutenticado();
@@ -572,15 +576,12 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             log.warn("No fue posible resolver usuario autenticado para auditoría override homeopático", ex);
         }
 
-        OrdenProduccion ordenRef = new OrdenProduccion();
-        ordenRef.setId(ordenProduccionId);
-
         OpHomeopaticoOverride auditoria = OpHomeopaticoOverride.builder()
-                .ordenProduccion(ordenRef)
+                .ordenProduccion(orden)
                 .producto(producto)
                 .semanasVigencia(semanasVigencia)
                 .cantidadSolicitada(cantidadSolicitada)
-                .motivo(motivo != null ? motivo.trim() : null)
+                .motivo(motivoNormalizado)
                 .usuario(usuarioActual)
                 .build();
 

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -362,8 +362,14 @@ class OrdenProduccionServiceImplTest {
                 .esValida(true)
                 .orden(new OrdenProduccionResponseDTO())
                 .build();
+        Long versionEsperada = 5L;
         resultado.getOrden().id = 900L;
-        doReturn(resultado).when(service).guardarConValidacionStock(any(OrdenProduccion.class));
+        doAnswer(invocation -> {
+            OrdenProduccion orden = invocation.getArgument(0);
+            orden.setId(900L);
+            orden.setVersion(versionEsperada);
+            return resultado;
+        }).when(service).guardarConValidacionStock(any(OrdenProduccion.class));
 
         CrearOrdenProduccionRequestDTO dto = new CrearOrdenProduccionRequestDTO();
         dto.setProductoId(32L);
@@ -379,8 +385,15 @@ class OrdenProduccionServiceImplTest {
         ArgumentCaptor<OpHomeopaticoOverride> captor = ArgumentCaptor.forClass(OpHomeopaticoOverride.class);
         verify(opHomeopaticoOverrideRepository).save(captor.capture());
         assertThat(captor.getValue().getOrdenProduccion().getId()).isEqualTo(900L);
+        assertThat(captor.getValue().getOrdenProduccion().getVersion()).isEqualTo(versionEsperada);
         assertThat(captor.getValue().getProducto().getId()).isEqualTo(32);
         assertThat(captor.getValue().getSemanasVigencia()).isEqualTo(78);
+
+        ArgumentCaptor<OrdenProduccion> ordenCaptor = ArgumentCaptor.forClass(OrdenProduccion.class);
+        verify(service).guardarConValidacionStock(ordenCaptor.capture());
+        assertThat(ordenCaptor.getValue().getConfirmacionHomeopatico()).isTrue();
+        assertThat(ordenCaptor.getValue().getMotivoOverrideHomeopatico())
+                .isEqualTo("Se requiere este lote para cubrir pedido regulatorio urgente");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Evitar la excepción de Hibernate 6 por entidad `OrdenProduccion` detached con `@Version` nulo al confirmar override homeopático tras el `POST /api/produccion/ordenes`.
- Mantener el comportamiento original que exige confirmación cuando aplica `OP_HOMEOPATICO_REQUIERE_CONFIRMACION` sin cambiar la validación previa.

### Description
- Cambiado en `crearOrden(...)` para invocar `registrarOverrideHomeopatico(orden, ...)` usando la misma instancia `OrdenProduccion` (managed) cuando la orden tiene `id` ya asignado, en lugar de reconstruir una referencia solo por `id` (archivo modificado: `src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java`).
- Refactor de `registrarOverrideHomeopatico(...)` para recibir la entidad `OrdenProduccion` managed, normalizar el `motivo`, setear `confirmacionHomeopatico` y `motivoOverrideHomeopatico` sobre la misma entidad y construir la auditoría con esa instancia (sin crear una nueva `OrdenProduccion` detached).
- Verificación del mapper: `ProduccionMapper.toEntity(...)` no mapea `id` ni `version` desde DTOs, por lo que no se introducen ids/version desde el cliente (archivo revisado: `src/main/java/com/willyes/clemenintegra/produccion/mapper/ProduccionMapper.java`).
- Tests ajustados en `src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java` para simular `version` en la orden persistida y para afirmar que la orden usada en el flujo es la misma (confirmación y motivo seteados) y que la auditoría guarda id/version esperados.

### Testing
- Ejecutado: `mvn -Dtest=OrdenProduccionServiceImplTest,OrdenProduccionControllerTest test`.
- Resultado: `BUILD SUCCESS`, todos los tests ejecutados pasaron (`Tests run: 78, Failures: 0, Errors: 0`).
- Verificación: en la ejecución de tests no se reprodujo la `PropertyValueException` por `OrdenProduccion.version = null` en el flujo cubierto y las aserciones nuevas sobre la orden y la auditoría pasan correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c9c138b248333bdb273fcbe293eaa)