### PR TITLE
Fix negative inventory adjustments using explicit tipoAjuste

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/AjusteInventarioRequestDTO.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/AjusteInventarioRequestDTO.java
@@ -15,6 +15,9 @@ public class AjusteInventarioRequestDTO {
     //@DecimalMin(value = "0.01", message = "La cantidad debe ser mayor a cero")
     private BigDecimal cantidad;
 
+    @NotNull(message = "El tipo de ajuste es obligatorio")
+    private TipoAjuste tipoAjuste;
+
     @NotBlank(message = "El motivo es obligatorio")
     private String motivo;
 

--- a/src/main/java/com/willyes/clemenintegra/inventario/dto/TipoAjuste.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/dto/TipoAjuste.java
@@ -1,0 +1,7 @@
+package com.willyes.clemenintegra.inventario.dto;
+
+public enum TipoAjuste {
+    POSITIVO,
+    NEGATIVO
+}
+

--- a/src/main/java/com/willyes/clemenintegra/inventario/service/AjusteInventarioServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/service/AjusteInventarioServiceImpl.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.inventario.service;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioResponseDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
+import com.willyes.clemenintegra.inventario.dto.TipoAjuste;
 import com.willyes.clemenintegra.inventario.mapper.AjusteInventarioMapper;
 import com.willyes.clemenintegra.inventario.model.AjusteInventario;
 import com.willyes.clemenintegra.inventario.model.enums.ClasificacionMovimientoInventario;
@@ -70,9 +71,9 @@ public class AjusteInventarioServiceImpl implements AjusteInventarioService {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "LOTE_NO_PERTENECE_ALMACEN_ORIGEN");
         }
 
-        ClasificacionMovimientoInventario clasificacion = dto.getCantidad().compareTo(BigDecimal.ZERO) > 0
-                ? ClasificacionMovimientoInventario.AJUSTE_POSITIVO
-                : ClasificacionMovimientoInventario.AJUSTE_NEGATIVO;
+        ClasificacionMovimientoInventario clasificacion = dto.getTipoAjuste() == TipoAjuste.NEGATIVO
+                ? ClasificacionMovimientoInventario.AJUSTE_NEGATIVO
+                : ClasificacionMovimientoInventario.AJUSTE_POSITIVO;
 
         Long motivoMovimientoId = motivoMovimientoRepository.findByMotivo(clasificacion)
                 .map(m -> m.getId())

--- a/src/test/java/com/willyes/clemenintegra/inventario/controller/AjusteInventarioControllerSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/controller/AjusteInventarioControllerSecurityTest.java
@@ -3,6 +3,7 @@ package com.willyes.clemenintegra.inventario.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioResponseDTO;
+import com.willyes.clemenintegra.inventario.dto.TipoAjuste;
 import com.willyes.clemenintegra.inventario.service.AjusteInventarioService;
 import com.willyes.clemenintegra.shared.logging.RequestIdFilter;
 import com.willyes.clemenintegra.shared.performance.RequestTimingFilter;
