### PR TITLE
Fix /api/productos/buscar to accept `term` alias for autocomplete

### DIFF
--- a/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
+++ b/src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java
@@ -20,6 +20,7 @@ import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +44,10 @@ public class ProductoController {
     @PreAuthorize("hasAnyAuthority('ROL_CONTADOR','ROL_JEFE_ALMACENES','ROL_SUPER_ADMIN','ROL_COMPRADOR')")
     public ResponseEntity<Page<ProductoAutocompleteDTO>> buscarProductosParaAjustes(
             @RequestParam(name = "query", required = false) String query,
+            @RequestParam(name = "term", required = false) String term,
             @PageableDefault(size = 20, sort = "nombre", direction = Sort.Direction.ASC) Pageable pageable) {
-        Page<ProductoAutocompleteDTO> page = productoService.buscarAutocompleteInventarioAjustes(query, pageable);
+        String searchTerm = StringUtils.hasText(query) ? query : term;
+        Page<ProductoAutocompleteDTO> page = productoService.buscarAutocompleteInventarioAjustes(searchTerm, pageable);
         return ResponseEntity.ok(page);
     }
 

--- a/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
+++ b/src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java
@@ -290,6 +290,24 @@ class ProductoControllerSmokeTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ROL_CONTADOR")
+    @DisplayName("GET /api/productos/buscar acepta term por compatibilidad")
+    void buscarProductosParaAjustes_aceptaTerm() throws Exception {
+        ProductoAutocompleteDTO response = new ProductoAutocompleteDTO(12, "SKU-AL-01", "Almidón de maíz", null);
+        when(productoService.buscarAutocompleteInventarioAjustes(eq("al"), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/productos/buscar")
+                        .param("term", "al")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].codigoSku").value("SKU-AL-01"));
+
+        verify(productoService).buscarAutocompleteInventarioAjustes(eq("al"), any(Pageable.class));
+    }
+
+    @Test
     @WithMockUser(authorities = "ROL_SUPER_ADMIN")
     @DisplayName("GET /api/productos/insumos/autocomplete devuelve 200 y unidad de medida en DTO")
     void buscarInsumosAutocomplete_deberiaRetornarUnidadMedida() throws Exception {


### PR DESCRIPTION
### Motivation
- The autocomplete endpoint `GET /api/productos/buscar` expected a `query` parameter while the front was sending `term`, causing the service to receive `null` and return an empty `Page` due to its minimum-length check. 
- The intent is to restore compatibility with existing clients (regularización de trazabilidad) with a minimal, non-breaking change so results appear when the UI sends `term`.

### Description
- `ProductoController#buscarProductosParaAjustes` now accepts an additional `@RequestParam(name = "term", required = false)` and selects `query` when present or `term` otherwise, forwarding the chosen value to `productoService.buscarAutocompleteInventarioAjustes`; change is in `src/main/java/com/willyes/clemenintegra/inventario/controller/ProductoController.java`.
- Added a controller smoke test `buscarProductosParaAjustes_aceptaTerm` that verifies `term` is accepted for `ROL_CONTADOR` in `src/test/java/com/willyes/clemenintegra/inventario/web/ProductoControllerSmokeTest.java`.
- No changes to repository queries, pagination, or security rules were made; `SecurityConfig` already permits `ROL_CONTADOR` for `GET /api/productos/**` and the service/repository behavior is unchanged.

### Testing
- Ran the focused tests with `mvn -Dtest=ProductoControllerSmokeTest,ProductoRepositoryAutocompleteTest test` and both test classes passed with no failures. 
- Existing `ProductoRepositoryAutocompleteTest` confirms repository `buscarAutocompleteInventarioAjustes` returns expected matches by `nombre`/`codigoSku`, preventing regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f9de47a8c8333adcf5639150da3ce)