### PR TITLE
Make OP cierre idempotent and avoid duplicate PT ENTRADA movements

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/repository/MovimientoInventarioRepository.java
@@ -355,4 +355,15 @@ public interface MovimientoInventarioRepository extends JpaRepository<Movimiento
     })
     List<MovimientoInventario> findByOrdenProduccionIdOrderByFechaIngresoAsc(Long ordenProduccionId);
 
+    Optional<MovimientoInventario> findFirstByOrdenProduccionIdAndLoteIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
+            Long ordenProduccionId,
+            Long loteId,
+            TipoMovimiento tipoMovimiento,
+            ClasificacionMovimientoInventario clasificacion);
+
+    Optional<MovimientoInventario> findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
+            Long ordenProduccionId,
+            TipoMovimiento tipoMovimiento,
+            ClasificacionMovimientoInventario clasificacion);
+
 }

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1019,10 +1019,34 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             OrdenProduccion orden = repository.findByIdForUpdate(id)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ORDEN_NO_ENCONTRADA"));
 
-            if (orden.getEstado() == EstadoProduccion.FINALIZADA ||
-                    orden.getEstado() == EstadoProduccion.CANCELADA ||
+            if (orden.getEstado() == EstadoProduccion.CANCELADA ||
                     orden.getEstado() == EstadoProduccion.CERRADA_INCOMPLETA) {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ORDEN_NO_CERRABLE");
+            }
+
+            if (orden.getEstado() == EstadoProduccion.FINALIZADA) {
+                ClasificacionMovimientoInventario clasifCierreFinalizado;
+                try {
+                    clasifCierreFinalizado = ClasificacionMovimientoInventario.valueOf(clasificacionEntradaPtConf);
+                } catch (IllegalArgumentException ex) {
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CLASIFICACION_ENTRADA_PT_INVALIDA");
+                }
+                Optional<MovimientoInventario> movimientoCierreExistente = movimientoInventarioRepository
+                        .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
+                                orden.getId(),
+                                TipoMovimiento.ENTRADA,
+                                clasifCierreFinalizado);
+                if (movimientoCierreExistente.isPresent()) {
+                    MovimientoInventario movimiento = movimientoCierreExistente.get();
+                    Long loteMovimientoId = movimiento.getLote() != null ? movimiento.getLote().getId() : null;
+                    log.info(
+                            "Cierre OP idempotente: ya existe movimiento cierre opId={}, loteId={}, movimientoId={}",
+                            orden.getId(),
+                            loteMovimientoId,
+                            movimiento.getId());
+                    return orden;
+                }
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "OP_YA_FINALIZADA");
             }
 
             if (dto.getCantidad() == null) {
@@ -1259,6 +1283,22 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             TipoMovimientoDetalle tipoDetalleEntrada = tipoMovimientoDetalleRepository.findById(tipoDetalleEntradaId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "TIPO_DETALLE_ENTRADA_INEXISTENTE"));
 
+            Optional<MovimientoInventario> movimientoCierreExistente = movimientoInventarioRepository
+                    .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
+                            orden.getId(),
+                            TipoMovimiento.ENTRADA,
+                            clasifEntrada);
+            if (movimientoCierreExistente.isPresent()) {
+                MovimientoInventario movimiento = movimientoCierreExistente.get();
+                Long loteMovimientoId = movimiento.getLote() != null ? movimiento.getLote().getId() : null;
+                log.info(
+                        "Cierre OP idempotente: ya existe movimiento cierre opId={}, loteId={}, movimientoId={}",
+                        orden.getId(),
+                        loteMovimientoId,
+                        movimiento.getId());
+                return orden;
+            }
+
             BigDecimal acumulada = producidaAntes;
             BigDecimal nuevaAcumulada = producidaDespues;
             BigDecimal porcentajeCumplimiento = calcularPorcentajeCumplimiento(nuevaAcumulada, cantidadProgramada);