@@ -110,6 +111,7 @@ class AjusteInventarioControllerSecurityTest {
     void permiteCrearAjusteConPermisoInventario() throws Exception {
         AjusteInventarioRequestDTO request = AjusteInventarioRequestDTO.builder()
                 .cantidad(new BigDecimal("3.00"))
+                .tipoAjuste(TipoAjuste.POSITIVO)
                 .motivo("Corrección")
                 .productoId(10L)
                 .almacenId(2L)

--- a/src/test/java/com/willyes/clemenintegra/inventario/service/AjusteInventarioServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/service/AjusteInventarioServiceImplTest.java
@@ -2,6 +2,7 @@ package com.willyes.clemenintegra.inventario.service;
 
 import com.willyes.clemenintegra.inventario.dto.AjusteInventarioRequestDTO;
 import com.willyes.clemenintegra.inventario.dto.MovimientoInventarioDTO;
+import com.willyes.clemenintegra.inventario.dto.TipoAjuste;
 import com.willyes.clemenintegra.inventario.mapper.AjusteInventarioMapper;
 import com.willyes.clemenintegra.inventario.model.AjusteInventario;
 import com.willyes.clemenintegra.inventario.model.Almacen;
@@ -118,7 +119,8 @@ class AjusteInventarioServiceImplTest {
     @Test
     void ajuste_negativo_crea_movimiento_y_decrementa_stock_lote() {
         AjusteInventarioRequestDTO dto = AjusteInventarioRequestDTO.builder()
-                .cantidad(new BigDecimal("-5"))
+                .cantidad(new BigDecimal("5"))
+                .tipoAjuste(TipoAjuste.NEGATIVO)
                 .motivo("Ajuste negativo")
                 .observaciones("descuento")
                 .productoId(10L)
@@ -139,7 +141,8 @@ class AjusteInventarioServiceImplTest {
     @Test
     void ajuste_negativo_no_permite_stock_negativo() {
         AjusteInventarioRequestDTO dto = AjusteInventarioRequestDTO.builder()
-                .cantidad(new BigDecimal("-5000"))
+                .cantidad(new BigDecimal("5000"))
+                .tipoAjuste(TipoAjuste.NEGATIVO)
                 .motivo("Ajuste negativo")
                 .observaciones("insuficiente")
                 .productoId(10L)
@@ -161,6 +164,7 @@ class AjusteInventarioServiceImplTest {
     void ajuste_positivo_crea_movimiento_y_incrementa_stock_lote() {
         AjusteInventarioRequestDTO dto = AjusteInventarioRequestDTO.builder()
                 .cantidad(new BigDecimal("7"))
+                .tipoAjuste(TipoAjuste.POSITIVO)
                 .motivo("Ajuste positivo")
                 .observaciones("sumar")
                 .productoId(10L)

--- a/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
+++ b/src/test/java/com/willyes/clemenintegra/shared/security/ContadorRoleSecurityTest.java
@@ -346,9 +346,10 @@ class ContadorRoleSecurityTest {
                                   "motivo":"Ajuste",
                                   "observaciones":"ok",
                                   "cantidad":1,
+                                  "tipoAjuste":"POSITIVO",
                                   "productoId":1,
                                   "almacenId":1,
-                                  "usuarioId":1
+                                  "loteProductoId":1
                                 }
                                 """))
                 .andExpect(status().isOk());


### PR DESCRIPTION
### Motivation
- The backend inferred adjustment direction from the numeric sign of `cantidad`, but the frontend sends `cantidad` always positive, so NEGATIVO adjustments were being treated as positive and stock increased.
- The goal is to make the adjustment direction explicit while keeping `cantidad` positive in the request (UX) and without changing `MovimientoInventarioServiceImpl`.

### Description
- Added an enum `TipoAjuste { POSITIVO, NEGATIVO }` in `src/main/java/.../dto/TipoAjuste.java` to represent adjustment direction.
- Added a required `tipoAjuste` field (`@NotNull`) to `AjusteInventarioRequestDTO` to make request direction explicit.
- Changed `AjusteInventarioServiceImpl.crear(...)` to derive `ClasificacionMovimientoInventario` from `dto.getTipoAjuste()` instead of the sign of `cantidad`, and kept `dto.getCantidad().abs()` when building `MovimientoInventarioDTO` so `cantidad` remains positive in messages.
- Updated related tests and controller/security test payloads to the new contract (`cantidad > 0` + `tipoAjuste`) to assert correct mapping to `AJUSTE_NEGATIVO`/`AJUSTE_POSITIVO` and that insufficient stock returns 422 without persisting.

### Testing
- Ran the focused test suite with `mvn -q -Dtest=AjusteInventarioServiceImplTest,AjusteInventarioControllerSecurityTest,ContadorRoleSecurityTest test` and the tests completed successfully.
- The updated unit tests cover: negative adjustment with positive `cantidad` mapping to `AJUSTE_NEGATIVO`, positive adjustment mapping to `AJUSTE_POSITIVO`, and insufficient stock returning `422 LOTE_STOCK_INSUFICIENTE` with no partial persistence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d3d43b95c83338483fadcfa6f27e9)