### PR TITLE
Mover guard idempotente temprano en registrarCierre para evitar side-effects

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -1024,20 +1024,22 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ORDEN_NO_CERRABLE");
             }
 
+            ClasificacionMovimientoInventario clasifEntrada;
+            try {
+                clasifEntrada = ClasificacionMovimientoInventario.valueOf(clasificacionEntradaPtConf);
+            } catch (IllegalArgumentException ex) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CLASIFICACION_ENTRADA_PT_INVALIDA");
+            }
+
+            Optional<MovimientoInventario> movimientoCierreExistenteTemprano = movimientoInventarioRepository
+                    .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
+                            orden.getId(),
+                            TipoMovimiento.ENTRADA,
+                            clasifEntrada);
+
             if (orden.getEstado() == EstadoProduccion.FINALIZADA) {
-                ClasificacionMovimientoInventario clasifCierreFinalizado;
-                try {
-                    clasifCierreFinalizado = ClasificacionMovimientoInventario.valueOf(clasificacionEntradaPtConf);
-                } catch (IllegalArgumentException ex) {
-                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CLASIFICACION_ENTRADA_PT_INVALIDA");
-                }
-                Optional<MovimientoInventario> movimientoCierreExistente = movimientoInventarioRepository
-                        .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
-                                orden.getId(),
-                                TipoMovimiento.ENTRADA,
-                                clasifCierreFinalizado);
-                if (movimientoCierreExistente.isPresent()) {
-                    MovimientoInventario movimiento = movimientoCierreExistente.get();
+                if (movimientoCierreExistenteTemprano.isPresent()) {
+                    MovimientoInventario movimiento = movimientoCierreExistenteTemprano.get();
                     Long loteMovimientoId = movimiento.getLote() != null ? movimiento.getLote().getId() : null;
                     log.info(
                             "Cierre OP idempotente: ya existe movimiento cierre opId={}, loteId={}, movimientoId={}",
@@ -1047,6 +1049,17 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
                     return orden;
                 }
                 throw new ResponseStatusException(HttpStatus.CONFLICT, "OP_YA_FINALIZADA");
+            }
+
+            if (movimientoCierreExistenteTemprano.isPresent()) {
+                MovimientoInventario movimiento = movimientoCierreExistenteTemprano.get();
+                Long loteMovimientoId = movimiento.getLote() != null ? movimiento.getLote().getId() : null;
+                log.info(
+                        "Cierre OP idempotente: ya existe movimiento cierre opId={}, loteId={}, movimientoId={}",
+                        orden.getId(),
+                        loteMovimientoId,
+                        movimiento.getId());
+                return orden;
             }
 
             if (dto.getCantidad() == null) {
@@ -1272,32 +1285,9 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
             MotivoMovimiento motivoEntrada = motivoMovimientoRepository.findById(motivoEntradaId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MOTIVO_ENTRADA_PT_INEXISTENTE"));
 
-            ClasificacionMovimientoInventario clasifEntrada;
-            try {
-                clasifEntrada = ClasificacionMovimientoInventario.valueOf(clasificacionEntradaPtConf);
-            } catch (IllegalArgumentException ex) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "CLASIFICACION_ENTRADA_PT_INVALIDA");
-            }
-
             Long tipoDetalleEntradaId = catalogResolver.getTipoDetalleEntradaId();
             TipoMovimientoDetalle tipoDetalleEntrada = tipoMovimientoDetalleRepository.findById(tipoDetalleEntradaId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "TIPO_DETALLE_ENTRADA_INEXISTENTE"));
-
-            Optional<MovimientoInventario> movimientoCierreExistente = movimientoInventarioRepository
-                    .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
-                            orden.getId(),
-                            TipoMovimiento.ENTRADA,
-                            clasifEntrada);
-            if (movimientoCierreExistente.isPresent()) {
-                MovimientoInventario movimiento = movimientoCierreExistente.get();
-                Long loteMovimientoId = movimiento.getLote() != null ? movimiento.getLote().getId() : null;
-                log.info(
-                        "Cierre OP idempotente: ya existe movimiento cierre opId={}, loteId={}, movimientoId={}",
-                        orden.getId(),
-                        loteMovimientoId,
-                        movimiento.getId());
-                return orden;
-            }
 
             BigDecimal acumulada = producidaAntes;
             BigDecimal nuevaAcumulada = producidaDespues;

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -2021,7 +2021,11 @@ class OrdenProduccionServiceImplTest {
         OrdenProduccion segundo = service.registrarCierre(500L, dto);
 
         assertThat(segundo).isSameAs(orden);
+        verify(movimientoInventarioService, times(1)).consumirInsumosPorOrden(eq(500L), anyLong(), anyLong());
         verify(movimientoInventarioService, times(1)).registrarMovimiento(any());
+        verify(cierreProduccionRepository, times(1)).save(any());
+        verify(reservaLoteService, times(1)).liberarReservasPorOrden(500L);
+        verify(loteProductoRepository, times(1)).save(any(LoteProducto.class));
         verify(movimientoInventarioRepository, times(2))
                 .findFirstByOrdenProduccionIdAndTipoMovimientoAndClasificacionOrderByIdAsc(
                         eq(500L),


### PR DESCRIPTION
### Motivation
- Evitar efectos secundarios (consumos, reservas, guardados) cuando un segundo intento/doble click llega a `registrarCierre(...)` y ya existe el movimiento de cierre.
- Mantener la semántica actual para OP `FINALIZADA`: si existe movimiento de cierre retorna idempotente; si no existe retorna `409 OP_YA_FINALIZADA`.

### Description
- Reubiqué la búsqueda y guarda idempotente por `ordenId + TipoMovimiento.ENTRADA + clasificacionEntradaPtConf` inmediatamente después de `repository.findByIdForUpdate(id)` y la validación de estados no cerrables, antes de cualquier consumo/reserva/creación de cierre/recalculo/guardado de lote.
- Conservar la verificación especial para `FINALIZADA` (ahora reutiliza la primera búsqueda para decidir idempotencia o `409`).
- Eliminé la comprobación redundante más abajo en el método para evitar chequeos duplicados, preservando la segunda defensa por `op + lote + ENTRADA + clasificacion` que queda intacta.
- Actualicé el test unitario `registrarCierre_idempotente_reintento` para asegurar que en el segundo intento NO se producen side-effects verificando explícitamente que `registrarMovimiento`, consumo, `cierreProduccionRepository.save`, `reservaLoteService.liberarReservasPorOrden` y `loteProductoRepository.save` se invoquen solo una vez.

### Testing
- Se ejecutó el test objetivo con `mvn -q -Dtest=OrdenProduccionServiceImplTest test` y la suite correspondiente al caso modificado pasó correctamente.
- El test ajustado `registrarCierre_idempotente_reintento` ahora valida la ausencia de efectos secundarios en el reintento y tuvo resultado exitoso en la ejecución local.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d0d62a4988333b64ad45b7031584f)