### PR TITLE
Implement stock-impacting inventory adjustments via movement flow

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/AjusteInventarioRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/AjusteInventarioRequestDTO.java
@@ -26,7 +26,6 @@ public class AjusteInventarioRequestDTO {
     @NotNull(message = "El ID del almacén es obligatorio")
     private Long almacenId;
 
-    @NotNull(message = "El ID del usuario es obligatorio")
-    private Long usuarioId;
+    @NotNull(message = "El ID del lote es obligatorio")
+    private Long loteProductoId;
 }
-

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/AjusteInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/AjusteInventarioServiceImpl.java
@@ -1,18 +1,30 @@
 package com.willyes.clemenintegra.inventario.service;
 
-import com.willyes.clemenintegra.inventario.dto.*;
+import com.willyes.clemenintegra.inventario.dto.AjusteInventarioRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.AjusteInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
 import com.willyes.clemenintegra.inventario.mapper.AjusteInventarioMapper;
 import com.willyes.clemenintegra.inventario.model.AjusteInventario;
-import com.willyes.clemenintegra.inventario.repository.*;
-import com.willyes.clemenintegra.shared.repository.UsuarioRepository;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.model.enums.TipoMovimiento;
+import com.willyes.clemenintegra.inventario.repository.AjusteInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MotivoMovimientoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.TipoMovimientoDetalleRepository;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-import java.math.BigDecimal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +34,11 @@ public class AjusteInventarioServiceImpl implements AjusteInventarioService {
     private final AjusteInventarioMapper mapper;
     private final ProductoRepository productoRepository;
     private final AlmacenRepository almacenRepository;
-    private final UsuarioRepository usuarioRepository;
+    private final LoteProductoRepository loteProductoRepository;
+    private final UsuarioService usuarioService;
+    private final MovimientoInventarioService movimientoInventarioService;
+    private final MotivoMovimientoRepository motivoMovimientoRepository;
+    private final TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
 
 
     public Page<AjusteInventarioResponseDTO> listar(Pageable pageable) {
@@ -30,6 +46,7 @@ public class AjusteInventarioServiceImpl implements AjusteInventarioService {
         return page.map(mapper::toResponseDTO);
     }
 
+    @Transactional(rollbackFor = Exception.class)
     public AjusteInventarioResponseDTO crear(AjusteInventarioRequestDTO dto) {
 
         if (dto.getCantidad().compareTo(BigDecimal.ZERO) == 0) {
@@ -40,8 +57,67 @@ public class AjusteInventarioServiceImpl implements AjusteInventarioService {
                 .orElseThrow(() -> new IllegalArgumentException("Producto no encontrado"));
         var almacen = almacenRepository.findById(dto.getAlmacenId())
                 .orElseThrow(() -> new IllegalArgumentException("Almacén no encontrado"));
-        var usuario = usuarioRepository.findById(dto.getUsuarioId())
-                .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado"));
+        var usuario = usuarioService.obtenerUsuarioAutenticado();
+
+        var lote = loteProductoRepository.findByIdForUpdate(dto.getLoteProductoId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_ENCONTRADO"));
+
+        if (lote.getProducto() == null || !Objects.equals(lote.getProducto().getId(), producto.getId())) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_PRODUCTO_INVALIDO");
+        }
+
+        if (lote.getAlmacen() == null || !Objects.equals(lote.getAlmacen().getId(), almacen.getId().intValue())) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_PERTENECE_ALMACEN_ORIGEN");
+        }
+
+        ClasificacionMovimientoInventario clasificacion = dto.getCantidad().compareTo(BigDecimal.ZERO) > 0
+                ? ClasificacionMovimientoInventario.AJUSTE_POSITIVO
+                : ClasificacionMovimientoInventario.AJUSTE_NEGATIVO;
+
+        Long motivoMovimientoId = motivoMovimientoRepository.findByMotivo(clasificacion)
+                .map(m -> m.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "MOTIVO_AJUSTE_NO_CONFIGURADO"));
+
+        Long tipoDetalleId = tipoMovimientoDetalleRepository.findByDescripcion(clasificacion.name())
+                .map(t -> t.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "TIPO_DETALLE_AJUSTE_NO_CONFIGURADO"));
+
+        MovimientoInventarioDTO movimientoDto = new MovimientoInventarioDTO(
+                null,
+                dto.getCantidad().abs(),
+                TipoMovimiento.AJUSTE,
+                clasificacion,
+                dto.getMotivo(),
+                dto.getObservaciones(),
+                null,
+                null,
+                null,
+                producto.getId(),
+                lote.getId(),
+                clasificacion == ClasificacionMovimientoInventario.AJUSTE_NEGATIVO ? almacen.getId() : null,
+                clasificacion == ClasificacionMovimientoInventario.AJUSTE_POSITIVO ? almacen.getId() : null,
+                null,
+                null,
+                motivoMovimientoId,
+                tipoDetalleId,
+                null,
+                usuario.getId(),
+                null,
+                null,
+                null,
+                lote.getCodigoLote(),
+                null,
+                null,
+                Boolean.FALSE,
+                null,
+                null,
+                null
+        );
+
+        movimientoInventarioService.registrarMovimiento(movimientoDto);
+
         var entity = mapper.toEntity(dto, producto, almacen, usuario);
         entity.setFecha(LocalDateTime.now());
         var guardado = repository.save(entity);
@@ -52,4 +128,3 @@ public class AjusteInventarioServiceImpl implements AjusteInventarioService {
         repository.deleteById(id);
     }
 }
-

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/AjusteInventarioControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/AjusteInventarioControllerSecurityTest.java
@@ -113,7 +113,7 @@ class AjusteInventarioControllerSecurityTest {
                 .motivo("Corrección")
                 .productoId(10L)
                 .almacenId(2L)
-                .usuarioId(5L)
+                .loteProductoId(20L)
                 .build();
 
         when(ajusteInventarioService.crear(any(AjusteInventarioRequestDTO.class)))

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/AjusteInventarioServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/AjusteInventarioServiceImplTest.java
@@ -1,0 +1,180 @@
+package com.willyes.clemenintegra.inventario.service;
+
+import com.willyes.clemenintegra.inventario.dto.AjusteInventarioRequestDTO;
+import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
+import com.willyes.clemenintegra.inventario.mapper.AjusteInventarioMapper;
+import com.willyes.clemenintegra.inventario.model.AjusteInventario;
+import com.willyes.clemenintegra.inventario.model.Almacen;
+import com.willyes.clemenintegra.inventario.model.LoteProducto;
+import com.willyes.clemenintegra.inventario.model.MotivoMovimiento;
+import com.willyes.clemenintegra.inventario.model.Producto;
+import com.willyes.clemenintegra.inventario.model.TipoMovimientoDetalle;
+import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
+import com.willyes.clemenintegra.inventario.repository.AjusteInventarioRepository;
+import com.willyes.clemenintegra.inventario.repository.AlmacenRepository;
+import com.willyes.clemenintegra.inventario.repository.LoteProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.MotivoMovimientoRepository;
+import com.willyes.clemenintegra.inventario.repository.ProductoRepository;
+import com.willyes.clemenintegra.inventario.repository.TipoMovimientoDetalleRepository;
+import com.willyes.clemenintegra.shared.model.Usuario;
+import com.willyes.clemenintegra.shared.service.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AjusteInventarioServiceImplTest {
+
+    @Mock
+    private AjusteInventarioRepository repository;
+    @Mock
+    private AjusteInventarioMapper mapper;
+    @Mock
+    private ProductoRepository productoRepository;
+    @Mock
+    private AlmacenRepository almacenRepository;
+    @Mock
+    private LoteProductoRepository loteProductoRepository;
+    @Mock
+    private UsuarioService usuarioService;
+    @Mock
+    private MovimientoInventarioService movimientoInventarioService;
+    @Mock
+    private MotivoMovimientoRepository motivoMovimientoRepository;
+    @Mock
+    private TipoMovimientoDetalleRepository tipoMovimientoDetalleRepository;
+
+    @InjectMocks
+    private AjusteInventarioServiceImpl service;
+
+    private Producto producto;
+    private Almacen almacen;
+    private LoteProducto lote;
+    private Usuario usuario;
+
+    @BeforeEach
+    void setUp() {
+        producto = new Producto();
+        producto.setId(10);
+
+        almacen = new Almacen();
+        almacen.setId(2);
+
+        lote = new LoteProducto();
+        lote.setId(99L);
+        lote.setProducto(producto);
+        lote.setAlmacen(almacen);
+        lote.setCodigoLote("L-99");
+
+        usuario = new Usuario();
+        usuario.setId(5L);
+
+        MotivoMovimiento motivo = new MotivoMovimiento();
+        motivo.setId(100L);
+
+        TipoMovimientoDetalle tipoDetalle = new TipoMovimientoDetalle();
+        tipoDetalle.setId(200L);
+
+        when(productoRepository.findById(10L)).thenReturn(Optional.of(producto));
+        when(almacenRepository.findById(2L)).thenReturn(Optional.of(almacen));
+        when(loteProductoRepository.findByIdForUpdate(99L)).thenReturn(Optional.of(lote));
+        when(usuarioService.obtenerUsuarioAutenticado()).thenReturn(usuario);
+        when(motivoMovimientoRepository.findByMotivo(ClasificacionMovimientoInventario.AJUSTE_NEGATIVO))
+                .thenReturn(Optional.of(motivo));
+        when(motivoMovimientoRepository.findByMotivo(ClasificacionMovimientoInventario.AJUSTE_POSITIVO))
+                .thenReturn(Optional.of(motivo));
+        when(tipoMovimientoDetalleRepository.findByDescripcion(ClasificacionMovimientoInventario.AJUSTE_NEGATIVO.name()))
+                .thenReturn(Optional.of(tipoDetalle));
+        when(tipoMovimientoDetalleRepository.findByDescripcion(ClasificacionMovimientoInventario.AJUSTE_POSITIVO.name()))
+                .thenReturn(Optional.of(tipoDetalle));
+
+        AjusteInventario ajuste = new AjusteInventario();
+        when(mapper.toEntity(any(), any(), any(), any())).thenReturn(ajuste);
+        when(repository.save(any(AjusteInventario.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(mapper.toResponseDTO(any(AjusteInventario.class)))
+                .thenReturn(com.willyes.clemenintegra.inventario.dto.AjusteInventarioResponseDTO.builder().id(1L).build());
+    }
+
+    @Test
+    void ajuste_negativo_crea_movimiento_y_decrementa_stock_lote() {
+        AjusteInventarioRequestDTO dto = AjusteInventarioRequestDTO.builder()
+                .cantidad(new BigDecimal("-5"))
+                .motivo("Ajuste negativo")
+                .observaciones("descuento")
+                .productoId(10L)
+                .almacenId(2L)
+                .loteProductoId(99L)
+                .build();
+
+        service.crear(dto);
+
+        ArgumentCaptor<MovimientoInventarioDTO> captor = ArgumentCaptor.forClass(MovimientoInventarioDTO.class);
+        verify(movimientoInventarioService).registrarMovimiento(captor.capture());
+        MovimientoInventarioDTO movimiento = captor.getValue();
+        assertThat(movimiento.clasificacionMovimientoInventario()).isEqualTo(ClasificacionMovimientoInventario.AJUSTE_NEGATIVO);
+        assertThat(movimiento.cantidad()).isEqualByComparingTo(new BigDecimal("5"));
+        verify(repository).save(any(AjusteInventario.class));
+    }
+
+    @Test
+    void ajuste_negativo_no_permite_stock_negativo() {
+        AjusteInventarioRequestDTO dto = AjusteInventarioRequestDTO.builder()
+                .cantidad(new BigDecimal("-5000"))
+                .motivo("Ajuste negativo")
+                .observaciones("insuficiente")
+                .productoId(10L)
+                .almacenId(2L)
+                .loteProductoId(99L)
+                .build();
+
+        doThrow(new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_STOCK_INSUFICIENTE"))
+                .when(movimientoInventarioService).registrarMovimiento(any(MovimientoInventarioDTO.class));
+
+        assertThatThrownBy(() -> service.crear(dto))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("422 UNPROCESSABLE_ENTITY");
+
+        verify(repository, never()).save(any(AjusteInventario.class));
+    }
+
+    @Test
+    void ajuste_positivo_crea_movimiento_y_incrementa_stock_lote() {
+        AjusteInventarioRequestDTO dto = AjusteInventarioRequestDTO.builder()
+                .cantidad(new BigDecimal("7"))
+                .motivo("Ajuste positivo")
+                .observaciones("sumar")
+                .productoId(10L)
+                .almacenId(2L)
+                .loteProductoId(99L)
+                .build();
+
+        service.crear(dto);
+
+        ArgumentCaptor<MovimientoInventarioDTO> captor = ArgumentCaptor.forClass(MovimientoInventarioDTO.class);
+        verify(movimientoInventarioService).registrarMovimiento(captor.capture());
+        MovimientoInventarioDTO movimiento = captor.getValue();
+        assertThat(movimiento.clasificacionMovimientoInventario()).isEqualTo(ClasificacionMovimientoInventario.AJUSTE_POSITIVO);
+        assertThat(movimiento.cantidad()).isEqualByComparingTo(new BigDecimal("7"));
+        verify(repository).save(any(AjusteInventario.class));
+    }
+}


### PR DESCRIPTION
### Motivation
- The existing Ajustes flow only recorded administrative adjustments without affecting real stock; adjustments must create real `MovimientoInventario` records and update lot stock so they appear in Movimientos/Kardex. 
- The adjustment must be tied to a specific lot, use the authenticated user for attribution, and run atomically to avoid partial updates.

### Description
- Updated `AjusteInventarioRequestDTO` to require `loteProductoId` and removed `usuarioId` from the request payload so adjustments target a specific lot (`src/main/java/.../AjusteInventarioRequestDTO.java`).
- Reworked `AjusteInventarioServiceImpl.crear` to be transactional (`@Transactional`) and to: lock the lot via `LoteProductoRepository.findByIdForUpdate`, validate the lot belongs to the `productoId` and `almacenId`, determine `AJUSTE_POSITIVO`/`AJUSTE_NEGATIVO`, resolve `motivoMovimientoId` and `tipoMovimientoDetalleId` from catalog repositories, build a `MovimientoInventarioDTO` for `TipoMovimiento.AJUSTE`, call `movimientoInventarioService.registrarMovimiento(...)`, then persist the administrative `AjusteInventario` entity (`src/main/java/.../AjusteInventarioServiceImpl.java`).
- Use `UsuarioService.obtenerUsuarioAutenticado()` for the responsible user instead of trusting frontend `usuarioId`, and throw `422 UNPROCESSABLE_ENTITY` (`ResponseStatusException`) when the lot is missing/invalid or movement metadata is not configured.
- Added unit tests covering the three required scenarios and updated the controller security test to use `loteProductoId`: `AjusteInventarioServiceImplTest` implements `ajuste_negativo_crea_movimiento_y_decrementa_stock_lote`, `ajuste_negativo_no_permite_stock_negativo`, and `ajuste_positivo_crea_movimiento_y_incrementa_stock_lote`, and `AjusteInventarioControllerSecurityTest` payload now includes `loteProductoId` (`src/test/java/...`).

### Testing
- Ran targeted tests with `mvn -Dtest=AjusteInventarioServiceImplTest,AjusteInventarioControllerSecurityTest test`, addressed an initial `UnnecessaryStubbingException` by setting `@MockitoSettings(strictness = Strictness.LENIENT)` in the new unit test, and re-ran the tests successfully.
- Verified project compiles with `mvn -DskipTests compile` (compile succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d29b87d448333aa3fcf2e85d45454)