### PR TITLE
fix(auth): permitir ROL_COMPRADOR en GET /api/productos/buscar

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -40,7 +40,7 @@ public class ProductoController {
     private final UsuarioRepository usuarioRepository;
 
     @GetMapping("/buscar")
-    @PreAuthorize("hasAnyAuthority('ROL_CONTADOR','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROL_CONTADOR','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR')")
     public ResponseEntity<Page<ProductoAutocompleteDTO>> buscarProductosParaAjustes(
             @RequestParam(name = "query", required = false) String query,
             @PageableDefault(size = 20, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -232,6 +232,26 @@ class ProductoControllerSmokeTest {
         verify(productoService).buscarAutocompleteInventarioAjustes(eq("resveratrol"), any(Pageable.class));
     }
 
+
+    @Test
+    @WithMockUser(authorities = "ROL_COMPRADOR")
+    @DisplayName("GET /api/productos/buscar permite acceso a comprador")
+    void buscarProductosParaAjustes_compradorOk() throws Exception {
+        ProductoAutocompleteDTO response = new ProductoAutocompleteDTO(6, "SKU-COMP", "Producto Compras", null);
+
+        when(productoService.buscarAutocompleteInventarioAjustes(eq("compras"), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/productos/buscar")
+                        .param("query", "compras")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].codigoSku").value("SKU-COMP"))
+                .andExpect(jsonPath("$.content[0].nombre").value("Producto Compras"));
+
+        verify(productoService).buscarAutocompleteInventarioAjustes(eq("compras"), any(Pageable.class));
+    }
     @Test
     @WithMockUser(authorities = "ROL_ALMACENISTA")
     @DisplayName("GET /api/productos/buscar rechaza roles sin permiso")


### PR DESCRIPTION
### Motivation

- El buscador de productos devolvía `403` para usuarios con `ROL_COMPRADOR` cuando se usa desde Compras, por lo que es necesario otorgar acceso de solo lectura a ese rol sin tocar `SecurityConfig`.

### Description

- Se actualizó el `@PreAuthorize` en `ProductoController` para incluir `ROL_COMPRADOR` en el acceso a `GET /api/productos/buscar` (archivo `src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java`, línea 43 mod.).
- Se agregó un test en `ProductoControllerSmokeTest` que verifica que `ROL_COMPRADOR` obtiene `200 OK` en `GET /api/productos/buscar?query=compras` (archivo `src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java`, líneas 236-254 insertadas), manteniendo la prueba que asegura `ROL_ALMACENISTA` recibe `403`.

### Testing

- Ejecutado: `mvn -Dtest=ProductoControllerSmokeTest,ProductoControllerSecurityTest test` y la suite relacionada pasó con `BUILD SUCCESS` (13 tests, 0 fallos).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e2f24d0648333bd7b1e862f45f654)