### PR TITLE
Fix OP code generation to use highest daily suffix

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java
@@ -32,6 +32,9 @@ public interface OrdenProduccionRepository extends JpaRepository<OrdenProduccion
 
     Long countByCodigoOrdenStartingWith(String prefijo);
 
+    @Query("select op.codigoOrden from OrdenProduccion op where op.codigoOrden like concat(:prefijo, '-%')")
+    List<String> findCodigosByPrefijo(@Param("prefijo") String prefijo);
+
     Optional<OrdenProduccion> findTopByLoteProduccionStartingWithOrderByLoteProduccionDesc(String prefix);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
+++ b/src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java
@@ -168,8 +168,23 @@ public class OrdenProduccionServiceImpl implements OrdenProduccionService {
     private String generarCodigoOrden() {
         String fecha = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         String prefijo = "OP-CLEMEN-" + fecha;
-        Long contador = repository.countByCodigoOrdenStartingWith(prefijo);
-        return prefijo + "-" + String.format("%02d", contador + 1);
+        List<String> codigosDia = repository.findCodigosByPrefijo(prefijo);
+
+        int siguienteConsecutivo = codigosDia.stream()
+                .map(codigo -> codigo.substring(prefijo.length() + 1))
+                .map(String::trim)
+                .filter(sufijo -> !sufijo.isEmpty())
+                .map(sufijo -> {
+                    try {
+                        return Integer.parseInt(sufijo);
+                    } catch (NumberFormatException ex) {
+                        return 0;
+                    }
+                })
+                .max(Integer::compareTo)
+                .orElse(0) + 1;
+
+        return prefijo + "-" + String.format("%02d", siguienteConsecutivo);
     }
 
     private String generarCodigoLote(Producto producto) {

--- a/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
+++ b/src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java
@@ -154,6 +154,7 @@ class OrdenProduccionServiceImplTest {
             return op;
         });
         lenient().when(ordenProduccionRepository.countByCodigoOrdenStartingWith(any())).thenReturn(0L);
+        lenient().when(ordenProduccionRepository.findCodigosByPrefijo(any())).thenReturn(List.of());
         EtapaPlantilla etapa = EtapaPlantilla.builder()
                 .id(1L)
                 .nombre("Preparación")
@@ -182,6 +183,38 @@ class OrdenProduccionServiceImplTest {
         lenient().when(motivoMovimientoRepository.findById(11L)).thenReturn(Optional.of(motivoSalida));
         lenient().when(movimientoInventarioRepository.sumaCantidadPorOrdenProductoTipoDetalle(anyLong(), anyLong(), any(), anyLong()))
                 .thenReturn(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("generarCodigoOrden usa el máximo consecutivo del día")
+    void generarCodigoOrden_usaMaximoConsecutivoDelDia() {
+        String prefijo = "OP-CLEMEN-" + LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        when(ordenProduccionRepository.findCodigosByPrefijo(prefijo))
+                .thenReturn(List.of(
+                        prefijo + "-01",
+                        prefijo + "-04",
+                        prefijo + "-02"
+                ));
+
+        String codigo = ReflectionTestUtils.invokeMethod(service, "generarCodigoOrden");
+
+        assertThat(codigo).isEqualTo(prefijo + "-05");
+    }
+
+    @Test
+    @DisplayName("generarCodigoOrden ignora sufijos inválidos")
+    void generarCodigoOrden_ignoraSufijosInvalidos() {
+        String prefijo = "OP-CLEMEN-" + LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        when(ordenProduccionRepository.findCodigosByPrefijo(prefijo))
+                .thenReturn(List.of(
+                        prefijo + "-AA",
+                        prefijo + "-  ",
+                        prefijo + "-03"
+                ));
+
+        String codigo = ReflectionTestUtils.invokeMethod(service, "generarCodigoOrden");
+
+        assertThat(codigo).isEqualTo(prefijo + "-04");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Evitar colisiones en códigos de orden de producción cuando hay huecos en la secuencia diaria (p. ej. registros eliminados o fallidos) usando el conteo de filas puede generar duplicados.

### Description
- Añadí en el repositorio el query `findCodigosByPrefijo(String prefijo)` para recuperar todos los `codigoOrden` del día con un prefijo dado (`OP-CLEMEN-yyyyMMdd`).
- Reemplacé la generación previa que usaba `countByCodigoOrdenStartingWith` por una implementación que parsea los sufijos numéricos existentes y calcula el siguiente como `max(sufijo_numérico) + 1`, ignorando sufijos vacíos o no numéricos.
- Agregué pruebas unitarias en `OrdenProduccionServiceImplTest` que verifican el comportamiento con sufijos no contiguos y con sufijos inválidos.
- Archivos modificados: `src/main/java/com/willyes/clemenintegra/produccion/repository/OrdenProduccionRepository.java`, `src/main/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImpl.java`, `src/test/java/com/willyes/clemenintegra/produccion/service/OrdenProduccionServiceImplTest.java`.

### Testing
- Ejecuté `mvn -Dtest=OrdenProduccionServiceImplTest test`.
- Resultado: `BUILD SUCCESS` con `Tests run: 65, Failures: 0, Errors: 0`, las pruebas añadidas y existentes pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f7556683c83339f3d35717d4daa62)