### PR TITLE
Arreglar detalle de solicitud: usar `findById` + `@EntityGraph` y añadir ruta plural

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoController.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/inventario/solicitudes")
+@RequestMapping({"/api/inventario/solicitudes", "/api/inventarios/solicitudes"})
 @RequiredArgsConstructor
 public class SolicitudMovimientoController {
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/SolicitudMovimientoRepository.java
@@ -65,6 +65,23 @@ public interface SolicitudMovimientoRepository extends JpaRepository<SolicitudMo
             "where s.id = :id")
     java.util.Optional<SolicitudMovimiento> findWithDetalles(@Param("id") Long id);
 
+    @EntityGraph(attributePaths = {
+            "producto",
+            "producto.unidadMedida",
+            "lote",
+            "almacenOrigen",
+            "almacenDestino",
+            "usuarioSolicitante",
+            "ordenProduccion",
+            "motivoMovimiento",
+            "tipoMovimientoDetalle",
+            "detalles",
+            "detalles.lote",
+            "detalles.almacenOrigen",
+            "detalles.almacenDestino"
+    })
+    Optional<SolicitudMovimiento> findById(Long id);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select s from SolicitudMovimiento s where s.id = :id")
     Optional<SolicitudMovimiento> findByIdWithLock(@Param("id") Long id);

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImpl.java
@@ -295,9 +295,8 @@ public class SolicitudMovimientoServiceImpl implements SolicitudMovimientoServic
     @Override
     @Transactional(readOnly = true)
     public SolicitudMovimientoResponseDTO obtenerSolicitud(Long id) {
-        var solicitud = repository.findWithDetalles(id)
-                .orElseGet(() -> repository.findById(id)
-                        .orElseThrow(() -> new EntityNotFoundException("Solicitud no encontrada: " + id)));
+        var solicitud = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Solicitud no encontrada: " + id));
 
         SolicitudMovimientoResponseDTO dto = toResponse(solicitud);
         if (solicitud.getProducto() != null) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/SolicitudMovimientoControllerSecurityTest.java
@@ -143,6 +143,26 @@ class SolicitudMovimientoControllerSecurityTest {
     }
 
     @Test
+    void listarPorOrdenYConsultarDetalleEnRutaPluralRespondeOk() throws Exception {
+        when(solicitudMovimientoService.listGroupByOrden(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+        when(solicitudMovimientoService.obtenerSolicitud(321L))
+                .thenReturn(SolicitudMovimientoResponseDTO.builder().id(321L).build());
+
+        mockMvc.perform(get("/api/inventarios/solicitudes/por-orden")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(SecurityMockMvcRequestPostProcessors.user("jefe-produccion")
+                                .authorities(() -> "ROL_JEFE_PRODUCCION")))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/inventarios/solicitudes/321")
+                        .with(SecurityMockMvcRequestPostProcessors.user("jefe-produccion")
+                                .authorities(() -> "ROL_JEFE_PRODUCCION")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     void planeadorNoPuedeAprobarSolicitudes() throws Exception {
         mockMvc.perform(put("/api/inventario/solicitudes/1/aprobar")
                         .with(SecurityMockMvcRequestPostProcessors.user("planeador")

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/SolicitudMovimientoServiceImplPorOrdenTest.java
@@ -38,6 +38,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -311,7 +313,7 @@ class SolicitudMovimientoServiceImplPorOrdenTest {
                 .detalles(List.of(detalle1, detalle2))
                 .build();
 
-        when(repository.findWithDetalles(eq(114L))).thenReturn(java.util.Optional.of(solicitud));
+        when(repository.findById(eq(114L))).thenReturn(java.util.Optional.of(solicitud));
 
         SolicitudMovimientoResponseDTO respuesta = service.obtenerSolicitud(114L);
 
@@ -323,4 +325,24 @@ class SolicitudMovimientoServiceImplPorOrdenTest {
         assertThat(respuesta.getDetalles().get(1).getLoteProductoId()).isEqualTo(60L);
         assertThat(respuesta.getDetalles().get(1).getLoteId()).isEqualTo(60L);
     }
+    @Test
+    void obtenerSolicitudNoDependeDeFindWithDetalles() {
+        SolicitudMovimiento solicitud = SolicitudMovimiento.builder()
+                .id(999L)
+                .detalles(List.of(SolicitudMovimientoDetalle.builder()
+                        .id(701L)
+                        .cantidad(BigDecimal.ONE)
+                        .estado(EstadoSolicitudMovimientoDetalle.PENDIENTE)
+                        .build()))
+                .build();
+
+        when(repository.findById(eq(999L))).thenReturn(java.util.Optional.of(solicitud));
+
+        SolicitudMovimientoResponseDTO respuesta = service.obtenerSolicitud(999L);
+
+        assertThat(respuesta.getId()).isEqualTo(999L);
+        assertThat(respuesta.getDetalles()).hasSize(1);
+        verify(repository, never()).findWithDetalles(999L);
+    }
+
 }


### PR DESCRIPTION
### Motivation
- El endpoint de detalle `GET /api/inventarios/solicitudes/{id}` devolvía 404 aun cuando el `id` existía porque el flujo dependía de un query custom (`findWithDetalles(id)`) que no siempre retornaba la entidad; además había desalineación entre rutas plural (`/api/inventarios/...`) y singular (`/api/inventario/...`) usadas por distintos controladores. 

### Description
- Cambiado el flujo de `obtenerSolicitud(Long id)` para usar `repository.findById(id)` y lanzar `EntityNotFoundException` si no existe, evitando depender de `findWithDetalles(id)`.
- Agregado un método `findById(Long id)` con `@EntityGraph(...)` en `SolicitudMovimientoRepository` para cargar `detalles` y las asociaciones necesarias para el mapeo del DTO de detalle.
- Añadido alias plural en el `@RequestMapping` de `SolicitudMovimientoController` para exponer `{"/api/inventario/solicitudes", "/api/inventarios/solicitudes"}` y así alinear la ruta de detalle con la usada por el listado por orden.
- Añadidos/ajustados tests: el test de servicio ahora usa `findById` para verificar que `obtenerSolicitud` serializa detalles correctamente y un test adicional verifica que ya no se depende de `findWithDetalles`; el test de controller MockMvc agrega un caso que llama la ruta plural de listado y el detalle plural, ambos esperando `200`.

### Testing
- Ejecutado `mvn -q -Dtest=SolicitudMovimientoServiceImplPorOrdenTest,SolicitudMovimientoControllerSecurityTest test` y los tests objetivo pasaron correctamente.
- Ejecutado `mvn -q test` para la suite completa y falló por un test ajeno (`OrdenProduccionControllerSecurityTest.crearOrden_conRolPlaneador_devuelve201`), por lo que la suite completa no está verde; el fallo no está relacionado con este cambio.
- Los cambios fueron committeados y contienen modificaciones puntuales en `repository`, `service`, `controller` y tests para evitar regresiones.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cc211953c8333a04b6f3610d84089)