@@ -1376,6 +1416,22 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             loteProductoRepository.save(lote);
             log.info("OP-cierre lote op={}, producto={}, loteId={}, codigoLote={}, cantidad={}, fechaFabricacion={}, fechaVencimiento={}, almacenId={}, estado={}, usuario={}",
                     orden.getId(), orden.getProducto().getId(), lote.getId(), codigoLote, cantidad, fechaFabricacion, fechaVencimiento, destino.getId(), estadoLote, usuario.getId());
+
+            Optional<MovimientoInventario> movimientoCierrePorLote = movimientoInventarioRepository
+                    .findFirstByOrdenProduccionIdAndLoteIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
+                            orden.getId(),
+                            lote.getId(),
+                            TipoMovimiento.ENTRADA,
+                            clasifEntrada);
+            if (movimientoCierrePorLote.isPresent()) {
+                MovimientoInventario movimiento = movimientoCierrePorLote.get();
+                log.info(
+                        "Cierre OP idempotente: ya existe movimiento cierre opId={}, loteId={}, movimientoId={}",
+                        orden.getId(),
+                        lote.getId(),
+                        movimiento.getId());
+                return orden;
+            }
 
             MovimientoInventarioDTO movDto = new MovimientoInventarioDTO(
                     null,

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -1507,7 +1507,7 @@ class OrdenProduccionServiceImplTest {
         assertThatThrownBy(() -> service.registrarCierre(255L, dto))
                 .isInstanceOf(ResponseStatusException.class)
                 .extracting("reason")
-                .isEqualTo("ORDEN_NO_CERRABLE");
+                .isEqualTo("OP_YA_FINALIZADA");
 
         verify(movimientoInventarioService, never()).consumirInsumosPorOrden(anyLong(), any(), anyLong());
     }
@@ -1990,6 +1990,77 @@ class OrdenProduccionServiceImplTest {
         assertThat(consumos.get()).isEqualTo(1);
     }
 
+
+    @Test
+    @DisplayName("registrarCierre idempotente en reintento no duplica entrada de PT")
+    void registrarCierre_idempotente_reintento() {
+        OrdenProduccion orden = crearOrdenBase(500L, new BigDecimal("30000"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("30000"))
+                .tipo(TipoCierre.TOTAL)
+                .build();
+
+        service.registrarCierre(500L, dto);
+
+        MovimientoInventario movimientoExistente = new MovimientoInventario();
+        movimientoExistente.setId(3007L);
+        LoteProducto loteExistente = new LoteProducto();
+        loteExistente.setId(9001L);
+        loteExistente.setStockLote(new BigDecimal("30000"));
+        movimientoExistente.setLote(loteExistente);
+        when(movimientoInventarioRepository
+                .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
+                        eq(500L),
+                        eq(TipoMovimiento.ENTRADA),
+                        eq(ClasificacionMovimientoInventario.ENTRADA_PRODUCTO_TERMINADO)))
+                .thenReturn(Optional.of(movimientoExistente));
+
+        OrdenProduccion segundo = service.registrarCierre(500L, dto);
+
+        assertThat(segundo).isSameAs(orden);
+        verify(movimientoInventarioService, times(1)).registrarMovimiento(any());
+        verify(movimientoInventarioRepository, times(2))
+                .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
+                        eq(500L),
+                        eq(TipoMovimiento.ENTRADA),
+                        eq(ClasificacionMovimientoInventario.ENTRADA_PRODUCTO_TERMINADO));
+    }
+
+    @Test
+    @DisplayName("registrarCierre concurrente usa lock y no duplica movimiento cierre")
+    void registrarCierre_concurrente_no_duplica() {
+        OrdenProduccion orden = crearOrdenBase(501L, new BigDecimal("30000"), BigDecimal.ZERO, EstadoProduccion.EN_PROCESO);
+        stubInfraCierre(orden, 1L);
+        when(cierreProduccionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CierreProduccionRequestDTO dto = CierreProduccionRequestDTO.builder()
+                .cantidad(new BigDecimal("30000"))
+                .tipo(TipoCierre.TOTAL)
+                .build();
+
+        service.registrarCierre(501L, dto);
+
+        MovimientoInventario movimientoExistente = new MovimientoInventario();
+        movimientoExistente.setId(4001L);
+        LoteProducto loteExistente = new LoteProducto();
+        loteExistente.setId(9002L);
+        movimientoExistente.setLote(loteExistente);
+        when(movimientoInventarioRepository
+                .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
+                        eq(501L),
+                        eq(TipoMovimiento.ENTRADA),
+                        eq(ClasificacionMovimientoInventario.ENTRADA_PRODUCTO_TERMINADO)))
+                .thenReturn(Optional.of(movimientoExistente));
+
+        service.registrarCierre(501L, dto);
+
+        verify(ordenProduccionRepository, times(2)).findByIdForUpdate(501L);
+        verify(movimientoInventarioService, times(1)).registrarMovimiento(any());
+    }
+
     @Test
     @DisplayName("registrarCierre definitivo rechaza cierre sin producción acumulada")
     void registrarCierre_definitivoSinProduccion() {
@@ -2292,6 +2363,12 @@ class OrdenProduccionServiceImplTest {
         when(movimientoInventarioRepository
                 .findByOrdenProduccionIdAndOrdenProduccionEtapaIdAndClasificacionOrderByFechaIngresoAsc(anyLong(), anyLong(), any()))
                 .thenReturn(List.of());
+        when(movimientoInventarioRepository
+                .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(anyLong(), any(), any()))
+                .thenReturn(Optional.empty());
+        when(movimientoInventarioRepository
+                .findFirstByOrdenProduccionIdAndLoteIdAndTipoMovimientoAndClasificacionOrderByIdAsc(anyLong(), anyLong(), any(), any()))
+                .thenReturn(Optional.empty());
 
         when(catalogResolver.getAlmacenPtId()).thenReturn(30L);
         when(catalogResolver.getAlmacenCuarentenaId()).thenReturn(31L);


### PR DESCRIPTION
### Motivation

- Prevent duplicate ENTRADA movimientos y doble-suma de `stock_lote` when a production close (`registrarCierre`) is retried or occurs concurrently, which caused multiple 30k ENTRADA records for the same lote.

### Description

- Added repository finders in `MovimientoInventarioRepository` to detect an existing cierre movement by OP+clasificación and by OP+lote+clasificación (`findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc` and `findFirstByOrdenProduccionIdAndLoteIdAndTipoMovimientoAndClasificacionOrderByIdAsc`).
- In `OrdenProduccionServiceImpl.registrarCierre(...)` kept the pessimistic lock (`findByIdForUpdate`) and implemented idempotency guards: if OP is `FINALIZADA` try to detect an existing cierre movement and return idempotently; otherwise return `409 OP_YA_FINALIZADA` to signal conflict.
- Before creating the PT `ENTRADA` movement the service now queries for an existing cierre movimiento (by OP and by OP+lote) and, if present, logs an INFO diagnostic `Cierre OP idempotente: ya existe movimiento cierre opId=..., loteId=..., movimientoId=...` and returns early without creating movement or changing `stock_lote`.
- Added/updated unit tests in `OrdenProduccionServiceImplTest` that assert: (a) retry idempotency does not create a second ENTRADA; (b) concurrent/repeated execution preserves a single movement; and adjusted expectations for the finalized-case to return `OP_YA_FINALIZADA` when appropriate.

### Testing

- Ran focused tests for the modified service: `mvn -Dtest=OrdenProduccionServiceImplTest#registrarCierre_idempotente_reintento,OrdenProduccionServiceImplTest#registrarCierre_concurrente_no_duplica,OrdenProduccionServiceImplTest#registrarCierre_idempotenciaOrdenFinalizada test` and they passed.
- Ran the full service test class: `mvn -Dtest=OrdenProduccionServiceImplTest test` (OrdenProduccionServiceImplTest, 63 tests) and the suite completed with no failing tests after the patch.
- Logs include INFO entries indicating idempotent detections (e.g. `Cierre OP idempotente: ya existe movimiento cierre opId=..., loteId=..., movimientoId=...`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d09b7a9a0833380f8360d18b16a4c)