### PR TITLE
Allow ROL_JEFE_PRODUCCION to access solicitud detail and add security tests

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
@@ -82,7 +82,7 @@ public class SolicitudMovimientoController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_JEFE_ALMACENES','ROL_ALMACENISTA','ROL_JEFE_PRODUCCION','ROL_PLANEADOR','ROL_SUPER_ADMIN')")
     public ResponseEntity<SolicitudMovimientoResponseDTO> obtener(@PathVariable Long id) {
         return ResponseEntity.ok(service.obtenerSolicitud(id));
     }

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoControllerSecurityTest.java
@@ -1,5 +1,6 @@
 package com.willyes.clemenintegra.inventario.controller;
 
+import com.willyes.clemenintegra.inventario.dto.SolicitudMovimientoResponseDTO;
 import com.willyes.clemenintegra.inventario.service.SolicitudMovimientoService;
 import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
 import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
@@ -10,6 +11,7 @@ import com.willyes.clemenintegra.shared.security.SecurityConfig;
 import com.willyes.clemenintegra.shared.security.SuperAdminSoloLecturaWriteBlockFilter;
 import com.willyes.clemenintegra.shared.security.UsuarioInactivoFilter;
 import com.willyes.clemenintegra.shared.service.UsuarioService;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -115,6 +117,29 @@ class SolicitudMovimientoControllerSecurityTest {
                         .with(SecurityMockMvcRequestPostProcessors.user("planeador")
                                 .authorities(() -> "ROL_PLANEADOR")))
                 .andExpect(status().isOk());
+    }
+
+
+    @Test
+    void jefeProduccionPuedeVerDetalleSolicitud() throws Exception {
+        when(solicitudMovimientoService.obtenerSolicitud(1L))
+                .thenReturn(SolicitudMovimientoResponseDTO.builder().id(1L).build());
+
+        mockMvc.perform(get("/api/inventario/solicitudes/1")
+                        .with(SecurityMockMvcRequestPostProcessors.user("jefe-produccion")
+                                .authorities(() -> "ROL_JEFE_PRODUCCION")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void jefeProduccionRecibeNotFoundSiSolicitudNoExiste() throws Exception {
+        when(solicitudMovimientoService.obtenerSolicitud(999L))
+                .thenThrow(new EntityNotFoundException("Solicitud no encontrada: 999"));
+
+        mockMvc.perform(get("/api/inventario/solicitudes/999")
+                        .with(SecurityMockMvcRequestPostProcessors.user("jefe-produccion")
+                                .authorities(() -> "ROL_JEFE_PRODUCCION")))
+                .andExpect(status().isNotFound());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- The detail endpoint for solicitudes (`GET /api/inventario/solicitudes/{id}`) lacked `ROL_JEFE_PRODUCCION` in its method-level authorization causing 403 for that role while listing was allowed. 
- The change aims to minimally align permissions so roles that can list can view details when appropriate, without touching HTTP methods or business logic.

### Description
- Added `ROL_JEFE_PRODUCCION` to the method `@PreAuthorize` on the controller method that handles `GET /api/inventario/solicitudes/{id}` in `src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java` (around lines 84-88). 
- Did not change any routes, HTTP methods, or business logic; `PUT /{id}/aprobar` and other endpoints remain unchanged. 
- Added two MockMvc security tests in `src/test/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoControllerSecurityTest.java` that verify a user with `ROL_JEFE_PRODUCCION` receives `200` for an existing solicitud and `404` when the id does not exist (tests inserted near lines ~123-143). 
- Verified there are no conflicting request matchers in `SecurityConfig` (it already allows `ROL_JEFE_PRODUCCION` for `/api/inventario/solicitudes/**`) so no config changes were required (`src/main/java/.../shared/security/SecurityConfig.java` around lines 509-526).

### Testing
- Ran the focused test suite with `mvn -q -Dtest=SolicitudMovimientoControllerSecurityTest test` which executed the updated MockMvc tests. 
- Result: tests passed (the two new cases + existing assertions in the class succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cbcadd6808333aeeedea5238e5b88)